### PR TITLE
fix: RLS write policies cross-check parent ownership (#113)

### DIFF
--- a/packages/gui/supabase/migrations/0029_rls_cross_check_parent_ownership.sql
+++ b/packages/gui/supabase/migrations/0029_rls_cross_check_parent_ownership.sql
@@ -1,0 +1,66 @@
+-- 0029_rls_cross_check_parent_ownership.sql
+-- Tighten the admin-write RLS policies on workflow_runs / agent_runs /
+-- agent_run_events so they also cross-check parent-row ownership.
+--
+-- The 0008 policies only verified the row's own workspace_id:
+--   for all using (is_workspace_admin(workspace_id))
+--        with check (is_workspace_admin(workspace_id));
+-- A workspace admin could therefore insert/update a child row that points at a
+-- *parent* in a different workspace (e.g. an agent_run_events row whose own
+-- workspace_id matches a workspace they admin, but whose workflow_run_id /
+-- agent_run_id belongs to workspace B). The FK only checks the parent exists,
+-- not that its workspace_id matches. Same for agent_runs.workflow_run_id and
+-- workflow_runs.job_id (an admin could claim any job by setting job_id).
+--
+-- The realtime writers all use the service-role client (bypasses RLS), so the
+-- production blast radius is limited today — but the policy is the only line of
+-- defence if a future SSR action ever writes through the user-context client.
+-- This migration adds the missing parent-ownership checks to the WITH CHECK
+-- (and, where relevant, USING) clauses.
+
+-- ─── workflow_runs: cross-check job ownership ────────────────────────────
+drop policy "workflow_runs_admin_write" on workflow_runs;
+create policy "workflow_runs_admin_write" on workflow_runs
+  for all
+  using (is_workspace_admin(workspace_id))
+  with check (
+    is_workspace_admin(workspace_id)
+    and (job_id is null or exists (
+      select 1 from jobs j
+      where j.id = workflow_runs.job_id
+        and j.workspace_id = workflow_runs.workspace_id
+    ))
+  );
+
+-- ─── agent_runs: cross-check workflow_run ownership ──────────────────────
+drop policy "agent_runs_admin_write" on agent_runs;
+create policy "agent_runs_admin_write" on agent_runs
+  for all
+  using (is_workspace_admin(workspace_id))
+  with check (
+    is_workspace_admin(workspace_id)
+    and exists (
+      select 1 from workflow_runs wr
+      where wr.id = agent_runs.workflow_run_id
+        and wr.workspace_id = agent_runs.workspace_id
+    )
+  );
+
+-- ─── agent_run_events: cross-check workflow_run + agent_run ownership ─────
+drop policy "agent_run_events_admin_write" on agent_run_events;
+create policy "agent_run_events_admin_write" on agent_run_events
+  for all
+  using (is_workspace_admin(workspace_id))
+  with check (
+    is_workspace_admin(workspace_id)
+    and exists (
+      select 1 from workflow_runs wr
+      where wr.id = agent_run_events.workflow_run_id
+        and wr.workspace_id = agent_run_events.workspace_id
+    )
+    and (agent_run_id is null or exists (
+      select 1 from agent_runs ar
+      where ar.id = agent_run_events.agent_run_id
+        and ar.workspace_id = agent_run_events.workspace_id
+    ))
+  );


### PR DESCRIPTION
## Summary

The admin-write RLS policies on `workflow_runs` / `agent_runs` / `agent_run_events` (introduced in `0008_agent_runs.sql`) only verified the row's own `workspace_id`. Because the FK constraints only check that a parent row *exists* (not that its `workspace_id` matches), a workspace admin could insert/update a child row whose parent belongs to a **different** workspace — e.g. inject `agent_run_events` into another tenant's run timeline by supplying a foreign `workflow_run_id` / `agent_run_id`.

The realtime writers all use the service-role client (which bypasses RLS), so today's production blast radius is limited, but the policy is the only line of defence if a future SSR action ever writes through the user-context client.

## Fix

New migration `0029_rls_cross_check_parent_ownership.sql` recreates the three admin-write policies with tightened `WITH CHECK` clauses that also verify parent ownership:

- `workflow_runs`: `job_id` (when set) must match `workspace_id`
- `agent_runs`: `workflow_run_id` must match `workspace_id`
- `agent_run_events`: `workflow_run_id` must match, and `agent_run_id` (when set) must match `workspace_id`

Does not touch the already-applied `0008` migration.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)