### PR TITLE
feat(deploy): bundle Supabase in root compose with Kong templating + internal URL

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -2,27 +2,63 @@
 # Copy to `.env` (or paste each value into Dokploy's env-var UI).
 # See MIGRATION.md for the full reference + optional tuning vars.
 
-# ── Public URL ────────────────────────────────────────────────────────────────
-# The browser-visible URL of the GUI. Used to render runner-registration
-# commands, the GitHub App webhook target, and OAuth redirects.
+# ─── Public URLs ──────────────────────────────────────────────────────────────
+# Browser-visible URLs. The GUI domain serves the cockpit; the Supabase domain
+# fronts Kong so the browser-side `@supabase/supabase-js` client can reach
+# auth / rest / realtime. Both must be set up as Dokploy domains pointing at
+# the `gui` and `kong` services respectively.
 NEXT_PUBLIC_APP_URL=https://cezar.yourdomain.com
+NEXT_PUBLIC_SUPABASE_URL=https://supabase.yourdomain.com
 
-# ── Supabase (required) ───────────────────────────────────────────────────────
-# Project Settings → API in the Supabase dashboard.
-NEXT_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOi...
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOi...
+# Server-side override: when set, SSR + middleware + the OAuth callback hit
+# this URL directly over the Docker network instead of bouncing through
+# Traefik. The browser-side client always uses NEXT_PUBLIC_SUPABASE_URL.
+# Leave commented to fall back to the public URL (e.g. Supabase Cloud).
+SUPABASE_INTERNAL_URL=http://kong:8000
 
-# ── Anthropic API (required for the managed cron path) ───────────────────────
+# ─── Supabase keys ────────────────────────────────────────────────────────────
+# DEFAULTS BELOW ARE THE PUBLIC SUPABASE DEV KEYS. ROTATE BEFORE EXPOSING THE
+# STACK TO THE INTERNET — anyone can mint service_role tokens against them.
+#
+# To rotate:
+#   1. Pick a new secret: `openssl rand -base64 48`
+#   2. Mint matching anon + service_role JWTs signed with that secret
+#      (any JWT library; payload: {"iss":"supabase","role":"<anon|service_role>","exp":<future-unix-ts>}).
+#   3. Update SUPABASE_JWT_SECRET, NEXT_PUBLIC_SUPABASE_ANON_KEY,
+#      SUPABASE_SERVICE_ROLE_KEY here AND in infra/supabase/kong.yml
+#      (the `keyauth_credentials.key` entries).
+SUPABASE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+
+# ─── Supabase Postgres + Realtime ─────────────────────────────────────────────
+# Change before exposing. Used by gotrue, postgrest, realtime, and the migrator.
+POSTGRES_PASSWORD=postgres
+# Generate fresh: `openssl rand -base64 48`
+SUPABASE_REALTIME_SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
+# Optional override; defaults to "supabaserealtime".
+# SUPABASE_REALTIME_ENC_KEY=
+
+# ─── GoTrue (auth) ────────────────────────────────────────────────────────────
+# Set both if you want "Sign in with GitHub" via Supabase Auth. Create an
+# OAuth App at https://github.com/settings/developers; callback URL is
+# `${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/callback`.
+GOTRUE_GITHUB_CLIENT_ID=
+GOTRUE_GITHUB_CLIENT_SECRET=
+# GOTRUE_DISABLE_SIGNUP=false
+# GOTRUE_SMTP_ADMIN_EMAIL=admin@yourdomain.com
+
+# ─── Anthropic (required for the managed cron path) ───────────────────────────
 ANTHROPIC_API_KEY=sk-ant-...
 
-# ── Cron bearer (required) ────────────────────────────────────────────────────
+# ─── Cron bearer (required) ───────────────────────────────────────────────────
 # Generate with: openssl rand -hex 32
 CRON_SECRET=replace-me-with-a-long-random-string
 
