### PR TITLE
fix: centralize run-status palette into one source of truth (#130)

### DIFF
--- a/packages/gui/src/components/icons.tsx
+++ b/packages/gui/src/components/icons.tsx
@@ -1,4 +1,5 @@
 import type { SVGProps } from 'react';
+import { RUN_STATUS_PALETTE } from './run-status-palette';
 
 type IconProps = SVGProps<SVGSVGElement>;
 
@@ -232,22 +233,35 @@ export function StatusDotIcon({
   tone = 'enabled',
   ...props
 }: IconProps & {
-  tone?: 'enabled' | 'disabled' | 'warning' | 'error' | 'running' | 'queued' | 'succeeded';
+  tone?:
+    | 'enabled'
+    | 'disabled'
+    | 'warning'
+    | 'error'
+    | 'running'
+    | 'queued'
+    | 'paused'
+    | 'succeeded';
 }) {
+  // Run-status tones derive their colour from the single RUN_STATUS_PALETTE
+  // source of truth so this icon stays in sync with run-status-dots.tsx.
+  // 'warning' aliases the 'paused' colour; 'enabled'/'disabled' are
+  // icon-level semantics with no run-status equivalent.
   const color =
     tone === 'enabled'
       ? '#df7412'
       : tone === 'warning'
-        ? '#ffb786'
+        ? RUN_STATUS_PALETTE.paused.hex
         : tone === 'error'
-          ? '#ffb4ab'
+          ? RUN_STATUS_PALETTE.failed.hex
           : tone === 'running'
-            ? '#60a5fa'
-            : tone === 'succeeded'
-              ? '#22c55e'
-              : tone === 'queued'
-                ? '#8c909f'
-                : '#8c909f';
+            ? RUN_STATUS_PALETTE.running.hex
+            : tone === 'paused'
+              ? RUN_STATUS_PALETTE.paused.hex
+              : tone === 'succeeded'
+                ? RUN_STATUS_PALETTE.succeeded.hex
+                : // 'queued' and 'disabled'/fallthrough share the neutral grey
+                  RUN_STATUS_PALETTE.queued.hex;
   return (
     <svg {...base} {...props} fill={color} stroke="none">
       <circle cx="12" cy="12" r="4" />

--- a/packages/gui/src/components/run-status-dots.tsx
+++ b/packages/gui/src/components/run-status-dots.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { cn } from './ui/cn';
+import { RUN_STATUS_PALETTE } from './run-status-palette';
 import type { ActionRunSummary, RunStatus } from '@/lib/action-runs-loader';
 
 // ─────────────────────────────────────────────────────────────────────
@@ -69,7 +70,7 @@ function RunDot({ run }: { run: ActionRunSummary }) {
         aria-label={`${run.actionName} — ${run.status}`}
         className={cn(
           'inline-block h-[14px] w-[14px] rounded-full ring-1 ring-inset ring-black/20 transition-transform',
-          STATUS_COLOR[run.status],
+          RUN_STATUS_PALETTE[run.status].dot,
           run.status === 'running' && 'animate-pulse',
           'hover:scale-125 focus-visible:outline-none focus-visible:scale-125 focus-visible:ring-2 focus-visible:ring-primary',
         )}
@@ -112,7 +113,7 @@ function RunTooltip({ run }: { run: ActionRunSummary }) {
       <header className="flex items-start justify-between gap-3 border-b border-outline-variant/60 px-3 py-2.5">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className={cn('h-2.5 w-2.5 shrink-0 rounded-full', STATUS_COLOR[run.status])} />
+            <span className={cn('h-2.5 w-2.5 shrink-0 rounded-full', RUN_STATUS_PALETTE[run.status].dot)} />
             <span className="truncate font-mono text-[12px] font-semibold uppercase tracking-wider text-on-surface">
               {run.actionName}
             </span>
@@ -181,7 +182,7 @@ function OverflowTooltip({ runs }: { runs: ActionRunSummary[] }) {
               href={`/cockpit/${r.workflowRunId}`}
               className="flex items-center gap-2 px-3 py-2 text-xs hover:bg-surface-container/60"
             >
-              <span className={cn('h-2 w-2 shrink-0 rounded-full', STATUS_COLOR[r.status])} />
+              <span className={cn('h-2 w-2 shrink-0 rounded-full', RUN_STATUS_PALETTE[r.status].dot)} />
               <span className="truncate font-mono text-on-surface">{r.actionName}</span>
               <span className="ml-auto shrink-0 text-[10px] text-outline">
                 {formatRelative(r.startedAt)}
@@ -210,7 +211,7 @@ function StatusChip({ status }: { status: RunStatus }) {
     <span
       className={cn(
         'inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 font-display text-[9.5px] font-semibold uppercase tracking-wider',
-        STATUS_CHIP[status],
+        RUN_STATUS_PALETTE[status].chip,
       )}
     >
       {status === 'queued' ? 'enqueued' : status}
@@ -352,28 +353,6 @@ function TooltipPortal({
     document.body,
   );
 }
-
-// ─────────────────────────────────────────────────────────────────────
-// Status → color/style maps. Kept here (not in tailwind tokens) because
-// these are status-specific semantics that don't belong in the palette.
-// ─────────────────────────────────────────────────────────────────────
-const STATUS_COLOR: Record<RunStatus, string> = {
-  queued: 'bg-[#8c909f]',
-  running: 'bg-[#60a5fa]',
-  paused: 'bg-[#ffb786]',
-  succeeded: 'bg-[#22c55e]',
-  failed: 'bg-[#ffb4ab]',
-  skipped: 'bg-[#525866]',
-};
-
-const STATUS_CHIP: Record<RunStatus, string> = {
-  queued: 'border-outline-variant bg-surface-container text-on-surface-variant',
-  running: 'border-primary/40 bg-primary/10 text-primary',
-  paused: 'border-tertiary/40 bg-tertiary/10 text-tertiary',
-  succeeded: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
-  failed: 'border-error/40 bg-error/10 text-error',
-  skipped: 'border-outline-variant bg-surface-container text-outline',
-};
 
 function statusVerb(status: RunStatus, finished: boolean): string {
   if (status === 'running') return 'Running';

--- a/packages/gui/src/components/run-status-palette.ts
+++ b/packages/gui/src/components/run-status-palette.ts
@@ -1,0 +1,53 @@
+import type { RunStatus } from '@/lib/action-runs-loader';
+
+// ─────────────────────────────────────────────────────────────────────
+// Single source of truth for the run-status semantic palette.
+//
+// Every place that renders a RunStatus colour (the dots/tooltips in
+// run-status-dots.tsx, the status chip, and the SVG StatusDotIcon) reads
+// from here so the same logical status looks identical across the UI and
+// theme tweaks only need to happen once.
+//
+//   dot — Tailwind bg-* class for the solid status dot
+//   chip — Tailwind border/bg/text classes for the status chip
+//   hex — literal colour for the SVG <circle fill>, which can't take a
+//         Tailwind class. Kept in sync with `dot` above.
+// ─────────────────────────────────────────────────────────────────────
+export interface RunStatusStyle {
+  dot: string;
+  chip: string;
+  hex: string;
+}
+
+export const RUN_STATUS_PALETTE: Record<RunStatus, RunStatusStyle> = {
+  queued: {
+    dot: 'bg-[#8c909f]',
+    chip: 'border-outline-variant bg-surface-container text-on-surface-variant',
+    hex: '#8c909f',
+  },
+  running: {
+    dot: 'bg-[#60a5fa]',
+    chip: 'border-primary/40 bg-primary/10 text-primary',
+    hex: '#60a5fa',
+  },
+  paused: {
+    dot: 'bg-[#ffb786]',
+    chip: 'border-tertiary/40 bg-tertiary/10 text-tertiary',
+    hex: '#ffb786',
+  },
+  succeeded: {
+    dot: 'bg-[#22c55e]',
+    chip: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+    hex: '#22c55e',
+  },
+  failed: {
+    dot: 'bg-[#ffb4ab]',
+    chip: 'border-error/40 bg-error/10 text-error',
+    hex: '#ffb4ab',
+  },
+  skipped: {
+    dot: 'bg-[#525866]',
+    chip: 'border-outline-variant bg-surface-container text-outline',
+    hex: '#525866',
+  },
+};


### PR DESCRIPTION
## Summary

The run-status semantic palette had three independent sources of truth:

- `STATUS_COLOR` in `run-status-dots.tsx` — hard-coded hex (`#22c55e`, `#ffb786`, …)
- `STATUS_CHIP` in `run-status-dots.tsx` — theme tokens (`tertiary`, `error`, `emerald-300`)
- `StatusDotIcon` in `icons.tsx` — its own `tone` enum (missing `paused`)

This let the same logical status render in different colours and made theme tweaks drift.

This PR introduces `packages/gui/src/components/run-status-palette.ts`, exporting a single `RUN_STATUS_PALETTE` keyed by `RunStatus` with `{ dot, chip, hex }` per status:

- `run-status-dots.tsx` now reads `dot`/`chip` from the palette (old `STATUS_COLOR`/`STATUS_CHIP` maps removed).
- `StatusDotIcon` derives its run-status tone colours from the same palette via `hex` (the SVG `<circle fill>` can't take a Tailwind class), and gains the previously-missing `paused` tone.

Colours are unchanged from the prior behaviour — this only removes the duplication so there's one place to edit.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)