### PR TITLE
fix: validate CLI version banner in runner backend-detect (#66)

### DIFF
--- a/packages/runner/src/backend-detect.ts
+++ b/packages/runner/src/backend-detect.ts
@@ -17,15 +17,34 @@ export interface BackendCheck {
  * interactive flow); callers print a "run `claude login` / `codex login`" hint.
  */
 export async function detectBackends(): Promise<BackendCheck[]> {
-  const probes: Array<{ backend: BackendCheck['backend']; binary: string; loginCmd: string }> = [
-    { backend: 'claude-cli', binary: 'claude', loginCmd: 'claude login' },
-    { backend: 'codex-cli', binary: 'codex', loginCmd: 'codex login' },
+  const probes: Array<{
+    backend: BackendCheck['backend'];
+    binary: string;
+    loginCmd: string;
+    versionRegex: RegExp;
+  }> = [
+    // The Anthropic Claude CLI prints e.g. `claude version 1.0.13` (or `claude code version …`).
+    { backend: 'claude-cli', binary: 'claude', loginCmd: 'claude login', versionRegex: /^claude(\s+code)?\s+version\s+\d+\.\d+/i },
+    // The Codex CLI prints e.g. `codex 0.4.2`.
+    { backend: 'codex-cli', binary: 'codex', loginCmd: 'codex login', versionRegex: /^codex\s+\d+\.\d+/i },
   ];
   return Promise.all(
-    probes.map(async ({ backend, binary, loginCmd }) => {
+    probes.map(async ({ backend, binary, loginCmd, versionRegex }) => {
       try {
         const { stdout } = await exec(binary, ['--version'], { timeout: 10_000 });
-        return { backend, binary, available: true, version: stdout.trim(), hint: `if not authenticated, run \`${loginCmd}\`` };
+        const version = stdout.trim();
+        if (!versionRegex.test(version)) {
+          // A generic `claude`/`codex` binary (a shell wrapper, an unrelated vendor tool)
+          // shadows the real CLI on $PATH. Advertising it would make the daemon claim jobs
+          // it can't run, thrashing the queue — reject anything that doesn't match the banner.
+          return {
+            backend,
+            binary,
+            available: false,
+            hint: `\`${binary}\` is on PATH but doesn't look like the expected CLI (got: ${version.slice(0, 80)})`,
+          };
+        }
+        return { backend, binary, available: true, version, hint: `if not authenticated, run \`${loginCmd}\`` };
       } catch {
         return { backend, binary, available: false, hint: `install the \`${binary}\` CLI and run \`${loginCmd}\`` };
       }


### PR DESCRIPTION
## Summary

`detectBackends` in `packages/runner/src/backend-detect.ts` treated any zero-exit `<bin> --version` with non-empty stdout as a working backend. Because `claude` and `codex` are generic names, an unrelated binary on `$PATH` (a shell wrapper, another vendor's tool) would be advertised as an available backend. The daemon then claims `claude-cli`/`codex-cli` jobs it can't actually run, thrashing the queue.

## Fix

Each probe now carries an expected version-banner regex:
- `claude` must print `claude version <semver>` (or `claude code version …`)
- `codex` must print `codex <semver>`

If the `--version` output doesn't match, the backend is reported as unavailable with a clear hint showing what was actually found, instead of being falsely advertised.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)