### PR TITLE
fix: switchWorkspace/deleteWorkspace auth & membership checks (#101)

### DIFF
--- a/packages/gui/src/app/workspace/actions.ts
+++ b/packages/gui/src/app/workspace/actions.ts
@@ -1,9 +1,23 @@
 'use server';
 
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { getSessionUser } from '@/lib/auth';
 import { setActiveWorkspace } from '@/lib/workspace';
 import { redirect } from 'next/navigation';
 
 export async function switchWorkspace(workspaceId: string) {
+  const user = await getSessionUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const supabase = createSupabaseAdminClient();
+  const { data: member } = await supabase
+    .from('workspace_members')
+    .select('role')
+    .eq('workspace_id', workspaceId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!member) throw new Error('Not a member of this workspace');
+
   await setActiveWorkspace(workspaceId);
   redirect('/dashboard');
 }

--- a/packages/gui/src/app/workspaces/actions.ts
+++ b/packages/gui/src/app/workspaces/actions.ts
@@ -223,6 +223,13 @@ export async function deleteWorkspace(workspaceId: string) {
   const user = await getSessionUser();
   if (!user) throw new Error('Not authenticated');
   const supabase = createSupabaseAdminClient();
+  const { data: member } = await supabase
+    .from('workspace_members')
+    .select('role')
+    .eq('workspace_id', workspaceId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!member || member.role !== 'admin') throw new Error('Admin role required');
   const { error } = await supabase.from('workspaces').delete().eq('id', workspaceId);
   if (error) throw new Error(error.message);
   redirect('/dashboard');


### PR DESCRIPTION
## Summary

`switchWorkspace` (`packages/gui/src/app/workspace/actions.ts`) accepted any `workspaceId` and pinned the active-workspace cookie via `setActiveWorkspace` with no session or membership check, letting a caller steer themselves into any workspace UUID. It now requires a session user and verifies a `workspace_members` row before flipping the cookie.

`deleteWorkspace` (`packages/gui/src/app/workspaces/actions.ts`) called `getSessionUser()` but deleted the workspace row through the service-role (RLS-bypassing) admin client with no membership/role check. It now requires an admin membership before deleting.

Both follow the existing membership-check pattern used by `startLabelAnalysisForWorkspace` / `acceptLabelAnalysis` in the same surface.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)