### PR TITLE
fix: harden cron sync routes — timeout, pagination cap, no leaked errors (#96)

### DIFF
--- a/packages/core/src/services/github.service.ts
+++ b/packages/core/src/services/github.service.ts
@@ -115,9 +115,29 @@ export class GitHubService {
     this.repo = config.github.repo;
   }
 
-  async fetchAllIssues(includeClosed = false): Promise<RawIssue[]> {
+  async fetchAllIssues(includeClosed = false, maxItems?: number): Promise<RawIssue[]> {
     const state = includeClosed ? 'all' : 'open';
     try {
+      if (maxItems != null) {
+        const collected: RawIssue[] = [];
+        const iterator = this.octokit.paginate.iterator(this.octokit.rest.issues.listForRepo, {
+          owner: this.owner,
+          repo: this.repo,
+          state,
+          per_page: 100,
+          sort: 'created',
+          direction: 'asc',
+        });
+        for await (const { data } of iterator) {
+          for (const i of data) {
+            if (i.pull_request) continue; // exclude PRs
+            collected.push(this.mapIssue(i));
+            if (collected.length >= maxItems) return collected;
+          }
+        }
+        return collected;
+      }
+
       const issues = await this.octokit.paginate(this.octokit.rest.issues.listForRepo, {
         owner: this.owner,
         repo: this.repo,
@@ -160,34 +180,55 @@ export class GitHubService {
     }
   }
 
-  async listOpenPullRequests(): Promise<RawPullRequest[]> {
+  async listOpenPullRequests(maxItems?: number): Promise<RawPullRequest[]> {
+    const mapPr = (
+      p: Awaited<ReturnType<Octokit['rest']['pulls']['list']>>['data'][number],
+    ): RawPullRequest => ({
+      number: p.number,
+      title: p.title,
+      body: p.body ?? '',
+      state: p.state === 'closed' ? 'closed' : 'open',
+      draft: p.draft ?? false,
+      labels: Array.isArray(p.labels)
+        ? p.labels
+            .map((l) => (typeof l === 'string' ? l : l?.name ?? null))
+            .filter((n): n is string => typeof n === 'string' && n.length > 0)
+        : [],
+      author: p.user?.login ?? 'unknown',
+      htmlUrl: p.html_url,
+      headSha: p.head?.sha ?? null,
+      headRef: p.head?.ref ?? null,
+      baseRef: p.base?.ref ?? null,
+      referencedIssues: extractReferencedIssues(`${p.title}\n${p.body ?? ''}`),
+      createdAt: p.created_at,
+      updatedAt: p.updated_at,
+    });
+
     try {
+      if (maxItems != null) {
+        const collected: RawPullRequest[] = [];
+        const iterator = this.octokit.paginate.iterator(this.octokit.rest.pulls.list, {
+          owner: this.owner,
+          repo: this.repo,
+          state: 'open',
+          per_page: 100,
+        });
+        for await (const { data } of iterator) {
+          for (const p of data) {
+            collected.push(mapPr(p));
+            if (collected.length >= maxItems) return collected;
+          }
+        }
+        return collected;
+      }
+
       const prs = await this.octokit.paginate(this.octokit.rest.pulls.list, {
         owner: this.owner,
         repo: this.repo,
         state: 'open',
         per_page: 100,
       });
-      return prs.map(p => ({
-        number: p.number,
-        title: p.title,
-        body: p.body ?? '',
-        state: p.state === 'closed' ? 'closed' : 'open',
-        draft: p.draft ?? false,
-        labels: Array.isArray(p.labels)
-          ? p.labels
-              .map((l) => (typeof l === 'string' ? l : l?.name ?? null))
-              .filter((n): n is string => typeof n === 'string' && n.length > 0)
-          : [],
-        author: p.user?.login ?? 'unknown',
-        htmlUrl: p.html_url,
-        headSha: p.head?.sha ?? null,
-        headRef: p.head?.ref ?? null,
-        baseRef: p.base?.ref ?? null,
-        referencedIssues: extractReferencedIssues(`${p.title}\n${p.body ?? ''}`),
-        createdAt: p.created_at,
-        updatedAt: p.updated_at,
-      }));
+      return prs.map(mapPr);
     } catch (error) {
       this.handleError(error);
       throw error;

--- a/packages/gui/src/app/api/cron/issue-sync/route.ts
+++ b/packages/gui/src/app/api/cron/issue-sync/route.ts
@@ -6,12 +6,29 @@ export const runtime = 'nodejs';
 
 // Cap per-tick work so one oversized repo can't blow the cron timeout.
 const MAX_WORKSPACES_PER_TICK = 10;
+// Per-workspace wall-clock budget — one slow GitHub API call (or its retry
+// window) must not hold the whole tick hostage.
+const PER_WORKSPACE_TIMEOUT_MS = 20_000;
+// Bound how many issues a single tick pulls into memory so a mega-repo with
+// thousands of open issues can't OOM/timeout the cron.
+const MAX_ISSUES_PER_TICK = 1_000;
 
 type Workspace = {
   id: string;
   repo_owner: string;
   repo_name: string;
 };
+
+// Reject (without unwinding the underlying work) once `ms` elapses so one
+// stuck GitHub call can't pin the request.
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
 
 /**
  * GitHub → store reconcile cron. The webhook receiver covers new-issue events
@@ -52,11 +69,17 @@ export async function GET(req: Request) {
   const results = await Promise.all(
     (workspaces as Workspace[]).map(async (ws) => {
       try {
-        return await syncOne(ws, supabase, core);
+        return await withTimeout(
+          syncOne(ws, supabase, core),
+          PER_WORKSPACE_TIMEOUT_MS,
+          'issue sync',
+        );
       } catch (err) {
+        // Log the full error server-side; never echo raw GitHub/Octokit error
+        // text to the caller (it can carry tokens or other internals).
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`[issue-sync] workspace ${ws.id} failed:`, msg);
-        return { workspaceId: ws.id, ok: false, error: msg };
+        return { workspaceId: ws.id, ok: false, error: 'sync_failed' };
       }
     }),
   );
@@ -76,7 +99,7 @@ async function syncOne(
     github: { owner: ws.repo_owner, repo: ws.repo_name, token },
   } as any);
 
-  const openIssues = await github.fetchAllIssues(false);
+  const openIssues = await github.fetchAllIssues(false, MAX_ISSUES_PER_TICK);
 
   if (openIssues.length > 0) {
     const rows = openIssues.map(i => ({

--- a/packages/gui/src/app/api/cron/prs-sync/route.ts
+++ b/packages/gui/src/app/api/cron/prs-sync/route.ts
@@ -6,12 +6,29 @@ export const runtime = 'nodejs';
 
 // Cap per-tick work so one oversized repo can't blow the cron timeout.
 const MAX_WORKSPACES_PER_TICK = 10;
+// Per-workspace wall-clock budget — one slow GitHub API call (or its retry
+// window) must not hold the whole tick hostage.
+const PER_WORKSPACE_TIMEOUT_MS = 20_000;
+// Bound how many PRs a single tick pulls into memory so a mega-repo with
+// thousands of open PRs can't OOM/timeout the cron.
+const MAX_PRS_PER_TICK = 1_000;
 
 type Workspace = {
   id: string;
   repo_owner: string;
   repo_name: string;
 };
+
+// Reject (without unwinding the underlying work) once `ms` elapses so one
+// stuck GitHub call can't pin the request.
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
 
 /**
  * GitHub → store reconcile cron for pull requests. Sibling of `issue-sync`.
@@ -52,11 +69,17 @@ export async function GET(req: Request) {
   const results = await Promise.all(
     (workspaces as Workspace[]).map(async (ws) => {
       try {
-        return await syncOne(ws, supabase, core);
+        return await withTimeout(
+          syncOne(ws, supabase, core),
+          PER_WORKSPACE_TIMEOUT_MS,
+          'prs sync',
+        );
       } catch (err) {
+        // Log the full error server-side; never echo raw GitHub/Octokit error
+        // text to the caller (it can carry tokens or other internals).
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`[prs-sync] workspace ${ws.id} failed:`, msg);
-        return { workspaceId: ws.id, ok: false, error: msg };
+        return { workspaceId: ws.id, ok: false, error: 'sync_failed' };
       }
     }),
   );
@@ -76,7 +99,7 @@ async function syncOne(
     github: { owner: ws.repo_owner, repo: ws.repo_name, token },
   } as never);
 
-  const openPrs = await github.listOpenPullRequests();
+  const openPrs = await github.listOpenPullRequests(MAX_PRS_PER_TICK);
 
   if (openPrs.length > 0) {
     const rows = openPrs.map((p) => ({


### PR DESCRIPTION
## Summary

The `issue-sync` and `prs-sync` cron routes fanned out over up to 10 workspaces with three latent problems (audit #96):

1. **No per-workspace timeout** — one slow GitHub call (or its retry window) held the entire request.
2. **No pagination cap** — a repo with thousands of open issues/PRs was fully buffered into memory before upsert, risking OOM/timeout for every workspace in the tick.
3. **Raw error messages echoed to the caller** — a future Octokit version that logs the token on auth failure would leak it to anyone with `CRON_SECRET`.

## Changes

- Add a `withTimeout` wrapper around each per-workspace `syncOne` (20s budget) in both routes.
- Add an optional `maxItems` arg to `GitHubService.fetchAllIssues` / `listOpenPullRequests`, implemented with `paginate.iterator` so it stops early instead of buffering everything. Default behavior (no cap) is unchanged. Both crons now cap at 1000 items per tick.
- Replace the verbatim error string in the JSON response with a stable `"sync_failed"` category; the full error is still logged server-side.

Scoped to the two cron routes plus the two core service methods they call. No migration needed.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)