### PR TITLE
fix: serialize per-repo worktree to prevent concurrent-job corruption (#78)

### DIFF
--- a/packages/gui/src/app/skills/skills-action.ts
+++ b/packages/gui/src/app/skills/skills-action.ts
@@ -7,7 +7,7 @@ import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { loadWorkspaceConfig } from '@/lib/load-workspace-config';
-import { ensureRepoClone } from '@/lib/repo-clone';
+import { ensureRepoClone, withRepoLock } from '@/lib/repo-clone';
 
 const exec = promisify(execFile);
 
@@ -57,22 +57,26 @@ export async function refreshRepoSkills(): Promise<RefreshSkillsResult> {
   }
   if (!token) return { ok: false, error: 'No GitHub token — sign out and back in to refresh' };
 
-  let repoRoot: string;
+  // Hold the per-repo worktree lock across the clone + reads (rev-parse +
+  // discoverSkills) so a concurrent triage/autofix job can't checkout/reset the
+  // shared tree out from under us (see withRepoLock in lib/repo-clone).
+  let commitSha: string | null = null;
+  let skills: Awaited<ReturnType<typeof core.discoverSkills>>;
   try {
-    repoRoot = await ensureRepoClone(owner, repo, token, baseBranch);
+    ({ commitSha, skills } = await withRepoLock(owner, repo, async () => {
+      const repoRoot = await ensureRepoClone(owner, repo, token, baseBranch);
+      let sha: string | null = null;
+      try {
+        const { stdout } = await exec('git', ['rev-parse', 'HEAD'], { cwd: repoRoot });
+        sha = stdout.trim() || null;
+      } catch {
+        sha = null;
+      }
+      return { commitSha: sha, skills: await core.discoverSkills(repoRoot, skillsDir) };
+    }));
   } catch (err) {
     return { ok: false, error: `Clone failed: ${err instanceof Error ? err.message : String(err)}` };
   }
-
-  let commitSha: string | null = null;
-  try {
-    const { stdout } = await exec('git', ['rev-parse', 'HEAD'], { cwd: repoRoot });
-    commitSha = stdout.trim() || null;
-  } catch {
-    commitSha = null;
-  }
-
-  const skills = await core.discoverSkills(repoRoot, skillsDir);
   // discoverSkills now returns the merged catalog (built-in shipped with
   // Cezar + repo skills under .ai/skills). We cache both so the GUI doesn't
   // need to re-discover built-ins on every render — the source field tells

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -11,7 +11,7 @@ import {
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { loadWorkspaceConfig } from '@/lib/load-workspace-config';
-import { ensureRepoClone } from '@/lib/repo-clone';
+import { ensureRepoClone, withRepoLock } from '@/lib/repo-clone';
 import type { Database } from '@/lib/supabase/types';
 
 /**
@@ -478,17 +478,24 @@ export async function renderStepPreview(params: {
   let skillBodyMissing = true;
   try {
     const config = await loadWorkspaceConfig(workspace.id, supabase, {});
-    if (!config.autofix.repoRoot && config.github.owner && config.github.repo) {
-      config.autofix.repoRoot = await ensureRepoClone(
-        config.github.owner,
-        config.github.repo,
-        config.github.token,
-        config.autofix.baseBranch,
-      );
-    }
-    if (config.autofix.repoRoot) {
-      const skills = await discoverSkills(config.autofix.repoRoot, config.autofix.skillsDir ?? '.ai/skills');
-      const hit = skills.find((s) => s.name === step.skill);
+    if (config.github.owner && config.github.repo) {
+      // Serialize the clone + skill read on the shared per-repo worktree so a
+      // concurrent triage/autofix job can't reset it mid-read (see
+      // withRepoLock in lib/repo-clone).
+      const owner = config.github.owner;
+      const repo = config.github.repo;
+      const hit = await withRepoLock(owner, repo, async () => {
+        if (!config.autofix.repoRoot) {
+          config.autofix.repoRoot = await ensureRepoClone(
+            owner,
+            repo,
+            config.github.token,
+            config.autofix.baseBranch,
+          );
+        }
+        const skills = await discoverSkills(config.autofix.repoRoot, config.autofix.skillsDir ?? '.ai/skills');
+        return skills.find((s) => s.name === step.skill);
+      });
       if (hit) {
         skillBody = hit.body;
         skillBodyMissing = false;

--- a/packages/gui/src/lib/execute-label-analysis-job.ts
+++ b/packages/gui/src/lib/execute-label-analysis-job.ts
@@ -5,7 +5,7 @@ import { Octokit } from '@octokit/rest';
 import Anthropic from '@anthropic-ai/sdk';
 import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { ensureRepoClone } from './repo-clone';
+import { ensureRepoClone, withRepoLock } from './repo-clone';
 import type {
   Database,
   LabelAnalysisDraft,
@@ -155,8 +155,12 @@ export async function executeLabelAnalysisJob(
     // ── 2. codebase guide files ───────────────────────────────────────
     let codebaseGuides: Array<{ path: string; content: string }> = [];
     try {
-      const repoRoot = await ensureRepoClone(owner, repo, githubToken);
-      codebaseGuides = await readCodebaseGuides(repoRoot);
+      // Hold the per-repo worktree lock across the clone + read so a sibling
+      // triage/autofix job can't checkout/reset the tree mid-read.
+      codebaseGuides = await withRepoLock(owner, repo, async () => {
+        const repoRoot = await ensureRepoClone(owner, repo, githubToken);
+        return readCodebaseGuides(repoRoot);
+      });
     } catch (err) {
       // Non-fatal — the analysis just runs without codebase guides.
       console.warn(

--- a/packages/gui/src/lib/execute-workflow-job.ts
+++ b/packages/gui/src/lib/execute-workflow-job.ts
@@ -4,7 +4,7 @@ import { SupabaseStoreAdapter } from './adapters/supabase-store';
 import { loadWorkspaceConfig } from './load-workspace-config';
 import { loadWorkspaceLabels } from './load-workspace-labels';
 import { createWorkflowRunPersister, type WorkflowRunPersister } from './persist-workflow-run';
-import { ensureRepoClone } from './repo-clone';
+import { acquireRepoLock, ensureRepoClone } from './repo-clone';
 import { runTriagePassJob } from './run-triage-pass-job';
 import type { Database } from './supabase/types';
 
@@ -49,6 +49,10 @@ export async function executeWorkflowJob(
 ): Promise<void> {
   const { workspaceId, workflow, issueNumber, prNumber, jobId, ciFollowupSeed, flowId, flowInput } = params;
   let persister: WorkflowRunPersister | null = null;
+  // Held for the whole run: the engine clones into a per-repo shared worktree
+  // and the agent edits it across steps, so concurrent jobs for the same repo
+  // must be serialized (see withRepoLock in repo-clone). Released in finally.
+  let releaseRepoLock: (() => void) | null = null;
 
   const finishJob = async (status: Database['public']['Tables']['jobs']['Row']['status']): Promise<void> => {
     if (!jobId) return;
@@ -99,6 +103,10 @@ export async function executeWorkflowJob(
     const labels: WorkspaceLabel[] = await loadWorkspaceLabels(adminSupabase, workspaceId);
 
     if (!config.autofix.repoRoot) {
+      // Serialize on the shared per-repo worktree before the clone, and hold
+      // the lock until the run finishes (released in the finally below) so a
+      // sibling job can't reset/checkout the tree while the agent edits it.
+      releaseRepoLock = await acquireRepoLock(config.github.owner, config.github.repo);
       const repoRoot = await ensureRepoClone(
         config.github.owner,
         config.github.repo,
@@ -336,6 +344,9 @@ export async function executeWorkflowJob(
     console.error('[dispatch] executeWorkflowJob failed:', message);
     if (persister) await persister.fail(message).catch(() => {});
     await finishJob('failed').catch(() => {});
+  } finally {
+    // Release the per-repo worktree lock so the next job for this repo can run.
+    releaseRepoLock?.();
   }
 }
 

--- a/packages/gui/src/lib/repo-clone.ts
+++ b/packages/gui/src/lib/repo-clone.ts
@@ -10,11 +10,84 @@ const exec = promisify(execFile);
 const REPOS_DIR = join(homedir(), '.cezar', 'repos');
 
 /**
+ * Per-(owner,repo) in-process serialization for the shared working tree under
+ * `~/.cezar/repos/<owner>-<repo>`.
+ *
+ * `ensureRepoClone` shares one working tree per repo and does `git fetch` +
+ * `git reset --hard`; the cron dispatcher fires several jobs per tick, so two
+ * jobs for the same workspace (e.g. a webhook burst of `triage` jobs, or a
+ * `triage` + `autofix`) would otherwise race on the same checkout — one job's
+ * reset clobbers files an agent in another job is editing, and concurrent
+ * fetches can corrupt the pack files. The lock is held for the full duration of
+ * the work that touches the tree (clone + agent run), not just the clone.
+ *
+ * This serializes within a single Node process only; a multi-replica
+ * deployment must rely on the job lease (`claim_next_job` /
+ * `requeue_stalled_jobs`) keeping at most one live run per repo.
+ */
+const repoLocks = new Map<string, Promise<void>>();
+
+function repoLockKey(owner: string, repo: string): string {
+  return `${owner}/${repo}`;
+}
+
+/**
+ * Acquires the per-(owner,repo) working-tree lock and resolves once it's held.
+ * Returns a `release` function the caller MUST call (e.g. from a `finally`)
+ * when it's done with the worktree. Prefer {@link withRepoLock} unless the
+ * locked region spans control flow a callback can't easily wrap.
+ */
+export async function acquireRepoLock(owner: string, repo: string): Promise<() => void> {
+  const key = repoLockKey(owner, repo);
+  const prev = repoLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Chain so the next waiter starts only after this one releases. Swallow a
+  // prior rejection (there shouldn't be one — `next` only ever resolves) so the
+  // chain never gets stuck.
+  repoLocks.set(key, prev.then(() => next, () => next));
+  await prev.catch(() => {});
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+    if (repoLocks.get(key) === next) repoLocks.delete(key);
+  };
+}
+
+/**
+ * Runs `fn` while holding the per-(owner,repo) working-tree lock. Wrap every
+ * region that touches the shared clone (the {@link ensureRepoClone} call plus
+ * whatever reads/writes the returned worktree) in this so concurrent jobs for
+ * the same repo can't corrupt each other's checkout.
+ */
+export async function withRepoLock<T>(
+  owner: string,
+  repo: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireRepoLock(owner, repo);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
  * Ensures a local clone of the repo exists and is up-to-date.
  * Returns the absolute path to the repo root.
  *
  * Clones to ~/.cezar/repos/<owner>-<repo>. If already cloned,
  * fetches latest from origin.
+ *
+ * NOTE: the returned worktree is shared per repo. Callers MUST run this call —
+ * and everything that subsequently reads/writes the returned path — inside
+ * {@link withRepoLock} so concurrent jobs for the same repo don't race on the
+ * checkout (see the comment on {@link withRepoLock}).
  */
 export async function ensureRepoClone(
   owner: string,


### PR DESCRIPTION
## Summary

`ensureRepoClone` shares a single working tree per `owner/repo` under `~/.cezar/repos/<owner>-<repo>` and does `git fetch` + `git checkout` + `git reset --hard`. The cron dispatcher claims up to `CEZAR_DISPATCH_BATCH` jobs per tick and fires `executeWorkflowJob` for each fire-and-forget, so two jobs for the same workspace (a webhook burst of `triage` jobs, or `triage` + `autofix`) raced on that shared checkout — one job's `reset --hard` clobbered files an agent in another job was editing, both saw each other's local commits/index, and concurrent `git fetch` could corrupt the pack files.

## Fix

Added a per-`(owner,repo)` in-process async mutex in `packages/gui/src/lib/repo-clone.ts` (`acquireRepoLock` / `withRepoLock`) — option 2 from the issue — and hold it across the whole region that touches the shared tree:

- **`execute-workflow-job.ts`** — acquire the lock before the clone and release it in a new `finally`, so the lock spans the entire agent run (the agent edits the tree across steps, not just during the clone).
- **`execute-label-analysis-job.ts`**, **`skills/skills-action.ts`**, **`workflows/actions.ts`** — wrap the clone + read (`readCodebaseGuides` / `rev-parse` / `discoverSkills`) in `withRepoLock`.

Serializes within a single Node process; multi-replica deployments still rely on the job lease (`claim_next_job` / `requeue_stalled_jobs`) to keep at most one live run per repo, which is documented on the helper. The runner package has its own per-job worktree path (`prepareJobWorktree`) and is unaffected.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)