### PR TITLE
fix: surface tool-use loop exhaustion as a failure (#28)

### DIFF
--- a/packages/core/src/actions-v2/runner.ts
+++ b/packages/core/src/actions-v2/runner.ts
@@ -302,6 +302,10 @@ async function runToolUseMode(
   type Message = { role: 'user' | 'assistant'; content: string | ContentBlock[] };
   const messages: Message[] = [{ role: 'user', content: mode.userMessage }];
   let finalText = '';
+  // Tracks whether the loop ran out of iterations while the model was still
+  // calling tools. If it does, the run never produced a final answer — surface
+  // that as a failure rather than returning an empty-text "success".
+  let exhausted = true;
 
   for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
     const resp = await mode.client.messages.create({
@@ -328,6 +332,7 @@ async function runToolUseMode(
     // No tool calls → this is the final answer. Capture the text blocks.
     if (toolUses.length === 0) {
       finalText = extractText(resp);
+      exhausted = false;
       break;
     }
 
@@ -360,6 +365,12 @@ async function runToolUseMode(
       });
     }
     messages.push({ role: 'user', content: resultBlocks });
+  }
+
+  if (exhausted) {
+    throw new Error(
+      `tool-use loop exceeded ${MAX_TOOL_ITERATIONS} iterations without a final answer`,
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

`runToolUseMode` in `packages/core/src/actions-v2/runner.ts` only assigned `finalText` when the model returned *no* `tool_use` blocks. If the model kept calling tools until `MAX_TOOL_ITERATIONS` (8) was hit, the loop ended with `finalText = ''` and the runner returned a normal-looking `ActionRunResult` — an endlessly-looping run looked healthy, the auto-commenter posted a fallback body, and `runTriagePass` recorded `ok: true`.

This change tracks whether the loop exited via a real final answer (`exhausted` flag) and throws when the iteration budget is exhausted. `runTriagePass` already wraps each action in try/catch and records `ok: false` with the error message, so the cockpit now surfaces the failure — important for cost containment and operator intervention. Because the throw propagates before the auto-comment block, no misleading fallback comment is posted.

Implementation matches the fix suggested in the issue.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)