### PR TITLE
fix: throttle /workflows polling and skip background tabs (#89)

### DIFF
--- a/packages/gui/src/app/workflows/workflows-client.tsx
+++ b/packages/gui/src/app/workflows/workflows-client.tsx
@@ -44,10 +44,12 @@ export function WorkflowsClient({ workspaceName, workspaceRole, initialFlows, av
 
   useEffect(() => {
     if (dirty.size > 0 || pendingNew) return;
-    const i = window.setInterval(async () => {
-      const next = await listFlows();
-      setFlows(next);
-    }, 4000);
+    const tick = () => {
+      // Don't burn Supabase request budget polling a background tab.
+      if (document.visibilityState !== 'visible') return;
+      listFlows().then(setFlows);
+    };
+    const i = window.setInterval(tick, 15000);
     return () => window.clearInterval(i);
   }, [dirty.size, pendingNew]);
 


### PR DESCRIPTION
## Summary

The `/workflows` page polled the hefty `listFlows()` server action every **4 seconds** while idle. `listFlows()` joins `workflow_runs` (last 7d), `agent_runs`, and `agent_run_events` per latest step plus a `repo_skills` lookup, so every open tab — including background ones — kept firing that query bundle against the workspace connection.

This change applies the audit's suggested minimal fix:
- Guard the tick on `document.visibilityState === 'visible'` so background tabs stop polling.
- Slow the cadence from 4s to 15s.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)