### PR TITLE
fix: bound analytics fetch and surface load errors (#124)

### DIFF
--- a/packages/gui/src/app/analytics/load-analytics.ts
+++ b/packages/gui/src/app/analytics/load-analytics.ts
@@ -39,9 +39,13 @@ export async function loadAnalytics(workspaceId: string): Promise<AnalyticsData 
   try {
     const supabase = await createSupabaseServerClient();
 
+    // Velocity only needs the last 12 weeks; cap the runs fetch so the page
+    // stays O(recent activity) instead of O(workspace history).
+    const since = new Date(Date.now() - 12 * 7 * 24 * 60 * 60 * 1000).toISOString();
+
     const [{ data: issues }, { data: runs }] = await Promise.all([
-      supabase.from('issues').select('number, state, labels, analysis, created_at').eq('workspace_id', workspaceId),
-      supabase.from('workflow_runs').select('id, workflow, issue_number, status, tokens_used, started_at').eq('workspace_id', workspaceId).order('started_at', { ascending: false }),
+      supabase.from('issues').select('number, state, labels, analysis, created_at').eq('workspace_id', workspaceId).gte('created_at', since),
+      supabase.from('workflow_runs').select('id, workflow, issue_number, status, tokens_used, started_at').eq('workspace_id', workspaceId).order('started_at', { ascending: false }).limit(200),
     ]);
 
     const allIssues = issues ?? [];
@@ -98,7 +102,8 @@ export async function loadAnalytics(workspaceId: string): Promise<AnalyticsData 
       .slice(0, 12);
 
     return { velocity, runOutcomes, costs, totalTokens, priorityDist, typeDist, labelDist };
-  } catch {
+  } catch (err) {
+    console.error('loadAnalytics failed', err);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

The analytics loader (`packages/gui/src/app/analytics/load-analytics.ts`) fetched **all** issues and **all** `workflow_runs` for a workspace with no time window and no limit, making the page O(workspace history). Errors were swallowed by a bare `catch {}`, leaving no breadcrumb when the page showed "Failed to load analytics".

This change:
- Adds a `gte('created_at', since)` filter to the issues query, scoping it to the last 12 weeks (the only window velocity and the distributions render).
- Caps the `workflow_runs` query with `.limit(200)`, keeping the existing `started_at desc` ordering so the cost-tracking card still sees the most recent runs.
- Replaces `catch {}` with `catch (err) { console.error('loadAnalytics failed', err); return null }` so failures are logged.

Note: column names follow the existing code (`created_at`, `started_at`), which differ slightly from the illustrative snippet in the issue.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)