### PR TITLE
fix: preserve unrelated config namespaces in saveWorkspaceConfig (#74)

### DIFF
--- a/packages/gui/src/app/settings/actions.ts
+++ b/packages/gui/src/app/settings/actions.ts
@@ -79,9 +79,26 @@ export async function saveWorkspaceConfig(
   };
 
   const supabase = await createSupabaseServerClient();
+
+  // Read-modify-write: preserve any other top-level config namespaces
+  // (e.g. github, workflow, dispatch, agent-backend overrides) that this
+  // form does not edit — a full `update({ config })` would wipe them.
+  const { data: existing, error: readError } = await supabase
+    .from('workspaces')
+    .select('config')
+    .eq('id', workspace.id)
+    .single();
+  if (readError) return { error: readError.message };
+
+  const merged = {
+    ...((existing?.config as Record<string, unknown>) ?? {}),
+    sync: config.sync,
+    autofix: config.autofix,
+  };
+
   const { error } = await supabase
     .from('workspaces')
-    .update({ config })
+    .update({ config: merged })
     .eq('id', workspace.id);
 
   if (error) return { error: error.message };


### PR DESCRIPTION
## Summary

`saveWorkspaceConfig` built a fresh `config` object from only the `sync` and `autofix` form fields, then issued `update({ config })` — replacing the entire `workspaces.config` JSONB column. Any other top-level keys (`github`, `workflow` incl. `workflow.useEngine`, `dispatch`, agent-backend overrides, manual SQL backfills) were silently wiped on every Save click.

This switches to a read-modify-write: SELECT the existing `config`, merge the form's `sync`/`autofix` namespaces over it, then UPDATE — so unrelated namespaces round-trip intact.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)