### PR TITLE
fix: enqueueWorkflowRun job-kind allowlist + number validation (#84)

### DIFF
--- a/packages/gui/src/app/cockpit/actions.ts
+++ b/packages/gui/src/app/cockpit/actions.ts
@@ -227,6 +227,8 @@ export async function retryRun(runId: string): Promise<ActionResult> {
  * This is the minimal "enqueue from the UI" path; `retryRun` above also inserts
  * jobs.
  */
+const ENQUEUEABLE_KINDS: readonly JobKind[] = ['autofix', 'triage', 'ci-followup'];
+
 export async function enqueueWorkflowRun(params: {
   workflow: JobKind;
   issueNumber?: number;
@@ -237,6 +239,22 @@ export async function enqueueWorkflowRun(params: {
   const workspace = await getActiveWorkspace();
   if (!workspace) return { error: 'No workspace selected' };
   if (workspace.role === 'viewer') return { error: 'Viewers cannot start runs' };
+
+  if (!ENQUEUEABLE_KINDS.includes(params.workflow)) {
+    return { error: 'Unsupported workflow kind' };
+  }
+  if (
+    params.issueNumber != null &&
+    (!Number.isInteger(params.issueNumber) || params.issueNumber <= 0)
+  ) {
+    return { error: 'Invalid issue number' };
+  }
+  if (
+    params.prNumber != null &&
+    (!Number.isInteger(params.prNumber) || params.prNumber <= 0)
+  ) {
+    return { error: 'Invalid PR number' };
+  }
 
   const repo =
     workspace.repoOwner && workspace.repoName ? `${workspace.repoOwner}/${workspace.repoName}` : null;


### PR DESCRIPTION
## Summary

`enqueueWorkflowRun` (cockpit server action) took `params.workflow: JobKind` from the client and inserted it straight into `jobs.kind` with no runtime allowlist. The cockpit UI only surfaces `autofix`/`triage`, but a signed-in non-viewer could craft a direct server-action call and enqueue an unsupported kind (`label-analysis` — the executor expects an `analysisId` and would crash; `flow` — no `flowId`). `issueNumber`/`prNumber` were also not range-validated.

This adds:
- An `ENQUEUEABLE_KINDS` allowlist (`autofix`, `triage`, `ci-followup`) — anything else returns `Unsupported workflow kind`.
- Integer/positive validation for `issueNumber` and `prNumber`.

Scoped to the one server action; the existing `EnqueueRunButton` only ever sends `autofix`/`triage`, so no UI change is needed.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)