### PR TITLE
fix: cezar run --issue with non-numeric value silently runs on no issues (#67)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'dotenv/config';
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import chalk from 'chalk';
 import { loadConfig, IssueStore } from '@cezar/core';
 import { initCommand } from './commands/init.js';
@@ -55,7 +55,13 @@ program.command('run <action>')
   .description('Run a data-driven Action against issues in the local store')
   .option('--all', 'Run against every issue in the store')
   .option('--unanalyzed', 'Run only against issues without prior analysis for this action (default)')
-  .option('--issue <n>', 'Target a single issue number', v => parseInt(v, 10))
+  .option('--issue <n>', 'Target a single issue number', v => {
+    const n = Number.parseInt(v, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== v.trim()) {
+      throw new InvalidArgumentError(`--issue must be a positive integer, got "${v}".`);
+    }
+    return n;
+  })
   .option('--apply', 'Apply effects to GitHub (default is dry-run)')
   .option('--dry-run', 'Force dry-run; never write to GitHub')
   .action(async (actionName, opts) => {


### PR DESCRIPTION
## Summary

`cezar run <action> --issue <n>` parsed the value with `parseInt(v, 10)` and did not validate the result. Passing a non-numeric value like `--issue abc` produced `NaN`, and because `NaN != null` is `true`, the scope resolved to `{ kind: 'single', number: NaN }`. `selectIssues` then matched zero issues, printed "No issues match the selected scope.", and exited `0` — a silent no-op on a typo, the worst kind of CI failure. Negative numbers and decimals (`--issue 12.5` → `12`) slipped through silently too.

## Fix

Validate at the Commander option boundary: reject anything that isn't a positive integer by throwing `InvalidArgumentError` (which Commander renders as a clean error message and exits with code 1, rather than an uncaught stack trace).

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)