### PR TITLE
fix: add idempotency guard to runActionNow (#105)

### DIFF
--- a/packages/gui/src/app/actions/[name]/run-now-action.ts
+++ b/packages/gui/src/app/actions/[name]/run-now-action.ts
@@ -12,7 +12,18 @@ export interface RunNowResult {
   ok: boolean;
   error?: string;
   workflowRunId?: string;
+  /** True when we short-circuited to a recent identical run instead of launching a new one. */
+  deduped?: boolean;
 }
+
+/**
+ * Idempotency window for run-now: a second click against the same
+ * (action, target number, workspace) within this many ms is short-circuited to
+ * the existing run instead of launching a fresh agent pass. Guards against a
+ * user holding down "Run now" (or scripting it) racking up Anthropic spend and
+ * spamming duplicate comments on the same issue/PR.
+ */
+const RUN_NOW_DEDUPE_WINDOW_MS = 5 * 60 * 1000;
 
 /**
  * Real, synchronous "run this action against this issue or PR" — the
@@ -112,6 +123,27 @@ export async function runActionNow(actionId: string, number: number): Promise<Ru
   const repoSlug = `${workspace.repoOwner}/${workspace.repoName}`;
 
   const isPr = actionRow.target === 'pr';
+
+  // ── idempotency guard ────────────────────────────────────────────────────
+  // If an identical run-now (same action, same target, same workspace) already
+  // ran (or is still running) within the dedupe window, surface that run
+  // instead of launching another agent pass + posting a duplicate comment.
+  const dedupeSince = new Date(Date.now() - RUN_NOW_DEDUPE_WINDOW_MS).toISOString();
+  const { data: recentRun } = await supabase
+    .from('workflow_runs')
+    .select('id')
+    .eq('workspace_id', workspace.id)
+    .eq('workflow', 'single-action')
+    .eq(isPr ? 'pr_number' : 'issue_number', number)
+    .in('status', ['queued', 'running', 'succeeded'])
+    .eq('outcome->>action', actionRow.name)
+    .gte('created_at', dedupeSince)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (recentRun?.id) {
+    return { ok: true, workflowRunId: recentRun.id, deduped: true };
+  }
 
   // ── persistence ─────────────────────────────────────────────────────────
   const persister = await createWorkflowRunPersister(supabase, {


### PR DESCRIPTION
## Summary

`runActionNow` (the "Run now" server action behind the issue/PR run-now modals) launched a full agent pass — posting comments and applying effects when `action_auto_comment` is on — every time it was invoked. Holding down the button or scripting it racked up Anthropic spend and spammed duplicate comments on the same issue/PR.

This adds an **idempotency guard**: before persisting a new `single-action` `workflow_runs` row, it checks for an existing `queued`/`running`/`succeeded` run for the same `(action, target number, workspace)` within a 5-minute window. If one exists, it short-circuits and returns that run's id (with `deduped: true`).

Because all three run-now modals already do `router.push(`/cockpit/${r.workflowRunId}`)` on success, the short-circuit transparently navigates the user to the prior cockpit run — the "already ran, view it" UX the audit suggested — with no client changes.

The expensive `core.runAction` (Anthropic pass + effects/comments) is skipped on the dedup path.

### Notes / scope
- No schema change. The guard reuses existing `workflow_runs` columns (`workflow`, `issue_number`/`pr_number`, `outcome->>action`, `created_at`, `status`). `outcome.action` is written by `persister.finalize`, so completed run-now rows always carry it.
- Scoped intentionally to the idempotency check (the primary cost/spam vector). A per-user rate-limit table and the simulate-endpoint cap (also mentioned in the audit) are larger, separable changes left out to keep this diff minimal.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)