### PR TITLE
fix: scope label-analysis job cancel to selected analyses (#85)

### DIFF
--- a/packages/gui/src/app/settings/labels-actions.ts
+++ b/packages/gui/src/app/settings/labels-actions.ts
@@ -109,7 +109,8 @@ export async function cancelLabelAnalysis(): Promise<{ ok: boolean; cancelled: n
     .update({ status: 'cancelled', updated_at: ts })
     .eq('workspace_id', workspace.id)
     .eq('kind', 'label-analysis')
-    .in('status', ['queued', 'claimed', 'running']);
+    .in('status', ['queued', 'claimed', 'running'])
+    .in('payload->>analysisId', analysisIds);
   if (jErr) {
     // Non-fatal: analyses are already cancelled. Log + continue.
     console.error('[cancelLabelAnalysis] job update failed:', jErr.message);


### PR DESCRIPTION
## Summary

`cancelLabelAnalysis` in `packages/gui/src/app/settings/labels-actions.ts` marked the in-flight analyses as cancelled, then ran a broad `jobs` update that hit **every** queued/claimed/running `label-analysis` job for the workspace — not just the ones it had selected. A concurrent admin click or an auto-retry that enqueued a fresh job in the gap between the SELECT and the UPDATE would get killed.

This scopes the job cancel to the `analysisIds` we just marked cancelled by adding `.in('payload->>analysisId', analysisIds)`, matching the intent already described in the in-code comment.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)