### PR TITLE
fix: run-action modals stay open while a run is in flight (#128)

### DIFF
--- a/packages/gui/src/app/issues/run-action-for-issue-modal.tsx
+++ b/packages/gui/src/app/issues/run-action-for-issue-modal.tsx
@@ -29,6 +29,8 @@ export function RunActionForIssueModal({ issueNumber, issueTitle, onClose }: Run
   const [selectedId, setSelectedId] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const pendingRef = useRef(false);
+  pendingRef.current = pending;
 
   useEffect(() => {
     lastFocused.current = document.activeElement as HTMLElement | null;
@@ -41,6 +43,7 @@ export function RunActionForIssueModal({ issueNumber, issueTitle, onClose }: Run
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         e.stopPropagation();
+        if (pendingRef.current) return;
         onClose();
         return;
       }
@@ -105,6 +108,7 @@ export function RunActionForIssueModal({ issueNumber, issueTitle, onClose }: Run
     <div
       role="presentation"
       onClick={(e) => {
+        if (pending) return;
         if (e.target === e.currentTarget) onClose();
       }}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"

--- a/packages/gui/src/app/prs/run-action-for-pr-modal.tsx
+++ b/packages/gui/src/app/prs/run-action-for-pr-modal.tsx
@@ -29,6 +29,8 @@ export function RunActionForPrModal({ prNumber, prTitle, onClose }: RunActionFor
   const [selectedId, setSelectedId] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const pendingRef = useRef(false);
+  pendingRef.current = pending;
 
   useEffect(() => {
     lastFocused.current = document.activeElement as HTMLElement | null;
@@ -41,6 +43,7 @@ export function RunActionForPrModal({ prNumber, prTitle, onClose }: RunActionFor
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         e.stopPropagation();
+        if (pendingRef.current) return;
         onClose();
         return;
       }
@@ -105,6 +108,7 @@ export function RunActionForPrModal({ prNumber, prTitle, onClose }: RunActionFor
     <div
       role="presentation"
       onClick={(e) => {
+        if (pending) return;
         if (e.target === e.currentTarget) onClose();
       }}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"


### PR DESCRIPTION
## Summary
The `RunActionForIssueModal` and its twin `RunActionForPrModal` disabled the **Cancel** button while a run was pending, but the **backdrop click** and **Escape** key still closed the dialog mid-submit. That close raced against the `router.push('/cockpit/...')` on fast failures, leaving users unsure whether a run had been enqueued — and prone to double-submitting.

This guards both dismissal paths against the `pending` state:
- Backdrop `onClick` early-returns while `pending`.
- The Escape `keydown` handler early-returns while `pending` (via a `pendingRef`, since that effect only depends on `onClose` and would otherwise capture a stale `pending`).

The modal now only closes once the run resolves (navigating to the cockpit) or surfaces its inline error. Minimal, mirrored change across both modals; no behavior change to the happy path.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)