### PR TITLE
fix: LivingComment.start() throw leaks the run as forever-running (#40)

### DIFF
--- a/packages/core/src/workflows/workflow-engine.ts
+++ b/packages/core/src/workflows/workflow-engine.ts
@@ -385,11 +385,15 @@ export class WorkflowEngine {
         });
       }
       if (disposeWorktree) await disposeWorktree().catch(() => {});
+      // Best-effort: finalizing the living comment must never throw out of
+      // finishRun — that would discard the run result and leak the run.
       await living.finalize({
         done: status === 'succeeded',
         prNumber,
         prUrl,
         reason,
+      }).catch((err) => {
+        ctx.onEvent?.(`[#${ctx.issueNumber}] living comment finalize failed: ${(err as Error).message}`);
       });
       return {
         status,
@@ -407,7 +411,14 @@ export class WorkflowEngine {
       };
     };
 
-    await living.start();
+    // Best-effort, mirroring how appendSection/rerender already swallow GitHub
+    // errors: a flaky GitHub API at run-start must not leak the run as
+    // forever-running (it would skip the try/catch loop and never reach
+    // finishRun, leaking the unified session + worktree). The living comment is
+    // best-effort per its own design — the step results are the source of truth.
+    await living.start().catch((err: Error) => {
+      ctx.onEvent?.(`[#${ctx.issueNumber}] living comment start failed: ${err.message}`);
+    });
     ctx.onEvent?.(`[#${ctx.issueNumber}] workflow '${workflow.id}' — ${workflow.steps.length} step(s)`);
 
     // Build a quick lookup for which loop (if any) a step belongs to. Apply


### PR DESCRIPTION
## Summary

`runWorkflow` called `await living.start();` before entering the step `try/catch` loop. `LivingComment.start()` posts a fresh issue/PR comment via `github.addComment` with no error handling, so a transient GitHub failure (5xx, rate limit, network blip, missing repo permissions) would bubble past `runWorkflow` without ever reaching `finishRun`. That left the run forever-stuck: the `workflow_runs` row never transitioned out of `queued`/`running`, the unified claude session was leaked (no `stop()`), and the worktree was leaked (`disposeWorktree` never ran).

This wraps `start()` in a best-effort `.catch`, mirroring how `appendSection` / `rerender` already swallow GitHub errors (the living comment is best-effort per its own design — step results are the source of truth). It also guards the `finalize()` call in `finishRun` so the run result is always returned even if the completion-path re-render throws.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)