### PR TITLE
fix: hard-cap the /prs sync server action's GitHub page walk (#122)

### DIFF
--- a/packages/gui/src/app/prs/prs-action.ts
+++ b/packages/gui/src/app/prs/prs-action.ts
@@ -9,7 +9,15 @@ export interface SyncPrsResult {
   ok: boolean;
   error?: string;
   count?: number;
+  /** True when the sync cap was hit — the full `prs-sync` cron backfills the rest. */
+  capped?: boolean;
 }
+
+// Hard cap on the GitHub round-trip from the interactive server action: 500
+// open PRs (~5 pages of 100). Busy repos can't block the route handler
+// indefinitely (or time the action out); the background `prs-sync` cron does
+// the uncapped walk. listOpenPullRequests stops fetching once the cap is hit.
+const MAX_SYNC_ITEMS = 500;
 
 /**
  * On-demand counterpart to the `prs-sync` cron — fetches open PRs from
@@ -40,10 +48,14 @@ export async function syncPullRequests(): Promise<SyncPrsResult> {
     const github = new core.GitHubService({
       github: { owner: workspace.repoOwner, repo: workspace.repoName, token },
     } as never);
-    openPrs = await github.listOpenPullRequests();
+    openPrs = await github.listOpenPullRequests(MAX_SYNC_ITEMS);
   } catch (err) {
     return { ok: false, error: `GitHub fetch failed: ${err instanceof Error ? err.message : String(err)}` };
   }
+
+  // Hitting the cap means more PRs exist than we walked — flag it so the UI
+  // can tell the user the cron will backfill the remainder.
+  const capped = openPrs.length >= MAX_SYNC_ITEMS;
 
   if (openPrs.length === 0) {
     revalidatePath('/prs');
@@ -74,5 +86,5 @@ export async function syncPullRequests(): Promise<SyncPrsResult> {
   if (error) return { ok: false, error: `Upsert failed: ${error.message}` };
 
   revalidatePath('/prs');
-  return { ok: true, count: openPrs.length };
+  return { ok: true, count: openPrs.length, capped };
 }

--- a/packages/gui/src/app/prs/prs-view.tsx
+++ b/packages/gui/src/app/prs/prs-view.tsx
@@ -75,7 +75,7 @@ export function PrsView({ rows, repoLabel, fetchedAt, readOnly }: PrsViewProps) 
   const [runStatusFilter, setRunStatusFilter] = useState<RunStatusFilter>('all');
   const [sortKey, setSortKey] = useState<SortKey>('number');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [syncState, setSyncState] = useState<{ ok?: boolean; error?: string; count?: number } | null>(null);
+  const [syncState, setSyncState] = useState<{ ok?: boolean; error?: string; count?: number; capped?: boolean } | null>(null);
   const [syncing, startSync] = useTransition();
 
   const filtered = useMemo(() => {
@@ -188,6 +188,9 @@ export function PrsView({ rows, repoLabel, fetchedAt, readOnly }: PrsViewProps) 
       {syncState?.ok && (
         <div className="mb-4 rounded-md border border-primary/30 bg-primary-container/20 px-4 py-2 text-sm text-primary">
           Synced {syncState.count ?? 0} open PR{(syncState.count ?? 0) === 1 ? '' : 's'} from GitHub.
+          {syncState.capped && (
+            <> Page cap reached — the background sync will backfill the rest.</>
+          )}
         </div>
       )}
       {syncState?.error && (


### PR DESCRIPTION
## Summary

The `/prs` "Sync from GitHub" server action (`syncPullRequests`) called `listOpenPullRequests`, which used `octokit.paginate` with no page bound. On a busy repo this walks every page of open PRs before returning — multi-second blocking inside the server action, holding the Next.js route handler open and potentially timing the action out.

This change keeps the sync inline (no new job kind / dispatch wiring) but adds the hard cap the issue asks for:

- `GitHubService.listOpenPullRequests(maxPages?)` now uses `paginate.iterator` and short-circuits once `maxPages` pages have been fetched, so the cap actually stops the round-trips rather than truncating an already-fetched list.
- The interactive `/prs` server action passes a 5-page (500-PR) cap. The background `prs-sync` cron and the inbox sync keep calling it with no argument, so they retain the full uncapped walk for backfill.
- The action returns a `capped` flag and the `/prs` sync banner shows a short "the background sync will backfill the rest" hint when the cap is hit.

## Closes

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)