### PR TITLE
fix(auth): align Supabase URL across all cookie-bearing clients

### DIFF
--- a/packages/gui/src/app/auth/actions.ts
+++ b/packages/gui/src/app/auth/actions.ts
@@ -2,14 +2,13 @@
 
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
-import { headers } from 'next/headers';
 
 export async function signInWithGitHub() {
-  // signInWithOAuth returns a URL the browser will follow — must be built
-  // against the public Supabase URL, not the internal kong:8000 hostname.
-  const supabase = await createSupabaseServerClient({ usePublicUrl: true });
-  const headerStore = await headers();
-  const origin = headerStore.get('origin') ?? 'http://localhost:3000';
+  const supabase = await createSupabaseServerClient();
+  // Prefer the configured public app URL — `headers().get('origin')` returns
+  // the container bind address (`http://0.0.0.0:3000`) when Next runs behind
+  // Traefik without trusted-forwarded-host plumbing.
+  const origin = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'github',

--- a/packages/gui/src/app/auth/callback/route.ts
+++ b/packages/gui/src/app/auth/callback/route.ts
@@ -3,15 +3,19 @@ import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
-  const { searchParams, origin } = request.nextUrl;
+  const { searchParams } = request.nextUrl;
   const code = searchParams.get('code');
   const next = searchParams.get('next') ?? '/dashboard';
+  // Use the configured public app URL — `request.nextUrl.origin` is
+  // `http://0.0.0.0:3000` inside the standalone container behind Traefik.
+  const origin = process.env.NEXT_PUBLIC_APP_URL ?? request.nextUrl.origin;
 
   if (code) {
     const cookieStore = await cookies();
     const supabase = createServerClient(
-      // Server-side: prefer the internal Docker URL when set.
-      process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      // Public URL — @supabase/ssr derives the PKCE-verifier cookie name from
+      // the URL host. Must match what signInWithGitHub used to set it.
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       {
         cookies: {

--- a/packages/gui/src/lib/supabase/server.ts
+++ b/packages/gui/src/lib/supabase/server.ts
@@ -8,14 +8,17 @@ import type { Database } from './types';
  * Per-request client scoped to the signed-in user's session. RLS policies
  * apply to every query — this is the right client for most reads.
  *
- * Pass `{ usePublicUrl: true }` for code paths that produce a URL the *browser*
- * will follow (OAuth redirects, magic links). The default uses the internal
- * Docker hostname (SUPABASE_INTERNAL_URL), which the browser can't resolve.
+ * Always built against the *public* Supabase URL, not SUPABASE_INTERNAL_URL.
+ * `@supabase/ssr` derives the session cookie name from the URL host
+ * (`sb-<host>-auth-token`), so if the browser client (always public) and
+ * the server client (internal) disagreed, every cookie read would miss and
+ * OAuth code exchange would fail with `auth_failed`. The internal-URL
+ * shortcut is preserved for the admin client below, which doesn't use
+ * cookies.
  */
-export async function createSupabaseServerClient(opts?: { usePublicUrl?: boolean }) {
+export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
-  const baseUrl = opts?.usePublicUrl ? supabaseEnv.url() : supabaseEnv.internalUrl();
-  return createServerClient<Database>(baseUrl, supabaseEnv.anonKey(), {
+  return createServerClient<Database>(supabaseEnv.url(), supabaseEnv.anonKey(), {
     cookies: {
       getAll: () => cookieStore.getAll(),
       setAll: (entries) => {
@@ -35,6 +38,9 @@ export async function createSupabaseServerClient(opts?: { usePublicUrl?: boolean
  * Privileged client that bypasses RLS. Only use inside server-only code paths
  * that have already authorized the caller (e.g. webhook handlers, admin
  * maintenance). Never expose to components rendered client-side.
+ *
+ * Uses SUPABASE_INTERNAL_URL so webhook + cron paths shortcut Kong over the
+ * Docker network instead of bouncing through Traefik.
  */
 export function createSupabaseAdminClient() {
   return createClient<Database>(supabaseEnv.internalUrl(), supabaseEnv.serviceRoleKey(), {

--- a/packages/gui/src/middleware.ts
+++ b/packages/gui/src/middleware.ts
@@ -26,11 +26,10 @@ export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
-    // SUPABASE_INTERNAL_URL keeps the per-request auth.getUser() call on the
-    // Docker network in self-hosted setups; falls back to the public URL.
-    // Inlined here (not via lib/supabase/env) because middleware can run in
-    // the edge runtime where the env helper may not resolve runtime vars.
-    process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    // Must match the public URL used by the browser + server clients —
+    // @supabase/ssr derives the session cookie name from the URL host, so
+    // mixing internal/public URLs causes cookie lookups to silently miss.
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {


### PR DESCRIPTION
## Summary

Follow-up to #16 — that PR fixed the OAuth init URL (browser was redirected to \`http://kong:8000/auth/v1/authorize?...\`) but two related bugs surfaced after deploy:

1. **\`exchangeCodeForSession\` → \`auth_failed\`.** \`@supabase/ssr\` derives the session cookie name from the URL host (\`sb-<host>-auth-token\`). OAuth init wrote the PKCE verifier under the public-host key; the callback's server client (still on \`SUPABASE_INTERNAL_URL\`) looked for it under the internal-host key. Silent miss → exchange fails.

2. **Callback redirected to \`http://0.0.0.0:3000/login?error=auth_failed\`.** \`request.nextUrl.origin\` returns the container's bind address inside the standalone Next server behind Traefik, not the public app URL.

## Change

- \`createSupabaseServerClient\`, \`middleware\`, and \`/auth/callback\` all build against \`NEXT_PUBLIC_SUPABASE_URL\`. Cookie names line up across browser → server → middleware.
- \`createSupabaseAdminClient\` keeps \`SUPABASE_INTERNAL_URL\` — it doesn't touch cookies, and the internal hop still benefits webhook + cron paths.
- OAuth init action and the callback both build redirect URLs from \`NEXT_PUBLIC_APP_URL\` instead of \`headers().origin\` / \`request.nextUrl.origin\`.

## Test plan

- [ ] Click \"Sign in with GitHub\" → URL bar shows \`https://supabase.comerito.com/auth/v1/authorize?...\`.
- [ ] GitHub callback completes → land on \`/inbox\` (or \`/workspaces/new\`), no \`auth_failed\`.
- [ ] Subsequent SSR queries (cockpit, inbox) still work — session cookie survives.
- [ ] \`/api/github/webhook\` + \`/api/cron/*\` continue to use the internal URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)