### PR TITLE
fix: redact GitHub token from runner error logs (#59)

### DIFF
--- a/packages/runner/src/execute-job-locally.ts
+++ b/packages/runner/src/execute-job-locally.ts
@@ -4,6 +4,7 @@ import type { AgentRunRecord, Config } from '@cezar/core';
 import type { ClaimedJob, RunnerEvent } from './runner-client.js';
 import { RunnerClient } from './runner-client.js';
 import { prepareJobWorktree, type JobWorktree } from './repo-clone.js';
+import { redactToken } from './redact.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -286,7 +287,10 @@ export async function executeJobLocally(
     await flush();
     await client.finalizeRun(workflowRunId, { ...result.finalize, tokensUsed, sessionId: runSessionId ?? null });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    // Redact any GitHub token before it reaches stderr, journalctl, or the
+    // cockpit: `execFile` clone/fetch failures carry the token-bearing URL in
+    // `err.message` (`Command failed: git clone https://x-access-token:…@…`).
+    const message = redactToken(err instanceof Error ? err.message : String(err));
     console.error(`[runner] job ${job.id} failed:`, message);
     await flush().catch(() => {});
     await client.finalizeRun(workflowRunId, { status: 'failed', reason: message, tokensUsed }).catch((e) => {

--- a/packages/runner/src/redact.ts
+++ b/packages/runner/src/redact.ts
@@ -1,0 +1,17 @@
+/**
+ * Strips GitHub install/user tokens out of free-form strings before they hit a
+ * log sink, the cockpit, or `finalizeRun({ reason })`.
+ *
+ * `execFile` failures prepend `Command failed: <argv joined>` to `err.message`,
+ * and the clone/fetch argv embeds the token in
+ * `https://x-access-token:<TOKEN>@github.com/...`. Without this scrub a single
+ * transient `git clone` failure would smear a live install token across stderr,
+ * `journalctl`, centralized logging, and the cockpit UI. Defense-in-depth on top
+ * of keeping the token off argv where possible.
+ */
+export function redactToken(s: string): string {
+  return s
+    .replace(/x-access-token:[A-Za-z0-9_.-]+@/g, 'x-access-token:***@')
+    .replace(/ghs_[A-Za-z0-9]{20,}/g, 'ghs_***')
+    .replace(/ghp_[A-Za-z0-9]{20,}/g, 'ghp_***');
+}

--- a/packages/runner/src/runner-daemon.ts
+++ b/packages/runner/src/runner-daemon.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import { RunnerClient, type ClaimedJob, type RunnerUtilizationPayload } from './runner-client.js';
 import { executeJobLocally } from './execute-job-locally.js';
 import { maintainBareClones } from './repo-clone.js';
+import { redactToken } from './redact.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -218,7 +219,10 @@ export class RunnerDaemon {
       // stays NULL for those rows (no attribution, no error).
       runnerId: this.runnerId,
     }).catch((err) => {
-      console.error(`[runner] job ${claimed.job.id} crashed:`, err instanceof Error ? err.message : err);
+      console.error(
+        `[runner] job ${claimed.job.id} crashed:`,
+        redactToken(err instanceof Error ? err.message : String(err)),
+      );
     }).finally(() => {
       this.inFlight.delete(claimed.job.id);
       console.log(`[runner] job ${claimed.job.id} finished (${this.inFlight.size} in flight)`);


### PR DESCRIPTION
## Summary

`execFile` errors from `child_process` prepend `Command failed: <argv joined>` to `err.message`. The git clone/fetch argv in `repo-clone.ts` embeds the install token in a `https://x-access-token:<TOKEN>@github.com/...` URL, so any transient failure (DNS, 5xx, disk full) leaked a live token into:

- the runner's stderr / `journalctl`
- centralized logging (Datadog, Loki)
- the cockpit UI, via `finalizeRun({ reason: message })`

## Fix

- New `packages/runner/src/redact.ts` exporting `redactToken()` (scrubs `x-access-token:<tok>@`, `ghs_…`, `ghp_…`).
- Wrap the two error sinks that surface clone/fetch failures:
  - `execute-job-locally.ts` job-failed catch — redacted message now feeds both `console.error` and `finalizeRun({ reason })`.
  - `runner-daemon.ts` `job crashed` log.

Defense-in-depth scrub at the logging boundary; scoped to the runner package, no behavior change on the success path.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)