### PR TITLE
fix(readme): swap inline SVG logo for asset-referenced banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 <div align="center">
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 200" width="528" height="120" fill="currentColor" role="img" aria-label="CEZAR">
-  <title>CEZAR</title>
-  <path fill-rule="evenodd" d="M20 20H180V180H20ZM52 52H148V148H52ZM76 70L76 130L126 100Z"/>
-  <g transform="translate(127 0)">
-    <path fill-rule="evenodd" d="M73 20H183V52H105V148H183V180H73ZM209 20H319V52H241V84H297V116H241V148H319V180H209ZM345 20H455V52L385 148H455V180H345V148L415 52H345ZM481 180L511 20H561L591 180ZM520 110L530 50H542L552 110ZM513 180L525 130H547L559 180ZM617 20H727V102H649V180H617ZM649 42H705V80H649ZM649 102H681L727 180H695Z"/>
-  </g>
-</svg>
+<img src="docs/images/cezar-banner.svg" alt="CEZAR" width="528" height="120">
 
 **Software delivery life cycle cockpit for managing projects and co-working with agents.**
 

--- a/docs/images/cezar-banner.svg
+++ b/docs/images/cezar-banner.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 200" role="img" aria-label="CEZAR">
+  <title>CEZAR</title>
+  <style>
+    path { fill: #0a0a0a; }
+    @media (prefers-color-scheme: dark) {
+      path { fill: #fafafa; }
+    }
+  </style>
+  <path fill-rule="evenodd" d="M20 20H180V180H20ZM52 52H148V148H52ZM76 70L76 130L126 100Z"/>
+  <g transform="translate(127 0)">
+    <path fill-rule="evenodd" d="M73 20H183V52H105V148H183V180H73ZM209 20H319V52H241V84H297V116H241V148H319V180H209ZM345 20H455V52L385 148H455V180H345V148L415 52H345ZM481 180L511 20H561L591 180ZM520 110L530 50H542L552 110ZM513 180L525 130H547L559 180ZM617 20H727V102H649V180H617ZM649 42H705V80H649ZM649 102H681L727 180H695Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

The CEZAR wordmark+mark at the top of the README was rendering as literal `<title>CEZAR</title>` text on GitHub (see attached screenshot in the conversation that prompted this) — because GitHub strips inline `<svg>` blocks from rendered README markdown for security and only the inner `<title>` text survives.

### Fix

- New file: `docs/images/cezar-banner.svg` — same combined mark + wordmark geometry as the inline original, but standalone.
- README swaps the 7-line inline SVG block for a one-line `<img src="docs/images/cezar-banner.svg" alt="CEZAR" width="528" height="120">`.
- The new SVG carries an embedded `@media (prefers-color-scheme: dark)` stylesheet so it renders near-black on light themes and near-white on dark themes. (The inline version used `fill="currentColor"`, which only resolves correctly when the SVG is inline; once referenced via `<img>` it would have collapsed to default black and been invisible in GitHub's dark mode.)

## Test plan

- [ ] Open the rendered README on GitHub in light mode — CEZAR mark + wordmark visible at the top.
- [ ] Switch GitHub UI to dark mode — same logo, inverted to near-white.
- [ ] Confirm no literal `<title>CEZAR</title>` text leaks through anywhere.