### PR TITLE
fix: team role/remove actions throw raw errors with no UI feedback (#73)

### DIFF
--- a/packages/gui/src/app/settings/team-actions.ts
+++ b/packages/gui/src/app/settings/team-actions.ts
@@ -43,36 +43,45 @@ export async function inviteMember(
   return { ok: true };
 }
 
-export async function changeMemberRole(userId: string, role: WorkspaceRole) {
+export async function changeMemberRole(
+  userId: string,
+  role: WorkspaceRole,
+): Promise<TeamActionState> {
   const user = await getSessionUser();
-  if (!user) throw new Error('Not authenticated');
+  if (!user) return { error: 'Not authenticated' };
   const workspace = await getActiveWorkspace();
-  if (!workspace || workspace.role !== 'admin') throw new Error('Admin access required');
-  if (userId === user.id) throw new Error('Cannot change your own role');
+  if (!workspace || workspace.role !== 'admin') return { error: 'Admin access required' };
+  if (userId === user.id) return { error: 'Cannot change your own role' };
 
   const supabase = createSupabaseAdminClient();
-  await supabase
+  const { error } = await supabase
     .from('workspace_members')
     .update({ role })
     .eq('workspace_id', workspace.id)
     .eq('user_id', userId);
 
+  if (error) return { error: error.message };
+
   revalidatePath('/settings');
+  return { ok: true };
 }
 
-export async function removeMember(userId: string) {
+export async function removeMember(userId: string): Promise<TeamActionState> {
   const user = await getSessionUser();
-  if (!user) throw new Error('Not authenticated');
+  if (!user) return { error: 'Not authenticated' };
   const workspace = await getActiveWorkspace();
-  if (!workspace || workspace.role !== 'admin') throw new Error('Admin access required');
-  if (userId === user.id) throw new Error('Cannot remove yourself');
+  if (!workspace || workspace.role !== 'admin') return { error: 'Admin access required' };
+  if (userId === user.id) return { error: 'Cannot remove yourself' };
 
   const supabase = createSupabaseAdminClient();
-  await supabase
+  const { error } = await supabase
     .from('workspace_members')
     .delete()
     .eq('workspace_id', workspace.id)
     .eq('user_id', userId);
 
+  if (error) return { error: error.message };
+
   revalidatePath('/settings');
+  return { ok: true };
 }

--- a/packages/gui/src/app/settings/team-section.tsx
+++ b/packages/gui/src/app/settings/team-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useActionState } from 'react';
+import { useActionState, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
 import { cn } from '@/components/ui/cn';
 import { TrashIcon } from '@/components/icons';
 import { inviteMember, changeMemberRole, removeMember, type TeamActionState } from './team-actions';
@@ -22,9 +23,36 @@ interface TeamSectionProps {
 
 export function TeamSection({ members, isAdmin, currentUserId }: TeamSectionProps) {
   const [inviteState, inviteAction, invitePending] = useActionState<TeamActionState, FormData>(inviteMember, {});
+  const router = useRouter();
+  const [memberError, setMemberError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onRoleChange = (userId: string, role: WorkspaceRole): void => {
+    setMemberError(null);
+    startTransition(async () => {
+      const res = await changeMemberRole(userId, role);
+      if (!res?.ok) setMemberError(res?.error ?? 'Failed to change role');
+      else router.refresh();
+    });
+  };
+
+  const onRemove = (userId: string, label: string): void => {
+    if (!confirm(`Remove ${label} from this workspace?`)) return;
+    setMemberError(null);
+    startTransition(async () => {
+      const res = await removeMember(userId);
+      if (!res?.ok) setMemberError(res?.error ?? 'Failed to remove member');
+      else router.refresh();
+    });
+  };
 
   return (
     <div className="space-y-6">
+      {memberError && (
+        <div className="rounded-md border border-error/40 bg-error/10 px-3 py-2 text-xs text-error">
+          {memberError}
+        </div>
+      )}
       {/* Members table */}
       <div className="overflow-hidden rounded-md border border-outline-variant">
         <table className="min-w-full text-sm">
@@ -63,8 +91,9 @@ export function TeamSection({ members, isAdmin, currentUserId }: TeamSectionProp
                   {isAdmin && m.userId !== currentUserId ? (
                     <select
                       value={m.role}
-                      onChange={(e) => changeMemberRole(m.userId, e.target.value as WorkspaceRole)}
-                      className="h-8 rounded-md border border-outline-variant bg-surface px-2 text-xs text-on-surface focus:border-primary focus:outline-none"
+                      onChange={(e) => onRoleChange(m.userId, e.target.value as WorkspaceRole)}
+                      disabled={pending}
+                      className="h-8 rounded-md border border-outline-variant bg-surface px-2 text-xs text-on-surface focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <option value="admin">admin</option>
                       <option value="actor">actor</option>
@@ -81,8 +110,9 @@ export function TeamSection({ members, isAdmin, currentUserId }: TeamSectionProp
                   <td className="px-4 py-3 text-right align-middle">
                     {m.userId !== currentUserId && (
                       <button
-                        onClick={() => removeMember(m.userId)}
-                        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-outline-variant text-on-surface-variant transition-colors hover:border-error/40 hover:text-error"
+                        onClick={() => onRemove(m.userId, m.name || m.email)}
+                        disabled={pending}
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-outline-variant text-on-surface-variant transition-colors hover:border-error/40 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
                         title="Remove member"
                         aria-label={`Remove ${m.name || m.email}`}
                       >


### PR DESCRIPTION
## Summary

`changeMemberRole` and `removeMember` (settings team actions) used to `throw new Error(...)` and were called directly from `onChange`/`onClick` handlers in `team-section.tsx` without `await`/`.catch`. This produced unhandled promise rejections, no visible revalidation, and silently swallowed Supabase errors.

### Changes
- **`team-actions.ts`**: both actions now return the existing `{ ok, error }` `TeamActionState` shape instead of throwing, and the Supabase `update`/`delete` `error` is checked and surfaced.
- **`team-section.tsx`**: the client wires both handlers through `useTransition`, shows failures in an inline error banner, and calls `router.refresh()` on success so the page reflects server truth. The role `<select>` stays controlled by `m.role`, so a failed change reverts visually instead of showing a stale value.
- Added a `confirm(...)` guard before removing a member, and disabled the controls while a transition is pending.

The fix mirrors the established pattern already used by `inviteMember` and `labels-section.tsx` in the same folder.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)