### PR TITLE
fix: stop auto-applying zero-confidence effects under default thresholds (#24)

### DIFF
--- a/packages/core/src/actions-v2/action.ts
+++ b/packages/core/src/actions-v2/action.ts
@@ -53,6 +53,15 @@ export interface HitlConfidenceConfig {
 
 export type ConfidenceConfig = AutoConfidenceConfig | HitlConfidenceConfig;
 
+/**
+ * Default `autoAcceptAbove` threshold used when an action's `confidence_config`
+ * is absent or malformed. A model that explicitly self-reports confidence below
+ * this bar is no longer auto-applied; effects that emit no confidence at all are
+ * still treated as fully confident (see the runner's `applyOrDefer`), preserving
+ * legacy actions that never emit confidence.
+ */
+export const DEFAULT_AUTO_ACCEPT_ABOVE = 80;
+
 export type ActionTrigger =
   | 'manual'
   | 'on-issue-opened'

--- a/packages/core/src/actions-v2/loader.ts
+++ b/packages/core/src/actions-v2/loader.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_AUTO_ACCEPT_ABOVE } from './action.js';
 import type {
   AcceptanceMode,
   ActionDef,
@@ -102,11 +103,11 @@ function parseConfidenceConfig(value: unknown): ConfidenceConfig {
     if (!Number.isFinite(n)) return fallback;
     return Math.max(0, Math.min(100, Math.round(n)));
   };
-  const high = clamp(obj.autoAcceptAbove, 0);
+  const high = clamp(obj.autoAcceptAbove, DEFAULT_AUTO_ACCEPT_ABOVE);
   if ('autoDenyBelow' in obj) {
     return {
       autoAcceptAbove: high,
-      autoDenyBelow: Math.min(clamp(obj.autoDenyBelow, 0), high - 1),
+      autoDenyBelow: Math.max(0, Math.min(clamp(obj.autoDenyBelow, 0), high - 1)),
     };
   }
   return { autoAcceptAbove: high };

--- a/packages/core/src/actions-v2/runner.ts
+++ b/packages/core/src/actions-v2/runner.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { DEFAULT_AUTO_ACCEPT_ABOVE } from './action.js';
 import type { ActionDef, ActionRunResult } from './action.js';
 import type { Skill } from '../skills/skill-catalog.js';
 import {
@@ -381,9 +382,13 @@ async function runToolUseMode(
  *                           ≥ autoDenyBelow   : defer,
  *                           <                 : drop
  *
- * When no confidence is provided on the call, treats it as 100 (fully
- * confident) so existing actions that don't emit confidence keep applying
- * everything.
+ * When neither the model emits a confidence on the call nor the action
+ * configures a `confidenceConfig`, the effect is treated as fully confident so
+ * legacy actions that never emit confidence keep applying everything. As soon
+ * as the model self-reports a confidence, or the action configures a threshold,
+ * the effect is routed against `DEFAULT_AUTO_ACCEPT_ABOVE` (when unconfigured) —
+ * so a model that emits `_confidence: 0` to signal uncertainty is no longer
+ * auto-applied.
  */
 async function applyOrDefer(
   call: EffectCall,
@@ -391,9 +396,23 @@ async function applyOrDefer(
   ctx: EffectContext,
   deferSink: DeferSink | undefined,
 ): Promise<{ outcome: 'applied' | 'deferred' | 'dropped' | 'error'; summary: string }> {
-  const confidence = call.confidence ?? 100;
   const mode = action.acceptanceMode ?? 'auto';
-  const cfg = action.confidenceConfig ?? { autoAcceptAbove: 0 };
+
+  // Legacy escape hatch: an action with no threshold processing whatsoever
+  // (no configured confidenceConfig) AND a call carrying no model confidence is
+  // applied unconditionally — that's the pre-confidence contract.
+  if (action.confidenceConfig === undefined && call.confidence === undefined) {
+    try {
+      const summary = await executeEffect(call, ctx);
+      return { outcome: 'applied', summary };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { outcome: 'error', summary: `error: ${message}` };
+    }
+  }
+
+  const confidence = call.confidence ?? 100;
+  const cfg = action.confidenceConfig ?? { autoAcceptAbove: DEFAULT_AUTO_ACCEPT_ABOVE };
   const acceptAbove = cfg.autoAcceptAbove;
   const denyBelow = 'autoDenyBelow' in cfg ? cfg.autoDenyBelow : 0;
 


### PR DESCRIPTION
## Summary

`applyOrDefer` and `parseConfidenceConfig` both defaulted `autoAcceptAbove` to `0` when an action had no `confidence_config` (the default state for the rows seeded in `0014_seed_default_actions.sql`). The accept check `confidence >= 0` then always passed, so **every effect was auto-applied** — including ones a model self-reports at `_confidence: 0` to signal uncertainty — turning the human-in-the-loop safety net into a no-op. The HITL `autoDenyBelow` clamp also collapsed to a nonsensical `-1` when `autoAcceptAbove` was `0`.

## Changes

- Add a shared `DEFAULT_AUTO_ACCEPT_ABOVE = 80` (in `actions-v2/action.ts`) and use it as the loader default in `parseConfidenceConfig`, so DB-loaded actions with no configured threshold now require `>= 80` confidence to auto-apply.
- In `applyOrDefer` (`actions-v2/runner.ts`), keep the legacy "apply everything" contract **only** when both the action configures no `confidenceConfig` and the model emits no confidence; otherwise route against the default threshold, so an explicit `_confidence: 0` is dropped, not applied.
- Guard the HITL `autoDenyBelow` clamp with `Math.max(0, ...)` so it no longer produces `-1`.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)