### PR TITLE
fix: rate-limit & debounce syncAndDigest to cap LLM spend (#104)

### DIFF
--- a/packages/gui/src/app/inbox/inbox-view.tsx
+++ b/packages/gui/src/app/inbox/inbox-view.tsx
@@ -91,6 +91,11 @@ interface SkillFilterOption {
 
 const ALL_SKILLS_OPTION: SkillFilterOption = { id: 'all', label: 'All skills' };
 
+// Client-side mirror of the server-side sync cooldown (see sync-action.ts /
+// migration 0029). Keeps the button disabled for the same window so the user
+// can't fire calls the server will only reject.
+const SYNC_COOLDOWN_MS = 30_000;
+
 // Humanize an action name like 'log-analyzer' → 'Log analyzer'. The action
 // name is the canonical identifier; the label is purely presentational.
 function humanizeActionName(name: string): string {
@@ -190,6 +195,10 @@ export function InboxView({
   const [typeFilter, setTypeFilter] = useState<(typeof TYPE_FILTERS)[number]>(TYPE_FILTERS[0]);
   const [syncing, setSyncing] = useState(false);
   const [syncedAt, setSyncedAt] = useState<number>(initialSyncedAt);
+  // Epoch-ms until which the sync button stays disabled — mirrors the
+  // server-side cooldown so we don't fire calls the server will reject.
+  const [cooldownUntil, setCooldownUntil] = useState<number>(0);
+  const [, forceCooldownTick] = useState(0);
   const [toast, setToast] = useState<string | null>(null);
 
   // ── derived counts / filters ──
@@ -363,14 +372,20 @@ export function InboxView({
   }, [selectedFindings, router]);
 
   const handleSync = useCallback(async () => {
+    if (Date.now() < cooldownUntil) return;
     setSyncing(true);
     const result = await syncAndDigest();
     setSyncing(false);
     if (!result.ok) {
+      // The server enforces its own cooldown; mirror it client-side so the
+      // button stays disabled for the same window instead of letting the
+      // user keep firing rejected calls.
+      if (result.retryAfter) setCooldownUntil(Date.now() + result.retryAfter * 1000);
       setToast(`Sync failed: ${result.error ?? 'unknown'}`);
       return;
     }
     setSyncedAt(Date.now());
+    setCooldownUntil(Date.now() + SYNC_COOLDOWN_MS);
     const bits: string[] = [];
     if (result.issuesFetched) {
       const created = result.issuesCreated ?? 0;
@@ -380,9 +395,11 @@ export function InboxView({
     if (result.digestsCreated) bits.push(`${result.digestsCreated} digested`);
     if (result.commentsFetched) bits.push(`${result.commentsFetched} commented`);
     if (result.prsUpdated) bits.push(`${result.prsUpdated} PR${result.prsUpdated === 1 ? '' : 's'}`);
-    setToast(bits.length > 0 ? `Synced: ${bits.join(' · ')}` : 'Already up to date');
+    let summary = bits.length > 0 ? `Synced: ${bits.join(' · ')}` : 'Already up to date';
+    if (result.truncated) summary += ' · more to digest — sync again in a minute';
+    setToast(summary);
     router.refresh();
-  }, [router]);
+  }, [router, cooldownUntil]);
 
   // ── keyboard: Cmd+A / Ctrl+A selects all visible findings ──
   useEffect(() => {
@@ -406,6 +423,15 @@ export function InboxView({
     const t = setTimeout(() => setToast(null), 1800);
     return () => clearTimeout(t);
   }, [toast]);
+
+  // ── re-enable the sync button when the cooldown elapses ──
+  useEffect(() => {
+    if (cooldownUntil <= Date.now()) return;
+    const t = setTimeout(() => forceCooldownTick((n) => n + 1), cooldownUntil - Date.now());
+    return () => clearTimeout(t);
+  }, [cooldownUntil]);
+
+  const inCooldown = cooldownUntil > Date.now();
 
   const pendingTotal = counts.decisions;
   const hasAny = visibleItems.length > 0;
@@ -435,16 +461,18 @@ export function InboxView({
           <button
             type="button"
             onClick={handleSync}
-            disabled={syncing}
+            disabled={syncing || inCooldown}
+            title={inCooldown ? 'Synced moments ago — wait a few seconds before retrying' : undefined}
             className={cn(
               'inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors',
-              syncing
-                ? 'cursor-wait border-outline-variant bg-surface-container text-on-surface-variant'
+              syncing || inCooldown
+                ? 'cursor-not-allowed border-outline-variant bg-surface-container text-on-surface-variant'
                 : 'border-primary/40 bg-primary/10 text-primary hover:border-primary/60 hover:bg-primary/15',
+              syncing && 'cursor-wait',
             )}
           >
             <RefreshIcon className={cn('h-4 w-4', syncing && 'animate-spin')} />
-            {syncing ? 'Syncing…' : 'Sync & Digest'}
+            {syncing ? 'Syncing…' : inCooldown ? 'Synced just now' : 'Sync & Digest'}
           </button>
         </div>
       </header>

--- a/packages/gui/src/app/inbox/sync-action.ts
+++ b/packages/gui/src/app/inbox/sync-action.ts
@@ -27,7 +27,22 @@ export interface SyncResult {
   digestsCreated?: number;
   commentsFetched?: number;
   prsUpdated?: number;
+  /** Set when the per-call digest cap was hit — more issues remain undigested. */
+  truncated?: boolean;
+  /** Seconds the caller should wait before retrying (set on a cooldown rejection). */
+  retryAfter?: number;
 }
+
+// Server-side rate limit: refuse a fresh sync within this window of the last
+// one, and collapse concurrent calls (two tabs / rapid clicks) to a single
+// run. Every sync is real Anthropic spend, so we gate it at the source rather
+// than trusting the client's disabled button. See migration 0029.
+const SYNC_COOLDOWN_SECONDS = 30;
+
+// Cap on digests generated per click. Onboarding a huge repo shouldn't bill
+// Claude for thousands of digests in one shot; the UI surfaces `truncated` so
+// the user can sync again to drain the rest.
+const MAX_DIGESTS_PER_SYNC = 200;
 
 export async function syncAndDigest(): Promise<SyncResult> {
   const user = await getSessionUser();
@@ -48,6 +63,28 @@ export async function syncAndDigest(): Promise<SyncResult> {
   if (!token) return { ok: false, error: 'No GitHub token — sign out and back in to sync' };
 
   const supabase = createSupabaseAdminClient();
+
+  // ── Rate limit + concurrency guard ──
+  // claim_sync_slot atomically stamps workspaces.last_synced_at = now() and
+  // returns true iff the previous sync is older than the cooldown. Concurrent
+  // callers both run the UPDATE but only the first to commit matches the
+  // predicate, so exactly one wins — the rest get `false` and bail before any
+  // GitHub fetch or LLM call. Done before any paid work so spam is free.
+  const { data: claimed, error: claimErr } = await supabase.rpc('claim_sync_slot', {
+    wid: workspace.id,
+    p_cooldown_seconds: SYNC_COOLDOWN_SECONDS,
+  });
+  if (claimErr) {
+    return { ok: false, error: `Sync gate failed: ${claimErr.message}` };
+  }
+  if (!claimed) {
+    return {
+      ok: false,
+      error: 'Synced moments ago — wait a few seconds before retrying.',
+      retryAfter: SYNC_COOLDOWN_SECONDS,
+    };
+  }
+
   const adapter = new SupabaseStoreAdapter(supabase, workspace.id);
 
   // The store may be empty for a newly-connected workspace; tolerate that
@@ -116,8 +153,13 @@ export async function syncAndDigest(): Promise<SyncResult> {
 
   // ── 2. Generate digests for issues that don't have one yet ──
   let digestsCreated = 0;
+  let truncated = false;
   try {
-    const needDigest = store.getIssues({ hasDigest: false });
+    const allNeedDigest = store.getIssues({ hasDigest: false });
+    // Cap the LLM spend per click; surface `truncated` so the UI can prompt
+    // another sync to drain the remainder.
+    truncated = allNeedDigest.length > MAX_DIGESTS_PER_SYNC;
+    const needDigest = truncated ? allNeedDigest.slice(0, MAX_DIGESTS_PER_SYNC) : allNeedDigest;
     if (needDigest.length > 0) {
       const llm = new core.LLMService(config);
       const issueData = needDigest.map((i) => ({ number: i.number, title: i.title, body: i.body }));
@@ -194,5 +236,6 @@ export async function syncAndDigest(): Promise<SyncResult> {
     digestsCreated,
     commentsFetched,
     prsUpdated,
+    truncated,
   };
 }

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -119,13 +119,15 @@ export interface Database {
           separate_comment_per_step: boolean;
           action_auto_comment: boolean;
           auto_triage_action_id: string | null;
+          last_synced_at: string | null;
           created_at: string;
           updated_at: string;
         };
-        Insert: Omit<Database['public']['Tables']['workspaces']['Row'], 'id' | 'created_at' | 'updated_at' | 'auto_triage_action_id' | 'action_auto_comment'> & {
+        Insert: Omit<Database['public']['Tables']['workspaces']['Row'], 'id' | 'created_at' | 'updated_at' | 'auto_triage_action_id' | 'action_auto_comment' | 'last_synced_at'> & {
           id?: string;
           auto_triage_action_id?: string | null;
           action_auto_comment?: boolean;
+          last_synced_at?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/packages/gui/supabase/migrations/0029_workspace_sync_cooldown.sql
+++ b/packages/gui/supabase/migrations/0029_workspace_sync_cooldown.sql
@@ -1,0 +1,45 @@
+-- 0029_workspace_sync_cooldown.sql
+-- Server-side rate limit + concurrency guard for the "Sync & Digest" action.
+--
+-- syncAndDigest() (packages/gui/src/app/inbox/sync-action.ts) fetches issues
+-- from GitHub and runs LLMService.generateDigests against every undigested
+-- issue — every click is real Anthropic spend. Before this migration there
+-- was no server-side debounce and no concurrency check, so rapid clicks or
+-- two tabs racing could bill Claude multiple times for the same batch.
+--
+-- We add a dedicated `last_synced_at` timestamp (distinct from the store's
+-- meta.lastSyncedAt, which background crons/webhooks also bump) and an atomic
+-- `claim_sync_slot` that both enforces a cooldown and collapses concurrent
+-- callers: only the single UPDATE that wins the cooldown window returns true.
+
+alter table workspaces
+  add column if not exists last_synced_at timestamptz;
+
+-- ─── claim_sync_slot ────────────────────────────────────────────────────
+-- Atomically claims the manual-sync slot for a workspace. Returns true and
+-- stamps last_synced_at = now() iff the previous sync is older than
+-- p_cooldown_seconds (or never ran); returns false otherwise. The WHERE
+-- guard makes this race-safe — two concurrent callers both run the UPDATE,
+-- but only the first to commit matches the predicate, so exactly one wins.
+create or replace function claim_sync_slot(wid uuid, p_cooldown_seconds int default 30)
+returns boolean
+language plpgsql
+as $$
+declare
+  claimed boolean;
+begin
+  update workspaces
+     set last_synced_at = now()
+   where id = wid
+     and (
+       last_synced_at is null
+       or last_synced_at < now() - make_interval(secs => p_cooldown_seconds)
+     )
+  returning true into claimed;
+  return coalesce(claimed, false);
+end;
+$$;
+
+-- Matches the access-control posture of claim_next_job: the function body is
+-- the gate, not the caller. syncAndDigest invokes it with the service-role key.
+grant execute on function claim_sync_slot(uuid, int) to anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

The Inbox **Sync & Digest** button calls `syncAndDigest()`, which fetches issues from GitHub and runs `LLMService.generateDigests` against every undigested issue — **every click is real Anthropic spend**. The client only disabled the button for the duration of the in-flight call, so rapid clicks or two tabs racing could bill Claude multiple times for the same batch. There was no server-side debounce, no concurrency check, and no cap on digests per click.

### Server-side (the gate that actually protects spend)
- **Migration `0029_workspace_sync_cooldown.sql`** — adds `workspaces.last_synced_at` and an atomic `claim_sync_slot(wid, p_cooldown_seconds)`. It stamps `last_synced_at = now()` and returns `true` only when the previous sync is older than the cooldown; the single guarded `UPDATE` collapses concurrent callers so exactly one wins and the rest bail **before any GitHub/LLM work**.
- `syncAndDigest` claims the slot up front and returns a friendly `{ ok: false, retryAfter }` envelope when rejected (default 30s window).
- Caps digests at **200 per call** and surfaces `truncated: true` so the UI can prompt another sync to drain the rest.

### Client-side
- Mirrors the 30s cooldown: disables the button, shows "Synced just now", re-enables on a timer, and appends a truncation hint to the toast.

`last_synced_at` is a dedicated manual-sync timestamp, independent of the store's `meta.lastSyncedAt` (which background crons/webhooks also bump), so the cooldown only governs the user-triggered paid path.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)