### PR TITLE
fix: close autofix enqueue dedupe TOCTOU race (#90)

### DIFF
--- a/packages/gui/src/lib/maybe-enqueue-autofix-from-triage.ts
+++ b/packages/gui/src/lib/maybe-enqueue-autofix-from-triage.ts
@@ -83,18 +83,12 @@ export async function maybeEnqueueAutofixFromTriage(
       return { enqueued: false, reason: `bugConfidence ${confidence.toFixed(2)} < threshold ${threshold.toFixed(2)}` };
     }
 
-    // ── dedupe ──
+    // ── dedupe (best-effort early-outs) ──
+    // The open-jobs check is enforced atomically at INSERT time by the
+    // `enqueue_autofix_if_not_open` RPC below (migration 0029) — these two
+    // remaining checks are cheap early-outs that aren't part of the jobs-row
+    // TOCTOU race.
     {
-      const { data: openJobs } = await adminSupabase
-        .from('jobs')
-        .select('id')
-        .eq('workspace_id', workspaceId)
-        .eq('kind', 'autofix')
-        .eq('issue_number', issueNumber)
-        .in('status', ['queued', 'claimed', 'running'])
-        .limit(1);
-      if (openJobs && openJobs.length > 0) return { enqueued: false, reason: 'an autofix job is already queued/running for this issue' };
-
       const { data: openRuns } = await adminSupabase
         .from('workflow_runs')
         .select('id')
@@ -118,25 +112,25 @@ export async function maybeEnqueueAutofixFromTriage(
     // Phase 4 soft affinity — prefer the runner that handled the parent
     // triage when one is known (cron-path parents leave it null, which
     // means "no preference; any matching runner may claim").
-    const preferred = parentRunnerId
-      ? {
-          preferred_runner_id: parentRunnerId,
-          preferred_until: new Date(Date.now() + SOFT_AFFINITY_WINDOW_MS).toISOString(),
-        }
-      : {};
-    const { error: insErr } = await adminSupabase.from('jobs').insert({
-      workspace_id: workspaceId,
-      repo,
-      kind: 'autofix',
-      issue_number: issueNumber,
-      pr_number: null,
-      priority: 10,
-      status: 'queued',
-      max_attempts: 1,
-      payload: { trigger: 'triage' },
-      ...preferred,
+    const preferredUntil = parentRunnerId
+      ? new Date(Date.now() + SOFT_AFFINITY_WINDOW_MS).toISOString()
+      : null;
+    // Atomic enqueue: the RPC's `INSERT … WHERE NOT EXISTS` (migration 0029)
+    // closes the TOCTOU race against the open-jobs check — two concurrent
+    // triage finalizations can't both queue an autofix for the same issue.
+    // Returns the new job id, or null when an open autofix job already exists.
+    const { data: jobId, error: insErr } = await adminSupabase.rpc('enqueue_autofix_if_not_open', {
+      p_workspace_id: workspaceId,
+      p_repo: repo,
+      p_issue_number: issueNumber,
+      p_payload: { trigger: 'triage' },
+      p_priority: 10,
+      p_max_attempts: 1,
+      p_preferred_runner_id: parentRunnerId ?? null,
+      p_preferred_until: preferredUntil,
     });
     if (insErr) return { enqueued: false, reason: `enqueue failed: ${insErr.message}` };
+    if (!jobId) return { enqueued: false, reason: 'an autofix job is already queued/running for this issue' };
     return { enqueued: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/gui/supabase/migrations/0029_enqueue_autofix_dedupe.sql
+++ b/packages/gui/supabase/migrations/0029_enqueue_autofix_dedupe.sql
@@ -1,0 +1,67 @@
+-- Close the TOCTOU race in `maybeEnqueueAutofixFromTriage` (audit #90).
+--
+-- The TS helper used to SELECT for an open autofix job, then INSERT — with
+-- nothing serializing the two, two concurrent triage finalizations for the
+-- same issue (a webhook-triggered triage racing a triage-sweep one, say)
+-- could both pass the SELECT and both INSERT, queueing duplicate autofix jobs
+-- that the dispatcher then runs twice (two clones, two LLM bills, a branch-name
+-- collision on `autofix/<issue>`).
+--
+-- This makes the "no open autofix job for this issue" check atomic with the
+-- insert via a single `INSERT … SELECT … WHERE NOT EXISTS`, plus a partial
+-- unique index as a hard backstop so even a torn read can't land two rows.
+
+-- ─── partial unique index (hard backstop) ───────────────────────────────
+-- At most one *open* (queued/claimed/running) autofix job per (workspace, issue).
+-- Partial so terminal jobs (done/failed/cancelled) and a future re-queue don't
+-- collide with it. `issue_number` is nullable on `jobs`; the predicate's
+-- `issue_number is not null` keeps issue-less rows out of the index entirely.
+create unique index if not exists jobs_open_autofix_unique_idx
+  on jobs (workspace_id, issue_number)
+  where kind = 'autofix'
+    and issue_number is not null
+    and status in ('queued', 'claimed', 'running');
+
+-- ─── enqueue_autofix_if_not_open ────────────────────────────────────────
+-- Inserts an autofix `jobs` row only if no open autofix job already exists for
+-- the same (workspace, issue). The WHERE NOT EXISTS guard and the INSERT run in
+-- one statement, so two concurrent callers can't both pass the check. On a lost
+-- race the loser inserts zero rows (and the unique index above would reject it
+-- anyway). Returns the new job id, or NULL when nothing was inserted.
+create or replace function enqueue_autofix_if_not_open(
+  p_workspace_id       uuid,
+  p_repo               text,
+  p_issue_number       integer,
+  p_payload            jsonb default '{}'::jsonb,
+  p_priority           integer default 10,
+  p_max_attempts       integer default 1,
+  p_preferred_runner_id uuid default null,
+  p_preferred_until    timestamptz default null
+)
+returns uuid
+language sql
+as $$
+  insert into jobs (
+    workspace_id, repo, kind, issue_number, pr_number,
+    priority, status, max_attempts, payload,
+    preferred_runner_id, preferred_until
+  )
+  select
+    p_workspace_id, p_repo, 'autofix', p_issue_number, null,
+    p_priority, 'queued', p_max_attempts, p_payload,
+    p_preferred_runner_id, p_preferred_until
+  where not exists (
+    select 1 from jobs
+     where workspace_id = p_workspace_id
+       and kind = 'autofix'
+       and issue_number = p_issue_number
+       and status in ('queued', 'claimed', 'running')
+  )
+  returning id;
+$$;
+
+-- Called from the cron dispatch path and the runner-finalize PATCH route, both
+-- of which use the service-role key. The body is the access-control surface.
+grant execute on function enqueue_autofix_if_not_open(
+  uuid, text, integer, jsonb, integer, integer, uuid, timestamptz
+) to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

`maybeEnqueueAutofixFromTriage` ran a SELECT for an open autofix job, then a separate `INSERT INTO jobs`, with nothing serializing the two. Two concurrent triage finalizations for the same issue (e.g. a webhook-triggered triage racing a `triage-sweep` one) could both pass the dedupe check and both insert an autofix job — duplicate runs racing on the same `autofix/<issue>` branch, plus two clones and two LLM bills.

## Fix

- New migration `0029_enqueue_autofix_dedupe.sql`:
  - `enqueue_autofix_if_not_open` RPC that performs the dedupe check and the insert in a single `INSERT … SELECT … WHERE NOT EXISTS` statement, so two concurrent callers can't both pass the check. Returns the new job id, or NULL when an open autofix job already exists.
  - A partial unique index on `jobs (workspace_id, issue_number) WHERE kind='autofix' AND status IN ('queued','claimed','running')` as a hard backstop.
- `maybe-enqueue-autofix-from-triage.ts` now calls the RPC instead of the racy SELECT+INSERT. The cheap `workflow_runs` / `analysis.autofixStatus` early-outs are kept (they aren't part of the jobs-row race). Both call sites (cron dispatch + runner-finalize PATCH) go through this helper, so both are covered.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)