### PR TITLE
fix: validate ?next= on /auth/callback to block open redirect (#119)

### DIFF
--- a/packages/gui/src/app/auth/callback/route.ts
+++ b/packages/gui/src/app/auth/callback/route.ts
@@ -5,7 +5,15 @@ import { NextResponse, type NextRequest } from 'next/server';
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const code = searchParams.get('code');
-  const next = searchParams.get('next') ?? '/dashboard';
+  // Only allow same-origin relative paths to prevent open-redirect via `next`.
+  // Reject protocol-relative (`//evil.com`) and backslash (`/\evil.com`) values.
+  const rawNext = searchParams.get('next') ?? '/dashboard';
+  const next =
+    rawNext.startsWith('/') &&
+    !rawNext.startsWith('//') &&
+    !rawNext.startsWith('/\\')
+      ? rawNext
+      : '/dashboard';
   // Use the configured public app URL — `request.nextUrl.origin` is
   // `http://0.0.0.0:3000` inside the standalone container behind Traefik.
   const origin = process.env.NEXT_PUBLIC_APP_URL ?? request.nextUrl.origin;


### PR DESCRIPTION
## Summary

The OAuth callback (`packages/gui/src/app/auth/callback/route.ts`) concatenated the user-controlled `next` query parameter directly into the post-auth redirect URL (`` `${origin}${next}` ``) with no validation. Values such as `next=//evil.com` or `next=/\evil.com` would redirect users off-site after they completed sign-in — a classic open-redirect exploitable in phishing flows.

This restricts `next` to same-origin relative paths: it must start with a single `/` and is rejected if it begins with `//` (protocol-relative) or `/\` (backslash), falling back to `/dashboard`.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)