### PR TITLE
fix: escape worktreePath in compose YAML override (#39)

### DIFF
--- a/packages/core/src/provision/docker-compose-env.ts
+++ b/packages/core/src/provision/docker-compose-env.ts
@@ -73,13 +73,13 @@ export class DockerComposeEnv implements RunEnv {
           'services:',
           `  ${this.opts.service}:`,
           '    volumes:',
-          `      - ${this.opts.worktreePath}:${this.opts.workdir}`,
+          `      - ${yamlString(`${this.opts.worktreePath}:${this.opts.workdir}`)}`,
         ];
         // Publish the dev-server container port to an ephemeral host port so
         // concurrent runs don't collide. Only affects `up` (run --rm ignores it).
         if (ds.enabled && ds.port) {
           lines.push('    ports:', `      - "${ds.port}"`);
-          if (ds.command.trim()) lines.push(`    command: ${ds.command}`);
+          if (ds.command.trim()) lines.push(`    command: ${yamlString(ds.command)}`);
         }
         lines.push('');
         await writeFile(this.overrideFile, lines.join('\n'), 'utf8');
@@ -169,6 +169,16 @@ export class DockerComposeEnv implements RunEnv {
       this.overrideFile = null;
     }
   }
+}
+
+/**
+ * Quote a string as a YAML double-quoted scalar so values containing `:`, `#`,
+ * leading `-`, or other YAML-significant characters (e.g. worktree paths on
+ * macOS/Windows/CI temp dirs, or a dev-server command with a colon) survive
+ * the override file intact instead of producing malformed YAML.
+ */
+export function yamlString(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 /** Parse `docker compose port` output (e.g. `0.0.0.0:54213` / `[::]:54213`) → the host port. */


### PR DESCRIPTION
## Summary

`DockerComposeEnv.ensureOverride` built the compose override file with raw string interpolation, so a worktree path (or dev-server `command`) containing YAML-significant characters — `:`, `#`, a leading `-` — produced malformed YAML and a hard-to-diagnose `docker compose` parse error. Such characters can show up in worktree paths on macOS/Windows runners or CI temp dirs.

This quotes both the bind-mount value and the `command` string as YAML double-quoted scalars via a small `yamlString` helper (backslash + double-quote escaping), matching the already-quoted `ports` line.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)