### PR TITLE
fix(db): seed_default_actions ON CONFLICT target broken since 0015

### DIFF
--- a/packages/gui/supabase/migrations/0028_fix_seed_default_actions_conflict.sql
+++ b/packages/gui/supabase/migrations/0028_fix_seed_default_actions_conflict.sql
@@ -1,0 +1,59 @@
+-- 0028_fix_seed_default_actions_conflict.sql
+-- Fix the dangling ON CONFLICT target in seed_default_actions left behind
+-- by 0015_action_overrides.sql.
+--
+-- 0014 created seed_default_actions(uuid) with
+--   `on conflict (workspace_id, name) do nothing`
+-- in all 15 inserts, targeting the unique constraint
+-- actions_workspace_id_name_key.
+--
+-- 0015 dropped that constraint and replaced it with
+--   actions_workspace_id_name_kind_key (workspace_id, name, kind)
+-- so user-overrides can share a name with the built-in they replace.
+-- The seed function was never updated, so any call to it raises
+--   "there is no unique or exclusion constraint matching the ON CONFLICT
+--    specification"
+-- on the very first insert. The workspace-creation server action swallows
+-- that error (logs only -- see packages/gui/src/app/workspaces/actions.ts),
+-- so every workspace created after 0015 has zero rows in `actions` and a
+-- NULL `workspaces.auto_triage_action_id`.
+--
+-- Rewriting the function body to use (workspace_id, name, kind) restores
+-- the original behaviour; backfilling every workspace recovers the empty
+-- ones (seed_default_actions is idempotent -- DO NOTHING + the
+-- auto_triage_action_id update is guarded by `IS NULL`).
+
+do $migrate$
+declare
+  v_src text;
+  v_new text;
+begin
+  v_src := pg_get_functiondef('public.seed_default_actions(uuid)'::regprocedure);
+  v_new := regexp_replace(
+    v_src,
+    'on conflict \(workspace_id, name\) do nothing',
+    'on conflict (workspace_id, name, kind) do nothing',
+    'gi'
+  );
+  if v_new = v_src then
+    raise notice 'seed_default_actions: ON CONFLICT target already correct, skipping rewrite';
+  else
+    execute v_new;
+    raise notice 'seed_default_actions: ON CONFLICT target rewritten to (workspace_id, name, kind)';
+  end if;
+end
+$migrate$;
+
+-- Backfill: re-seed every existing workspace. Idempotent on already-seeded
+-- workspaces (ON CONFLICT DO NOTHING + auto_triage pointer guarded by IS NULL),
+-- so this is safe to run on workspaces that were unaffected and recovers the
+-- ones that were stuck empty since 0015.
+do $backfill$
+declare
+  ws record;
+begin
+  for ws in select id from workspaces loop
+    perform seed_default_actions(ws.id);
+  end loop;
+end
+$backfill$;


### PR DESCRIPTION
## Summary

Restores built-in Actions in the GUI for newly created workspaces. Every workspace created since migration `0015` shipped has been silently coming up with **zero rows** in the `actions` table and a **NULL** `workspaces.auto_triage_action_id` — which is why no built-ins appear in the GUI after a fresh setup.

### Root cause

- `0014_seed_default_actions.sql` defines `seed_default_actions(uuid)` with `on conflict (workspace_id, name) do nothing` in all 15 INSERTs, targeting the unique constraint `actions_workspace_id_name_key`.
- `0015_action_overrides.sql:20-24` drops that constraint and replaces it with `actions_workspace_id_name_kind_key (workspace_id, name, kind)` so user-overrides can share a name with the built-in they replace.
- The seed function was never updated. Postgres raises `there is no unique or exclusion constraint matching the ON CONFLICT specification` on the very first insert, aborting the function.
- `packages/gui/src/app/workspaces/actions.ts:68-73` logs the error but doesn't fail workspace creation — the comment literally says _"Failure here is non-fatal: the workspace is usable without actions, the user can hit a 'seed defaults' button from the cockpit later"_ (no such button exists).

Net: fresh workspace → silent seed crash → empty `actions` → `/settings/actions` shows nothing.

### Fix

One migration: `0028_fix_seed_default_actions_conflict.sql`.

1. Pull the current function source via `pg_get_functiondef('public.seed_default_actions(uuid)'::regprocedure)`.
2. `regexp_replace` the bad ON CONFLICT target with `(workspace_id, name, kind)` (case-insensitive, idempotent — `RAISE NOTICE` if nothing changed).
3. `EXECUTE` the rewritten definition as `CREATE OR REPLACE`.
4. Re-run the original 0014-style backfill loop so every existing workspace gets re-seeded.

`seed_default_actions` is already idempotent — `ON CONFLICT DO NOTHING` plus the `auto_triage_action_id` update guarded by `IS NULL` — so the backfill is safe on workspaces that were unaffected (e.g. workspaces created before 0015 shipped, which already have all 15 rows).

No code changes needed. The TypeScript Supabase types file isn't auto-generated and no columns changed, so types stay as-is.

## Test plan

- [ ] Apply migration `0028` to a Supabase env that was created post-`0015` and has 1+ workspaces.
- [ ] Verify `RAISE NOTICE` says "ON CONFLICT target rewritten" the first time, "already correct" on a second run.
- [ ] Verify `SELECT count(*) FROM actions WHERE workspace_id = '<existing workspace>'` returns 15.
- [ ] Verify `SELECT auto_triage_action_id FROM workspaces WHERE id = '<existing workspace>'` is non-NULL.
- [ ] Create a new workspace through the GUI wizard; verify `/settings/actions` shows all 15 built-ins.
- [ ] Apply 0028 a second time to confirm idempotency (RAISE NOTICE should say "already correct"; row counts unchanged).