### PR TITLE
fix: push thrown-step record into runRecords (#32)

### DIFF
--- a/packages/core/src/workflows/workflow-engine.ts
+++ b/packages/core/src/workflows/workflow-engine.ts
@@ -605,6 +605,7 @@ export class WorkflowEngine {
           record.status = 'failed';
           record.error = msg;
           record.finishedAt = new Date().toISOString();
+          runRecords.push(record);
           ctx.onRunRecord?.(record);
         }
         return finishRun('failed', `step '${step.id}' threw: ${msg}`);


### PR DESCRIPTION
## Summary

When a workflow step throws, the catch block in `workflow-engine.ts` updated the synthetic `record` (`status='failed'`, error, `finishedAt`) and called `ctx.onRunRecord?.(record)`, but never pushed it into the local `runRecords` array. The engine then returned `finishRun('failed', …)`, building `WorkflowRunResult.runRecords` from the un-pushed array.

As a result, callers that walk `result.runRecords` (run-translation, CLI prints, tests) silently underreported the failed step and lost its accumulated token totals, while the cockpit's `onRunRecord` subscriber correctly received it — an inconsistency.

The fix pushes the record before returning, mirroring the normal success path which pushes then notifies.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)