### PR TITLE
fix: ActionGrid run drawer can be reopened after closing (#132)

### DIFF
--- a/packages/gui/src/components/action-grid.tsx
+++ b/packages/gui/src/components/action-grid.tsx
@@ -16,11 +16,13 @@ interface ActionGridProps {
 
 export function ActionGrid({ badges }: ActionGridProps) {
   const [activeRun, setActiveRun] = useState<{ runId: string; actionId: string; label: string } | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   async function handleRun(tile: ActionTile) {
     const result = await startAction(tile.id);
     if (result.ok && result.runId) {
       setActiveRun({ runId: result.runId, actionId: tile.id, label: tile.label });
+      setDrawerOpen(true);
     }
   }
 
@@ -43,7 +45,9 @@ export function ActionGrid({ badges }: ActionGridProps) {
                     badge={badges?.[tile.id]}
                     isRunning={activeRun?.actionId === tile.id}
                     onRun={() => handleRun(tile)}
-                    onViewLogs={() => activeRun?.actionId === tile.id && setActiveRun((r) => r)}
+                    onViewLogs={() => {
+                      if (activeRun?.actionId === tile.id) setDrawerOpen(true);
+                    }}
                   />
                 ))}
               </div>
@@ -52,11 +56,11 @@ export function ActionGrid({ badges }: ActionGridProps) {
         })}
       </div>
 
-      {activeRun && (
+      {activeRun && drawerOpen && (
         <RunDrawer
           runId={activeRun.runId}
           actionLabel={activeRun.label}
-          onClose={() => setActiveRun(null)}
+          onClose={() => setDrawerOpen(false)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

The "Running…" pill in `ActionGrid` looked clickable but did nothing once the run drawer had been dismissed. Its `onViewLogs` handler called `setActiveRun((r) => r)`, which bails out via `Object.is` and never re-rendered the drawer.

The fix splits state into two pieces:
- `activeRun` — which run is active (keeps the pill visible)
- `drawerOpen` — whether the drawer is currently shown

Closing the drawer now only flips `drawerOpen` to `false`, leaving `activeRun` intact. Clicking the "Running…" pill flips `drawerOpen` back to `true`, reopening the drawer for the active run.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)