### PR TITLE
fix: surface error when post-sync store reload returns null (#71)

### DIFF
--- a/packages/cli/src/ui/hub.ts
+++ b/packages/cli/src/ui/hub.ts
@@ -44,7 +44,13 @@ export async function launchHub(store: IssueStore | null, config: Config): Promi
       try {
         await syncCommand({}, config);
         const reloaded = await IssueStore.loadOrNull(config.store.path);
-        if (reloaded) store = reloaded;
+        if (!reloaded) {
+          console.error(
+            chalk.red('  Store disappeared after sync. Run `cezar init` to recreate it.'),
+          );
+          return;
+        }
+        store = reloaded;
       } catch (err) {
         if ((err as Error).name === 'ExitPromptError') throw err;
         console.error(chalk.red(`\n  sync failed: ${(err as Error).message}`));


### PR DESCRIPTION
## Summary

After a successful `sync`, the hub reloads the store via `IssueStore.loadOrNull`. If that returned null (e.g. the store file was concurrently deleted or hit an I/O/migration error), the `return` dropped the user straight back to the shell with no message — looking like a crash right after sync succeeded.

This adds an explicit error message pointing the user at `cezar init` before returning, matching the fix suggested in the audit.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)