### PR TITLE
fix: coalesce per-job workspace SELECTs into one fetch (#98)

### DIFF
--- a/packages/gui/src/lib/execute-workflow-job.ts
+++ b/packages/gui/src/lib/execute-workflow-job.ts
@@ -66,19 +66,22 @@ export async function executeWorkflowJob(
     const adapter = new SupabaseStoreAdapter(adminSupabase, workspaceId);
     const store = await core.IssueStore.fromPort(adapter);
 
+    // Read the workspace row ONCE (issue #98). The same row feeds the owner
+    // peek, the merged-config load, the workflow settings, and the triage
+    // pass — collapsing four `SELECT … FROM workspaces WHERE id=$ws` round-trips
+    // into one column-broad fetch per job.
+    const { data: workspaceRow } = await adminSupabase
+      .from('workspaces')
+      .select(
+        'config, repo_owner, repo_name, auto_triage_enabled, autofix_enabled, separate_comment_per_step, action_auto_comment',
+      )
+      .eq('id', workspaceId)
+      .single();
+
     // GitHub token: prefer an installation token (if a GitHub App is wired up),
     // else fall back to the per-workspace admin token the crons use.
     let githubToken: string | null = null;
-    let owner: string | undefined;
-    {
-      // Peek at the workspace to learn the owner before the full config load.
-      const { data: ws } = await adminSupabase
-        .from('workspaces')
-        .select('repo_owner, repo_name')
-        .eq('id', workspaceId)
-        .single();
-      owner = ws?.repo_owner ?? undefined;
-    }
+    const owner: string | undefined = workspaceRow?.repo_owner ?? undefined;
     if (owner && core.GitHubAppService.isConfigured()) {
       try {
         githubToken = await new core.GitHubAppService().getInstallationToken(owner);
@@ -89,7 +92,10 @@ export async function executeWorkflowJob(
     if (!githubToken) githubToken = await resolveWorkspaceToken(workspaceId, adminSupabase);
     if (!githubToken) throw new Error('no github token available for workspace');
 
-    const config = await loadWorkspaceConfig(workspaceId, adminSupabase, { githubToken });
+    const config = await loadWorkspaceConfig(workspaceId, adminSupabase, {
+      githubToken,
+      prefetchedWorkspace: workspaceRow,
+    });
     // Phase 3c — the dispatcher always runs the declarative engine.
     config.workflow = { ...(config.workflow ?? {}), useEngine: true };
 
@@ -273,6 +279,7 @@ export async function executeWorkflowJob(
         supabase: adminSupabase,
         persister,
         labels,
+        actionAutoComment: workspaceRow?.action_auto_comment ?? null,
         deferSink: async ({ call, confidence, summary, action, target }) => {
           // Write the deferred effect to pending_decisions for the inbox.
           const { error } = await adminSupabase.from('pending_decisions').insert({

--- a/packages/gui/src/lib/load-workspace-config.ts
+++ b/packages/gui/src/lib/load-workspace-config.ts
@@ -1,7 +1,18 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Config } from '@cezar/core';
 import type { Database } from './supabase/types';
-import { loadWorkflowBindings, loadWorkflowSettings } from './workflow-config';
+import { loadWorkflowBindings, loadWorkflowSettings, type WorkspaceWorkflowRow } from './workflow-config';
+
+/**
+ * The subset of `workspaces` columns `loadWorkspaceConfig` reads. A caller that
+ * has already fetched the row (e.g. `executeWorkflowJob`) can pass it via
+ * `overrides.prefetchedWorkspace` to skip the redundant `SELECT`.
+ */
+export type WorkspaceConfigRow = Pick<
+  Database['public']['Tables']['workspaces']['Row'],
+  'config' | 'repo_owner' | 'repo_name'
+> &
+  WorkspaceWorkflowRow;
 
 /**
  * Loads a merged config: cosmiconfig defaults + workspace JSONB overrides.
@@ -10,7 +21,13 @@ import { loadWorkflowBindings, loadWorkflowSettings } from './workflow-config';
 export async function loadWorkspaceConfig(
   workspaceId: string,
   supabase: SupabaseClient<Database>,
-  overrides?: { githubToken?: string; repoOwner?: string; repoName?: string },
+  overrides?: {
+    githubToken?: string;
+    repoOwner?: string;
+    repoName?: string;
+    /** Pre-fetched `workspaces` row — when set, no `SELECT` is issued. */
+    prefetchedWorkspace?: WorkspaceConfigRow | null;
+  },
 ): Promise<Config> {
   const core = await import('@cezar/core');
 
@@ -27,11 +44,16 @@ export async function loadWorkspaceConfig(
     });
   }
 
-  const { data: ws } = await supabase
-    .from('workspaces')
-    .select('config, repo_owner, repo_name')
-    .eq('id', workspaceId)
-    .single();
+  let ws: WorkspaceConfigRow | null;
+  if (overrides?.prefetchedWorkspace !== undefined) {
+    ws = overrides.prefetchedWorkspace;
+  } else {
+    ({ data: ws } = await supabase
+      .from('workspaces')
+      .select('config, repo_owner, repo_name, auto_triage_enabled, autofix_enabled, separate_comment_per_step')
+      .eq('id', workspaceId)
+      .single());
+  }
 
   const wsConfig = (ws?.config ?? {}) as Record<string, unknown>;
 
@@ -92,7 +114,7 @@ export async function loadWorkspaceConfig(
   baseConfig.workflow = {
     useEngine,
     bindings: await loadWorkflowBindings(workspaceId, supabase, baseConfig.github.repo || undefined),
-    settings: await loadWorkflowSettings(workspaceId, supabase),
+    settings: await loadWorkflowSettings(workspaceId, supabase, ws),
   };
 
   return baseConfig;

--- a/packages/gui/src/lib/run-triage-pass-job.ts
+++ b/packages/gui/src/lib/run-triage-pass-job.ts
@@ -24,6 +24,11 @@ export interface RunTriagePassJobParams {
   deferSink?: TriagePassDeferSink;
   /** Workspace label catalog appended to each action's system message. */
   labels?: WorkspaceLabel[];
+  /**
+   * Pre-fetched `workspaces.action_auto_comment` flag. When provided (including
+   * `null`), the per-job `SELECT action_auto_comment FROM workspaces` is skipped.
+   */
+  actionAutoComment?: boolean | null;
 }
 
 export interface RunTriagePassJobResult {
@@ -55,12 +60,18 @@ export async function runTriagePassJob(params: RunTriagePassJobParams): Promise<
   const core = await import('@cezar/core');
   const { issueNumber, github, supabase, persister, workspaceId, trigger, deferSink, labels } = params;
 
-  const { data: workspaceRow } = await supabase
-    .from('workspaces')
-    .select('action_auto_comment')
-    .eq('id', workspaceId)
-    .single();
-  const autoCommentEnabled = workspaceRow?.action_auto_comment ?? true;
+  let actionAutoComment: boolean | null;
+  if (params.actionAutoComment !== undefined) {
+    actionAutoComment = params.actionAutoComment;
+  } else {
+    const { data: workspaceRow } = await supabase
+      .from('workspaces')
+      .select('action_auto_comment')
+      .eq('id', workspaceId)
+      .single();
+    actionAutoComment = workspaceRow?.action_auto_comment ?? null;
+  }
+  const autoCommentEnabled = actionAutoComment ?? true;
 
   await persister.recordEvent('lifecycle', { message: `triage-pass: fetching issue #${issueNumber}` });
   const fetched = await github.getIssueWithComments(issueNumber);

--- a/packages/gui/src/lib/workflow-config.ts
+++ b/packages/gui/src/lib/workflow-config.ts
@@ -6,6 +6,16 @@ import type { Database, WorkflowBackend } from './supabase/types';
 const VALID_BACKENDS: WorkflowBackend[] = ['anthropic-api', 'claude-cli', 'codex-cli'];
 
 /**
+ * The subset of `workspaces` columns the workflow loaders read. When a caller
+ * has already fetched the row (e.g. `executeWorkflowJob`), it can thread it
+ * down so the loaders skip a redundant `SELECT … FROM workspaces`.
+ */
+export type WorkspaceWorkflowRow = Pick<
+  Database['public']['Tables']['workspaces']['Row'],
+  'auto_triage_enabled' | 'autofix_enabled' | 'separate_comment_per_step'
+>;
+
+/**
  * Loads the workspace's `workflow_bindings` rows (for this repo, plus the
  * repo-agnostic null-repo rows) as core `WorkflowBinding`s. Rows that set
  * nothing (skill/backend/model all null AND extra_tools empty) are dropped —
@@ -46,16 +56,26 @@ export async function loadWorkflowBindings(
   return bindings;
 }
 
-/** Reads the three workflow toggle columns off the `workspaces` row, defaulting via core. */
+/**
+ * Reads the three workflow toggle columns off the `workspaces` row, defaulting
+ * via core. Pass `prefetched` to reuse an already-loaded row and skip the
+ * `SELECT`.
+ */
 export async function loadWorkflowSettings(
   workspaceId: string,
   supabase: SupabaseClient<Database>,
+  prefetched?: WorkspaceWorkflowRow | null,
 ): Promise<WorkspaceWorkflowSettings> {
-  const { data } = await supabase
-    .from('workspaces')
-    .select('auto_triage_enabled, autofix_enabled, separate_comment_per_step')
-    .eq('id', workspaceId)
-    .single();
+  let data: WorkspaceWorkflowRow | null;
+  if (prefetched !== undefined) {
+    data = prefetched;
+  } else {
+    ({ data } = await supabase
+      .from('workspaces')
+      .select('auto_triage_enabled, autofix_enabled, separate_comment_per_step')
+      .eq('id', workspaceId)
+      .single());
+  }
 
   if (!data) return { ...DEFAULT_WORKSPACE_WORKFLOW_SETTINGS };
   return {


### PR DESCRIPTION
## Summary

`executeWorkflowJob` (the `/api/cron/dispatch` per-job path) was issuing four
separate `SELECT … FROM workspaces WHERE id=$ws` round-trips for every claimed
job:

1. owner peek (`repo_owner, repo_name`)
2. `loadWorkspaceConfig` (`config, repo_owner, repo_name`)
3. `loadWorkflowSettings` (`auto_triage_enabled, autofix_enabled, separate_comment_per_step`)
4. `runTriagePassJob` (`action_auto_comment`)

With `CEZAR_DISPATCH_BATCH=3` on a 60s tick that's ~12 redundant workspace
SELECTs/min/replica for the same handful of rows, each carrying the supabase
RTT latency floor.

## Fix

Read the workspace row **once** with a column-broad `select` in
`executeWorkflowJob`, then thread it down as an optional injected dependency:

- `loadWorkspaceConfig` — new `overrides.prefetchedWorkspace`
- `loadWorkflowSettings` — new optional `prefetched` row argument
- `runTriagePassJob` — new optional `actionAutoComment` flag

All three params are optional. Every other caller (settings, inbox, workflows,
runner routes, etc.) keeps its own self-contained SELECT, so behavior is
unchanged for them. Only the hot dispatch path now does a single fetch.

The broader `loadConfig()` TTL / merged-config LRU cache ideas from the issue
were left out to keep this change focused and free of staleness/invalidation
concerns — the round-trip coalescing is the clear, safe win.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)