### PR TITLE
fix: dedupe enqueueWorkflowRun and runFlowOnIssue against in-flight jobs (#91)

### DIFF
--- a/packages/gui/src/app/cockpit/actions.ts
+++ b/packages/gui/src/app/cockpit/actions.ts
@@ -242,6 +242,23 @@ export async function enqueueWorkflowRun(params: {
     workspace.repoOwner && workspace.repoName ? `${workspace.repoOwner}/${workspace.repoName}` : null;
 
   const supabase = createSupabaseAdminClient();
+
+  // Dedupe: a double-click, network burst, or stale tab must not queue two
+  // jobs for the same workflow+issue. If one's already in flight, return it.
+  if (params.issueNumber != null) {
+    const { data: existing } = await supabase
+      .from('jobs')
+      .select('id')
+      .eq('workspace_id', workspace.id)
+      .eq('kind', params.workflow)
+      .eq('issue_number', params.issueNumber)
+      .in('status', ['queued', 'claimed', 'running'])
+      .limit(1);
+    if (existing && existing.length > 0) {
+      return { ok: true, jobId: existing[0].id };
+    }
+  }
+
   const { data, error } = await supabase
     .from('jobs')
     .insert({

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -362,6 +362,22 @@ export async function runFlowOnIssue(params: {
     ? `${workspace.repoOwner}/${workspace.repoName}`
     : null;
 
+  // Dedupe: a double-click, network burst, or stale tab must not queue two
+  // jobs for the same flow+issue. Key on payload->>flowId so different flows
+  // on the same issue don't collide. If one's already in flight, return it.
+  const { data: open } = await supabase
+    .from('jobs')
+    .select('id, payload')
+    .eq('workspace_id', workspace.id)
+    .eq('kind', 'flow')
+    .eq('issue_number', params.issueNumber)
+    .in('status', ['queued', 'claimed', 'running']);
+  const existing = (open ?? []).find((row) => {
+    const p = (row.payload ?? {}) as { flowId?: string };
+    return p.flowId === params.flowId;
+  });
+  if (existing) return { ok: true, jobId: existing.id };
+
   const { data: job, error } = await supabase
     .from('jobs')
     .insert({


### PR DESCRIPTION
## Summary

Both UI-triggered enqueue paths — the Cockpit's "Run workflow" button (`enqueueWorkflowRun`) and the Workflows page's "Run on issue #" (`runFlowOnIssue`) — inserted a fresh `jobs` row on every click with no dedupe. A double-click, network burst, or stale tab could queue two jobs for the same workflow+issue that both race through `/api/cron/dispatch` into duplicate `workflow_runs` (wasted tokens, two PRs, interleaved commits).

This mirrors the existing dedupe in the GitHub webhook receiver: before inserting, check for an existing `queued`/`claimed`/`running` job for the same `workspace_id` + `kind` + `issue_number` (and additionally `payload->>flowId` for flows, so different flows on the same issue don't collide). If one is already in flight, return its `jobId` instead of inserting.

`enqueueWorkflowRun` only dedupes when an `issueNumber` is present (issue-less runs have no natural dedupe key).

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)