### PR TITLE
chore(images): drop unused A logo variant, keep B

### DIFF
--- a/docs/images/cezar-logo-A-prompt.svg
+++ b/docs/images/cezar-logo-A-prompt.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 200" fill="currentColor" role="img" aria-label="CEZAR">
-  <title>CEZAR</title>
-  <path d="M30 60L95 100L30 140" fill="none" stroke="currentColor" stroke-width="36" stroke-linecap="square" stroke-linejoin="miter" stroke-miterlimit="2"/>
-  <g transform="translate(67 0)">
-    <path fill-rule="evenodd" d="M73 20H183V52H105V148H183V180H73ZM209 20H319V52H241V84H297V116H241V148H319V180H209ZM345 20H455V52L385 148H455V180H345V148L415 52H345ZM481 180L511 20H561L591 180ZM520 110L530 50H542L552 110ZM513 180L525 130H547L559 180ZM617 20H727V102H649V180H617ZM649 42H705V80H649ZM649 102H681L727 180H695Z"/>
-  </g>
-</svg>


### PR DESCRIPTION
## Summary

The rebrand checked in two concept variants for the CEZAR mark:
- `docs/images/cezar-logo-A-prompt.svg` — the CLI-prompt chevron `>` glyph
- `docs/images/cezar-logo-B-frame.svg` — the frame / play-button glyph

Neither is referenced anywhere in the codebase (verified via repo-wide grep across `.md`, `.tsx`, `.ts`, `.html`, `.json`). Per direction: keep B, drop A.

The README banner at `docs/images/cezar-banner.svg` already uses B's geometry (the inline SVG it was extracted from was the B variant), so this PR has no effect on rendered output — pure file removal.

## Test plan

- [ ] Rendered README still shows the CEZAR wordmark + frame mark at the top.
- [ ] `git grep cezar-logo-A` returns nothing.