### PR TITLE
fix: clean up leaked workflow_runs row on aborted runner claim (#76)

### DIFF
--- a/packages/gui/src/app/api/runner/jobs/route.ts
+++ b/packages/gui/src/app/api/runner/jobs/route.ts
@@ -81,8 +81,20 @@ export async function GET(req: Request) {
   if (!job) return NextResponse.json({ job: null });
 
   // From here on, any failure should release the job back to the queue so it
-  // isn't stuck `claimed` until the watchdog.
+  // isn't stuck `claimed` until the watchdog. If we already inserted a fresh
+  // `workflow_runs` row for this claim (vs. reusing an in-flight one), mark it
+  // `failed` so it doesn't leak as a phantom `running` row the next claim's
+  // reuse branch could latch onto — leaving two runners writing to it.
+  let insertedRunRowId: string | null = null;
   const releaseJob = async () => {
+    if (insertedRunRowId) {
+      await admin.from('workflow_runs').update({
+        status: 'failed',
+        finished_at: new Date().toISOString(),
+        reason: 'claim aborted before runner ack',
+        updated_at: new Date().toISOString(),
+      }).eq('id', insertedRunRowId);
+    }
     await admin.from('jobs').update({
       status: 'queued',
       claimed_by_runner: null,
@@ -243,6 +255,10 @@ export async function GET(req: Request) {
         .single();
       if (runErr || !runRow) throw new Error(`workflow_runs insert failed: ${runErr?.message}`);
       runRowId = runRow.id;
+      // Track the freshly-inserted row so `releaseJob` can mark it `failed`
+      // rather than leak it as a phantom `running` row. We don't touch the
+      // reuse branch's row — that one legitimately belongs to a prior claim.
+      insertedRunRowId = runRowId;
     }
 
     await admin.from('jobs').update({ status: 'running', updated_at: new Date().toISOString() }).eq('id', job.id);


### PR DESCRIPTION
## Summary

The runner `/api/runner/jobs` claim path inserts a `workflow_runs` row (`status='running'`) *before* marking the job running and returning the response to the runner. The `releaseJob` recovery (run in the `catch` block) only requeued the `jobs` row — it never cleaned up the `workflow_runs` row it had inserted.

So when a claim aborts after the insert (runner disconnect, proxy timeout, serialization error, runner crash before recording the run id), the `workflow_runs` row stays `running` forever as a phantom run that never emits events. Worse: the next claim's reuse branch keys on `job_id` and latches onto that orphaned `running` row, so two runners could end up writing to the same row.

## Fix

Track the freshly-inserted `workflow_runs` row id (`insertedRunRowId`) and, in `releaseJob`, mark it `failed` (with `finished_at` + a `reason`) before requeuing the job. The reuse branch's row is deliberately left untouched — it legitimately belongs to a prior claim that this request only re-claimed.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)