-# ── GitHub App (required for webhooks + autofix) ─────────────────────────────
-# See docs/github-app-setup.md. Without WEBHOOK_SECRET the webhook returns 503
-# and Cezar falls back to the triage-sweep poll.
+# ─── GitHub App (required for webhooks + autofix) ─────────────────────────────
+# See docs/github-app-setup.md. Separate from the GoTrue GitHub OAuth above —
+# this is the App that posts on issues + opens PRs. Without WEBHOOK_SECRET the
+# webhook receiver returns 503 and Cezar falls back to the triage-sweep poll.
 GITHUB_APP_ID=123456
 # Paste the PEM with literal \n separators OR a real multi-line value — the
 # server normalizes \n to newlines. For docker compose, a single-line value
@@ -30,11 +66,11 @@ GITHUB_APP_ID=123456
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n"
 GITHUB_APP_WEBHOOK_SECRET=replace-me
 
-# ── Workflow engine ───────────────────────────────────────────────────────────
+# ─── Workflow engine ──────────────────────────────────────────────────────────
 # `true` flips the engine on globally (recommended for self-hosted).
 CEZAR_USE_WORKFLOW_ENGINE=true
 
-# ── Dispatcher tuning (optional — defaults shown) ────────────────────────────
+# ─── Dispatcher tuning (optional — defaults shown) ────────────────────────────
 # CEZAR_DISPATCH_BATCH=3
 # CEZAR_DISPATCH_STALE_MINUTES=15
 # CEZAR_RUNNER_OFFLINE_MINUTES=3
@@ -48,7 +84,7 @@ CEZAR_USE_WORKFLOW_ENGINE=true
 # CSV of cron paths to skip, e.g. /api/cron/issue-sync
 # CEZAR_INPROCESS_CRON_DISABLED=
 
-# ── Self-hosted runner ───────────────────────────────────────────────────────
+# ─── Self-hosted runner ───────────────────────────────────────────────────────
 # Issue this token in the GUI: Settings → Runners → Register a runner.
 # Shown once; treat it like a password.
 CEZAR_RUNNER_TOKEN=replace-me

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,16 @@ RUN corepack enable
 COPY --from=deps /app ./
 COPY . .
 
-ENV NEXT_TELEMETRY_DISABLED=1
+# NEXT_PUBLIC_* values must be present during `next build` — Next inlines them
+# into the client JS bundle. Compose passes them via `build.args`; we re-export
+# them as ENV so `next build` (which reads process.env) picks them up.
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL} \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY} \
+    NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL} \
+    NEXT_TELEMETRY_DISABLED=1
 
 # @cezar/core must be built before `next build`, since the GUI imports its
 # compiled `dist/` (it's listed in `serverExternalPackages`).

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,14 +1,43 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Cezar — self-hosted stack for Dokploy / generic Docker hosts.
+# Cezar — full self-hosted stack for Dokploy / generic Docker hosts.
 #
-#   gui     — the Next.js cockpit (also fires the /api/cron/* routes via the
-#             in-process scheduler; CEZAR_INPROCESS_CRON=true).
-#   runner  — optional @cezar/runner daemon for subscription CLIs
-#             (`claude` / `codex`). Comment out if you only need the
-#             managed-API path.
+# Bundles the Cezar GUI + runner with a local Supabase stack so the whole app
+# runs on a single host with no external SaaS dependency. Two domains needed
+# in Dokploy (both fronted by Traefik):
 #
