### PR TITLE
fix: detect bare GH-123 and owner/repo#123 issue refs (#43)

### DIFF
--- a/packages/core/src/services/github.service.ts
+++ b/packages/core/src/services/github.service.ts
@@ -53,9 +53,15 @@ export interface RawPullRequest {
 export function extractReferencedIssues(text: string): number[] {
   if (!text) return [];
   const refs = new Set<number>();
-  const re = /(?<![A-Za-z0-9_])(?:GH-)?#(\d+)\b/gi;
+  // Two passes — bare `GH-123` and `[owner/repo]#123` / `#123`.
+  const bareGh = /(?<![A-Za-z0-9_])GH-(\d+)\b/gi;
+  const hash = /(?<![A-Za-z0-9_])(?:[\w.-]+\/[\w.-]+)?#(\d+)\b/gi;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) {
+  while ((m = bareGh.exec(text)) !== null) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n > 0) refs.add(n);
+  }
+  while ((m = hash.exec(text)) !== null) {
     const n = Number(m[1]);
     if (Number.isFinite(n) && n > 0) refs.add(n);
   }


### PR DESCRIPTION
## Summary

`extractReferencedIssues` (in `packages/core/src/services/github.service.ts`) used a single regex `/(?<![A-Za-z0-9_])(?:GH-)?#(\d+)\b/gi` that required a `#` after the optional `GH-` prefix. As a result the conventional bare `GH-123` form (which linguist and GitHub treat as a valid issue reference) and `owner/repo#123` cross-repo references were silently dropped — leaving the `referencedIssues` link detection in `listOpenPullRequests()` incomplete and risking green-lighting an autofix on an issue someone already has a PR for.

The fix splits detection into two passes: one for bare `GH-123`, and one for `[owner/repo]#123` / `#123`.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)