### PR TITLE
fix: clear safety timer and preserve exit code in waitForExit (#45)

### DIFF
--- a/packages/core/src/agents/claude-cli-runner.ts
+++ b/packages/core/src/agents/claude-cli-runner.ts
@@ -515,11 +515,14 @@ function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number | nu
     const fin = (code: number | null) => {
       if (done) return;
       done = true;
+      clearTimeout(safety);
       resolve(code);
     };
     child.once('close', (code) => fin(code));
     child.once('exit', (code) => fin(code));
-    child.once('error', () => fin(null));
+    // Don't swallow a late error as a clean null exit — fall back to the
+    // child's own exit code (which is non-null/non-zero on failure).
+    child.once('error', () => fin(child.exitCode ?? null));
     // A SIGKILLed process may never emit 'close' through some edge cases.
     const safety = setTimeout(() => fin(child.exitCode ?? null), KILL_GRACE_MS + 5_000);
     if (typeof safety.unref === 'function') safety.unref();

--- a/packages/core/src/agents/codex-cli-runner.ts
+++ b/packages/core/src/agents/codex-cli-runner.ts
@@ -362,11 +362,14 @@ function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number | nu
     const fin = (code: number | null) => {
       if (done) return;
       done = true;
+      clearTimeout(safety);
       resolve(code);
     };
     child.once('close', (code) => fin(code));
     child.once('exit', (code) => fin(code));
-    child.once('error', () => fin(null));
+    // Don't swallow a late error as a clean null exit — fall back to the
+    // child's own exit code (which is non-null/non-zero on failure).
+    child.once('error', () => fin(child.exitCode ?? null));
     const safety = setTimeout(() => fin(child.exitCode ?? null), KILL_GRACE_MS + 5_000);
     if (typeof safety.unref === 'function') safety.unref();
   });


### PR DESCRIPTION
## Summary

`waitForExit` (duplicated verbatim in `claude-cli-runner.ts` and `codex-cli-runner.ts`) had two defects:

- **Timer leak:** `fin()` resolved the promise but never `clearTimeout`'d the 15s (`KILL_GRACE_MS + 5_000`) safety timer. Even on a clean 100ms exit, an `unref`'d timer + callback closure stayed pinned for 15s per run. The runner daemon and cron dispatch run many short jobs back-to-back, so these add up (and can fire late under mocked timers in tests).
- **Swallowed errors:** `child.once('error', () => fin(null))` mapped a late `error` event to a clean `null` exit code, making real job failures look like "completed with no usage reported" rather than failures the dispatcher should requeue.

## Fix

- `fin()` now calls `clearTimeout(safety)` on resolve.
- The `error` handler falls back to `child.exitCode ?? null` (non-null/non-zero on failure) instead of swallowing the error as `null`.

Applied identically to both runner copies.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)