### PR TITLE
fix: re-read port-backed store before save to prevent concurrent-write loss (#27)

### DIFF
--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -82,7 +82,27 @@ export class IssueStore {
 
   async save(): Promise<void> {
     if (this.port) {
-      await this.port.save(this.data);
+      // Re-read before save so concurrent runs (two triage/autofix jobs sharing
+      // a workspace) don't clobber each other's writes with a stale snapshot.
+      // Shallow-merge meta and replace per-issue, preserving any issues only the
+      // fresh copy has (written by another in-flight run since we loaded).
+      let toSave = this.data;
+      try {
+        const fresh = await this.port.load();
+        const byNumber = new Map(fresh.issues.map((i) => [i.number, i]));
+        for (const issue of this.data.issues) {
+          byNumber.set(issue.number, issue);
+        }
+        toSave = {
+          meta: { ...fresh.meta, ...this.data.meta },
+          issues: Array.from(byNumber.values()),
+        };
+        this.data = toSave;
+      } catch {
+        // If the re-read fails, fall back to writing our own snapshot rather
+        // than dropping the save entirely.
+      }
+      await this.port.save(toSave);
       return;
     }
     const dir = dirname(this.filePath);

--- a/packages/core/tests/store/from-data.test.ts
+++ b/packages/core/tests/store/from-data.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import { IssueStore, type Store } from '@cezar/core';
+import { IssueStore, contentHash, type Store, type StorePort } from '@cezar/core';
+
+function makeIssue(number: number) {
+  const title = `Issue ${number}`;
+  const body = `Body ${number}`;
+  return {
+    number,
+    title,
+    body,
+    state: 'open' as const,
+    labels: [],
+    author: 'user1',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    htmlUrl: `https://github.com/test/repo/issues/${number}`,
+    contentHash: contentHash(title, body),
+    commentCount: 0,
+    reactions: 0,
+    comments: [],
+    commentsFetchedAt: null,
+    digest: null,
+    analysis: {},
+  };
+}
 
 const snapshot: Store = {
   meta: {
@@ -33,5 +56,59 @@ describe('IssueStore.fromData', () => {
   it('save() is a no-op without onSave', async () => {
     const store = IssueStore.fromData(snapshot);
     await expect(store.save()).resolves.toBeUndefined();
+  });
+});
+
+describe('IssueStore.fromPort concurrent save', () => {
+  // A mutable in-memory port standing in for Supabase/file: load() returns the
+  // current backing state so save() can re-read and merge.
+  function makePort(initial: Store): StorePort & { state: Store } {
+    return {
+      state: structuredClone(initial),
+      async load() { return structuredClone(this.state); },
+      async save(d) { this.state = structuredClone(d); },
+    };
+  }
+
+  it('does not clobber a concurrent run that wrote a different issue', async () => {
+    const backing: Store = {
+      meta: { owner: 'acme', repo: 'widgets', lastSyncedAt: null, totalFetched: 0, version: 1, orgMembers: [], orgMembersFetchedAt: null },
+      issues: [makeIssue(1), makeIssue(2)],
+    };
+    const port = makePort(backing);
+
+    // Both runs load the same snapshot.
+    const runA = await IssueStore.fromPort(port);
+    const runB = await IssueStore.fromPort(port);
+
+    // Run B writes analysis on issue #2 and saves first.
+    runB.setAnalysis(2, { priority: 'high' });
+    await runB.save();
+
+    // Run A (stale snapshot) writes analysis on issue #1 and saves second.
+    runA.setAnalysis(1, { priority: 'low' });
+    await runA.save();
+
+    // Both writes must survive.
+    expect(port.state.issues.find((i) => i.number === 2)!.analysis.priority).toBe('high');
+    expect(port.state.issues.find((i) => i.number === 1)!.analysis.priority).toBe('low');
+  });
+
+  it('preserves an issue only the concurrent run added', async () => {
+    const backing: Store = {
+      meta: { owner: 'acme', repo: 'widgets', lastSyncedAt: null, totalFetched: 0, version: 1, orgMembers: [], orgMembersFetchedAt: null },
+      issues: [makeIssue(1)],
+    };
+    const port = makePort(backing);
+
+    const runA = await IssueStore.fromPort(port);
+
+    // A concurrent run adds issue #2 after A loaded.
+    port.state.issues.push(makeIssue(2));
+
+    runA.setAnalysis(1, { priority: 'low' });
+    await runA.save();
+
+    expect(port.state.issues.map((i) => i.number).sort()).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary

`IssueStore.fromPort(port)` loaded the store data once and `save()` wrote the whole in-memory `Store` snapshot back through the port. In the GUI, two concurrent triage/autofix runs sharing a workspace each held a stale snapshot, so the second `save()` clobbered the first run's writes (last-write-wins on the entire `Store`, including `meta` and every issue's `analysis.*`).

This adds a re-read-before-save step on the port-backed path:
- `save()` now calls `port.load()` first, then merges before writing.
- `meta` is shallow-merged (this run's fields win).
- Issues are replaced per-number; issues only present in the fresh copy (added by another in-flight run since we loaded) are preserved.
- If the re-read fails, it falls back to writing the in-memory snapshot rather than dropping the save.

This is the "minimum stopgap" approach suggested in the issue (re-load + re-apply, diff-style per row). The Supabase adapter already upserts (no row deletion), so the merged set is safe. The file-backed CLI path is unchanged.

Added two focused tests covering: (1) two stale runs writing different issues both surviving, and (2) preserving an issue a concurrent run added.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)