### PR TITLE
fix: preserve action enabled state on save (#102)

### DIFF
--- a/packages/gui/src/app/actions/[name]/action-mutations.ts
+++ b/packages/gui/src/app/actions/[name]/action-mutations.ts
@@ -58,13 +58,14 @@ function revalidateAction(name: string) {
 interface ResolvedRow {
   id: string;
   kind: 'built-in' | 'user';
+  enabled: boolean;
 }
 
 async function loadCurrentRows(workspaceId: string, name: string): Promise<{ user: ResolvedRow | null; builtin: ResolvedRow | null }> {
   const supabase = createSupabaseAdminClient();
   const { data } = await supabase
     .from('actions')
-    .select('id, kind')
+    .select('id, kind, enabled')
     .eq('workspace_id', workspaceId)
     .eq('name', name);
   const rows = (data ?? []) as ResolvedRow[];
@@ -114,6 +115,11 @@ export async function saveAction(
   const supabase = createSupabaseAdminClient();
   const current = await loadCurrentRows(workspace.id, name);
 
+  // When the caller omits `enable`, preserve the current effective enabled
+  // state instead of force-writing `true` — otherwise editing any field would
+  // silently re-enable a disabled action.
+  const currentEnabled = current.user?.enabled ?? current.builtin?.enabled ?? true;
+
   const baseFields = {
     description: payload.description ?? null,
     system_prompt: payload.systemPrompt,
@@ -122,7 +128,7 @@ export async function saveAction(
     triggers: payload.triggers,
     effects: payload.effects,
     output_schema: schemaParse.value,
-    enabled: options.enable ?? true,
+    enabled: options.enable ?? currentEnabled,
     updated_by: user.id,
     model: payload.model,
     acceptance_mode: payload.acceptanceMode,


### PR DESCRIPTION
## Summary

`saveAction` (`packages/gui/src/app/actions/[name]/action-mutations.ts`) built its payload with `enabled: options.enable ?? true`. When a caller omitted `enable` — the common edit path where most edits don't intend to flip status — the stored `enabled` was force-written to `true`, silently re-enabling a previously disabled action. In the insert/override path this meant an admin who had disabled a built-in (via the kebab) and then edited any field would silently re-enable it, risking an unintended auto-triage pass that costs LLM money and posts comments.

## Fix

- `loadCurrentRows` now selects `enabled` alongside `id, kind`.
- `saveAction` defaults `enable` to the current effective enabled state (`user → built-in → true`) instead of `true`, so omitting `enable` preserves status on both the update and insert/override paths.

The explicit `{ enable: enabled }` passed from the Save form in `action-detail-view.tsx` continues to work unchanged.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)