### PR TITLE
fix: RunNowModal focuses issue select when issues finish loading (#133)

### DIFF
--- a/packages/gui/src/components/run-now-modal.tsx
+++ b/packages/gui/src/components/run-now-modal.tsx
@@ -19,6 +19,7 @@ export interface RunNowModalProps {
 export function RunNowModal({ actionId, actionName, target, onClose }: RunNowModalProps) {
   const router = useRouter();
   const dialogRef = useRef<HTMLDivElement>(null);
+  const selectRef = useRef<HTMLSelectElement>(null);
   const lastFocused = useRef<HTMLElement | null>(null);
   const [issues, setIssues] = useState<RunNowIssue[]>([]);
   const [issuesLoading, setIssuesLoading] = useState(target === 'issue');
@@ -87,6 +88,13 @@ export function RunNowModal({ actionId, actionName, target, onClose }: RunNowMod
     };
   }, [target]);
 
+  // Once the issue list finishes loading and the select becomes enabled,
+  // move focus to it so keyboard users land on the intended "pick from list" control.
+  useEffect(() => {
+    if (target !== 'issue' || useManual || issuesLoading) return;
+    selectRef.current?.focus();
+  }, [target, useManual, issuesLoading]);
+
   function resolveNumber(): number | null {
     if (useManual) {
       const n = Number.parseInt(manualNumber.trim(), 10);
@@ -143,6 +151,7 @@ export function RunNowModal({ actionId, actionName, target, onClose }: RunNowMod
                 Issue
               </span>
               <select
+                ref={selectRef}
                 value={selectedNumber ?? ''}
                 onChange={(e) => setSelectedNumber(Number(e.target.value))}
                 disabled={issuesLoading || pending}


### PR DESCRIPTION
## Summary

`RunNowModal`'s focus-trap effect runs once at mount, but at that point the issue `<select>` is still `disabled={issuesLoading}` while the recent-issues list loads async. Focus therefore landed on the "Enter a number manually" button and never moved back to the select once loading completed — so keyboard users started on the wrong control.

This adds a `selectRef` on the `<select>` and a second effect keyed on `issuesLoading` that focuses the select once it becomes enabled. The effect is guarded to the issue, non-manual flow so it doesn't steal focus for PR targets or when the empty list flips into manual-entry mode.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)