### PR TITLE
fix: retry Anthropic 429/529/5xx in LLMService (#36)

### DIFF
--- a/packages/core/src/services/llm.service.ts
+++ b/packages/core/src/services/llm.service.ts
@@ -26,6 +26,9 @@ export const DuplicateResponseSchema = z.object({
 export type DuplicateMatch = z.infer<typeof DuplicateResponseSchema>['duplicates'][number];
 
 export class LLMService {
+  /** Max retry attempts for transient Anthropic errors (429/529/5xx). */
+  private static readonly MAX_RETRIES = 4;
+
   private client: Anthropic;
   private model: string;
   private maxTokens: number;
@@ -153,15 +156,31 @@ Respond ONLY with valid JSON — no markdown, no explanation:
 }`;
   }
 
-  private async callLLM(prompt: string): Promise<string> {
-    const response = await this.client.messages.create({
-      model: this.model,
-      max_tokens: this.maxTokens,
-      messages: [{ role: 'user', content: prompt }],
-    });
+  private async callLLM(prompt: string, attempt = 0): Promise<string> {
+    try {
+      const response = await this.client.messages.create({
+        model: this.model,
+        max_tokens: this.maxTokens,
+        messages: [{ role: 'user', content: prompt }],
+      });
 
-    const textBlock = response.content.find(b => b.type === 'text');
-    return textBlock?.text ?? '';
+      const textBlock = response.content.find(b => b.type === 'text');
+      return textBlock?.text ?? '';
+    } catch (err: any) {
+      // Retry transient Anthropic errors with exponential backoff:
+      // 429 rate_limit_error, 529 overloaded_error, and 5xx server errors.
+      const status: number | undefined = err?.status;
+      const retryable = status === 429 || status === 529 || (typeof status === 'number' && status >= 500);
+      if (retryable && attempt < LLMService.MAX_RETRIES) {
+        const retryAfter = Number(err?.headers?.['retry-after']) * 1000;
+        const delay = Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter
+          : (2 ** attempt) * 1000;
+        await new Promise(r => setTimeout(r, delay));
+        return this.callLLM(prompt, attempt + 1);
+      }
+      throw err;
+    }
   }
 
   private parseJSON<T>(raw: string, schema: z.ZodSchema<T>): T | null {

--- a/packages/core/tests/services/llm.service.test.ts
+++ b/packages/core/tests/services/llm.service.test.ts
@@ -192,6 +192,68 @@ describe('LLMService', () => {
     });
   });
 
+  describe('retries on transient errors', () => {
+    it('retries on 429 and eventually succeeds', async () => {
+      vi.useFakeTimers();
+      try {
+        const rateLimited: any = new Error('rate limited');
+        rateLimited.status = 429;
+        mockCreate
+          .mockRejectedValueOnce(rateLimited)
+          .mockResolvedValueOnce({
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                digests: [{ number: 1, summary: 'ok', category: 'bug', affectedArea: 'core', keywords: ['a'] }],
+              }),
+            }],
+          });
+
+        const service = new LLMService(makeConfig());
+        const promise = service.generateDigests([{ number: 1, title: 'Issue 1', body: 'Body 1' }], 20);
+        await vi.runAllTimersAsync();
+        const result = await promise;
+
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+        expect(result.size).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not retry non-retryable errors (e.g. 400)', async () => {
+      const badRequest: any = new Error('bad request');
+      badRequest.status = 400;
+      mockCreate.mockRejectedValue(badRequest);
+
+      const service = new LLMService(makeConfig());
+      await expect(
+        service.generateDigests([{ number: 1, title: 'Issue 1', body: 'Body 1' }], 20),
+      ).rejects.toThrow('bad request');
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after exhausting retries on persistent 529', async () => {
+      vi.useFakeTimers();
+      try {
+        const overloaded: any = new Error('overloaded');
+        overloaded.status = 529;
+        mockCreate.mockRejectedValue(overloaded);
+
+        const service = new LLMService(makeConfig());
+        const promise = service.generateDigests([{ number: 1, title: 'Issue 1', body: 'Body 1' }], 20);
+        const assertion = expect(promise).rejects.toThrow('overloaded');
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        // initial attempt + 4 retries
+        expect(mockCreate).toHaveBeenCalledTimes(5);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('detectDuplicates', () => {
     it('parses valid duplicate response', async () => {
       mockCreate.mockResolvedValue({


### PR DESCRIPTION
## Summary

`LLMService.callLLM` issued a single `messages.create` call with no retry. Anthropic regularly returns `429 rate_limit_error`, `529 overloaded_error`, and transient `5xx` errors — a single hit failed the whole digest/duplicate batch, silently dropping digests under cron load (auto-triage then skips those issues because their digest is `null`).

This wraps `callLLM` with an exponential-backoff retry (up to 4 retries) for retryable status codes (`429`, `529`, `>= 500`), honoring the `retry-after` header when the server sends one. Non-retryable errors (e.g. `400`) still throw immediately on the first attempt, and a persistent transient error throws after exhausting retries (the existing throw-up-the-stack contract is preserved, so callers still surface hard failures).

## Tests

Adds three cases to `llm.service.test.ts`:
- retries on `429` and succeeds on the second attempt
- does not retry a non-retryable `400`
- gives up after the initial attempt + 4 retries on a persistent `529`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)