### PR TITLE
fix: confirm destructive inbox/skill actions (#109)

### DIFF
--- a/packages/gui/src/app/inbox/inbox-view.tsx
+++ b/packages/gui/src/app/inbox/inbox-view.tsx
@@ -352,6 +352,14 @@ export function InboxView({
   const bulkDismiss = useCallback(() => {
     const ids = Array.from(selectedFindings);
     if (ids.length === 0) return;
+    // Bulk-dismiss is hard to undo (reversible only by trawling Supabase rows),
+    // so confirm before dismissing a large batch.
+    if (ids.length > 5) {
+      const ok = window.confirm(
+        `Dismiss ${ids.length} findings? They won't reappear in the inbox.`,
+      );
+      if (!ok) return;
+    }
     setItems((prev) => removeFindingFromItems(prev, ids));
     setSelectedFindings(new Set());
     startTransition(async () => {

--- a/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
+++ b/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
@@ -590,7 +590,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
           disabled={readOnly || (!dirty && !hasOverride)}
           className="inline-flex h-9 items-center gap-2 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface-variant transition-colors hover:border-primary hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {hasOverride ? 'Revert to upstream' : 'Discard changes'}
+          {hasOverride ? 'Delete override' : 'Discard changes'}
         </button>
         <div className="flex items-center gap-2">
           {saveError && <span className="text-xs text-error">{saveError}</span>}


### PR DESCRIPTION
## Summary

Adds guardrails to two hard-to-undo paths flagged in the audit:

- **Inbox bulk dismiss** (`bulkDismiss`): now shows a `window.confirm` — "Dismiss N findings? They won't reappear in the inbox." — when more than 5 findings are selected. Bulk-dismiss is otherwise reversible only by trawling Supabase rows. Single-row dismiss is left as-is (optimistic UI + re-fetch makes it recoverable).
- **Skill detail footer**: the destructive button (which calls `deleteSkillOverride`) is now labeled **"Delete override"** when an override exists, instead of the softer "Revert to upstream", so the destructive intent is obvious. It already had a `window.confirm` guard.

Focused, minimal diff (9 insertions, 1 deletion) scoped to this issue.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)