### PR TITLE
fix: ack GitHub webhook with 200 on handler error (#75)

### DIFF
--- a/packages/gui/src/app/api/github/webhook/route.ts
+++ b/packages/gui/src/app/api/github/webhook/route.ts
@@ -74,7 +74,13 @@ export async function POST(req: Request): Promise<NextResponse> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[github-webhook] ${event} handler failed:`, msg);
-    return NextResponse.json({ error: 'handler error' }, { status: 500 });
+    // Ack with 200 even on a downstream failure: a 5xx makes GitHub retry the
+    // same delivery (~8 times / 24h), which — combined with the upsert/enqueue
+    // dedup not yet running — turns one flaky Supabase call into a storm of
+    // duplicate triage/flow jobs. We accepted the delivery and own the
+    // recovery (the triage-sweep poll is the safety net), so don't hand GitHub
+    // the retry queue.
+    return NextResponse.json({ ok: false, error: 'handler error' }, { status: 200 });
   }
 }
 


### PR DESCRIPTION
## Summary

The webhook receiver's catch-all returned **500** on any handler exception. GitHub treats 5xx responses as transient failures and retries the same delivery (~8 times over 24h). Combined with the not-yet-present delivery-id dedup and the check-then-insert race, one flaky Supabase call (statement timeout, momentary connection cap, a thrown `resolveWorkspaces`/`enqueueFlowsForIssueEvent`) could make GitHub hammer the same webhook and land multiple duplicate triage/flow jobs.

A queue-backed receiver's job is to "accept and ack fast, even if downstream work fails." Returning 500 surrenders that property.

## Change

The catch-all now responds **200** with `{ ok: false, error: 'handler error' }` so GitHub does not retry. The failure is still logged server-side, and `/api/cron/triage-sweep` remains the recovery safety net.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)