### PR TITLE
fix: dedup pending_decisions + index FK columns (#116)

### DIFF
--- a/packages/gui/src/lib/execute-workflow-job.ts
+++ b/packages/gui/src/lib/execute-workflow-job.ts
@@ -303,7 +303,11 @@ export async function executeWorkflowJob(
             summary,
             confidence,
           });
-          if (error) {
+          // 23505 = unique_violation against pending_decisions_dedup_idx: a
+          // pending decision for this (action, target, effect, args) already
+          // exists. That's the intended dedup behaviour (see migration 0029),
+          // not a failure — drop it silently.
+          if (error && error.code !== '23505') {
             console.error('[dispatch] pending_decisions insert failed:', error.message);
           }
         },

--- a/packages/gui/supabase/migrations/0029_pending_decisions_dedup.sql
+++ b/packages/gui/supabase/migrations/0029_pending_decisions_dedup.sql
@@ -1,0 +1,34 @@
+-- 0029_pending_decisions_dedup.sql
+-- Dedup + FK indexes for pending_decisions (migration 0019).
+--
+-- 0019 noted that the inbox/runner wants "is there already a pending decision
+-- for (action, issue, effect)?" for dedupe but never enforced it. The dispatch
+-- sink (`lib/execute-workflow-job.ts`) plain-`insert`s a new row for every
+-- deferred effect, so re-running the same action on the same target (e.g.
+-- an `issues.edited` triage firing while an `issues.opened` decision is still
+-- pending) silently creates duplicate inbox rows.
+--
+-- Enforce at most one *pending* decision per
+--   (workspace, action, target, effect, effect_args)
+-- so the duplicate insert hits the unique index and is swallowed (23505) by the
+-- sink. The index doubles as the lookup the inbox grouper/runner wanted.
+--
+-- Also index the two FK columns that the run-detail and action-settings
+-- "what's pending / what came out of this run?" queries filter on; both fell
+-- back to seq scans before.
+
+-- Dedup: at most one pending decision per
+-- (workspace, action, target, effect, effect_args hash).
+create unique index pending_decisions_dedup_idx
+  on pending_decisions (
+    workspace_id, action_id, target_kind,
+    coalesce(issue_number, 0), coalesce(pr_number, 0),
+    effect, md5(effect_args::text)
+  )
+  where status = 'pending';
+
+create index pending_decisions_action_idx
+  on pending_decisions (action_id) where status = 'pending';
+
+create index pending_decisions_workflow_run_idx
+  on pending_decisions (workflow_run_id) where workflow_run_id is not null;

--- a/packages/gui/supabase/migrations/0035_pending_decisions_dedup.sql
+++ b/packages/gui/supabase/migrations/0035_pending_decisions_dedup.sql
@@ -19,6 +19,23 @@
 
 -- Dedup: at most one pending decision per
 -- (workspace, action, target, effect, effect_args hash).
+-- Pre-clean: environments already exhibiting the duplicate-inbox bug hold
+-- duplicate *pending* rows, which would make the unique index below fail to
+-- build (plain CREATE INDEX, not CONCURRENTLY). Collapse each dedup-key group
+-- to its earliest row first so the index can apply everywhere.
+delete from pending_decisions p
+using (
+  select id, row_number() over (
+    partition by workspace_id, action_id, target_kind,
+                 coalesce(issue_number, 0), coalesce(pr_number, 0),
+                 effect, md5(effect_args::text)
+    order by created_at, id
+  ) as rn
+  from pending_decisions
+  where status = 'pending'
+) d
+where p.id = d.id and d.rn > 1;
+
 create unique index pending_decisions_dedup_idx
   on pending_decisions (
     workspace_id, action_id, target_kind,


### PR DESCRIPTION
## Summary

Migration 0019 documented but never enforced "at most one pending decision per (action, target, effect)". The dispatch sink in \`lib/execute-workflow-job.ts\` plain-\`insert\`s a row for every deferred effect, so re-running the same action on the same target (e.g. \`issues.edited\` firing while an \`issues.opened\` decision is still pending) silently created duplicate inbox rows. The \`action_id\` and \`workflow_run_id\` FK columns were also unindexed, forcing seq scans on the run-detail and action-settings "what's pending / what came out of this run?" queries.

## Changes

- New migration \`0029_pending_decisions_dedup.sql\`:
  - partial unique index \`pending_decisions_dedup_idx\` on \`(workspace_id, action_id, target_kind, coalesce(issue_number,0), coalesce(pr_number,0), effect, md5(effect_args::text))\` where \`status = 'pending'\` — enforces dedup and doubles as the lookup the inbox grouper/runner wanted.
  - partial FK indexes on \`action_id\` and \`workflow_run_id\`.
- The dispatch sink now treats a unique violation (\`23505\`) as the intended dedup no-op instead of logging it as an insert failure.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)