### PR TITLE
fix: don't silently fork upstream skill on first keystroke (#108)

### DIFF
--- a/packages/gui/src/app/skills/[name]/override-actions.ts
+++ b/packages/gui/src/app/skills/[name]/override-actions.ts
@@ -98,9 +98,15 @@ export async function saveSkillOverride(
 }
 
 /**
- * Body-only autosave. Creates the override if it didn't exist yet, copying
- * the metadata defaults. Cheaper than the full save so it can run on a
- * debounce.
+ * Body-only autosave. Updates the body of an *existing* override only.
+ *
+ * It deliberately does NOT create the override: forking an upstream skill must
+ * be an intentional act (the explicit "Save as override" / "Save & Enable"
+ * buttons, which carry the full metadata payload). Auto-creating here on the
+ * first keystroke would silently flip the skill to OVERRIDE and reset metadata
+ * to DB defaults — exactly the surprise the override pattern guards against.
+ * Callers gate this on the override already existing; if it somehow doesn't,
+ * we no-op with an error rather than insert a default row.
  */
 export async function autosaveSkillOverrideBody(
   skillName: string,
@@ -112,7 +118,6 @@ export async function autosaveSkillOverrideBody(
 
   const supabase = createSupabaseAdminClient();
 
-  // If a row exists, update only body. Otherwise insert a default row.
   const { data: existing } = await supabase
     .from('skill_overrides')
     .select('id')
@@ -120,27 +125,14 @@ export async function autosaveSkillOverrideBody(
     .eq('skill_name', skillName)
     .maybeSingle();
 
-  if (existing) {
-    const { data, error } = await supabase
-      .from('skill_overrides')
-      .update({ body, updated_by: user.id })
-      .eq('id', existing.id)
-      .select('updated_at, enabled')
-      .single();
-    if (error) return { ok: false, error: error.message };
-    revalidateSkill(skillName);
-    return { ok: true, updatedAt: data?.updated_at ?? undefined, enabled: data?.enabled ?? true };
+  if (!existing) {
+    return { ok: false, error: 'No override to autosave — use "Save as override" first' };
   }
 
   const { data, error } = await supabase
     .from('skill_overrides')
-    .insert({
-      workspace_id: workspace.id,
-      skill_name: skillName,
-      body,
-      updated_by: user.id,
-      created_by: user.id,
-    })
+    .update({ body, updated_by: user.id })
+    .eq('id', existing.id)
     .select('updated_at, enabled')
     .single();
   if (error) return { ok: false, error: error.message };

--- a/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
+++ b/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
@@ -124,10 +124,13 @@ export function SkillDetailView({ skill, readOnly }: Props) {
     skill.metadata.capabilities,
   ]);
 
-  // Debounced body autosave.
+  // Debounced body autosave. Only runs once an override already exists —
+  // editing an upstream (repo/built-in) skill must NOT silently fork it on the
+  // first keystroke. Until then the body stays "Unsaved" and the user opts in
+  // explicitly via "Save as override" / "Save & Enable Skill".
   const bodyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (!bodyDirty || readOnly) return;
+    if (!bodyDirty || readOnly || !hasOverride) return;
     if (bodyTimerRef.current) clearTimeout(bodyTimerRef.current);
     bodyTimerRef.current = setTimeout(async () => {
       setSaveState('saving');
@@ -136,7 +139,6 @@ export function SkillDetailView({ skill, readOnly }: Props) {
         setSaveState('saved');
         setSaveError(null);
         setBodyDirty(false);
-        setHasOverride(true);
         if (result.updatedAt) setOverrideUpdatedAt(result.updatedAt);
         if (typeof result.enabled === 'boolean') setEnabled(result.enabled);
       } else {
@@ -147,7 +149,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
     return () => {
       if (bodyTimerRef.current) clearTimeout(bodyTimerRef.current);
     };
-  }, [body, bodyDirty, readOnly, skill.name]);
+  }, [body, bodyDirty, readOnly, hasOverride, skill.name]);
 
   const buildPayload = useCallback(
     (): OverridePayload => ({


### PR DESCRIPTION
## Summary

The Instruction Workspace textarea on the skill detail page autosaved after 800ms even when viewing a repo/built-in skill that had **no override yet**. A single accidental keystroke called `autosaveSkillOverrideBody`, which inserted a brand-new `skill_overrides` row (`enabled: true`, all metadata fields left to DB defaults). From the user's perspective this silently:

- flipped the header badge from `AI_ASSISTED` to `OVERRIDE · ACTIVE`,
- marked the skill as `OVERRIDE` (with a `*`) in the Skills list,
- started ignoring future upstream `.ai/skills/<name>.md` edits,
- and could reset their in-form metadata picks (triggers/outputs/capabilities) to DB defaults.

Forking an upstream skill should be intentional.

## Fix

- **Client (`skill-detail-view.tsx`):** the debounced autosave effect now only fires once an override already exists (gated on `hasOverride`). Editing an upstream skill leaves the body in the `Unsaved` state until the user explicitly clicks **Save as override** or **Save & Enable Skill** — both of which already persist the full metadata payload, so no fields silently revert.
- **Server (`override-actions.ts`):** `autosaveSkillOverrideBody` no longer creates a default-metadata override as a fallback. It updates the body of an existing override only, returning an error otherwise — removing the silent default-metadata insert path entirely.

Scoped to the two files involved; no schema or migration changes.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)