-# Copy `.env.docker.example` to `.env` (or use Dokploy's env-var UI) before
-# bringing the stack up. See MIGRATION.md for the full env-var matrix.
+#   cezar.<yourdomain>     → service `gui`,  port 3000
+#   supabase.<yourdomain>  → service `kong`, port 8000
+#
+# The browser-side Supabase client (cockpit Realtime, inbox subscriptions,
+# label editor, etc.) hits the supabase.* URL directly from the user's browser,
+# so it must be publicly resolvable — it can't be `http://kong:8000`.
+#
+# Services:
+#   gui       — Next.js cockpit (also fires /api/cron/* via the in-process
+#               scheduler when CEZAR_INPROCESS_CRON=true).
+#   runner    — optional @cezar/runner daemon for subscription CLIs
+#               (`claude` / `codex`). Comment out if you only need the
+#               managed-API path.
+#   db        — Postgres 15 + wal2json (for Realtime's logical decoding).
+#   auth      — GoTrue: GitHub OAuth + session JWTs.
+#   migrator  — one-shot: applies packages/gui/supabase/migrations/*.sql,
+#               tracked in public._cezar_migrations.
+#   rest      — PostgREST: the auto-generated REST API the GUI calls.
+#   realtime  — supabase/realtime: WAL → websocket fanout.
+#   kong      — gateway routing /auth/v1, /rest/v1, /realtime/v1 to the above.
+#
+# Setup:
+#   1. Copy `.env.docker.example` → `.env` (or paste into Dokploy's env UI).
+#   2. ROTATE THE JWT KEYS. The defaults below are the well-known Supabase
+#      dev keys — anyone on the internet can mint a service_role token
+#      against them. See `infra/supabase/README.md` (or MIGRATION.md) for
+#      the rotation recipe.
+#   3. Apply Dokploy domains to `gui` and `kong` per above.
+#   4. Deploy. The migrator runs once on first boot.
+#
+# If you want to use Supabase Cloud instead of the bundled stack, comment out
+# db/auth/migrator/rest/realtime/kong and set the three NEXT_PUBLIC_SUPABASE_*
+# + SUPABASE_SERVICE_ROLE_KEY vars to your hosted project's values.
 # ─────────────────────────────────────────────────────────────────────────────
 
 services:
@@ -16,14 +45,32 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      # NEXT_PUBLIC_* vars are baked into the browser bundle at build time.
+      # Setting them as `environment:` only would make SSR work but break the
+      # client-side Supabase client (browser tries to call `undefined/...`).
+      args:
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+        NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL}
     image: cezar-gui:latest
     restart: unless-stopped
+    depends_on:
+      kong:
+        condition: service_started
+      migrator:
+        condition: service_completed_successfully
     environment:
       NODE_ENV: production
       PORT: "3000"
 
       # ── Supabase (required) ────────────────────────────────────────────────
