### PR TITLE
fix: enforce word boundary in isBashCommandAllowed (#21)

### DIFF
--- a/packages/core/src/agents/agent-runner.ts
+++ b/packages/core/src/agents/agent-runner.ts
@@ -119,7 +119,7 @@ export function isBashCommandAllowed(cmd: string, allowlist: string[]): boolean 
   const normalized = cmd.replace(/\s+/g, ' ').trim();
   return allowlist.some((allowed) => {
     const a = allowed.trim();
-    return normalized === a || normalized.startsWith(`${a} `) || normalized.startsWith(`${a}`);
+    return normalized === a || normalized.startsWith(`${a} `);
   });
 }
 


### PR DESCRIPTION
## Summary

`isBashCommandAllowed` is the only programmatic sandbox for `Bash` on the Anthropic-API agent path. Its third clause, `normalized.startsWith(\`${a}\`)`, matched any command sharing a prefix with an allowlist entry — with no word boundary — making the exact-match and `\`${a} \`` clauses redundant and silently granting over-broad permissions (e.g. `git status-stash` matched `git status`, `rm -rf /` matched `rm -rf /tmp/cezar-`).

This drops the bare `startsWith(a)` clause, keeping only the exact match and the boundary-guarded `startsWith(\`${a} \`)`.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)