### PR TITLE
fix: make runAction idempotent across re-runs (#25)

### DIFF
--- a/packages/core/src/actions-v2/auto-comment.ts
+++ b/packages/core/src/actions-v2/auto-comment.ts
@@ -59,3 +59,27 @@ export function actionAlreadyCommented(
   }
   return false;
 }
+
+/**
+ * The stable per-action tag embedded in every auto-comment — present both in
+ * the heading (`**Cezar · <name>**`) and the audit footer (`🤖 *Cezar · <name>
+ * · …*`). Used to dedupe against a prior run's comment so re-running an action
+ * on an edited issue doesn't re-post the same auto-comment.
+ */
+export function autoCommentTag(actionName: string): string {
+  return `Cezar · ${actionName}`;
+}
+
+/**
+ * Cross-run dedupe: returns true when a previous run of this action already
+ * left its auto-comment on the target. Scans fetched comment bodies for the
+ * action's stable tag. Complements `actionAlreadyCommented`, which only sees
+ * the *current* run's effects.
+ */
+export function actionPreviouslyCommented(
+  actionName: string,
+  comments: ReadonlyArray<{ body: string }>,
+): boolean {
+  const tag = autoCommentTag(actionName);
+  return comments.some((c) => c.body.includes(tag));
+}

--- a/packages/core/src/actions-v2/effects.ts
+++ b/packages/core/src/actions-v2/effects.ts
@@ -107,10 +107,23 @@ const linkDuplicate: EffectDef<{ duplicateOf: number; reason?: string }> = {
     reason: z.string().optional(),
   }),
   async execute({ duplicateOf, reason }, { github, targetNumber }) {
+    // Idempotency: re-running on an edited issue (or a webhook re-delivery)
+    // must not re-post the "Duplicate of #N" comment / re-add the label.
+    // Best-effort — if the comment fetch fails we fall through and post,
+    // preserving the prior behaviour.
+    const marker = `Duplicate of #${duplicateOf}`;
+    try {
+      const existing = await github.listIssueCommentsWithIds(targetNumber);
+      if (existing.some((c) => c.body.includes(marker))) {
+        return `#${targetNumber} already linked as duplicate of #${duplicateOf}`;
+      }
+    } catch {
+      // ignore — proceed to post.
+    }
     const note = reason ? ` Reason: ${reason}` : '';
     await github.addComment(
       targetNumber,
-      `Duplicate of #${duplicateOf}.${note}`,
+      `${marker}.${note}`,
     );
     await github.addLabel(targetNumber, 'duplicate');
     return `linked #${targetNumber} as duplicate of #${duplicateOf}`;

--- a/packages/core/src/actions-v2/index.ts
+++ b/packages/core/src/actions-v2/index.ts
@@ -21,6 +21,8 @@ export { runAction } from './runner.js';
 export {
   buildAutoCommentBody,
   actionAlreadyCommented,
+  actionPreviouslyCommented,
+  autoCommentTag,
   type BuildAutoCommentArgs,
 } from './auto-comment.js';
 export {

--- a/packages/core/src/actions-v2/runner.ts
+++ b/packages/core/src/actions-v2/runner.ts
@@ -5,7 +5,11 @@ import {
   formatLabelCatalogPrompt,
   type WorkspaceLabel,
 } from '../labels/label-catalog.js';
-import { actionAlreadyCommented, buildAutoCommentBody } from './auto-comment.js';
+import {
+  actionAlreadyCommented,
+  actionPreviouslyCommented,
+  buildAutoCommentBody,
+} from './auto-comment.js';
 import {
   ALL_EFFECT_NAMES,
   EFFECT_REGISTRY,
@@ -137,6 +141,21 @@ export async function runAction(
       });
 
   if (deps.autoComment?.enabled && !actionAlreadyCommented(result.effectsApplied)) {
+    // Cross-run dedupe: if a previous run of this action already posted its
+    // auto-comment on the target (re-triage after an issue edit, a webhook
+    // re-delivery, …), don't post it again. Best-effort — a fetch failure
+    // falls through to posting, preserving the prior behaviour.
+    let alreadyCommented = false;
+    try {
+      const existing = await deps.effectCtx.github.listIssueCommentsWithIds(
+        deps.effectCtx.targetNumber,
+      );
+      alreadyCommented = actionPreviouslyCommented(action.name, existing);
+    } catch {
+      alreadyCommented = false;
+    }
+    if (alreadyCommented) return result;
+
     const body = buildAutoCommentBody({
       actionName: action.name,
       text: result.text,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,8 @@ export {
   runTriagePass,
   buildAutoCommentBody,
   actionAlreadyCommented,
+  actionPreviouslyCommented,
+  autoCommentTag,
   type ActionDef,
   type ActionTrigger,
   type ActionRunResult,

--- a/packages/core/tests/actions-v2/auto-comment.test.ts
+++ b/packages/core/tests/actions-v2/auto-comment.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import { actionAlreadyCommented, buildAutoCommentBody, type BuildAutoCommentArgs } from '@cezar/core';
+import {
+  actionAlreadyCommented,
+  actionPreviouslyCommented,
+  autoCommentTag,
+  buildAutoCommentBody,
+  type BuildAutoCommentArgs,
+} from '@cezar/core';
 import type { EffectCall } from '@cezar/core';
 
 const baseMeta = {
@@ -106,5 +112,31 @@ describe('actionAlreadyCommented', () => {
 
   it('returns false on an empty list', () => {
     expect(actionAlreadyCommented([])).toBe(false);
+  });
+});
+
+describe('actionPreviouslyCommented', () => {
+  it('matches a prior run by the action footer/heading tag', () => {
+    // A real auto-comment from a prior run embeds the stable tag.
+    const prior = buildAutoCommentBody({
+      actionName: 'auto-triage',
+      text: 'Classified as a bug.',
+      effectsApplied: [],
+      meta: { actionName: 'auto-triage', model: 'claude-sonnet-4-6' },
+    });
+    expect(actionPreviouslyCommented('auto-triage', [{ body: prior }])).toBe(true);
+  });
+
+  it('returns false when no comment carries the action tag', () => {
+    expect(
+      actionPreviouslyCommented('auto-triage', [
+        { body: 'just a human comment' },
+        { body: autoCommentTag('some-other-action') },
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false on an empty comment list', () => {
+    expect(actionPreviouslyCommented('auto-triage', [])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`runAction` was not idempotent: when an `on-issue-edited` action re-fires (the issue body is edited again, or a webhook is re-delivered), each pass re-posted the Cezar auto-comment, and the `link-duplicate` effect re-posted its `Duplicate of #N` comment and re-added the `duplicate` label — spamming the issue thread.

The previous `actionAlreadyCommented` guard only inspected the **current** run's effects, so it couldn't catch a comment left by a **prior** run.

## Changes

- **`runner.ts`** — before posting the auto-comment, fetch the target's existing comments and skip if a prior run of the same action already left one. Matching uses the stable `Cezar · <action-name>` tag that appears in both the heading and the audit footer of every auto-comment.
- **`auto-comment.ts`** — new `autoCommentTag(actionName)` + `actionPreviouslyCommented(actionName, comments)` helpers (exported, unit-tested).
- **`effects.ts`** — `link-duplicate` now checks for an existing `Duplicate of #N` comment before posting/labelling, returning early if found.

Both fetch-based checks are best-effort: a fetch failure falls through to the prior posting behaviour, so the change can never make the runner fail.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)