### PR TITLE
fix: stop persisting GitHub token in bare-clone remote config (#58)

### DIFF
--- a/packages/core/src/actions/autofix/orchestrator.ts
+++ b/packages/core/src/actions/autofix/orchestrator.ts
@@ -263,6 +263,7 @@ export class AutofixOrchestrator {
           baseBranch: cfg.baseBranch,
           remote: cfg.remote,
           fetchRemote: cfg.fetchBeforeAttempt,
+          authArgs: this.github.gitAuthArgs(),
           // Always start fresh: local branches with this name are always
           // stale work from a prior run (cezar only pushes on review-pass).
           // Inheriting them lets the previous run's autosave commits leak
@@ -710,7 +711,7 @@ export class AutofixOrchestrator {
     // fetched PR tip when none exists yet.
     let prRef: string;
     try {
-      prRef = await fetchRemoteBranch(repoRoot, cfg.remote, input.branch);
+      prRef = await fetchRemoteBranch(repoRoot, cfg.remote, input.branch, this.github.gitAuthArgs());
     } catch (err) {
       return { status: 'failed', reason: `failed to fetch ${cfg.remote}/${input.branch}: ${(err as Error).message}`, branch: input.branch };
     }
@@ -724,6 +725,7 @@ export class AutofixOrchestrator {
         remote: cfg.remote,
         fetchRemote: cfg.fetchBeforeAttempt,
         startRef: prRef,
+        authArgs: this.github.gitAuthArgs(),
         resetBranch: false,
       });
     } catch (err) {
@@ -929,6 +931,7 @@ export class AutofixOrchestrator {
         baseBranch: cfg.baseBranch,
         remote: cfg.remote,
         fetchRemote: cfg.fetchBeforeAttempt,
+        authArgs: this.github.gitAuthArgs(),
         // Always start fresh — see the matching call site above.
         resetBranch: true,
         onWarn: (m) => opts.onEvent?.(`[#${issueNumber}] ${m}`),
@@ -1041,7 +1044,7 @@ export class AutofixOrchestrator {
     opts.onEvent?.(`[#${input.issueNumber}] CI-FIX ${input.attemptIndex}/${input.attemptMax} — fetching branch ${input.branch}`);
     let prRef: string;
     try {
-      prRef = await fetchRemoteBranch(repoRoot, cfg.remote, input.branch);
+      prRef = await fetchRemoteBranch(repoRoot, cfg.remote, input.branch, this.github.gitAuthArgs());
     } catch (err) {
       return { status: 'failed', reason: `failed to fetch ${cfg.remote}/${input.branch}: ${(err as Error).message}`, branch: input.branch };
     }
@@ -1055,6 +1058,7 @@ export class AutofixOrchestrator {
         remote: cfg.remote,
         fetchRemote: cfg.fetchBeforeAttempt,
         startRef: prRef,
+        authArgs: this.github.gitAuthArgs(),
         resetBranch: false,
         onWarn: (m) => opts.onEvent?.(`[#${input.issueNumber}] ${m}`),
       });

--- a/packages/core/src/actions/autofix/worktree.ts
+++ b/packages/core/src/actions/autofix/worktree.ts
@@ -38,10 +38,14 @@ export interface WorktreeHandle {
   dispose(): Promise<void>;
 }
 
-export async function fetchBaseBranch(repoRoot: string, remote: string, baseBranch: string): Promise<void> {
+// `authArgs` are command-time `git -c …` flags (e.g. from
+// `GitHubService.gitAuthArgs()`) that authenticate the HTTPS fetch without the
+// token being persisted in the remote URL. Defaults to none for callers whose
+// `origin` already carries credentials (e.g. the host's git config).
+export async function fetchBaseBranch(repoRoot: string, remote: string, baseBranch: string, authArgs: string[] = []): Promise<void> {
   // Intentionally narrow: we only need the base branch up to date. Avoids
   // touching unrelated refs in a large monorepo, and keeps the fetch cheap.
-  await runGit(repoRoot, ['fetch', '--prune', '--no-tags', remote, baseBranch]);
+  await runGit(repoRoot, [...authArgs, 'fetch', '--prune', '--no-tags', remote, baseBranch]);
 }
 
 // Private ref namespace cezar fetches PR branches into. Kept out of
@@ -60,9 +64,12 @@ export function cezarAutofixRef(branch: string): string {
 // `refs/heads/<branch>` so that, when the workspace points autofix.repoRoot at
 // a user's real checkout that happens to hold a local branch of the same name,
 // any unpushed local commits on `refs/heads/<branch>` are never destroyed.
-export async function fetchRemoteBranch(repoRoot: string, remote: string, branch: string): Promise<string> {
+//
+// `authArgs` are command-time `git -c …` flags (see fetchBaseBranch) that
+// authenticate the HTTPS fetch without persisting the token in the remote URL.
+export async function fetchRemoteBranch(repoRoot: string, remote: string, branch: string, authArgs: string[] = []): Promise<string> {
   const ref = cezarAutofixRef(branch);
-  await runGit(repoRoot, ['fetch', '--no-tags', remote, `+refs/heads/${branch}:${ref}`]);
+  await runGit(repoRoot, [...authArgs, 'fetch', '--no-tags', remote, `+refs/heads/${branch}:${ref}`]);
   return ref;
 }
 
@@ -187,6 +194,8 @@ export async function createWorktree(opts: {
   resetBranch?: boolean;
   /** Optional warn callback for non-fatal conditions (e.g. fetch fallback). */
   onWarn?: (message: string) => void;
+  /** Command-time `git -c …` auth flags for the base-branch fetch (see fetchBaseBranch). */
+  authArgs?: string[];
 }): Promise<WorktreeHandle> {
   await assertIsGitRepo(opts.repoRoot);
   await assertNotCezarCheckout(opts.repoRoot);
@@ -210,7 +219,7 @@ export async function createWorktree(opts: {
       let startingRef = opts.startRef ?? opts.baseBranch;
       if (!opts.startRef && opts.fetchRemote) {
         try {
-          await fetchBaseBranch(opts.repoRoot, opts.remote, opts.baseBranch);
+          await fetchBaseBranch(opts.repoRoot, opts.remote, opts.baseBranch, opts.authArgs);
           startingRef = `${opts.remote}/${opts.baseBranch}`;
         } catch (err) {
           // Fall back to local baseBranch if the fetch fails (offline, auth issue,

--- a/packages/core/src/services/github.service.ts
+++ b/packages/core/src/services/github.service.ts
@@ -111,6 +111,7 @@ export class GitHubService {
   private octokit: Octokit;
   private owner: string;
   private repo: string;
+  private token: string;
 
   constructor(config: Config) {
     if (!config.github.token) {
@@ -119,6 +120,7 @@ export class GitHubService {
     this.octokit = new Octokit({ auth: config.github.token });
     this.owner = config.github.owner;
     this.repo = config.github.repo;
+    this.token = config.github.token;
   }
 
   async fetchAllIssues(includeClosed = false, maxItems?: number): Promise<RawIssue[]> {
@@ -581,9 +583,20 @@ export class GitHubService {
     }
   }
 
+  /**
+   * Command-time git config args that authenticate HTTPS operations against
+   * GitHub via an `http.extraheader` Authorization header. Preferred over
+   * baking the token into a remote URL — the secret then never lands in
+   * `.git/config` on disk (see `@cezar/runner`'s `repo-clone.ts`).
+   */
+  gitAuthArgs(): string[] {
+    const authHeader = `Authorization: Basic ${Buffer.from(`x-access-token:${this.token}`).toString('base64')}`;
+    return ['-c', `http.extraheader=${authHeader}`];
+  }
+
   async pushBranch(branch: string, localRepoPath: string, remote = 'origin'): Promise<void> {
     try {
-      await execFileAsync('git', ['push', '--set-upstream', remote, branch], {
+      await execFileAsync('git', [...this.gitAuthArgs(), 'push', '--set-upstream', remote, branch], {
         cwd: localRepoPath,
       });
     } catch (error) {

--- a/packages/core/src/workflows/flow-runner.ts
+++ b/packages/core/src/workflows/flow-runner.ts
@@ -224,6 +224,7 @@ export async function runFlow(params: RunFlowParams): Promise<WorkflowRunResult<
       baseBranch: params.config.autofix?.baseBranch ?? 'main',
       remote: params.config.autofix?.remote ?? 'origin',
       fetchRemote: params.config.autofix?.fetchBeforeAttempt ?? true,
+      authArgs: params.github.gitAuthArgs(),
       onWarn: (m: string) => params.onEvent(m),
     });
     worktreePath = wt.path;

--- a/packages/runner/src/repo-clone.ts
+++ b/packages/runner/src/repo-clone.ts
@@ -46,17 +46,22 @@ export async function prepareJobWorktree(
 ): Promise<JobWorktree> {
   await mkdir(REPOS_DIR, { recursive: true });
   const barePath = barePathFor(owner, repo);
-  const cloneUrl = `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`;
+  // Persist only the plain URL in `<bare>/config`; the short-lived token is
+  // supplied at command time via `-c http.extraheader=…` so it never lands on
+  // disk (where it would survive between jobs, long past its 15-min lifetime).
+  const plainUrl = `https://github.com/${owner}/${repo}.git`;
+  const authHeader = `Authorization: Basic ${Buffer.from(`x-access-token:${githubToken}`).toString('base64')}`;
+  const auth = ['-c', `http.extraheader=${authHeader}`];
 
   if (existsSync(barePath)) {
-    await exec('git', ['--git-dir', barePath, 'remote', 'set-url', 'origin', cloneUrl]);
-    await exec('git', ['--git-dir', barePath, 'fetch', '--prune', 'origin']);
+    await exec('git', ['--git-dir', barePath, 'remote', 'set-url', 'origin', plainUrl]);
+    await exec('git', [...auth, '--git-dir', barePath, 'fetch', '--prune', 'origin']);
   } else {
-    await exec('git', ['clone', '--bare', cloneUrl, barePath]);
+    await exec('git', [...auth, 'clone', '--bare', plainUrl, barePath]);
     // Default `--bare` only fetches `refs/heads/<single>`; broaden so future
     // fetches mirror every remote head (matches `git clone` defaults).
     await exec('git', ['--git-dir', barePath, 'config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*']);
-    await exec('git', ['--git-dir', barePath, 'fetch', '--prune', 'origin']);
+    await exec('git', [...auth, '--git-dir', barePath, 'fetch', '--prune', 'origin']);
   }
 
   const safeJobId = jobId.replace(/[^a-zA-Z0-9-]/g, '_');


### PR DESCRIPTION
## Summary

The runner's `prepareJobWorktree` (`packages/runner/src/repo-clone.ts`) embedded the short-lived GitHub install token directly into the `origin` URL written to `~/.cezar/runner-repos/<owner>__<repo>.git/config`. The bare clone survives between jobs, so the token persisted on disk long past its ~15-minute lifetime — grep-able by anyone with read access to the host, and captured in `git reflog`, backups, and crash dumps.

This change persists only the plain `https://github.com/<owner>/<repo>.git` URL and supplies the token at command time via `-c http.extraheader=Authorization: Basic …` for clone/fetch, matching the approach suggested in the issue. The token now never lands in `.git/config`. The existing-clone branch also `set-url`s back to the plain URL, scrubbing any token left by a pre-fix install.

Because `git push` and the CI-follow-up branch fetches read `origin` (which is now token-free), they would otherwise lose authentication. To keep them working without re-introducing the leak:

- Added `GitHubService.gitAuthArgs()` — the same command-time `http.extraheader` Authorization header derived from the configured token.
- Threaded it through `pushBranch`, `fetchBaseBranch`, `fetchRemoteBranch`, and `createWorktree` (plus their orchestrator / flow-runner call sites) so every authenticated git network op carries credentials per-invocation. The header only affects HTTPS transport (SSH remotes ignore it), so the CLI path is unaffected.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)