### PR TITLE
fix: jobs table dedup UNIQUE constraint to stop duplicate queued jobs (#112)

### DIFF
--- a/packages/gui/src/app/api/github/webhook/route.ts
+++ b/packages/gui/src/app/api/github/webhook/route.ts
@@ -191,9 +191,13 @@ async function handleIssues(admin: SupabaseAdmin, payload: WebhookPayload): Prom
           max_attempts: 1,
           payload: { trigger: 'webhook', action },
         });
-        if (error) {
+        // The partial UNIQUE index (migration 0029) is the real dedup guard —
+        // the SELECT above just avoids the round-trip in the common case. A
+        // 23505 here means a concurrent delivery won the race, which is the
+        // intended outcome (one job), not a failure.
+        if (error && error.code !== '23505') {
           console.error(`[github-webhook] triage enqueue failed for ws ${ws.id}:`, error.message);
-        } else {
+        } else if (!error) {
           triageEnqueued++;
         }
       }
@@ -285,8 +289,12 @@ async function enqueueFlowsForIssueEvent(
         flowInput: String(args.issueNumber),
       },
     });
+    // 23505 = a concurrent delivery already enqueued this (flow, issue) job
+    // (partial UNIQUE index from migration 0029) — benign, not a failure.
     if (error) {
-      console.error(`[github-webhook] flow '${flow.name}' enqueue failed:`, error.message);
+      if (error.code !== '23505') {
+        console.error(`[github-webhook] flow '${flow.name}' enqueue failed:`, error.message);
+      }
       continue;
     }
     enqueued++;
@@ -418,8 +426,12 @@ async function handleCheckRun(admin: SupabaseAdmin, payload: WebhookPayload): Pr
       payload: { trigger: 'webhook', ciFollowup: ciFollowupSeed },
       ...preferred,
     });
+    // 23505 = a concurrent delivery already enqueued this ci-followup job
+    // (partial UNIQUE index from migration 0029) — benign, not a failure.
     if (error) {
-      console.error(`[github-webhook] ci-followup enqueue failed for ws ${ws.id}:`, error.message);
+      if (error.code !== '23505') {
+        console.error(`[github-webhook] ci-followup enqueue failed for ws ${ws.id}:`, error.message);
+      }
       continue;
     }
     enqueued++;

--- a/packages/gui/src/lib/maybe-enqueue-autofix-from-triage.ts
+++ b/packages/gui/src/lib/maybe-enqueue-autofix-from-triage.ts
@@ -136,7 +136,13 @@ export async function maybeEnqueueAutofixFromTriage(
       payload: { trigger: 'triage' },
       ...preferred,
     });
-    if (insErr) return { enqueued: false, reason: `enqueue failed: ${insErr.message}` };
+    // 23505 = a concurrent path already enqueued this autofix job (partial
+    // UNIQUE index from migration 0029) — treat as "already in flight", not a
+    // hard failure.
+    if (insErr) {
+      if (insErr.code === '23505') return { enqueued: false, reason: 'an autofix job is already queued/running for this issue' };
+      return { enqueued: false, reason: `enqueue failed: ${insErr.message}` };
+    }
     return { enqueued: true };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/gui/src/lib/scheduler/run-triage-sweep.ts
+++ b/packages/gui/src/lib/scheduler/run-triage-sweep.ts
@@ -101,8 +101,12 @@ async function sweepOne(
       max_attempts: 1,
       payload: { trigger: 'sweep' },
     });
+    // 23505 = a concurrent webhook/sweep already enqueued this triage job
+    // (partial UNIQUE index from migration 0029) — benign, not a failure.
     if (error) {
-      console.error(`[triage-sweep] enqueue failed for ws ${ws.id} #${issue.number}:`, error.message);
+      if (error.code !== '23505') {
+        console.error(`[triage-sweep] enqueue failed for ws ${ws.id} #${issue.number}:`, error.message);
+      }
       continue;
     }
     enqueued++;

--- a/packages/gui/supabase/migrations/0029_jobs_dedup_unique.sql
+++ b/packages/gui/supabase/migrations/0029_jobs_dedup_unique.sql
@@ -1,0 +1,30 @@
+-- 0029_jobs_dedup_unique.sql
+-- Enforce "one in-flight job per dedup key" at the database level.
+--
+-- The webhook receiver (packages/gui/src/app/api/github/webhook/route.ts) and
+-- the triage-sweep cron dedupe purely in application code: SELECT for an
+-- in-flight job, then INSERT if none found. There's no lock between the read
+-- and the write, so two concurrent deliveries (label-added + reopened in the
+-- same second, or GitHub's at-least-once retry) both see an empty result and
+-- both insert. Each duplicate burns a real Anthropic call, posts a duplicate
+-- cockpit "running" card, and (for autofix) opens a duplicate PR.
+--
+-- These partial UNIQUE indexes close the race. Combined with `ON CONFLICT DO
+-- NOTHING` on the enqueue paths, a concurrent double-insert collapses to one
+-- row. The predicate is scoped to in-flight statuses + non-null issue_number,
+-- so finished/failed/cancelled jobs never block a fresh re-enqueue.
+--
+--   * triage / autofix / ci-followup key on (workspace_id, kind, issue_number).
+--   * flow keys on (workspace_id, issue_number, payload->>'flowId') — one
+--     in-flight run per (flow, issue), matching the application dedupe in
+--     enqueueFlowsForIssueEvent.
+
+create unique index jobs_dedup_kind_idx on jobs (workspace_id, kind, issue_number)
+  where kind in ('triage', 'autofix', 'ci-followup')
+    and status in ('queued', 'claimed', 'running')
+    and issue_number is not null;
+
+create unique index jobs_dedup_flow_idx on jobs (workspace_id, issue_number, (payload ->> 'flowId'))
+  where kind = 'flow'
+    and status in ('queued', 'claimed', 'running')
+    and issue_number is not null;


### PR DESCRIPTION
## Summary

The `jobs` table had no UNIQUE constraint enforcing "one in-flight job per dedup key". The webhook receiver and the triage-sweep / triage→autofix paths deduped purely in application code via SELECT-then-INSERT, with no lock between the read and the write. Two concurrent deliveries (label-added + reopened in the same second, or GitHub's at-least-once retry) both saw an empty result and both inserted — burning a real Anthropic call, posting a duplicate cockpit "running" card, and (for autofix) opening duplicate PRs.

## Changes

- **New migration `0029_jobs_dedup_unique.sql`** adds two partial UNIQUE indexes, scoped to in-flight statuses (`queued`/`claimed`/`running`) and non-null `issue_number`:
  - `jobs_dedup_kind_idx (workspace_id, kind, issue_number)` — `triage` / `autofix` / `ci-followup`
  - `jobs_dedup_flow_idx (workspace_id, issue_number, payload->>'flowId')` — `flow`
- **Enqueue paths** (`webhook/route.ts`, `run-triage-sweep.ts`, `maybe-enqueue-autofix-from-triage.ts`) now treat a `23505` unique-violation as the intended outcome (one job won the race) rather than a hard error. The existing cheap SELECT stays as a common-case fast-path; the index is the real guard.

The finished/failed/cancelled statuses are excluded from the predicate, so a fresh re-enqueue after a job completes is never blocked.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)