### PR TITLE
fix: surface OAuth error path in UI and log (#120)

### DIFF
--- a/packages/gui/src/app/auth/callback/route.ts
+++ b/packages/gui/src/app/auth/callback/route.ts
@@ -30,7 +30,9 @@ export async function GET(request: NextRequest) {
     );
 
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-    if (!error) {
+    if (error) {
+      console.error('[auth/callback] exchangeCodeForSession failed:', error);
+    } else {
       const providerToken = data.session?.provider_token;
       if (providerToken && data.user) {
         await supabase.from('user_github_tokens').upsert({

--- a/packages/gui/src/app/login/page.tsx
+++ b/packages/gui/src/app/login/page.tsx
@@ -1,10 +1,11 @@
 import { signInWithGitHub } from '@/app/auth/actions';
 
-export default function LoginPage({
+export default async function LoginPage({
   searchParams,
 }: {
   searchParams: Promise<{ error?: string }>;
 }) {
+  const { error } = await searchParams;
   return (
     <div className="flex min-h-screen items-center justify-center bg-bg">
       <div className="w-full max-w-sm rounded-xl border border-border bg-bg-elevated p-8">
@@ -12,6 +13,14 @@ export default function LoginPage({
           <h1 className="text-2xl font-semibold tracking-tight">CEZAR</h1>
           <p className="mt-1 text-sm text-fg-muted">AI-powered issue intelligence</p>
         </div>
+        {error && (
+          <div
+            role="alert"
+            className="mb-4 rounded-md border border-error/40 bg-error/10 px-3 py-2 text-sm text-error"
+          >
+            Sign-in failed. Please try again or contact support if the problem persists.
+          </div>
+        )}
         <form action={signInWithGitHub}>
           <button
             type="submit"


### PR DESCRIPTION
## Summary

The OAuth error path was silently dropped — users saw a no-op login button with no feedback, and ops had no breadcrumb when OAuth misconfigured.

- `login/page.tsx` now awaits `searchParams` and renders a `role="alert"` banner when an `error` query param is present. This covers both `oauth_failed` (from `auth/actions.ts`) and `auth_failed` (from the callback route).
- `auth/callback/route.ts` now `console.error`s the `exchangeCodeForSession` failure before redirecting, giving ops/oncall a log breadcrumb.

Styling uses the existing `error` design token (`border-error/40 bg-error/10 text-error`) consistent with other error banners in the GUI.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)