### PR TITLE
fix: clamp HITL confidence config to keep low < high invariant (#106)

### DIFF
--- a/packages/gui/src/app/actions/[name]/acceptance-types.ts
+++ b/packages/gui/src/app/actions/[name]/acceptance-types.ts
@@ -64,11 +64,13 @@ export function coerceConfidenceConfig(
       autoAcceptAbove: clamp(obj.autoAcceptAbove, DEFAULT_AUTO_CONFIG.autoAcceptAbove),
     };
   }
-  const high = clamp(obj.autoAcceptAbove, DEFAULT_HITL_CONFIG.autoAcceptAbove);
+  // Floor `high` at 1 so the `low < high` invariant can hold even when the
+  // stored row came from `mode: 'auto'` with autoAcceptAbove: 0.
+  const high = Math.max(1, clamp(obj.autoAcceptAbove, DEFAULT_HITL_CONFIG.autoAcceptAbove));
   const low = clamp(obj.autoDenyBelow, DEFAULT_HITL_CONFIG.autoDenyBelow);
-  // Enforce invariant: low < high.
+  // Enforce invariant: 0 <= low < high.
   return {
-    autoDenyBelow: Math.min(low, high - 1),
+    autoDenyBelow: Math.max(0, Math.min(low, high - 1)),
     autoAcceptAbove: high,
   };
 }


### PR DESCRIPTION
## Summary

`coerceConfidenceConfig` (in `packages/gui/src/app/actions/[name]/acceptance-types.ts`) could return `autoDenyBelow: -1` for `mode: 'human-in-the-loop'` when a row written under `mode: 'auto'` (with `autoAcceptAbove: 0`) was toggled to HITL. With `high = 0`, `Math.min(low, high - 1)` returned `-1`, so the form rendered a sub-zero state that violated the documented 0–100 contract and would later be rejected by `validateConfidenceConfig` on save.

The fix floors `autoAcceptAbove` at `1` so the `low < high` invariant can actually hold, and clamps `autoDenyBelow` at `0`. For the problematic case this now yields a clean `{ autoDenyBelow: 0, autoAcceptAbove: 1 }`.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)