+      # NEXT_PUBLIC_SUPABASE_URL is the public URL baked into the browser
+      # bundle. SUPABASE_INTERNAL_URL shortcuts server-side calls to Kong over
+      # the Docker network so SSR doesn't bounce through Traefik. The server
+      # client (lib/supabase/server.ts) prefers SUPABASE_INTERNAL_URL when set;
+      # the browser client always uses NEXT_PUBLIC_SUPABASE_URL.
       NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      SUPABASE_INTERNAL_URL: ${SUPABASE_INTERNAL_URL:-http://kong:8000}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
 
@@ -35,9 +82,6 @@ services:
       CRON_SECRET: ${CRON_SECRET}
 
       # ── In-process cron scheduler (required on self-hosted) ────────────────
-      # Boots the scheduler from instrumentation.ts; drives /api/cron/dispatch,
-      # /api/cron/triage-sweep, /api/cron/issue-sync on the cadence from
-      # vercel.json (overridable via CEZAR_*_INTERVAL_MS).
       CEZAR_INPROCESS_CRON: "true"
       CEZAR_INPROCESS_CRON_BASE_URL: http://127.0.0.1:3000
 
@@ -53,12 +97,9 @@ services:
       CEZAR_RUNNER_OFFLINE_MINUTES: ${CEZAR_RUNNER_OFFLINE_MINUTES:-3}
       CEZAR_TRIAGE_SWEEP_BATCH: ${CEZAR_TRIAGE_SWEEP_BATCH:-10}
     ports:
-      # Host 3333 → container 3000. On Dokploy, Traefik fronts this — keep the
-      # bind on 127.0.0.1 so the port isn't exposed publicly. Remove the
-      # `127.0.0.1:` prefix if you're running compose standalone and exposing
-      # directly. The container still listens on 3000 internally, so the
-      # in-process scheduler and the `runner` → `gui:3000` traffic are
-      # unaffected.
+      # Host 3333 → container 3000. Dokploy/Traefik routes to the container
+      # over the Docker network, so this bind is purely for debug
+      # (`curl 127.0.0.1:3333/api/health` on the host).
       - "127.0.0.1:3333:3000"
     networks:
       - cezar
@@ -72,8 +113,6 @@ services:
     depends_on:
       - gui
     environment:
-      # Token is issued in the GUI: Settings → Runners → Register a runner.
-      # The runner long-polls /api/runner/jobs at this URL.
       CEZAR_RUNNER_URL: ${CEZAR_RUNNER_URL:-http://gui:3000}
       CEZAR_RUNNER_TOKEN: ${CEZAR_RUNNER_TOKEN}
     command:
@@ -91,9 +130,181 @@ services:
     networks:
       - cezar
 
+  # ── Supabase stack ────────────────────────────────────────────────────────
+  # If you switch to Supabase Cloud, comment out everything from `db:` through
+  # `kong:` (inclusive) and the `db-data` volume.
+
+  db:
+    build:
+      context: ./infra/supabase/db
+    image: cezar-supabase-db:local
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: postgres
+    command:
+      - postgres
+      - -c
+      - max_connections=200
+      - -c
+      - shared_buffers=256MB
+      - -c
+      - effective_cache_size=512MB
+      # supabase/realtime tails the WAL via logical replication.
+      - -c
+      - wal_level=logical
+      - -c
+      - max_wal_senders=10
+      - -c
+      - max_replication_slots=10
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - ./infra/supabase/init:/docker-entrypoint-initdb.d:ro
+    ports:
+      # Debug-only: direct psql access from the host loopback.
+      - "127.0.0.1:54322:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    networks:
+      - cezar
+
+  auth:
+    image: supabase/gotrue:v2.158.1
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: "9999"
+      # Public-facing URLs — GoTrue puts these in OAuth redirects + magic links.
+      API_EXTERNAL_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      GOTRUE_SITE_URL: ${NEXT_PUBLIC_APP_URL}
+      GOTRUE_URI_ALLOW_LIST: "${NEXT_PUBLIC_APP_URL}"
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD:-postgres}@db:5432/postgres?search_path=auth
+      DB_NAMESPACE: auth
+      GOTRUE_DISABLE_SIGNUP: "${GOTRUE_DISABLE_SIGNUP:-false}"
+      GOTRUE_JWT_SECRET: ${SUPABASE_JWT_SECRET}
+      GOTRUE_JWT_EXP: "3600"
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_ISSUER: ${NEXT_PUBLIC_SUPABASE_URL}/auth/v1
+      # GitHub OAuth — used by the GUI's "Sign in with GitHub" button.
+      GOTRUE_EXTERNAL_GITHUB_ENABLED: "${GOTRUE_GITHUB_CLIENT_ID:+true}"
+      GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: "${GOTRUE_GITHUB_CLIENT_ID:-}"
+      GOTRUE_EXTERNAL_GITHUB_SECRET: "${GOTRUE_GITHUB_CLIENT_SECRET:-}"
+      GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/callback"
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
+      GOTRUE_MAILER_AUTOCONFIRM: "true"
+      GOTRUE_SMTP_ADMIN_EMAIL: ${GOTRUE_SMTP_ADMIN_EMAIL:-admin@local.dev}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9999/health"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+    networks:
+      - cezar
+
+  migrator:
+    image: postgres:15-alpine
+    depends_on:
+      auth:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    volumes:
+      - ./packages/gui/supabase/migrations:/migrations:ro
+      - ./infra/supabase/migrate.sh:/migrate.sh:ro
+    entrypoint: ["/bin/sh", "/migrate.sh"]
+    restart: "no"
+    networks:
+      - cezar
+
+  rest:
+    image: postgrest/postgrest:v12.2.0
+    restart: unless-stopped
+    depends_on:
+      migrator:
+        condition: service_completed_successfully
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD:-postgres}@db:5432/postgres
+      PGRST_DB_SCHEMAS: public,storage
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${SUPABASE_JWT_SECRET}
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+    networks:
+      - cezar
+
+  realtime:
+    image: supabase/realtime:v2.30.34
+    restart: unless-stopped
+    depends_on:
+      migrator:
+        condition: service_completed_successfully
+    environment:
+      PORT: "4000"
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      DB_NAME: postgres
+      DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'
+      DB_ENC_KEY: ${SUPABASE_REALTIME_ENC_KEY:-supabaserealtime}
+      API_JWT_SECRET: ${SUPABASE_JWT_SECRET}
+      FLY_ALLOC_ID: fly123
+      FLY_APP_NAME: realtime
+      SECRET_KEY_BASE: ${SUPABASE_REALTIME_SECRET_KEY_BASE}
+      ERL_AFLAGS: -proto_dist inet_tcp
+      ENABLE_TAILSCALE: "false"
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: "10000"
+      APP_NAME: realtime
+      SEED_SELF_HOST: "true"
+      RUN_JANITOR: "true"
+    networks:
+      - cezar
+
+  kong:
+    image: kong:2.8.1
+    restart: unless-stopped
+    depends_on:
+      - auth
+      - rest
+      - realtime
+    # kong-entrypoint.sh substitutes JWT keys from env into the template, then
+    # exec's kong via its stock /docker-entrypoint.sh. KONG_DECLARATIVE_CONFIG
+    # points at the rendered file (/tmp/kong.yml), not the template.
+    entrypoint: ["/bin/sh", "/docker-entrypoint-cezar.sh"]
+    command: ["kong", "docker-start"]
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /tmp/kong.yml
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+    volumes:
+      - ./infra/supabase/kong.yml.template:/home/kong/kong.yml.template:ro
+      - ./infra/supabase/kong-entrypoint.sh:/docker-entrypoint-cezar.sh:ro
+    ports:
+      # Debug-only host bind. Dokploy/Traefik routes to port 8000 over the
+      # Docker network for the supabase.<yourdomain> domain.
+      - "127.0.0.1:54321:8000"
+    networks:
+      - cezar
+
 networks:
   cezar:
     driver: bridge
 
 volumes:
