### PR TITLE
fix: cap per-runner long-polls and release jobs on client disconnect (#83)

### DIFF
--- a/packages/gui/src/app/api/runner/jobs/route.ts
+++ b/packages/gui/src/app/api/runner/jobs/route.ts
@@ -70,8 +70,8 @@ export async function GET(req: Request) {
   // timeout / client disconnect) and try once more. We only enter this if the
   // caller asked for it AND the in-process listener pool has room — otherwise
   // we behave like the old short-poll (single attempt, return null).
-  if (!job && waitSec > 0 && canAcquireListener()) {
-    const woke = await waitForJobsQueuedNotify(waitSec * 1000, req.signal);
+  if (!job && waitSec > 0 && canAcquireListener(runner.id)) {
+    const woke = await waitForJobsQueuedNotify(waitSec * 1000, req.signal, runner.id);
     if (woke && !req.signal.aborted) {
       try { job = await claimOnce(); }
       catch (err) { return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 }); }
@@ -90,6 +90,18 @@ export async function GET(req: Request) {
       updated_at: new Date().toISOString(),
     }).eq('id', job.id);
   };
+
+  // Disconnect race: a claim can land AFTER the runner walked away (it timed
+  // out / aborted the long-poll between the NOTIFY wake and the claim
+  // committing). The runner will never read this response, so the job would
+  // sit `running`/`claimed` — showing a phantom `running` in the cockpit and
+  // orphaning the workflow_runs row below — until the lease expires. Give the
+  // job straight back and bail BEFORE the expensive workspace/config/store
+  // work. 499 = "client closed request" (nginx convention).
+  if (req.signal.aborted) {
+    await releaseJob().catch(() => {});
+    return new Response(null, { status: 499 });
+  }
 
   try {
     const core = await import('@cezar/core');

--- a/packages/gui/src/lib/pg-listen.ts
+++ b/packages/gui/src/lib/pg-listen.ts
@@ -41,15 +41,28 @@ export function getPgConnectionString(): string | null {
 const MAX_CONCURRENT_LISTENERS = 64;
 let activeListeners = 0;
 
+// Per-runner cap: a single buggy/malicious runner opening many concurrent
+// `?wait=25` connections must not be able to drain the whole global pool and
+// starve every other runner. Keep this small — a healthy runner only needs
+// one in-flight long-poll at a time; 2 leaves room for a re-poll racing the
+// previous one's teardown without ever monopolizing the pool.
+const MAX_LISTENERS_PER_RUNNER = 2;
+const perRunnerListeners = new Map<string, number>();
+
 /** Current count of in-flight long-poll connections (for /api/runner/jobs). */
 export function getActiveListenerCount(): number {
   return activeListeners;
 }
 
-/** True if the long-poll pool has room; callers use this to decide between
+/** True if the long-poll pool has room AND (when a runnerId is given) that
+ * runner is under its per-runner cap; callers use this to decide between
  * long-poll and short-poll on each request. */
-export function canAcquireListener(): boolean {
-  return activeListeners < MAX_CONCURRENT_LISTENERS;
+export function canAcquireListener(runnerId?: string): boolean {
+  if (activeListeners >= MAX_CONCURRENT_LISTENERS) return false;
+  if (runnerId !== undefined && (perRunnerListeners.get(runnerId) ?? 0) >= MAX_LISTENERS_PER_RUNNER) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -64,16 +77,18 @@ export function canAcquireListener(): boolean {
 export async function waitForJobsQueuedNotify(
   timeoutMs: number,
   abort?: AbortSignal,
+  runnerId?: string,
 ): Promise<boolean> {
   const conn = getPgConnectionString();
   if (!conn || timeoutMs <= 0) return false;
-  if (!canAcquireListener()) return false;
+  if (!canAcquireListener(runnerId)) return false;
 
   // Supabase's pooled connection string (pgbouncer) does NOT carry LISTEN
   // sessions. Allow callers to point at the direct (5432) connection string;
   // the helper just trusts whatever it gets.
   const client = new Client({ connectionString: conn });
   activeListeners += 1;
+  if (runnerId !== undefined) perRunnerListeners.set(runnerId, (perRunnerListeners.get(runnerId) ?? 0) + 1);
 
   let notified = false;
   let timer: NodeJS.Timeout | null = null;
@@ -108,6 +123,11 @@ export async function waitForJobsQueuedNotify(
     try { await client.query(`UNLISTEN ${JOBS_QUEUED_CHANNEL}`); } catch { /* terminal */ }
     try { await client.end(); } catch { /* terminal */ }
     activeListeners -= 1;
+    if (runnerId !== undefined) {
+      const next = (perRunnerListeners.get(runnerId) ?? 1) - 1;
+      if (next <= 0) perRunnerListeners.delete(runnerId);
+      else perRunnerListeners.set(runnerId, next);
+    }
   }
 
   return notified;


### PR DESCRIPTION
## Summary

Closes two resource-exhaustion gaps in the runner `/api/runner/jobs` long-poll path (audit issue #83):

- **Per-runner long-poll cap.** `canAcquireListener()` only enforced a single global cap (`MAX_CONCURRENT_LISTENERS = 64`), so one buggy/malicious runner could open many concurrent `?wait=25` connections and drain the whole pool, starving every other runner. Added a per-`runner.id` cap (`MAX_LISTENERS_PER_RUNNER = 2`) tracked in a `Map` alongside the global counter in `pg-listen.ts`. Both `canAcquireListener(runnerId)` and `waitForJobsQueuedNotify(..., runnerId)` now take an optional `runnerId` (backward-compatible).
- **Release on client disconnect.** A claim could commit *after* the runner already disconnected (raced between the NOTIFY wake and the claim committing). The runner never reads the response, so the job sat `running`/`claimed` — a phantom `running` in the cockpit plus an orphaned `workflow_runs` insert — until the lease expired. Now we re-check `req.signal.aborted` immediately after the claim succeeds and, if aborted, `releaseJob()` and return `499` *before* the expensive workspace/config/store work.

## Testing

Reviewed the change by reading it back. No build/typecheck run per task constraints. Both new params are optional so existing call sites are unaffected; the route is the sole caller.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)