### PR TITLE
fix: cap unbounded PR listing on the server (#123)

### DIFF
--- a/packages/gui/src/app/prs/page.tsx
+++ b/packages/gui/src/app/prs/page.tsx
@@ -3,6 +3,16 @@ import { getActiveWorkspace } from '@/lib/workspace';
 import { fetchRecentActionRuns } from '@/lib/action-runs-loader';
 import { PrsView, type PrRow } from './prs-view';
 
+/**
+ * Upper bound on PR rows shipped to the client. `PrsView` does its own
+ * filtering, sorting, and 10/25/50/100 pagination over this set, plus the
+ * TOTAL/OPEN/DRAFT/RUNNING stat counts — all of which need the rows in hand —
+ * so we cap rather than `.range()`-paginate (which would scope those features
+ * to a single page). Newest PRs win the cap via the `number desc` order.
+ * Mirrors the capped-listing convention in `cockpit/page.tsx`.
+ */
+const PR_FETCH_CAP = 500;
+
 export default async function PrsPage() {
   const workspace = await getActiveWorkspace();
 
@@ -31,7 +41,8 @@ export default async function PrsPage() {
           'number, title, state, draft, labels, author, html_url, head_ref, base_ref, pr_created_at, pr_updated_at, updated_at',
         )
         .eq('workspace_id', workspace.id)
-        .order('number', { ascending: false }),
+        .order('number', { ascending: false })
+        .limit(PR_FETCH_CAP),
       fetchRecentActionRuns(workspace.id, 'pr'),
     ]);
     if (prErr) throw new Error(prErr.message);


### PR DESCRIPTION
## Summary

The PRs page (`packages/gui/src/app/prs/page.tsx`) selected every `pull_requests` row for the workspace with no row limit, shipping the entire table to the client on every render. For workspaces with thousands of PRs this inflates the Supabase payload and hydration cost and slows first paint.

`PrsView` performs its own client-side filtering, sorting, 10/25/50/100 pagination, and stat-card aggregation (TOTAL/OPEN/DRAFT/RUNNING) over the full row set — all of which need every row in hand. A server-side `.range()` pagination would silently scope those features to a single page (a regression). Instead this adds a sane server-side cap via `.limit(PR_FETCH_CAP)` (500), ordered `number desc` so the newest PRs win the cap. This mirrors the capped-listing convention already used in `cockpit/page.tsx` (`.limit(100)` / `.limit(200)`).

Scoped to the PRs page only, per the issue's `[gui/prs]` area.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)