### PR TITLE
fix: autosave stages tracked files only to avoid committing secrets (#62)

### DIFF
--- a/packages/runner/src/execute-job-locally.ts
+++ b/packages/runner/src/execute-job-locally.ts
@@ -301,11 +301,19 @@ export async function executeJobLocally(
 }
 
 /**
- * Phase 5 autosave. Stages every change and commits with `--allow-empty` so
- * even a "nothing changed since last tick" iteration still leaves a heartbeat
- * commit. `commit.gpgsign=false` is set inline so a host with signing on by
- * default doesn't prompt; the author is hardcoded so we never depend on the
- * operator's git identity (and so the commits stand out in `git log`).
+ * Phase 5 autosave. Stages changes to *already-tracked* files (`git add -u`)
+ * and commits with `--allow-empty` so even a "nothing changed since last tick"
+ * iteration still leaves a heartbeat commit. `commit.gpgsign=false` is set
+ * inline so a host with signing on by default doesn't prompt; the author is
+ * hardcoded so we never depend on the operator's git identity (and so the
+ * commits stand out in `git log`).
+ *
+ * We deliberately use `-u` rather than `-A`: `-A` would stage *new* untracked
+ * files too — including `.env` / `credentials.json` an agent may have written
+ * while debugging, or large build/fixture blobs — and these autosave commits
+ * are published by the Phase 4 push-to-PR step without the agent reviewing
+ * them. Staging tracked files only loses some recoverable brand-new WIP but
+ * eliminates the secret-leak / diff-noise class (see issue #62).
  *
  * A `running` guard skips overlapping ticks — git is generally fast enough
  * that 90s gives plenty of slack, but a slow disk shouldn't queue stale
@@ -316,7 +324,7 @@ async function autosaveWorktree(cwd: string): Promise<void> {
   if (autosaveRunning) return;
   autosaveRunning = true;
   try {
-    await execFileAsync('git', ['add', '-A'], { cwd });
+    await execFileAsync('git', ['add', '-u'], { cwd });
     await execFileAsync(
       'git',
       [


### PR DESCRIPTION
## Summary

The Phase 5 worktree autosave in `packages/runner/src/execute-job-locally.ts` used `git add -A`, which stages **every** untracked file in the worktree — including `.env`/`credentials.json` an agent may write while debugging, plus large build/fixture blobs. Those autosave commits are published by the Phase 4 push-to-PR step without the agent ever reviewing them (it fires every 90s), leaking secrets onto the `cezar/job-<jobId>` branch and ballooning the PR diff with noise.

This switches autosave to `git add -u`, which stages only already-tracked files. This eliminates the secret-leak / diff-noise class (the issue's suggested fix #1) while preserving the heartbeat / crash-recovery purpose of autosave. The comment was updated to explain the `-u` vs `-A` choice.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)