### PR TITLE
fix: validate runner-reported github_installation_id on heartbeat (#80)

### DIFF
--- a/packages/gui/src/app/api/runner/heartbeat/route.ts
+++ b/packages/gui/src/app/api/runner/heartbeat/route.ts
@@ -65,6 +65,37 @@ export async function POST(req: Request) {
   });
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
+  // Trust-boundary guard (issue #80): `github_installation_id` is consumed by
+  // `/jobs` to mint an installation access token against ANY id the central
+  // App can reach. A runner must not be able to pivot to an arbitrary
+  // installation by self-reporting one on its own heartbeat. So:
+  //   • workspace-scoped runner → the requested id must equal its own
+  //     workspace's recorded `installation_id` (set by the GitHub App
+  //     `installation` webhook). Clearing (null) is always allowed.
+  //   • managed runner (no workspace_id) → refuse heartbeat-driven sets
+  //     entirely; a managed runner's install must be flipped in the admin GUI.
+  if (body.githubInstallationId !== undefined && body.githubInstallationId !== null) {
+    if (runner.workspace_id == null) {
+      return NextResponse.json(
+        { error: 'managed runners cannot self-set github_installation_id; configure it in the admin GUI' },
+        { status: 403 },
+      );
+    }
+    const { data: ws, error: wsErr } = await admin
+      .from('workspaces')
+      .select('installation_id')
+      .eq('id', runner.workspace_id)
+      .maybeSingle();
+    if (wsErr) return NextResponse.json({ error: wsErr.message }, { status: 500 });
+    // `workspaces.installation_id` is text; the runner reports a number.
+    if (!ws?.installation_id || String(body.githubInstallationId) !== ws.installation_id) {
+      return NextResponse.json(
+        { error: 'github_installation_id does not match this runner\'s workspace installation' },
+        { status: 403 },
+      );
+    }
+  }
+
   // Phase 4 (migration 0026) — runner self-describes its GitHub identity.
   // Phase 5 (migration 0027) — runner reports its utilization snapshot.
   // Only update fields the runner actually sent, so older daemons (and
@@ -81,8 +112,9 @@ export async function POST(req: Request) {
       patch.github_inherit_host = body.githubInheritHost;
     }
     if (body.githubInstallationId !== undefined) {
-      // null clears the per-runner install; a number sets it. The claim
-      // route enforces precedence (inherit_host wins).
+      // null clears the per-runner install; a number sets it (validated above
+      // to match the runner's workspace installation). The claim route
+      // enforces precedence (inherit_host wins).
       patch.github_installation_id = body.githubInstallationId;
     }
     if (body.utilization !== undefined) {

--- a/packages/gui/src/app/settings/runners/runners-actions.ts
+++ b/packages/gui/src/app/settings/runners/runners-actions.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getActiveWorkspace } from '@/lib/workspace';
-import { hashRunnerToken } from '@/app/api/runner/_auth';
+import { hashRunnerToken, invalidateRunnerAuth } from '@/app/api/runner/_auth';
 
 /** Backends a *self-hosted* runner may advertise. */
 const VALID_BACKENDS = ['claude-cli', 'codex-cli', 'anthropic-api'] as const;
@@ -78,12 +78,22 @@ export async function revokeRunner(
   if (!id) return { error: 'Missing runner id' };
 
   const supabase = await createSupabaseServerClient();
+  // Grab the token hash before deleting so we can drop it from the in-process
+  // runner-auth cache — without this the revoked token keeps authenticating
+  // for up to RUNNER_AUTH_TTL_MS (issue #80). Best-effort across runtimes.
+  const { data: row } = await supabase
+    .from('runners')
+    .select('token_hash')
+    .eq('id', id)
+    .eq('workspace_id', workspace.id)
+    .maybeSingle();
   const { error } = await supabase
     .from('runners')
     .delete()
     .eq('id', id)
     .eq('workspace_id', workspace.id);
   if (error) return { error: error.message };
+  if (row?.token_hash) invalidateRunnerAuth(row.token_hash);
 
   revalidatePath('/settings/runners');
   return { ok: true };


### PR DESCRIPTION
## Summary

The runner `POST /api/runner/heartbeat` route wrote the runner-supplied `github_installation_id` straight onto the `runners` row with no shape or ownership check. Because `/api/runner/jobs` mints a GitHub installation access token against that id, a curious or compromised runner could pivot to **any** installation the central App can reach simply by setting the field on its own heartbeat (the `/jobs` bound-runner check never re-verifies the requested installation against the runner's workspace).

This change guards the write:

- **Workspace-scoped runner** — the reported id must equal its workspace's recorded `installation_id` (the value set by the GitHub App `installation` webhook). Clearing it (`null`) is still allowed. Mismatch returns `403`.
- **Managed runner** (no `workspace_id`) — heartbeat-driven sets are refused entirely; such a runner's install id must be configured in the admin GUI. Returns `403`.

Also closes the secondary token-revocation gap from the audit: `invalidateRunnerAuth` is now wired into the `revokeRunner` flow so a revoked token stops authenticating immediately instead of lingering for the 30s auth-cache TTL (best-effort across runtimes — drops the entry in the process that handles the revoke).

Scope is limited to these two trust-boundary checks; the `utilization` JSONB write (low-risk, opaque) and the lease-renewal RPC (already filtered to `claimed_by_runner = runner.id` in-DB) are left as-is.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)