### PR TITLE
fix: parseStructured code-fence stripping misses bare/non-json fences (#42)

### DIFF
--- a/packages/core/src/agents/structured-output.ts
+++ b/packages/core/src/agents/structured-output.ts
@@ -37,7 +37,10 @@ export function costWeightedTokens(usage: RawUsage | undefined | null): number {
  * recover (retry, prose fallback, hard fail).
  */
 export function parseStructured<T>(raw: string, schema: z.ZodSchema<T>): T | null {
-  const cleaned = raw.replace(/^```json?\s*\n?/m, '').replace(/\n?```\s*$/m, '').trim();
+  const cleaned = raw
+    .replace(/^```(?:json|javascript|js|jsonl)?\s*\n?/im, '')
+    .replace(/\n?```\s*$/m, '')
+    .trim();
   try {
     return schema.parse(JSON.parse(cleaned));
   } catch {


### PR DESCRIPTION
## Summary

`parseStructured` in `packages/core/src/agents/structured-output.ts` stripped opening code fences with `/^\`\`\`json?\s*\n?/m`. The `?` made the trailing `n` optional rather than the whole `json` label, so:

- bare `\`\`\`` fences (no language tag) were not stripped
- `\`\`\`JSON`, `\`\`\`javascript`, etc. were not stripped

Unstripped fences make the fast `JSON.parse` path throw, falling through to `extractJsonObjectCandidates`, which returns only the first balanced `{...}` — the wrong block when the model emits an inline JSON example before the answer.

The fix makes the language tag optional, accepts common non-json tags, and matches case-insensitively:

```ts
const cleaned = raw
  .replace(/^```(?:json|javascript|js|jsonl)?\s*\n?/im, '')
  .replace(/\n?```\s*$/m, '')
  .trim();
```

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)