+  db-data:
   runner-home:

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -162,17 +162,24 @@ services:
       - rest
       - realtime
     restart: unless-stopped
+    # kong-entrypoint.sh substitutes JWT keys into the template at boot.
+    # Dev defaults are the well-known public Supabase demo keys.
+    entrypoint: ["/bin/sh", "/docker-entrypoint-cezar.sh"]
+    command: ["kong", "docker-start"]
     ports:
       - "127.0.0.1:54321:8000"
     environment:
       KONG_DATABASE: "off"
-      KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
+      KONG_DECLARATIVE_CONFIG: /tmp/kong.yml
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_PLUGINS: request-transformer,cors,key-auth,acl
       KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU}
     volumes:
-      - ./kong.yml:/home/kong/kong.yml:ro
+      - ./kong.yml.template:/home/kong/kong.yml.template:ro
+      - ./kong-entrypoint.sh:/docker-entrypoint-cezar.sh:ro
 
 volumes:
   db-data:

--- a/infra/supabase/kong-entrypoint.sh
+++ b/infra/supabase/kong-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Render kong.yml.template → /tmp/kong.yml with the JWT keys from env, then
+# exec kong via its stock entrypoint. Substitution uses `sed` (no extra
+# packages needed in the kong image) and only the two specific placeholders we
+# own, so the rest of the YAML can contain literal `$` chars without breaking.
+#
+# Compose mounts:
+#   /home/kong/kong.yml.template  (the template)
+#   this script at /docker-entrypoint-cezar.sh
+# And sets KONG_DECLARATIVE_CONFIG=/tmp/kong.yml so kong reads the rendered
+# file instead of the template.
+
+set -e
+
+: "${SUPABASE_ANON_KEY:?must be set}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?must be set}"
+
+# Escape `&`, `|`, `\` in the values so sed's replacement side stays literal.
+# JWT bodies are base64url so they never contain these in practice, but if a
+# value were ever rotated to something exotic the escape keeps sed honest.
+escape() {
+  printf '%s' "$1" | sed -e 's/[&|\\]/\\&/g'
+}
+ANON_ESC=$(escape "$SUPABASE_ANON_KEY")
+SERVICE_ESC=$(escape "$SUPABASE_SERVICE_ROLE_KEY")
+
+sed \
+  -e "s|\${SUPABASE_ANON_KEY}|${ANON_ESC}|g" \
+  -e "s|\${SUPABASE_SERVICE_ROLE_KEY}|${SERVICE_ESC}|g" \
+  /home/kong/kong.yml.template > /tmp/kong.yml
+
+exec /docker-entrypoint.sh "$@"

