### PR TITLE
fix: workspaces.installation_id bigint + UNIQUE (#117)

### DIFF
--- a/packages/gui/src/app/api/github/webhook/route.ts
+++ b/packages/gui/src/app/api/github/webhook/route.ts
@@ -501,13 +501,13 @@ async function handleInstallation(admin: SupabaseAdmin, payload: WebhookPayload)
       if (installationId != null && repo) {
         await admin
           .from('workspaces')
-          .update({ installation_id: String(installationId) })
+          .update({ installation_id: installationId })
           .eq('repo_owner', repo.owner.login)
           .eq('repo_name', repo.name);
       }
     } else if (action === 'deleted' || action === 'removed') {
       if (installationId != null) {
-        await admin.from('workspaces').update({ installation_id: null }).eq('installation_id', String(installationId));
+        await admin.from('workspaces').update({ installation_id: null }).eq('installation_id', installationId);
       } else if (repo) {
         await admin.from('workspaces').update({ installation_id: null }).eq('repo_owner', repo.owner.login).eq('repo_name', repo.name);
       }
@@ -534,7 +534,7 @@ async function resolveWorkspaces(
     const { data } = await admin
       .from('workspaces')
       .select('id, auto_triage_enabled')
-      .eq('installation_id', String(installationId));
+      .eq('installation_id', installationId);
     if (data && data.length > 0) return data;
   }
   const { data } = await admin

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -111,7 +111,7 @@ export interface Database {
           name: string;
           repo_owner: string;
           repo_name: string;
-          installation_id: string | null;
+          installation_id: number | null;
           config: Json;
           meta: Json;
           auto_triage_enabled: boolean;

--- a/packages/gui/supabase/migrations/0029_workspace_installation_id_bigint.sql
+++ b/packages/gui/supabase/migrations/0029_workspace_installation_id_bigint.sql
@@ -1,0 +1,30 @@
+-- 0029_workspace_installation_id_bigint.sql
+-- Aligns `workspaces.installation_id` with `runners.github_installation_id`.
+--
+-- Both columns hold the same identifier — the GitHub App installation id —
+-- but 0001 declared `workspaces.installation_id` as `text` while 0026
+-- (correctly) declared `runners.github_installation_id` as `bigint`, noting
+-- that GitHub install ids can exceed 2^31. The `text` column was the outlier:
+--
+--   * the webhook handler stored/queried it via `String(installationId)`,
+--     with nothing rejecting a blank or non-numeric value;
+--   * joining the two columns required a cast on every query;
+--   * no UNIQUE meant two workspaces provisioned against the same install
+--     would both silently "work", then collide at token-mint time (the wrong
+--     workspace's install token minted for the wrong repo).
+--
+-- This migration converts the column to `bigint` and adds a partial UNIQUE
+-- index so a duplicated install id fails at insert time instead of at the
+-- GitHub API call. Blank strings are normalised to NULL during the cast.
+
+-- ─── normalise legacy blanks, then convert text → bigint ────────────────────
+alter table workspaces
+  alter column installation_id type bigint
+  using nullif(installation_id, '')::bigint;
+
+-- ─── catch duplicate installs at insert time ────────────────────────────────
+-- Partial index: many workspaces legitimately have no install configured yet
+-- (NULL), so uniqueness only applies to rows that actually carry an id.
+create unique index if not exists workspaces_installation_id_unique
+  on workspaces (installation_id)
+  where installation_id is not null;


### PR DESCRIPTION
## Summary

`workspaces.installation_id` was declared `text` (migration 0001) while `runners.github_installation_id` is `bigint` (migration 0026) — both hold the same GitHub App installation id. The `text` column was the outlier and carried real risk: the webhook handler stored/queried install ids via `String(installationId)` with no validation, every join needed a cast, and the missing UNIQUE let two workspaces share one install id and then collide at token-mint time (the wrong workspace's install token minted for the wrong repo).

### Changes
- New migration `0029_workspace_installation_id_bigint.sql`: converts the column to `bigint` (`nullif(installation_id, '')::bigint` to normalise legacy blanks) and adds a partial UNIQUE index `workspaces_installation_id_unique` (NULL still allowed for un-provisioned workspaces).
- `webhook/route.ts`: stores/queries the numeric installation id directly instead of `String(installationId)`.
- `lib/supabase/types.ts`: `workspaces.installation_id` is now `number | null`.

Migration 0001 (already applied) is left untouched; the change ships as a new migration per the project's migration convention.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)