### PR TITLE
docs(env): pre-filled .env.local.example for local dev + simpler Quick start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ web_modules/
 .env.*
 !.env.example
 !.env.docker.example
+!.env.local.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -139,21 +139,19 @@ yarn install
 # 1. start the local Supabase stack (db + kong + Realtime in Docker)
 yarn db:start
 
-# 2. set env vars (see docs/SELF-HOSTING.md for the full list)
-cat > .env.local <<EOF
-NEXT_PUBLIC_SUPABASE_URL=...
-SUPABASE_SERVICE_ROLE_KEY=...
-ANTHROPIC_API_KEY=sk-ant-...
-GITHUB_APP_ID=...
-GITHUB_APP_PRIVATE_KEY="-----BEGIN..."
-GITHUB_APP_WEBHOOK_SECRET=...
-CRON_SECRET=...
-NEXT_PUBLIC_APP_URL=https://app.example.com
-EOF
+# 2. seed env from the local-dev example; everything but ANTHROPIC_API_KEY
+#    is pre-filled for the local Supabase stack
+cp packages/gui/.env.local.example packages/gui/.env.local
+# then edit packages/gui/.env.local and replace `sk-ant-REPLACE-ME` with
+# your Anthropic key. GitHub App vars are optional for local-only use.
 
 # 3. run
 yarn workspace @cezar/gui dev
 ```
+
+For self-hosted (non-local) deployments, see
+[`docs/SELF-HOSTING.md`](docs/SELF-HOSTING.md) for the full env-var list
+including hosted Supabase, the in-process scheduler, and tuning knobs.
 
 Then install the GitHub App on your repo, walk through the **Workspaces → New**
 wizard (project env preset, label-catalog analysis, workflow defaults), and

--- a/packages/gui/.env.local.example
+++ b/packages/gui/.env.local.example
@@ -1,0 +1,39 @@
+# Local-dev env for @cezar/gui.
+#
+# Copy this to packages/gui/.env.local, then fill in ANTHROPIC_API_KEY.
+# Everything else is pre-set for the local Supabase docker stack started
+# by `yarn db:start` (see infra/supabase/).
+#
+# Supabase URL / anon / service-role / Postgres URL below are the well-known
+# demo JWTs baked into infra/supabase/kong.yml. They only work against the
+# local stack's pinned JWT signing secret -- safe to commit, useless for
+# attacking any hosted Supabase project.
+
+# ─── Local Supabase (yarn db:start) ──────────────────────────────────────
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+
+# Direct Postgres connection used by the runner long-poll LISTEN/NOTIFY path
+# (GET /api/runner/jobs?wait=25). Same DB that's behind Supabase above.
+SUPABASE_DB_URL=postgres://postgres:postgres@127.0.0.1:54322/postgres
+
+# ─── App URL ─────────────────────────────────────────────────────────────
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ─── Cron auth ───────────────────────────────────────────────────────────
+# Bearer token /api/cron/* expects. Any string works locally.
+CRON_SECRET=local-dev-cron-secret
+
+# ─── Anthropic (REQUIRED) ────────────────────────────────────────────────
+# Get one at https://console.anthropic.com -> Settings -> API Keys.
+ANTHROPIC_API_KEY=sk-ant-REPLACE-ME
+
+# ─── GitHub App (optional for local-only use) ────────────────────────────
+# Skip these if you only want to drive the cockpit by hand. Webhook-driven
+# triage / autofix needs them; see docs/INSTALL.md for App setup. With the
+# webhook secret unset, /api/github/webhook returns 503 and the cron-driven
+# /api/cron/triage-sweep poll fallback is the only source of triage jobs.
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_WEBHOOK_SECRET=


### PR DESCRIPTION
## Summary

The README's Quick start was telling users to handwrite a `.env.local` heredoc with 8 placeholder values — including \`NEXT_PUBLIC_SUPABASE_URL\`, \`SUPABASE_SERVICE_ROLE_KEY\`, etc. — for a Supabase stack they hadn't deployed yet. With the local docker stack from \`yarn db:start\`, those values are **deterministic** (the demo JWTs are baked into \`infra/supabase/kong.yml\`, signed with the pinned dev JWT secret), so we can ship them in a pre-filled example file.

After this PR, step 2 of the Quick start is:

\`\`\`bash
cp packages/gui/.env.local.example packages/gui/.env.local
# edit ANTHROPIC_API_KEY
\`\`\`

instead of a 9-line heredoc.

### What's in `packages/gui/.env.local.example`

- **Pre-filled & ready to use**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL` (port 54322, for the Phase 3 LISTEN/NOTIFY long-poll path), `NEXT_PUBLIC_APP_URL=http://localhost:3000`, `CRON_SECRET=local-dev-cron-secret`.
- **One required field**: `ANTHROPIC_API_KEY=sk-ant-REPLACE-ME` — user fills in their Anthropic key.
- **Three optional fields**: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET` — left blank with a comment explaining that webhook-driven triage needs them but local-only cockpit exploration doesn't.

The pre-filled Supabase credentials are the canonical Supabase demo JWTs (`iss=supabase-demo`, signed with `super-secret-jwt-token-with-at-least-32-characters-long`). They only work against this docker stack and have zero value for attacking any hosted Supabase project — same trust model as committing them to `kong.yml`, which we already do.

### Also in this PR

- `.gitignore`: adds `!.env.local.example` to the allow-list (the existing `.env.*` block was hiding the new file). Matches the existing pattern for `.env.example` and `.env.docker.example`.
- `README.md`: replaces the heredoc with the `cp` command + a one-line pointer to `docs/SELF-HOSTING.md` for hosted-Supabase deployments.

## Test plan

- [ ] Fresh clone → `yarn install` → `yarn db:start` → `cp packages/gui/.env.local.example packages/gui/.env.local` → edit `ANTHROPIC_API_KEY` → `yarn workspace @cezar/gui dev` → open http://localhost:3000 → sign in → create a workspace.
- [ ] Confirm `/settings/actions` shows all 15 built-ins (migration 0028 already shipped, so the seed works).
- [ ] Confirm `/api/runner/jobs?wait=5` blocks rather than returning immediately when the queue is empty (proves `SUPABASE_DB_URL` is being read for LISTEN/NOTIFY).