--- a/infra/supabase/kong.yml.template
+++ b/infra/supabase/kong.yml.template
@@ -3,20 +3,23 @@ _format_version: "2.1"
 # Kong gateway routing for the local Supabase stack. Same path scheme as the
 # hosted product so `@supabase/supabase-js` (which builds URLs as
 # `{baseUrl}/rest/v1/...`, `{baseUrl}/auth/v1/...`, `{baseUrl}/realtime/v1/...`)
-# works against http://127.0.0.1:54321 without any client-side change.
+# works against the Kong endpoint without any client-side change.
+#
+# This file is a *template* — `kong-entrypoint.sh` substitutes the two `${...}`
+# placeholders below at container start, then exec's kong on the rendered file.
+# Rotate the JWT secret + regenerate both JWTs in env vars; no rebuild needed.
 #
 # `key-auth` matches the hosted behavior of demanding an `apikey` header on
-# every call. The two consumers below ship the well-known dev anon / service
-# role JWTs; clients pass them as the `apikey` header AND (for writes) as the
-# Authorization bearer so PostgREST picks up the role claim.
+# every call. Clients pass the JWT as the `apikey` header AND (for writes) as
+# the Authorization bearer so PostgREST picks up the role claim.
 
 consumers:
   - username: anon
     keyauth_credentials:
-      - key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+      - key: ${SUPABASE_ANON_KEY}
   - username: service_role
     keyauth_credentials:
-      - key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+      - key: ${SUPABASE_SERVICE_ROLE_KEY}
 
 acls:
   - consumer: anon

