### PR TITLE
fix: rate-limit & cap simulate routes against LLM cost abuse (#82)

### DIFF
--- a/packages/gui/src/app/api/actions/[name]/simulate/route.ts
+++ b/packages/gui/src/app/api/actions/[name]/simulate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { checkRateLimit, isPromptTooLarge, MAX_PROMPT_BYTES } from '@/lib/simulate-guard';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -48,6 +49,14 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
   const workspace = await getActiveWorkspace();
   if (!workspace) return new Response('No workspace selected', { status: 400 });
 
+  const rate = checkRateLimit(user.id);
+  if (!rate.ok) {
+    return new Response('Too many simulations — slow down and try again shortly.', {
+      status: 429,
+      headers: { 'retry-after': String(rate.retryAfterSec) },
+    });
+  }
+
   const { name: rawName } = await ctx.params;
   const actionName = decodeURIComponent(rawName);
 
@@ -92,6 +101,12 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
   if (!systemPrompt) {
     return new Response('Action has no system prompt to simulate.', { status: 400 });
   }
+  if (isPromptTooLarge(systemPrompt)) {
+    return new Response(
+      `System prompt is too large to simulate (max ${MAX_PROMPT_BYTES / 1024} KiB).`,
+      { status: 413 },
+    );
+  }
 
   const skillRefs = Array.isArray(payload.skillRefs)
     ? payload.skillRefs
@@ -127,6 +142,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
       messages: {
         stream: (input: unknown) => AsyncIterable<unknown> & {
           on: (event: string, cb: (data: unknown) => void) => void;
+          controller?: { abort: () => void };
         };
       };
     };
@@ -159,6 +175,16 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
           max_tokens: MAX_TOKENS,
           system: `${systemPrompt}${skillSection}`,
           messages: [{ role: 'user', content: userPrompt }],
+        });
+
+        // If the client disconnects, cancel the upstream Anthropic call so we
+        // stop paying for tokens no one will read.
+        req.signal.addEventListener('abort', () => {
+          try {
+            sdkStream.controller?.abort();
+          } catch {
+            /* best-effort */
+          }
         });
 
         sdkStream.on('text', (delta: unknown) => {

--- a/packages/gui/src/app/api/skills/[name]/simulate/route.ts
+++ b/packages/gui/src/app/api/skills/[name]/simulate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { checkRateLimit, isPromptTooLarge, MAX_PROMPT_BYTES } from '@/lib/simulate-guard';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -44,6 +45,14 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
   const workspace = await getActiveWorkspace();
   if (!workspace) return new Response('No workspace selected', { status: 400 });
 
+  const rate = checkRateLimit(user.id);
+  if (!rate.ok) {
+    return new Response('Too many simulations — slow down and try again shortly.', {
+      status: 429,
+      headers: { 'retry-after': String(rate.retryAfterSec) },
+    });
+  }
+
   const { name: rawName } = await ctx.params;
   const skillName = decodeURIComponent(rawName);
 
@@ -81,6 +90,12 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
       status: 400,
     });
   }
+  if (isPromptTooLarge(systemPrompt)) {
+    return new Response(
+      `Skill prompt is too large to simulate (max ${MAX_PROMPT_BYTES / 1024} KiB).`,
+      { status: 413 },
+    );
+  }
 
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
@@ -95,6 +110,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
       messages: {
         stream: (input: unknown) => AsyncIterable<unknown> & {
           on: (event: string, cb: (data: unknown) => void) => void;
+          controller?: { abort: () => void };
         };
       };
     };
@@ -129,6 +145,16 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ name: stri
           max_tokens: MAX_TOKENS,
           system: systemPrompt,
           messages: [{ role: 'user', content: userPrompt }],
