### PR TITLE
fix: validate loop stepIds so a malformed workflow fails clearly (#35)

### DIFF
--- a/packages/core/src/workflows/workflow-engine.ts
+++ b/packages/core/src/workflows/workflow-engine.ts
@@ -423,6 +423,21 @@ export class WorkflowEngine {
       for (const sid of loop.stepIds) loopOfStep.set(sid, loop);
     }
 
+    // Validate loops up front: a typo'd or stale `stepIds` entry would otherwise
+    // make `findIndex` return -1 and the cursor walk `steps[-1]` (undefined),
+    // dying as "step 'undefined' threw…" with no hint at the real cause. Catch
+    // it here and precompute each loop's first-step index so the jumps below are
+    // a guaranteed-valid map lookup rather than a re-scan that can return -1.
+    const loopFirstIndex = new Map<string, number>();
+    for (const loop of effectiveLoops) {
+      for (const sid of loop.stepIds) {
+        if (!workflow.steps.some((s) => s.id === sid)) {
+          throw new Error(`workflow '${workflow.id}' loop '${loop.id}' references unknown step '${sid}'`);
+        }
+      }
+      loopFirstIndex.set(loop.id, workflow.steps.findIndex((s) => s.id === loop.stepIds[0]));
+    }
+
     // Engine main loop. We walk `workflow.steps` by index; when a loop body
     // step fails-retriable (or returns goto-loop) we jump the cursor back to
     // the loop's first step and bump the iteration counter.
@@ -661,7 +676,7 @@ export class WorkflowEngine {
         }
         loopIterations.set(loop.id, next);
         ctx.onEvent?.(`[#${ctx.issueNumber}] loop '${loop.id}' — retry ${next}/${loop.maxIterations}: ${outcome.reason}`);
-        i = workflow.steps.findIndex((s) => s.id === loop.stepIds[0]);
+        i = loopFirstIndex.get(loop.id)!;
         continue;
       }
 
@@ -673,7 +688,7 @@ export class WorkflowEngine {
           return finishRun('failed', `loop '${targetLoop.id}' exhausted ${targetLoop.maxIterations} iteration(s)`);
         }
         loopIterations.set(targetLoop.id, next);
-        i = workflow.steps.findIndex((s) => s.id === targetLoop.stepIds[0]);
+        i = loopFirstIndex.get(targetLoop.id)!;
         continue;
       }
 
@@ -687,7 +702,7 @@ export class WorkflowEngine {
           }
           loopIterations.set(loop.id, next);
           ctx.onEvent?.(`[#${ctx.issueNumber}] loop '${loop.id}' — iteration ${next}/${loop.maxIterations}`);
-          i = workflow.steps.findIndex((s) => s.id === loop.stepIds[0]);
+          i = loopFirstIndex.get(loop.id)!;
           continue;
         }
       }


### PR DESCRIPTION
## Summary

A loop whose `stepIds[0]` (or any `stepIds` entry) didn't exist in `workflow.steps` made `findIndex` return `-1`. The engine then evaluated `-1 < N` ⇒ true and ran `workflow.steps[-1]` (`undefined`), dying as `step 'undefined' threw: Cannot read properties of undefined` — with no hint that the real problem was a malformed workflow. A cursor landing on `0` via a future indexing accident would also silently restart the run from step 0.

This fix, in `packages/core/src/workflows/workflow-engine.ts`:

- Validates every loop's `stepIds` against `workflow.steps` once at run-start, throwing a clear `workflow 'X' loop 'Y' references unknown step 'Z'` error.
- Precomputes each loop's first-step index into a `loopFirstIndex` map and replaces the three `findIndex` jumps (retry / goto-loop / until) with guaranteed-valid map lookups.

Focused change matching the issue's suggested approach; no behavior change for well-formed workflows.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)