### PR TITLE
fix: reject conflicting --apply and --dry-run in cezar run (#63)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -15,6 +15,11 @@ interface RunOptions {
 }
 
 export async function runCommand(actionName: string, opts: RunOptions, config: Config): Promise<void> {
+  if (opts.apply && opts.dryRun) {
+    console.error(chalk.red('Cannot pass both --apply and --dry-run.'));
+    process.exit(1);
+  }
+
   const catalog = await loadActionCatalog();
   const action = catalog.find((a) => a.name === actionName);
   if (!action) {


### PR DESCRIPTION
## Summary

`cezar run <action>` accepted both `--apply` and `--dry-run`. The runner computed `apply = opts.apply && !opts.dryRun`, so passing both silently downgraded to a dry-run while still exiting `0`. A user (or wrapper/CI script) explicitly asking to apply could believe effects were written when they were not — the only signal was a dim `dry-run` banner, easy to miss in CI logs.

This adds a guard at the top of `runCommand` that rejects the combination loudly and exits `1`:

```ts
if (opts.apply && opts.dryRun) {
  console.error(chalk.red('Cannot pass both --apply and --dry-run.'));
  process.exit(1);
}
```

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)