### PR TITLE
fix: cache pr-link marker id across flow steps (#44)

### DIFF
--- a/packages/core/src/workflows/flow-runner.ts
+++ b/packages/core/src/workflows/flow-runner.ts
@@ -20,7 +20,7 @@ import { runWorkflow } from './workflow-engine.js';
 import {
   describeMarkerForPrompt,
   findMarkerComment,
-  upsertMarkerComment,
+  upsertMarkerCommentById,
   type PrLinkData,
 } from './pr-link-marker.js';
 
@@ -159,13 +159,23 @@ export async function runFlow(params: RunFlowParams): Promise<WorkflowRunResult<
   let lastUpsertedPr: { number: number; state: string } | null = existingMarker
     ? { number: existingMarker.data.prNumber, state: existingMarker.data.prState }
     : null;
+  // The marker comment id is stable for the lifetime of the run: we found it
+  // once above. Cache it (or `null` when absent) and reuse it across every
+  // step's upsert so we never re-list the issue's comments per step.
+  let cachedMarkerId: number | null = existingMarker?.id ?? null;
+  const cachedMarkerOpenedAt = existingMarker?.data.openedAt;
 
   function scheduleMarkerUpsert(data: PrLinkData): void {
     // Skip when nothing changed — avoids spamming updateComment on every step
     // that echoes the PR number forward.
     if (lastUpsertedPr && lastUpsertedPr.number === data.prNumber && lastUpsertedPr.state === data.prState) return;
     lastUpsertedPr = { number: data.prNumber, state: data.prState };
-    const p = upsertMarkerComment(params.github, params.issueNumber, data)
+    const p = upsertMarkerCommentById(params.github, params.issueNumber, data, cachedMarkerId, cachedMarkerOpenedAt)
+      .then((res) => {
+        // Remember the id of a freshly-posted marker so subsequent upserts in
+        // this run edit it in place instead of posting another comment.
+        if (res.id != null) cachedMarkerId = res.id;
+      })
       .catch((err: Error) => {
         params.onEvent(`[flow] pr-link marker upsert failed: ${err.message}`);
       })

--- a/packages/core/src/workflows/pr-link-marker.ts
+++ b/packages/core/src/workflows/pr-link-marker.ts
@@ -163,6 +163,37 @@ export async function upsertMarkerComment(
   return { id: typeof id === 'number' ? id : null, created: true };
 }
 
+/** Upsert the marker when the caller already knows the comment id (or that no
+ *  marker exists). Unlike `upsertMarkerComment`, this skips the
+ *  `listIssueCommentsWithIds` fetch entirely — the marker id is stable for the
+ *  lifetime of a run, so callers that found it once at run start can cache it
+ *  and reuse it across every step's upsert instead of re-listing all comments.
+ *
+ *  Pass `existingId: null` when no marker was found at run start. `existingOpenedAt`
+ *  preserves the original PR-creation time across in-place edits (the same
+ *  invariant `upsertMarkerComment` upholds via the refetched comment). */
+export async function upsertMarkerCommentById(
+  github: PrLinkGitHubGateway,
+  issueNumber: number,
+  data: PrLinkData,
+  existingId: number | null,
+  existingOpenedAt?: string,
+): Promise<{ id: number | null; created: boolean }> {
+  const now = new Date().toISOString();
+  const merged: PrLinkData = {
+    ...data,
+    openedAt: data.openedAt ?? existingOpenedAt ?? now,
+    lastEventAt: data.lastEventAt ?? now,
+  };
+  const body = formatMarkerComment(merged);
+  if (existingId != null) {
+    await github.updateComment(existingId, body);
+    return { id: existingId, created: false };
+  }
+  const id = await github.addComment(issueNumber, body);
+  return { id: typeof id === 'number' ? id : null, created: true };
+}
+
 /** Compact one-line description of a marker for templates / log messages. */
 export function describeMarkerForPrompt(data: PrLinkData): string {
   const activity = classifyActivity(data.prState);

--- a/packages/core/tests/workflows/pr-link-marker.test.ts
+++ b/packages/core/tests/workflows/pr-link-marker.test.ts
@@ -6,6 +6,7 @@ import {
   formatMarkerComment,
   parseMarkerComment,
   upsertMarkerComment,
+  upsertMarkerCommentById,
   type PrLinkGitHubGateway,
 } from '../../src/workflows/pr-link-marker.js';
 
@@ -184,6 +185,67 @@ describe('upsertMarkerComment', () => {
     });
     const parsed = parseMarkerComment(gh.comments[0].body);
     expect(parsed?.lastEventAt).toBe('2026-05-25T10:00:00Z');
+  });
+});
+
+describe('upsertMarkerCommentById', () => {
+  it('creates a new comment when existingId is null — without listing comments', async () => {
+    const gh = new FakeGateway();
+    let listCalls = 0;
+    const origList = gh.listIssueCommentsWithIds.bind(gh);
+    gh.listIssueCommentsWithIds = async (issue: number) => {
+      listCalls += 1;
+      return origList(issue);
+    };
+
+    const result = await upsertMarkerCommentById(
+      gh,
+      1704,
+      { prNumber: 2050, prUrl: 'https://example.test/pr/2050', prState: 'draft' },
+      null,
+    );
+    expect(result.created).toBe(true);
+    expect(result.id).toBe(1000);
+    expect(gh.comments).toHaveLength(1);
+    // The whole point of the id-based overload: no re-fetch of the comment list.
+    expect(listCalls).toBe(0);
+  });
+
+  it('edits in place when existingId is known — without listing comments', async () => {
+    const gh = new FakeGateway();
+    gh.comments.push({
+      id: 200,
+      author: 'cezar',
+      body: formatMarkerComment({
+        prNumber: 2050,
+        prUrl: 'https://example.test/pr/2050',
+        prState: 'draft',
+        openedAt: '2026-05-25T00:00:00Z',
+      }),
+      createdAt: '2026-05-25T00:00:00Z',
+    });
+    let listCalls = 0;
+    const origList = gh.listIssueCommentsWithIds.bind(gh);
+    gh.listIssueCommentsWithIds = async (issue: number) => {
+      listCalls += 1;
+      return origList(issue);
+    };
+
+    const result = await upsertMarkerCommentById(
+      gh,
+      1704,
+      { prNumber: 2050, prUrl: 'https://example.test/pr/2050', prState: 'changes-requested' },
+      200,
+      '2026-05-25T00:00:00Z',
+    );
+    expect(result.created).toBe(false);
+    expect(result.id).toBe(200);
+    expect(gh.comments).toHaveLength(1);
+    const updated = parseMarkerComment(gh.comments[0].body);
+    expect(updated?.prState).toBe('changes-requested');
+    // openedAt is preserved from the passed-in value, matching upsertMarkerComment.
+    expect(updated?.openedAt).toBe('2026-05-25T00:00:00Z');
+    expect(listCalls).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

`upsertMarkerComment` re-fetched the issue's entire comment list (via `findMarkerComment` → `listIssueCommentsWithIds`, which Octokit paginates) on **every** call. In a flow, `scheduleMarkerUpsert` fires per step that emits a PR marker, so a single noisy autofix run made dozens of redundant `GET /repos/:o/:r/issues/:n/comments` requests — burning GitHub App rate limit and adding seconds of wall time. The first upsert also duplicated the `findMarkerComment` already done at run start.

## Fix

- Add `upsertMarkerCommentById(github, issueNumber, data, existingId, existingOpenedAt?)` in `pr-link-marker.ts` — an overload that takes a known comment id (or `null` when absent) and the original `openedAt`, skipping the comment-list fetch entirely. Merge/format logic is identical to `upsertMarkerComment`.
- `flow-runner.ts` now caches the marker id (and `openedAt`) from its existing run-start `findMarkerComment`, threads it through every upsert, and updates the cache when a fresh marker is created so later upserts edit it in place.
- The marker id is stable for the lifetime of a run, so this is pure waste removal — behavior is unchanged.
- The `workflow-engine.ts` autofix `open-pr` call site is one-shot per run and is left on `upsertMarkerComment` as-is.
- Added unit tests asserting the id-based overload never calls `listIssueCommentsWithIds` and preserves `openedAt`.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)