### PR TITLE
fix: cockpit realtime list respects active filters (#95)

### DIFF
--- a/packages/gui/src/app/cockpit/cockpit-list.tsx
+++ b/packages/gui/src/app/cockpit/cockpit-list.tsx
@@ -23,6 +23,9 @@ type WorkflowRunRow = Database['public']['Tables']['workflow_runs']['Row'];
 const STATUS_PILLS: DbWorkflowRunStatus[] = ['running', 'paused', 'queued', 'failed', 'succeeded', 'cancelled'];
 const WORKFLOW_OPTIONS = ['autofix', 'ci-followup', 'triage'] as const;
 
+// Keep the realtime list in step with the server-side `.limit(100)` cap.
+const REALTIME_ROW_CAP = 100;
+
 interface Props {
   workspaceId: string;
   repoOwner: string;
@@ -62,6 +65,15 @@ export function CockpitList({
     setSelected(new Set());
   }, [initialRuns]);
 
+  // Does an incoming row still belong in the list given the active filter bar?
+  const matchesFilters = useCallback(
+    (r: WorkflowRunRow) =>
+      (filters.statuses.length === 0 || filters.statuses.includes(r.status)) &&
+      (!filters.workflow || r.workflow === filters.workflow) &&
+      (!filters.repo || r.repo === filters.repo),
+    [filters.statuses, filters.workflow, filters.repo],
+  );
+
   // ── Realtime: postgres_changes on workflow_runs, scoped to this workspace ──
   useEffect(() => {
     const supabase = createSupabaseBrowserClient();
@@ -80,9 +92,14 @@ export function CockpitList({
           setRuns((prev) => {
             const idx = prev.findIndex((r) => r.id === row.id);
             if (idx === -1) {
-              // A brand-new run — prepend (it matches the workspace; filter
-              // refinement happens on next navigation/refresh).
-              return [row, ...prev];
+              // A brand-new run — prepend only if it matches the active filter,
+              // then trim to keep parity with the server-side limit.
+              return matchesFilters(row) ? [row, ...prev].slice(0, REALTIME_ROW_CAP) : prev;
+            }
+            // An update — drop the row if it no longer matches the filter
+            // (e.g. status changed out of scope), otherwise merge in place.
+            if (!matchesFilters(row)) {
+              return prev.filter((_, i) => i !== idx);
             }
             const next = prev.slice();
             next[idx] = { ...next[idx], ...row };
@@ -94,7 +111,7 @@ export function CockpitList({
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [workspaceId]);
+  }, [workspaceId, matchesFilters]);
 
   // ── Filter-bar query-string updates ──
   const setParam = useCallback(


### PR DESCRIPTION
## Summary

The cockpit list's Supabase realtime subscription on `workflow_runs` prepended every new row matching the workspace, ignoring the active status/workflow/repo filter bar, and never trimmed the list. This caused:

- Filtered-out rows to leak in (e.g. `succeeded` runs popping in while filtering on `running`).
- Unbounded growth of the `runs` array over a long-lived session, well past the server-side `.limit(100)` cap.

## Fix

Added a `matchesFilters` predicate (mirroring the server-side filter) applied to incoming realtime rows:

- **INSERTs** only prepend when they match the active filter, then the list is trimmed to the `REALTIME_ROW_CAP` (100) to match the server limit.
- **UPDATEs** that fall out of filter scope (e.g. `running` → `failed` while filtering on `running`) are removed from the list instead of retained.

Scoped to `packages/gui/src/app/cockpit/cockpit-list.tsx`.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)