### PR TITLE
fix: fetchRemoteBranch no longer clobbers local refs/heads/<branch> (#38)

### DIFF
--- a/packages/core/src/actions/autofix/orchestrator.ts
+++ b/packages/core/src/actions/autofix/orchestrator.ts
@@ -673,11 +673,14 @@ export class AutofixOrchestrator {
 
     opts.onEvent?.(`[#${input.issueNumber}] CI-FIX ${input.attemptIndex}/${input.attemptMax} — fetching branch ${input.branch}`);
 
-    // Materialise the PR branch locally. The follow-up worktree attaches to
-    // the existing branch (resetBranch:false) so the prior autofix commits
-    // stay — we're extending the PR, not replacing it.
+    // Materialise the PR branch into cezar's private ref namespace. The
+    // follow-up worktree attaches to the existing local branch
+    // (resetBranch:false) so the prior autofix commits stay — we're extending
+    // the PR, not replacing it — or starts a fresh local branch from the
+    // fetched PR tip when none exists yet.
+    let prRef: string;
     try {
-      await fetchRemoteBranch(repoRoot, cfg.remote, input.branch);
+      prRef = await fetchRemoteBranch(repoRoot, cfg.remote, input.branch);
     } catch (err) {
       return { status: 'failed', reason: `failed to fetch ${cfg.remote}/${input.branch}: ${(err as Error).message}`, branch: input.branch };
     }
@@ -690,6 +693,7 @@ export class AutofixOrchestrator {
         baseBranch: cfg.baseBranch,
         remote: cfg.remote,
         fetchRemote: cfg.fetchBeforeAttempt,
+        startRef: prRef,
         resetBranch: false,
       });
     } catch (err) {
@@ -993,8 +997,9 @@ export class AutofixOrchestrator {
     const repoRoot = resolve(cfg.repoRoot);
 
     opts.onEvent?.(`[#${input.issueNumber}] CI-FIX ${input.attemptIndex}/${input.attemptMax} — fetching branch ${input.branch}`);
+    let prRef: string;
     try {
-      await fetchRemoteBranch(repoRoot, cfg.remote, input.branch);
+      prRef = await fetchRemoteBranch(repoRoot, cfg.remote, input.branch);
     } catch (err) {
       return { status: 'failed', reason: `failed to fetch ${cfg.remote}/${input.branch}: ${(err as Error).message}`, branch: input.branch };
     }
@@ -1007,6 +1012,7 @@ export class AutofixOrchestrator {
         baseBranch: cfg.baseBranch,
         remote: cfg.remote,
         fetchRemote: cfg.fetchBeforeAttempt,
+        startRef: prRef,
         resetBranch: false,
         onWarn: (m) => opts.onEvent?.(`[#${input.issueNumber}] ${m}`),
       });

--- a/packages/core/src/actions/autofix/worktree.ts
+++ b/packages/core/src/actions/autofix/worktree.ts
@@ -21,12 +21,26 @@ export async function fetchBaseBranch(repoRoot: string, remote: string, baseBran
   await runGit(repoRoot, ['fetch', '--prune', '--no-tags', remote, baseBranch]);
 }
 
-// Fetch a specific remote branch and create (or fast-forward) a local ref
-// that tracks it. Used by the CI follow-up flow: the PR branch exists on
-// origin but may not be present in the cron worker's fresh clone, so we
-// materialise a local branch here before createWorktree can attach to it.
-export async function fetchRemoteBranch(repoRoot: string, remote: string, branch: string): Promise<void> {
-  await runGit(repoRoot, ['fetch', '--no-tags', remote, `+refs/heads/${branch}:refs/heads/${branch}`]);
+// Private ref namespace cezar fetches PR branches into. Kept out of
+// `refs/heads/` so a force-update here can never clobber a user's local
+// branch of the same name (see issue #38).
+export function cezarAutofixRef(branch: string): string {
+  return `refs/cezar-autofix/${branch}`;
+}
+
+// Fetch a specific remote branch into cezar's private ref namespace and return
+// that ref. Used by the CI follow-up flow: the PR branch exists on origin but
+// may not be present in the cron worker's fresh clone, so we materialise it
+// here before createWorktree starts a worktree from it.
+//
+// We force-update (`+`) into `refs/cezar-autofix/<branch>` rather than
+// `refs/heads/<branch>` so that, when the workspace points autofix.repoRoot at
+// a user's real checkout that happens to hold a local branch of the same name,
+// any unpushed local commits on `refs/heads/<branch>` are never destroyed.
+export async function fetchRemoteBranch(repoRoot: string, remote: string, branch: string): Promise<string> {
+  const ref = cezarAutofixRef(branch);
+  await runGit(repoRoot, ['fetch', '--no-tags', remote, `+refs/heads/${branch}:${ref}`]);
+  return ref;
 }
 
 async function runGit(cwd: string, args: string[]): Promise<string> {
@@ -109,6 +123,13 @@ export async function createWorktree(opts: {
   remote: string;
   /** If true, fetch the remote and start from `<remote>/<baseBranch>` (latest origin state). */
   fetchRemote?: boolean;
+  /**
+   * Explicit ref to start a freshly-created `branch` from, overriding `baseBranch`.
+   * Used by the CI follow-up flow to start from the fetched PR tip
+   * (`refs/cezar-autofix/<branch>`) when no local branch exists yet. Ignored
+   * when the local branch already exists and `resetBranch` is false.
+   */
+  startRef?: string;
   /** If true, delete any existing local branch so the new worktree starts fresh. Used on retry. */
   resetBranch?: boolean;
   /** Optional warn callback for non-fatal conditions (e.g. fetch fallback). */
@@ -126,8 +147,8 @@ export async function createWorktree(opts: {
   // baseBranch is behind origin, building on it guarantees PR merge conflicts
   // against the current GitHub state. Branching from <remote>/<baseBranch>
   // sidesteps the user's working copy entirely.
-  let startingRef = opts.baseBranch;
-  if (opts.fetchRemote) {
+  let startingRef = opts.startRef ?? opts.baseBranch;
+  if (!opts.startRef && opts.fetchRemote) {
     try {
       await fetchBaseBranch(opts.repoRoot, opts.remote, opts.baseBranch);
       startingRef = `${opts.remote}/${opts.baseBranch}`;


### PR DESCRIPTION
## Summary

`fetchRemoteBranch` used a forced refspec `+refs/heads/<branch>:refs/heads/<branch>`, force-updating the local branch in `autofix.repoRoot`. When a workspace points `repoRoot` at a user's real checkout that happens to hold a local branch of the same name (e.g. an inspection checkout or a crashed earlier attempt with extra commits), the CI follow-up flow silently rewrote `refs/heads/<branch>` to the remote tip — dropping any unpushed local commits.

## Fix

- `fetchRemoteBranch` now fetches into a private `refs/cezar-autofix/<branch>` namespace and returns that ref. `refs/heads/` is never touched, so unpushed local work is safe even when the force update happens.
- `createWorktree` gains an optional `startRef` so the CI follow-up callers start a freshly-created local branch from the fetched PR tip. The "extend an existing local branch" case (`resetBranch:false` with the branch already present) is unchanged.
- Both `processCiFollowup` callers in `orchestrator.ts` updated to pass the returned ref as `startRef`.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)