### PR TITLE
fix: debounce skill autocomplete to avoid per-keystroke queries (#111)

### DIFF
--- a/packages/gui/src/app/actions/[name]/action-detail-view.tsx
+++ b/packages/gui/src/app/actions/[name]/action-detail-view.tsx
@@ -82,6 +82,7 @@ const ALL_EFFECTS = [
 ] as const;
 
 const AUTOSAVE_DEBOUNCE_MS = 800;
+const SKILL_SEARCH_DEBOUNCE_MS = 200;
 
 type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -154,14 +155,16 @@ export function ActionDetailView({ action, readOnly }: Props) {
   ]);
 
   // Lazy skill suggestion fetch — only when the user opens the autocomplete.
+  // Debounced so a fast typist doesn't fire one server round-trip per keystroke.
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    const id = setTimeout(async () => {
       const items = await searchSkills(skillQuery);
       if (!cancelled) setSkillSuggestions(items);
-    })();
+    }, SKILL_SEARCH_DEBOUNCE_MS);
     return () => {
       cancelled = true;
+      clearTimeout(id);
     };
   }, [skillQuery]);
 


### PR DESCRIPTION
## Summary

The "Search skills to add…" autocomplete in the action detail view ran the `searchSkills` server action via `useEffect(..., [skillQuery])` on **every keystroke**, with each call being a fresh Supabase round-trip that fetches and filters the whole `repo_skills.skills` JSONB blob.

This wraps the fetch in a 200ms debounced `setTimeout` (mirroring the existing `AUTOSAVE_DEBOUNCE_MS` pattern in the same file), so a fast typist no longer triggers N back-to-back queries. The existing `cancelled` guard is retained to discard stale out-of-order responses that would otherwise flicker the dropdown.

Scope: single `useEffect` plus one new `SKILL_SEARCH_DEBOUNCE_MS` constant. No server-side or behavioral change beyond the debounce.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)