### PR TITLE
fix: reset per-child state in PersistentClaudeSession.start() (#22)

### DIFF
--- a/packages/core/src/agents/persistent-claude-session.ts
+++ b/packages/core/src/agents/persistent-claude-session.ts
@@ -130,6 +130,14 @@ export class PersistentClaudeSession {
    */
   start(): void {
     if (this.child) return;
+    // Reset all per-child state before spawning a fresh child. A prior child
+    // (e.g. closed by `closeIfIdle`) may have left a partial NDJSON line in
+    // `outBuffer` or a half-resolved phase; carrying that over into the new
+    // child corrupts its first parse / trips the in-flight guard.
+    this.outBuffer = '';
+    this.sawTerminal = false;
+    this.resultResolver = null;
+    this.resultRejecter = null;
     this.closedIdle = false;
     this.resumed = this.opts.resume === true;
     const args = this.buildArgs();
@@ -241,6 +249,10 @@ export class PersistentClaudeSession {
    * the conversation prefix is preserved.
    */
   closeIfIdle(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
     if (!this.child || this.resultResolver) return;
     this.closedIdle = true;
     const child = this.child;


### PR DESCRIPTION
## Summary

`PersistentClaudeSession.start()` is documented as idempotent and is called by `sendPhase` to lazily re-open the child after `closeIfIdle()`, but it only reset `closedIdle` and `resumed`. It left stale per-child state behind:

- `outBuffer` — a partial NDJSON line from the previous child's last stdout chunk gets concatenated with the new child's first chunk, breaking `JSON.parse`. The dropped line can be the per-phase `result` envelope, which makes `sendPhase` hang forever (no per-phase timeout) until the session-wide cap fires — bricking the run.
- `sawTerminal` / `resultResolver` / `resultRejecter` — a leftover resolver trips the "phase in flight" guard on the next `sendPhase`.

This now resets all per-child state in `start()` before spawning, and clears the dangling `idleTimer` in `closeIfIdle()`.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)