### PR TITLE
fix: FileStoreAdapter fsync before rename (#70)

### DIFF
--- a/packages/cli/src/adapters/file-store.adapter.ts
+++ b/packages/cli/src/adapters/file-store.adapter.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, rename, mkdir, unlink } from 'node:fs/promises';
+import { readFile, open, rename, mkdir, unlink } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { StoreSchema, type Store, type StorePort } from '@cezar/core';
@@ -22,8 +22,17 @@ export class FileStoreAdapter implements StorePort {
   async save(store: Store): Promise<void> {
     await mkdir(dirname(this.filePath), { recursive: true });
     const tmpPath = `${this.filePath}.${randomUUID()}.tmp`;
-    await writeFile(tmpPath, JSON.stringify(store, null, 2), 'utf-8');
     try {
+      // fsync the temp file before renaming so a crash/power loss between the
+      // write and the next fsync can't leave a zero-byte store.json (rename(2)
+      // only orders the dir entry, not the file data).
+      const fh = await open(tmpPath, 'w');
+      try {
+        await fh.writeFile(JSON.stringify(store, null, 2), 'utf-8');
+        await fh.sync();
+      } finally {
+        await fh.close();
+      }
       await rename(tmpPath, this.filePath);
     } catch (error) {
       await unlink(tmpPath).catch(() => {});


### PR DESCRIPTION
## Summary

The CLI file store's atomic-write path used `writeFile` followed by `rename`. `writeFile` does not fsync, so on Linux ext4 (`data=ordered`) or macOS APFS a power loss or `kill -9` between the write and the next fsync could leave the renamed `store.json` with zero bytes — `rename(2)` only orders the directory entry, not the file data. The next `cezar` invocation would then fail Zod validation and lose all local state (sync history, digests, analysis timestamps).

This change opens the temp file, writes, calls `fh.sync()` (fsync), then renames — so the file data is durably committed before the atomic rename. Temp-file cleanup on error now also covers a failure during the write/fsync phase.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)