### PR TITLE
fix: harden CockpitTabs isRunners path matching (#92)

### DIFF
--- a/packages/gui/src/app/cockpit/cockpit-tabs.tsx
+++ b/packages/gui/src/app/cockpit/cockpit-tabs.tsx
@@ -12,10 +12,12 @@ import { usePathname } from 'next/navigation';
  */
 export function CockpitTabs() {
   const pathname = usePathname() ?? '/cockpit';
-  // Detail pages match /cockpit/<uuid> but NOT /cockpit/runners.
-  const isDetail = /^\/cockpit\/[^/]+$/.test(pathname) && pathname !== '/cockpit/runners';
+  // Runners tab matches /cockpit/runners and its children, NOT sibling paths
+  // like /cockpit/runners-of-doom.
+  const isRunners = pathname === '/cockpit/runners' || pathname.startsWith('/cockpit/runners/');
+  // Detail pages match /cockpit/<id> but NOT the runners route.
+  const isDetail = /^\/cockpit\/[^/]+$/.test(pathname) && !isRunners;
   if (isDetail) return null;
-  const isRunners = pathname.startsWith('/cockpit/runners');
   return (
     <div className="border-b border-border bg-bg">
       <div className="flex items-center gap-1 px-8 pt-4">


### PR DESCRIPTION
## Summary

`CockpitTabs` marked the **Runners** tab active using `pathname.startsWith('/cockpit/runners')`, which produces false positives on sibling paths (e.g. `/cockpit/runners-of-doom`). It also left the detail-page carve-out hardcoded to the literal `'/cockpit/runners'`, so a future runners child route could be wrongly hidden.

This change:
- Computes `isRunners` as an exact match on `/cockpit/runners` plus its children (`/cockpit/runners/...`).
- Derives `isDetail` from `!isRunners` so the detail-page check and the runners tab stay in sync.

## Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)