### PR TITLE
fix: refuse runner token over plain HTTP unless opted in (#64)

### DIFF
--- a/packages/runner/src/runner-client.ts
+++ b/packages/runner/src/runner-client.ts
@@ -173,6 +173,29 @@ const MAX_RETRIES = 4;
  * with exponential backoff; throws hard on 401 (bad/revoked token). */
 export class RunnerClient {
   constructor(private readonly baseUrl: string, private readonly token: string) {
+    // Refuse to send the long-lived runner bearer token over a non-TLS
+    // transport. A prod typo (`http://…`) or a local-dev URL pasted into a
+    // deployment would otherwise leak the credential in plaintext on every
+    // claim/heartbeat/finalize call. Localhost stays painless; opt out with
+    // CEZAR_RUNNER_ALLOW_INSECURE=1 for non-localhost dev setups.
+    let parsed: URL;
+    try {
+      parsed = new URL(baseUrl);
+    } catch {
+      throw new Error(`cezar-runner: invalid --url / CEZAR_RUNNER_URL: '${baseUrl}'`);
+    }
+    const isLoopback =
+      parsed.hostname === 'localhost' ||
+      parsed.hostname === '127.0.0.1' ||
+      parsed.hostname === '[::1]' ||
+      parsed.hostname === '::1';
+    const allowInsecure = process.env.CEZAR_RUNNER_ALLOW_INSECURE === '1';
+    if (parsed.protocol !== 'https:' && !isLoopback && !allowInsecure) {
+      throw new Error(
+        `cezar-runner: refusing to send the runner token over ${parsed.protocol} ` +
+          `(${parsed.host}). Use an https:// URL, or set CEZAR_RUNNER_ALLOW_INSECURE=1 for local dev.`,
+      );
+    }
     this.baseUrl = baseUrl.replace(/\/+$/, '');
   }
 


### PR DESCRIPTION
## Summary

`cezar-runner start` accepted any URL for `--url` / `CEZAR_RUNNER_URL` and used it verbatim, so a prod typo (`http://…`) or a local-dev URL copied into a deployment would silently send the long-lived runner bearer token in plaintext on every claim/heartbeat/finalize call. The token authorizes claiming work and writing events for a workspace — the help text already says "treat it like a password".

`RunnerClient`'s constructor now parses the base URL and throws when the protocol is not `https:`, unless:
- the host is loopback (`localhost` / `127.0.0.1` / `::1`), or
- `CEZAR_RUNNER_ALLOW_INSECURE=1` is set (escape hatch for non-localhost dev).

An unparseable URL now also fails fast with a clear message. Localhost dev stays painless; production typos fail fast before the token ever leaves the host. The check lives in the constructor, the single choke point for the daemon and any other caller.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)