### PR TITLE
fix: [audit][core/agents] claude-cli passes the system prompt via argv — risks E2BIG on long prompts (#33)

### DIFF
--- a/packages/core/src/agents/claude-cli-runner.ts
+++ b/packages/core/src/agents/claude-cli-runner.ts
@@ -533,6 +533,14 @@ function wrapSpawnError(err: unknown, bin: string): Error {
       `${bin} CLI not found on PATH — install Claude Code or use the anthropic-api backend`,
     );
   }
+  if (code === 'E2BIG') {
+    // The combined argv (system prompt in --append-system-prompt, plus the
+    // user prompt in -p under print transport) blew past the OS ARG_MAX
+    // limit. Surface an actionable message instead of a bare `spawn E2BIG`.
+    return new Error(
+      `${bin}: prompt too large for argv (E2BIG) — use the stream-json transport (default; set CEZAR_CLI_TRANSPORT=stream-json) or shorten the system prompt`,
+    );
+  }
   return err instanceof Error ? err : new Error(String(err));
 }
 

--- a/packages/core/src/agents/persistent-claude-session.ts
+++ b/packages/core/src/agents/persistent-claude-session.ts
@@ -483,6 +483,13 @@ function wrapSpawnError(err: unknown, bin: string): Error {
   if (code === 'ENOENT') {
     return new Error(`${bin} CLI not found on PATH — install claude or fall back to staged mode`);
   }
+  if (code === 'E2BIG') {
+    // The system prompt passed via --append-system-prompt blew past the OS
+    // ARG_MAX limit. Surface an actionable message instead of `spawn E2BIG`.
+    return new Error(
+      `${bin}: prompt too large for argv (E2BIG) — shorten the system prompt or the bound skill body`,
+    );
+  }
   return err instanceof Error ? err : new Error(String(err));
 }
 

--- a/packages/core/tests/agents/claude-cli-runner.test.ts
+++ b/packages/core/tests/agents/claude-cli-runner.test.ts
@@ -173,6 +173,15 @@ describe('ClaudeCodeCliRunner', () => {
     ).rejects.toThrow(/claude CLI not found on PATH/);
   });
 
+  it('throws a clear error when the prompt exceeds ARG_MAX (E2BIG)', async () => {
+    const e2big: NodeJS.ErrnoException = Object.assign(new Error('spawn claude E2BIG'), { code: 'E2BIG' });
+    const { spawnFn } = makeFakeSpawn({ error: e2big });
+    const runner = new ClaudeCodeCliRunner({ spawnFn });
+    await expect(
+      runner.run({ systemPrompt: 's', userPrompt: 'u', cwd: '/tmp', allowedTools: ['Read'] }),
+    ).rejects.toThrow(/prompt too large for argv \(E2BIG\)/);
+  });
+
   it('throws when the CLI exits non-zero', async () => {
     const { spawnFn } = makeFakeSpawn({
       stdoutLines: [JSON.stringify({ type: 'system', subtype: 'init' })],


### PR DESCRIPTION
Fixes the issue reported in #33.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)