### PR TITLE
fix: stop leaking GitHub token via git remote URL / process listing (#100)

### DIFF
--- a/packages/gui/src/lib/repo-clone.ts
+++ b/packages/gui/src/lib/repo-clone.ts
@@ -10,11 +10,36 @@ const exec = promisify(execFile);
 const REPOS_DIR = join(homedir(), '.cezar', 'repos');
 
 /**
+ * Env var the in-repo credential helper reads the GitHub token from.
+ *
+ * The secret never lands in the remote URL (`.git/config`) or in any git
+ * process's argv (`/proc/<pid>/cmdline`): `origin` is set to a token-less URL
+ * and a tiny credential helper hands git `x-access-token:<token>` over stdin,
+ * pulling the password from this env var at run time. Subsequent in-process
+ * git calls (fetch/push via @cezar/core) inherit the same env, so they
+ * authenticate without re-embedding the token anywhere on disk.
+ */
+const TOKEN_ENV = 'CEZAR_GIT_TOKEN';
+
+// Shell credential helper: emits the username/password git's credential
+// protocol expects, reading the password from $CEZAR_GIT_TOKEN at run time.
+// Persisting this in .git/config is safe — it carries no secret, only the
+// name of the env var to read. The leading `!` marks it as a shell command.
+const CREDENTIAL_HELPER =
+  `!f() { echo username=x-access-token; echo "password=$${TOKEN_ENV}"; }; f`;
+
+/**
  * Ensures a local clone of the repo exists and is up-to-date.
  * Returns the absolute path to the repo root.
  *
  * Clones to ~/.cezar/repos/<owner>-<repo>. If already cloned,
  * fetches latest from origin.
+ *
+ * Authentication is supplied via a credential helper that reads the token from
+ * the process environment, so the token is never written to disk (the remote
+ * URL stays token-less) or exposed in the process listing (it is not passed as
+ * a git argument). The token is exported into `process.env` for the lifetime of
+ * the process so later in-process git operations (fetch/push) reuse it.
  */
 export async function ensureRepoClone(
   owner: string,
@@ -25,10 +50,18 @@ export async function ensureRepoClone(
   await mkdir(REPOS_DIR, { recursive: true });
 
   const repoDir = join(REPOS_DIR, `${owner}-${repo}`);
-  const cloneUrl = `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`;
+  // Token-less remote — the credential helper supplies auth at run time.
+  const remoteUrl = `https://github.com/${owner}/${repo}.git`;
+
+  // Expose the token to the credential helper (this process and the in-process
+  // git operations that follow). Never embedded in a URL or argv.
+  process.env[TOKEN_ENV] = githubToken;
 
   if (existsSync(join(repoDir, '.git'))) {
-    await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir });
+    // Migrate any pre-existing token-bearing remote to the token-less URL and
+    // install the credential helper so on-disk config never carries the secret.
+    await exec('git', ['remote', 'set-url', 'origin', remoteUrl], { cwd: repoDir });
+    await exec('git', ['config', 'credential.helper', CREDENTIAL_HELPER], { cwd: repoDir });
     await exec('git', ['fetch', 'origin'], { cwd: repoDir });
     await exec('git', ['checkout', baseBranch], { cwd: repoDir }).catch(() => {
       // branch might not exist locally yet
@@ -36,7 +69,14 @@ export async function ensureRepoClone(
     });
     await exec('git', ['reset', '--hard', `origin/${baseBranch}`], { cwd: repoDir });
   } else {
-    await exec('git', ['clone', '--depth', '50', '--branch', baseBranch, cloneUrl, repoDir]);
+    // `-c credential.helper=...` carries no secret (only the helper that reads
+    // $CEZAR_GIT_TOKEN), so it is safe in argv. Persist it afterwards too so
+    // fetch/push reuse it.
+    await exec('git', [
+      '-c', `credential.helper=${CREDENTIAL_HELPER}`,
+      'clone', '--depth', '50', '--branch', baseBranch, remoteUrl, repoDir,
+    ]);
+    await exec('git', ['config', 'credential.helper', CREDENTIAL_HELPER], { cwd: repoDir });
   }
 
   return repoDir;


### PR DESCRIPTION
## Summary

`ensureRepoClone` (`packages/gui/src/lib/repo-clone.ts`) embedded the GitHub token directly in the `origin` remote URL, persisting it to `.git/config` on disk, and passed it as a `git clone` argument, exposing it in the process listing (`/proc/<pid>/cmdline`). For the long-lived OAuth `provider_token` fallback this on-disk + argv leak is a meaningful defense-in-depth gap.

This change:
- Sets `origin` to a **token-less** URL (`https://github.com/<owner>/<repo>.git`) so no secret is persisted in `.git/config`.
- Supplies credentials via a git **credential helper** that reads the token from the `CEZAR_GIT_TOKEN` process env var at run time. The helper text — the only thing persisted (in `.git/config`) and the only auth-related `-c` argument on the clone — carries just the env-var name, never the secret.
- Exports the token into `process.env` so the subsequent **in-process** `fetch`/`push` (run via `@cezar/core` in the same dispatch process) authenticate the same way, without re-embedding the token in any URL or argv.

The pre-existing `git push origin` path in `@cezar/core` (`GitHubService.pushBranch`) keeps working unchanged: it inherits the process env and the persisted credential helper.

Verified locally that the helper fills `x-access-token` / token-from-env to git's credential protocol and that no raw token lands in `.git/config`.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)