+        });
+
+        // If the client disconnects, cancel the upstream Anthropic call so we
+        // stop paying for tokens no one will read.
+        req.signal.addEventListener('abort', () => {
+          try {
+            sdkStream.controller?.abort();
+          } catch {
+            /* best-effort */
+          }
         });
 
         sdkStream.on('text', (delta: unknown) => {

--- a/packages/gui/src/lib/simulate-guard.ts
+++ b/packages/gui/src/lib/simulate-guard.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared abuse guards for the LLM-backed `simulate` routes
+ * (`/api/actions/[name]/simulate`, `/api/skills/[name]/simulate`).
+ *
+ * Both routes accept an arbitrary system prompt from a logged-in workspace
+ * member and stream an Anthropic completion back. Without bounds a curious or
+ * compromised member can script the endpoint to grind through the shared
+ * `ANTHROPIC_API_KEY` budget. These helpers add:
+ *   - a per-user sliding-window rate limit (in-memory, best-effort), and
+ *   - a hard length cap on the user-supplied prompt.
+ */
+
+/** Max bytes for a user-supplied system prompt before we reject the request. */
+export const MAX_PROMPT_BYTES = 64 * 1024; // 64 KiB
+
+/** Sliding-window size for the rate limiter. */
+const WINDOW_MS = 60_000;
+/** Max simulations allowed per user within the window. */
+const MAX_PER_WINDOW = 10;
+
+// Best-effort in-memory limiter. Per-instance only (resets on redeploy / is not
+// shared across serverless instances), which is acceptable for a cost-abuse
+// guard on a logged-in-only feature — it caps the worst case per instance.
+const hits = new Map<string, number[]>();
+
+/**
+ * Records a hit for `key` and returns whether the caller is within the limit.
+ * When over the limit, `retryAfterSec` is the seconds until the oldest hit in
+ * the window expires.
+ */
+export function checkRateLimit(key: string): { ok: boolean; retryAfterSec: number } {
+  const now = Date.now();
+  const cutoff = now - WINDOW_MS;
+  const recent = (hits.get(key) ?? []).filter((t) => t > cutoff);
+
+  if (recent.length >= MAX_PER_WINDOW) {
+    const retryAfterSec = Math.max(1, Math.ceil((recent[0] + WINDOW_MS - now) / 1000));
+    hits.set(key, recent);
+    return { ok: false, retryAfterSec };
+  }
+
+  recent.push(now);
+  hits.set(key, recent);
+  return { ok: true, retryAfterSec: 0 };
+}
+
+/** True when the prompt exceeds {@link MAX_PROMPT_BYTES}. */
+export function isPromptTooLarge(prompt: string): boolean {
+  // Byte length, not character length — multibyte chars must count fully.
+  return Buffer.byteLength(prompt, 'utf8') > MAX_PROMPT_BYTES;
+}


### PR DESCRIPTION
## Summary

The two LLM-backed simulate routes — `/api/actions/[name]/simulate` and `/api/skills/[name]/simulate` — accept an arbitrary system prompt from any logged-in workspace member and stream an Anthropic completion back. They previously had:

- **no rate limit** per user/workspace,
- **no length cap** on the user-supplied prompt (it can be MB-scale even though `max_tokens` is capped on output), and
- **no cancellation** of the upstream call on client disconnect — the SDK keeps consuming tokens no one reads.

That lets a curious or compromised member script the endpoint and grind through the shared `ANTHROPIC_API_KEY` budget.

## Changes

- New `packages/gui/src/lib/simulate-guard.ts`:
  - `checkRateLimit(userId)` — per-user sliding-window limiter (10 sims / 60s, in-memory best-effort).
  - `isPromptTooLarge(prompt)` / `MAX_PROMPT_BYTES` — 64 KiB byte cap.
- Both routes now:
  - return **429** (with `retry-after`) when over the rate limit,
  - return **413** when the resolved system prompt exceeds 64 KiB,
  - register `req.signal` `abort` → `sdkStream.controller?.abort()` so a client disconnect cancels the upstream Anthropic call.

Scoped, additive, no behavior change for in-bounds requests.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)