### PR TITLE
fix: hub errors during run/sync drop the user out of the interactive menu (#65)

### DIFF
--- a/packages/cli/src/ui/hub.ts
+++ b/packages/cli/src/ui/hub.ts
@@ -41,15 +41,26 @@ export async function launchHub(store: IssueStore | null, config: Config): Promi
     if (choice === 'exit') return;
 
     if (choice === 'sync') {
-      await syncCommand({}, config);
-      const reloaded = await IssueStore.loadOrNull(config.store.path);
-      if (!reloaded) return;
-      store = reloaded;
+      try {
+        await syncCommand({}, config);
+        const reloaded = await IssueStore.loadOrNull(config.store.path);
+        if (reloaded) store = reloaded;
+      } catch (err) {
+        if ((err as Error).name === 'ExitPromptError') throw err;
+        console.error(chalk.red(`\n  sync failed: ${(err as Error).message}`));
+        console.log(chalk.dim('\n  Press Enter to continue.'));
+        await input({ message: '' }).catch(() => '');
+      }
       continue;
     }
 
     if (choice === 'run') {
-      await runActionFlow(config);
+      try {
+        await runActionFlow(config);
+      } catch (err) {
+        if ((err as Error).name === 'ExitPromptError') throw err;
+        console.error(chalk.red(`\n  action failed: ${(err as Error).message}`));
+      }
       console.log(chalk.dim('\n  Press Enter to continue.'));
       await input({ message: '' }).catch(() => '');
     }


### PR DESCRIPTION
## Summary

The hub loop called `syncCommand(...)` and `runActionFlow(...)` without a try/catch, so any thrown error (network blip, LLM 429, store corruption, Anthropic timeout) bubbled up to the top-level `program.parseAsync().catch()`, printing a raw red error and exiting the whole session.

This wraps both the `sync` and `run` branches in try/catch so a transient error surfaces inside the menu loop and the user returns to the action menu instead of the shell prompt. `ExitPromptError` (Ctrl-C) is re-thrown so it still propagates to the top-level handler in `index.ts`, which exits cleanly with code 0.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)