### PR TITLE
fix: preserve refreshed session cookies on middleware redirects (#97)

### DIFF
--- a/packages/gui/src/middleware.ts
+++ b/packages/gui/src/middleware.ts
@@ -49,16 +49,27 @@ export async function middleware(request: NextRequest) {
 
   const { data: { user } } = await supabase.auth.getUser();
 
+  // Any response we return INSTEAD of `supabaseResponse` (e.g. a redirect) must
+  // carry over the Set-Cookie headers `getAll()` may have refreshed onto
+  // `supabaseResponse`. Dropping them re-presents the rotated-out refresh token
+  // on the next request → Supabase 400 → silent logout.
+  const withSessionCookies = (response: NextResponse) => {
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      response.cookies.set(cookie.name, cookie.value, cookie);
+    });
+    return response;
+  };
+
   if (!user) {
     const loginUrl = request.nextUrl.clone();
     loginUrl.pathname = '/login';
-    return NextResponse.redirect(loginUrl);
+    return withSessionCookies(NextResponse.redirect(loginUrl));
   }
 
   if (request.nextUrl.pathname === '/login') {
     const dashUrl = request.nextUrl.clone();
     dashUrl.pathname = '/dashboard';
-    return NextResponse.redirect(dashUrl);
+    return withSessionCookies(NextResponse.redirect(dashUrl));
   }
 
   return supabaseResponse;


### PR DESCRIPTION
## Summary

The auth middleware (`packages/gui/src/middleware.ts`) constructs a Supabase server client and calls `supabase.auth.getUser()`, which may rotate the session cookies via the `setAll` callback during a JWT refresh. Those refreshed `Set-Cookie` headers land on `supabaseResponse`, but the two redirect branches (`/login` for unauthenticated users, `/login → /dashboard` for already-authenticated users) returned a fresh `NextResponse.redirect(...)` without carrying those cookies over.

When a refresh coincided with a redirect, the rotated cookies were dropped on the floor. The next request re-presented the old (rotated-out) refresh token, Supabase returned a 400, and the user was silently logged out.

This adds a small `withSessionCookies` helper that copies the cookies from `supabaseResponse` onto any response returned in its place, applied to both redirect branches — matching the Supabase SSR guidance to always copy cookies onto the response you return.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)