### PR TITLE
fix: drop store.path refine that breaks GUI/runner configs (#49)

### DIFF
--- a/packages/core/src/config/config.model.ts
+++ b/packages/core/src/config/config.model.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { resolve } from 'node:path';
 
 export const ConfigSchema = z.object({
   github: z.object({
@@ -13,10 +12,7 @@ export const ConfigSchema = z.object({
     apiKey: z.string().default(''),
   }).default({}),
   store: z.object({
-    path: z.string().default('.issue-store').refine(
-      (p) => resolve(p).startsWith(process.cwd()),
-      'Store path must be within the project directory',
-    ),
+    path: z.string().default('.issue-store'),
   }).default({}),
   sync: z.object({
     digestBatchSize: z.number().default(20),


### PR DESCRIPTION
## Summary

The `store.path` Zod refine validated that `resolve(path).startsWith(process.cwd())`. In the GUI (Next.js) and the runner daemon, `process.cwd()` is the host process's working directory — **not** the workspace repo root — so valid configs pointing at `repoRoot/.issue-store` (or a runner's tmp clone) failed validation with an unactionable `"Store path must be within the project directory"` error.

The guard protected against a non-threat: the `Config` is always parsed inside a trusted process (CLI/GUI/runner). This PR drops the refine and the now-unused `node:path` import, per the audit's suggested fix.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)