### PR TITLE
fix: cron routes fail closed when CRON_SECRET unset (#60)

### DIFF
--- a/packages/gui/src/app/api/cron/dispatch/route.ts
+++ b/packages/gui/src/app/api/cron/dispatch/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import { runDispatch } from '@/lib/scheduler/run-dispatch';
+import { requireCronSecret } from '@/lib/scheduler/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -10,13 +11,8 @@ export const runtime = 'nodejs';
 // (Vercel `vercel.json` schedules) or the in-process scheduler used in
 // self-hosted Node deployments (see `lib/scheduler/in-process-scheduler.ts`).
 export async function GET(req: Request) {
-  const expected = process.env.CRON_SECRET;
-  if (expected) {
-    const auth = req.headers.get('authorization');
-    if (auth !== `Bearer ${expected}`) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
-  }
+  const unauthorized = requireCronSecret(req);
+  if (unauthorized) return unauthorized;
 
   const supabase = createSupabaseAdminClient();
   const result = await runDispatch(supabase);

--- a/packages/gui/src/app/api/cron/issue-sync/route.ts
+++ b/packages/gui/src/app/api/cron/issue-sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { requireCronSecret } from '@/lib/scheduler/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -23,13 +24,8 @@ type Workspace = {
  * dispatcher + triage workflow then take over from there.
  */
 export async function GET(req: Request) {
-  const expected = process.env.CRON_SECRET;
-  if (expected) {
-    const auth = req.headers.get('authorization');
-    if (auth !== `Bearer ${expected}`) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
-  }
+  const unauthorized = requireCronSecret(req);
+  if (unauthorized) return unauthorized;
 
   const supabase = createSupabaseAdminClient();
 

--- a/packages/gui/src/app/api/cron/prs-sync/route.ts
+++ b/packages/gui/src/app/api/cron/prs-sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { requireCronSecret } from '@/lib/scheduler/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -24,13 +25,8 @@ type Workspace = {
  * flag and require only that a workspace exists.
  */
 export async function GET(req: Request) {
-  const expected = process.env.CRON_SECRET;
-  if (expected) {
-    const auth = req.headers.get('authorization');
-    if (auth !== `Bearer ${expected}`) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
-  }
+  const unauthorized = requireCronSecret(req);
+  if (unauthorized) return unauthorized;
 
   const supabase = createSupabaseAdminClient();
 

--- a/packages/gui/src/app/api/cron/triage-sweep/route.ts
+++ b/packages/gui/src/app/api/cron/triage-sweep/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import { runTriageSweep } from '@/lib/scheduler/run-triage-sweep';
+import { requireCronSecret } from '@/lib/scheduler/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -9,13 +10,8 @@ export const runtime = 'nodejs';
 // same logic is also called by the in-process scheduler in self-hosted Node
 // deployments (see `lib/scheduler/in-process-scheduler.ts`).
 export async function GET(req: Request) {
-  const expected = process.env.CRON_SECRET;
-  if (expected) {
-    const auth = req.headers.get('authorization');
-    if (auth !== `Bearer ${expected}`) {
-      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-    }
-  }
+  const unauthorized = requireCronSecret(req);
+  if (unauthorized) return unauthorized;
 
   const supabase = createSupabaseAdminClient();
   const result = await runTriageSweep(supabase);

--- a/packages/gui/src/lib/scheduler/cron-auth.ts
+++ b/packages/gui/src/lib/scheduler/cron-auth.ts
@@ -1,0 +1,26 @@
+import { timingSafeEqual } from 'node:crypto';
+import { NextResponse } from 'next/server';
+
+/**
+ * Shared auth guard for the `/api/cron/*` routes. Fails closed: if
+ * `CRON_SECRET` is unset (or empty) the route refuses all callers with a 503,
+ * so a misconfigured self-hosted `.env` can't turn the cron surface into an
+ * unauthenticated lever (mint GitHub tokens, fan out to every workspace, write
+ * to Supabase). Mirrors the webhook receiver's 503-until-configured intent.
+ *
+ * Returns a `NextResponse` to short-circuit the handler, or `null` when the
+ * request is authorized and the handler should proceed.
+ */
+export function requireCronSecret(req: Request): NextResponse | null {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) {
+    return NextResponse.json({ error: 'CRON_SECRET not configured' }, { status: 503 });
+  }
+  const auth = req.headers.get('authorization') ?? '';
+  const a = Buffer.from(auth);
+  const b = Buffer.from(`Bearer ${expected}`);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

All four `/api/cron/*` routes (`dispatch`, `triage-sweep`, `issue-sync`, `prs-sync`) shared an auth pattern that only enforced the Bearer check **when `CRON_SECRET` was set**:

```ts
const expected = process.env.CRON_SECRET;
if (expected) { /* require Bearer */ }
```

With the var unset or empty the guard was skipped entirely, so any anonymous Internet caller could drive `runDispatch` / `runTriageSweep` / `issue-sync` / `prs-sync` — minting GitHub installation tokens, fanning out to every workspace, and writing to Supabase (an unauthenticated DoS / credit-burn lever for misconfigured self-hosted deployments).

## Fix

- New shared `requireCronSecret(req)` helper in `packages/gui/src/lib/scheduler/cron-auth.ts` that **fails closed**: returns `503 { error: 'CRON_SECRET not configured' }` when the secret is unset, mirroring the webhook receiver's 503-until-configured intent.
- Uses `crypto.timingSafeEqual` on equal-length byte buffers for a constant-time comparison of the `Authorization` header.
- Applied to all four cron routes, replacing the inline guard.

The in-process scheduler already forwards the `Bearer` header when `CRON_SECRET` is set, so authorized ticks are unaffected; deployments that ran cron without a secret must now set one (correct fail-closed behavior).

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)