### PR TITLE
fix: finalize paused human-gate step record (#29)

### DIFF
--- a/packages/core/src/workflows/workflow-engine.ts
+++ b/packages/core/src/workflows/workflow-engine.ts
@@ -510,6 +510,15 @@ export class WorkflowEngine {
         } else if (step.kind === 'human-gate') {
           const r = await this.runHumanGate(step, stepCtx);
           if (r.kind === 'paused') {
+            // Finalize the synthetic record before bailing so the cockpit's
+            // `agent_runs` row for this gate transitions out of 'running'
+            // (StepRunStatus has no 'paused' — 'skipped' is the closest) and
+            // shows up in WorkflowRunResult.runRecords.
+            record!.status = 'skipped';
+            record!.summary = `paused — awaiting human decision at '${step.id}'`;
+            record!.finishedAt = new Date().toISOString();
+            runRecords.push(record!);
+            ctx.onRunRecord?.(record!);
             return finishRun('paused', `paused — awaiting human decision at '${step.id}'`);
           }
           outcome = r.outcome;


### PR DESCRIPTION
## Summary

When a `human-gate` step pauses (`runHumanGate` returns `{ kind: 'paused' }`), the workflow engine called `finishRun('paused', ...)` and returned immediately — never updating that step's synthetic `AgentRunRecord`. The record stayed `status: 'running'`, was never finalized, never emitted via `onRunRecord`, and was never appended to `runRecords`.

Consequences:
- The cockpit's `agent_runs` row for the gate stayed in `running` forever.
- `WorkflowRunResult.runRecords` omitted the gate entirely.
- `running`-row metrics over-reported concurrency.

## Fix

In the paused branch (`packages/core/src/workflows/workflow-engine.ts`), before returning, finalize the synthetic record: set `status = 'skipped'` (`StepRunStatus` has no `'paused'` variant, so `'skipped'` is the closest existing status and matches the `skip-run` convention elsewhere in the loop), set a `summary` and `finishedAt`, push it to `runRecords`, and fire `onRunRecord`.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)