--- a/packages/gui/src/app/auth/callback/route.ts
+++ b/packages/gui/src/app/auth/callback/route.ts
@@ -10,7 +10,8 @@ export async function GET(request: NextRequest) {
   if (code) {
     const cookieStore = await cookies();
     const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      // Server-side: prefer the internal Docker URL when set.
+      process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       {
         cookies: {

--- a/packages/gui/src/lib/supabase/env.ts
+++ b/packages/gui/src/lib/supabase/env.ts
@@ -5,7 +5,14 @@ function required(name: string): string {
 }
 
 export const supabaseEnv = {
+  // Public URL — used by the browser client and as the server-side fallback.
   url: (): string => required('NEXT_PUBLIC_SUPABASE_URL'),
+  // Server-side override so SSR traffic stays on the Docker network instead of
+  // egressing through Traefik. Auth still works because the user's session
+  // JWT travels in the request, not in Supabase-specific cookies tied to the
+  // public URL. Falls back to the public URL when unset (Vercel, single-host
+  // dev, etc.).
+  internalUrl: (): string => process.env.SUPABASE_INTERNAL_URL || required('NEXT_PUBLIC_SUPABASE_URL'),
   anonKey: (): string => required('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
   serviceRoleKey: (): string => required('SUPABASE_SERVICE_ROLE_KEY'),
 };

--- a/packages/gui/src/lib/supabase/server.ts
+++ b/packages/gui/src/lib/supabase/server.ts
@@ -10,7 +10,7 @@ import type { Database } from './types';
  */
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
-  return createServerClient<Database>(supabaseEnv.url(), supabaseEnv.anonKey(), {
+  return createServerClient<Database>(supabaseEnv.internalUrl(), supabaseEnv.anonKey(), {
     cookies: {
       getAll: () => cookieStore.getAll(),
       setAll: (entries) => {
@@ -32,7 +32,7 @@ export async function createSupabaseServerClient() {
  * maintenance). Never expose to components rendered client-side.
  */
 export function createSupabaseAdminClient() {
-  return createClient<Database>(supabaseEnv.url(), supabaseEnv.serviceRoleKey(), {
+  return createClient<Database>(supabaseEnv.internalUrl(), supabaseEnv.serviceRoleKey(), {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 }

--- a/packages/gui/src/middleware.ts
+++ b/packages/gui/src/middleware.ts
@@ -26,7 +26,11 @@ export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    // SUPABASE_INTERNAL_URL keeps the per-request auth.getUser() call on the
+    // Docker network in self-hosted setups; falls back to the public URL.
+    // Inlined here (not via lib/supabase/env) because middleware can run in
+    // the edge runtime where the env helper may not resolve runtime vars.
+    process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {


### PR DESCRIPTION
## Summary

- **Merged Supabase into root `compose.yaml`** — the full self-hosted Cezar (gui + runner + db + auth + rest + realtime + kong + migrator) now boots as a single Dokploy stack. Two domains needed: `cezar.<domain>` → `gui:3000`, `supabase.<domain>` → `kong:8000` (browser-side `@supabase/supabase-js` makes Realtime/auth calls direct from the user's browser, so Kong must be publicly resolvable).
- **Kong config is now templated** — `infra/supabase/kong.yml` → `kong.yml.template` with `${SUPABASE_ANON_KEY}` / `${SUPABASE_SERVICE_ROLE_KEY}` placeholders. `kong-entrypoint.sh` substitutes via `sed` at container boot, then exec's the stock kong entrypoint. Rotating JWTs is two env vars (no YAML edit, no rebuild).
- **`SUPABASE_INTERNAL_URL`** — new optional override. The server-side Supabase client (`lib/supabase/server.ts`, `middleware.ts`, `/auth/callback`) now prefers it so SSR + middleware traffic stays on the Docker network instead of bouncing through Traefik. Browser client untouched.
- **Dockerfile** picks up `NEXT_PUBLIC_*` build args so `next build` bakes the public Supabase URL into the client bundle.

Switching back to Supabase Cloud is a comment-out: leave `SUPABASE_INTERNAL_URL` unset and disable the `db/auth/migrator/rest/realtime/kong` services.

## Test plan

- [ ] `docker compose config --quiet` succeeds on a populated `.env`.
- [ ] First boot: `migrator` exits 0; `gui` reaches `/inbox` after login.
- [ ] OAuth: GitHub sign-in completes via `/auth/callback` (hits Kong via `SUPABASE_INTERNAL_URL`).
- [ ] Cockpit Realtime: open a workflow run, trigger a state change, confirm live update without refresh.
- [ ] Rotate keys: regenerate JWTs, update `NEXT_PUBLIC_SUPABASE_ANON_KEY` + `SUPABASE_SERVICE_ROLE_KEY`, restart kong + gui, confirm browser and SSR both still work.
- [ ] `infra/supabase/docker-compose.yml` dev stack still boots with the dev-key defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)