### PR TITLE
fix: startAutofix dedup TOCTOU race; add partial unique index (#121)

### DIFF
--- a/packages/gui/src/app/issues/autofix-actions.ts
+++ b/packages/gui/src/app/issues/autofix-actions.ts
@@ -19,7 +19,12 @@ export async function startAutofix(issueNumber: number): Promise<void> {
 
   const supabase = createSupabaseAdminClient();
 
-  // Dedupe — don't double-enqueue if there's already one in flight.
+  // Dedupe — don't double-enqueue if there's already one in flight. The
+  // SELECT below is a fast path for the common (no in-flight job) case, but
+  // it's racy on its own: two concurrent clicks both see zero rows. The
+  // authoritative guard is the `jobs_autofix_inflight_unique` partial unique
+  // index (migration 0029), which lets the database reject the second insert
+  // with 23505 — caught below and treated as a benign no-op.
   const { data: open } = await supabase
     .from('jobs')
     .select('id')
@@ -40,7 +45,12 @@ export async function startAutofix(issueNumber: number): Promise<void> {
       max_attempts: 1,
       payload: { trigger: 'manual' },
     });
-    if (error) throw new Error(`enqueue failed: ${error.message}`);
+    // 23505 = unique_violation: another concurrent request already enqueued
+    // an in-flight autofix for this issue. That's exactly the outcome we want
+    // (one job, not two), so swallow it instead of surfacing an error.
+    if (error && error.code !== '23505') {
+      throw new Error(`enqueue failed: ${error.message}`);
+    }
   }
 
   revalidatePath('/issues');

--- a/packages/gui/supabase/migrations/0029_jobs_autofix_inflight_unique.sql
+++ b/packages/gui/supabase/migrations/0029_jobs_autofix_inflight_unique.sql
@@ -1,0 +1,27 @@
+-- 0029_jobs_autofix_inflight_unique.sql
+-- Close the TOCTOU race in the `startAutofix` server action
+-- (packages/gui/src/app/issues/autofix-actions.ts).
+--
+-- That action SELECTs in-flight autofix jobs for an issue and, if none,
+-- INSERTs a new one in a separate statement. Two concurrent clicks (a
+-- double-click or a rapid retry) both observe zero open jobs and both
+-- insert, enqueuing duplicate autofix runs for the same issue. Each
+-- duplicate burns a clone + LLM budget on the same issue.
+--
+-- A partial unique index makes the database the single arbiter: at most
+-- one *in-flight* (queued/claimed/running) autofix job can exist per
+-- (workspace_id, issue_number). The second concurrent insert raises
+-- 23505 (unique_violation), which the server action now swallows as a
+-- benign "already in flight" no-op.
+--
+-- The index is partial on status so a finished/failed/cancelled job does
+-- not block re-running the issue later — only live work is deduped.
+--
+-- NOTE: the audit's suggested index keyed on `input->>'issue_number'`,
+-- but the `jobs` table stores the issue on a real `issue_number` integer
+-- column (see 0008_agent_runs.sql), so this index uses that column.
+
+create unique index if not exists jobs_autofix_inflight_unique
+  on jobs (workspace_id, issue_number)
+  where kind = 'autofix'
+    and status in ('queued', 'claimed', 'running');


### PR DESCRIPTION
## Summary

The `startAutofix` server action (`packages/gui/src/app/issues/autofix-actions.ts`) SELECTed in-flight autofix jobs for an issue and then INSERTed a new one in a separate statement. Two concurrent clicks (double-click / rapid retry) both observed zero open jobs and both inserted, enqueuing duplicate autofix runs for the same issue — each burning a redundant clone + LLM budget.

### Changes
- **New migration `0029_jobs_autofix_inflight_unique.sql`**: a partial unique index on `(workspace_id, issue_number)` `WHERE kind='autofix' AND status IN ('queued','claimed','running')`. The database is now the single arbiter of at-most-one in-flight autofix per issue. Partial on status, so a finished/failed/cancelled job never blocks a later re-run.
- **`autofix-actions.ts`**: the existing SELECT stays as a fast path for the common case; the INSERT now swallows a `23505` unique_violation as a benign no-op (matching existing `23505` handling in `workspaces/actions.ts`, `team-actions.ts`, `new-action-action.ts`).

### Note on the audit's suggestion
The audit's example index keyed on `input->>'issue_number'`, but the `jobs` table stores the issue on a real `issue_number` integer column (see `0008_agent_runs.sql`), so the index uses that column. The third suggested bullet (per-workspace rate-limit) was left out as a broader policy change beyond this minimal fix — the unique index already prevents the duplicate-work harm cited in the issue.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)