### PR TITLE
fix(compose): default GOTRUE_EXTERNAL_GITHUB_ENABLED to false, not empty string

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -40,9 +40,11 @@ SUPABASE_REALTIME_SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLr
 # SUPABASE_REALTIME_ENC_KEY=
 
 # ─── GoTrue (auth) ────────────────────────────────────────────────────────────
-# Set both if you want "Sign in with GitHub" via Supabase Auth. Create an
-# OAuth App at https://github.com/settings/developers; callback URL is
+# Opt-in for "Sign in with GitHub" via Supabase Auth: set GOTRUE_GITHUB_ENABLED
+# to "true" AND fill both client id/secret below. Create an OAuth App at
+# https://github.com/settings/developers; callback URL is
 # `${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/callback`.
+GOTRUE_GITHUB_ENABLED=false
 GOTRUE_GITHUB_CLIENT_ID=
 GOTRUE_GITHUB_CLIENT_SECRET=
 # GOTRUE_DISABLE_SIGNUP=false

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ web_modules/
 # dotenv environment variable files
 .env
 .env.*
+remote.env
 !.env.example
 !.env.docker.example
 !.env.local.example

--- a/compose.yaml
+++ b/compose.yaml
@@ -196,7 +196,11 @@ services:
       GOTRUE_JWT_AUD: authenticated
       GOTRUE_JWT_ISSUER: ${NEXT_PUBLIC_SUPABASE_URL}/auth/v1
       # GitHub OAuth — used by the GUI's "Sign in with GitHub" button.
-      GOTRUE_EXTERNAL_GITHUB_ENABLED: "${GOTRUE_GITHUB_CLIENT_ID:+true}"
+      # Opt-in: set GOTRUE_GITHUB_ENABLED=true AND fill the client id/secret.
+      # GoTrue rejects an empty string for the bool, so we default to "false"
+      # rather than the older `${GOTRUE_GITHUB_CLIENT_ID:+true}` trick (which
+      # evaluated to "" when the client id was blank).
+      GOTRUE_EXTERNAL_GITHUB_ENABLED: "${GOTRUE_GITHUB_ENABLED:-false}"
       GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: "${GOTRUE_GITHUB_CLIENT_ID:-}"
       GOTRUE_EXTERNAL_GITHUB_SECRET: "${GOTRUE_GITHUB_CLIENT_SECRET:-}"
       GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/callback"

--- a/infra/supabase/docker-compose.yml
+++ b/infra/supabase/docker-compose.yml
@@ -84,10 +84,10 @@ services:
       GOTRUE_JWT_ADMIN_ROLES: service_role
       GOTRUE_JWT_AUD: authenticated
       GOTRUE_JWT_ISSUER: http://127.0.0.1:54321/auth/v1
-      # GitHub OAuth: enable iff client id/secret are set in infra/supabase/.env.
-      # Compose substitutes ${VAR:-} to empty string if unset, which GoTrue
-      # treats as "not configured" and rejects the provider.
-      GOTRUE_EXTERNAL_GITHUB_ENABLED: "${LOCAL_GITHUB_CLIENT_ID:+true}"
+      # GitHub OAuth: opt-in via LOCAL_GITHUB_ENABLED=true in infra/supabase/.env.
+      # GoTrue rejects an empty string for the bool, so the default is "false"
+      # — set LOCAL_GITHUB_ENABLED=true alongside the client id/secret.
+      GOTRUE_EXTERNAL_GITHUB_ENABLED: "${LOCAL_GITHUB_ENABLED:-false}"
       GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: "${LOCAL_GITHUB_CLIENT_ID:-}"
       GOTRUE_EXTERNAL_GITHUB_SECRET: "${LOCAL_GITHUB_CLIENT_SECRET:-}"
       GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: "http://127.0.0.1:54321/auth/v1/callback"


### PR DESCRIPTION
## Summary

- GoTrue's `envconfig` parser rejects an empty string for `GOTRUE_EXTERNAL_GITHUB_ENABLED` (it wants `"true"` or `"false"`). The previous interpolation `\${GOTRUE_GITHUB_CLIENT_ID:+true}` collapsed to `""` when the client id was blank, crashing the auth container on boot:

  ```
  Failed to load configuration: envconfig.Process: assigning GOTRUE_EXTERNAL_GITHUB_ENABLED
    to Enabled: converting '' to type bool. details: strconv.ParseBool: parsing "": invalid syntax
  ```

  Auth crash-looped → migrator/rest/realtime/kong/gui all cascade-failed via `depends_on`.

- Switched to an explicit `GOTRUE_GITHUB_ENABLED` opt-in (defaults to `"false"`). Same fix applied to the dev compose under `infra/supabase/`. `.env.docker.example` documents the new flag.

- Gitignored `remote.env` (local-only template for pasting into Dokploy).

## Test plan

- [ ] `docker compose --env-file <env> config | grep GOTRUE_EXTERNAL_GITHUB_ENABLED` prints `"false"` when `GOTRUE_GITHUB_ENABLED` is unset.
- [ ] Deploy to Dokploy with `GOTRUE_GITHUB_CLIENT_ID` blank → auth container goes healthy → migrator runs → gui reaches `/login`.
- [ ] Set `GOTRUE_GITHUB_ENABLED=true` + real client id/secret → GitHub OAuth button on `/login` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)