### PR TITLE
feat(gui): non-blocking Sync & Digest with live status

### DIFF
--- a/packages/gui/src/app/inbox/inbox-view.tsx
+++ b/packages/gui/src/app/inbox/inbox-view.tsx
@@ -8,7 +8,6 @@ import {
   ChevronDownIcon,
   MoreVerticalIcon,
   PlayIcon,
-  RefreshIcon,
   RotateLeftIcon,
   SparkleSmallIcon,
   StatusDotIcon,
@@ -32,7 +31,7 @@ import {
   dismissDecisions,
   snoozeDecision,
 } from './decision-actions';
-import { syncAndDigest } from './sync-action';
+import { SyncButton, type SyncStatusRow } from '@/app/issues/sync-button';
 
 // ─────────────────────────────────────────────────────────────────────
 // Skill palette — each skill gets its own accent so confidence pills
@@ -115,6 +114,7 @@ interface InboxViewProps {
   syncedAt: number;
   healthAlerts: { id: string; text: string; severity: 'warn' | 'error' }[];
   actionNames: ActionFilterOption[];
+  initialSyncStatus: SyncStatusRow | null;
 }
 
 export function InboxView({
@@ -123,6 +123,7 @@ export function InboxView({
   syncedAt: initialSyncedAt,
   healthAlerts,
   actionNames,
+  initialSyncStatus,
 }: InboxViewProps) {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -188,9 +189,14 @@ export function InboxView({
     }
   }, [skillFilters, skillFilter]);
   const [typeFilter, setTypeFilter] = useState<(typeof TYPE_FILTERS)[number]>(TYPE_FILTERS[0]);
-  const [syncing, setSyncing] = useState(false);
   const [syncedAt, setSyncedAt] = useState<number>(initialSyncedAt);
   const [toast, setToast] = useState<string | null>(null);
+
+  // The sync now runs in the background (see SyncButton); when it finishes it
+  // triggers a server refresh, which re-supplies a fresh `syncedAt` prop.
+  useEffect(() => {
+    setSyncedAt(initialSyncedAt);
+  }, [initialSyncedAt]);
 
   // ── derived counts / filters ──
   const counts = useMemo(() => {
@@ -362,28 +368,6 @@ export function InboxView({
     });
   }, [selectedFindings, router]);
 
-  const handleSync = useCallback(async () => {
-    setSyncing(true);
-    const result = await syncAndDigest();
-    setSyncing(false);
-    if (!result.ok) {
-      setToast(`Sync failed: ${result.error ?? 'unknown'}`);
-      return;
-    }
-    setSyncedAt(Date.now());
-    const bits: string[] = [];
-    if (result.issuesFetched) {
-      const created = result.issuesCreated ?? 0;
-      const updated = result.issuesUpdated ?? 0;
-      bits.push(`${result.issuesFetched} issue${result.issuesFetched === 1 ? '' : 's'} (${created} new · ${updated} updated)`);
-    }
-    if (result.digestsCreated) bits.push(`${result.digestsCreated} digested`);
-    if (result.commentsFetched) bits.push(`${result.commentsFetched} commented`);
-    if (result.prsUpdated) bits.push(`${result.prsUpdated} PR${result.prsUpdated === 1 ? '' : 's'}`);
-    setToast(bits.length > 0 ? `Synced: ${bits.join(' · ')}` : 'Already up to date');
-    router.refresh();
-  }, [router]);
-
   // ── keyboard: Cmd+A / Ctrl+A selects all visible findings ──
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -432,20 +416,7 @@ export function InboxView({
               </span>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={handleSync}
-            disabled={syncing}
-            className={cn(
-              'inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition-colors',
-              syncing
-                ? 'cursor-wait border-outline-variant bg-surface-container text-on-surface-variant'
-                : 'border-primary/40 bg-primary/10 text-primary hover:border-primary/60 hover:bg-primary/15',
-            )}
-          >
-            <RefreshIcon className={cn('h-4 w-4', syncing && 'animate-spin')} />
-            {syncing ? 'Syncing…' : 'Sync & Digest'}
-          </button>
+          <SyncButton workspaceId={workspaceId} readOnly={false} initialStatus={initialSyncStatus} />
         </div>
       </header>
 

--- a/packages/gui/src/app/inbox/page.tsx
+++ b/packages/gui/src/app/inbox/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { loadInbox } from './load-inbox';
 import { InboxView } from './inbox-view';
 
@@ -21,7 +22,11 @@ export default async function InboxV2Page() {
     );
   }
 
-  const loaded = await loadInbox(workspace.id);
+  const supabase = await createSupabaseServerClient();
+  const [loaded, sync] = await Promise.all([
+    loadInbox(workspace.id),
+    supabase.from('sync_status').select('*').eq('workspace_id', workspace.id).maybeSingle(),
+  ]);
   return (
     <InboxView
       workspaceId={workspace.id}
@@ -29,6 +34,7 @@ export default async function InboxV2Page() {
       syncedAt={loaded.syncedAt}
       healthAlerts={loaded.healthAlerts}
       actionNames={loaded.actionNames}
+      initialSyncStatus={sync.data}
     />
   );
 }

--- a/packages/gui/src/app/inbox/sync-action.ts
+++ b/packages/gui/src/app/inbox/sync-action.ts
@@ -1,32 +1,58 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import { SupabaseStoreAdapter } from '@/lib/adapters/supabase-store';
 import { loadWorkspaceConfig } from '@/lib/load-workspace-config';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database, SyncCounts, SyncPhase, SyncStatusState } from '@/lib/supabase/types';
 
 // ─────────────────────────────────────────────────────────────────────
 // Sync & Digest — the global "pull from GitHub" action shared by the
 // Inbox and Issues page headers.
 //
-// Replaces the deleted dashboard/sync-action.ts (removed in the Phase D
-// /dashboard retirement) but drops the Realtime broadcast streaming —
-// the page just shows a spinner while the action runs and revalidates
-// when it returns. Re-add the channel pattern when initial syncs of
-// large repos start feeling too silent.
+// The four phases (fetch issues → digest → fetch comments → refresh PRs)
+// are external-API-bound and can take 30s–2min. Running them inline in the
+// server action used to block the whole UI (Next.js serializes server
+// actions, so navigations + router.refresh() queued behind it). Instead we
+// now do a fast in-request kickoff (auth + a row flip) and run the phases as
+// a detached background task that writes its progress into `sync_status`.
+// The client subscribes to that row over Realtime to show live progress and
+// refreshes when it lands on 'done'/'error'. The app is a long-lived Node
+// container (output: 'standalone', Docker/Dokploy), so a non-awaited promise
+// keeps running safely after the action returns.
 // ─────────────────────────────────────────────────────────────────────
 
+/** A `syncing` row older than this is treated as stale (e.g. the container
+ *  restarted mid-sync) and may be overwritten by a fresh sync. */
+const STALE_SYNC_MS = 10 * 60 * 1000;
+
 export interface SyncResult {
+  /** True once the background sync has been kicked off (not when it finishes). */
   ok: boolean;
   error?: string;
-  issuesFetched?: number;
-  issuesCreated?: number;
-  issuesUpdated?: number;
-  digestsCreated?: number;
-  commentsFetched?: number;
-  prsUpdated?: number;
+}
+
+type SyncStatusRow = Database['public']['Tables']['sync_status']['Row'];
+
+async function writeStatus(
+  supabase: SupabaseClient<Database>,
+  workspaceId: string,
+  patch: {
+    status: SyncStatusState;
+    phase?: SyncPhase | null;
+    message?: string | null;
+    counts?: SyncCounts;
+    error?: string | null;
+    started_at?: string | null;
+    finished_at?: string | null;
+  },
+): Promise<void> {
+  const { error } = await supabase
+    .from('sync_status')
+    .upsert({ workspace_id: workspaceId, ...patch }, { onConflict: 'workspace_id' });
+  if (error) console.warn('[syncAndDigest] sync_status write failed:', error.message);
 }
 
 export async function syncAndDigest(): Promise<SyncResult> {
@@ -35,6 +61,23 @@ export async function syncAndDigest(): Promise<SyncResult> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return { ok: false, error: 'No workspace selected' };
   if (workspace.role !== 'admin') return { ok: false, error: 'Only admins can sync' };
+
+  const supabase = createSupabaseAdminClient();
+
+  // ── Concurrency guard: refuse to start a second sync while one is live. ──
+  // A `syncing` row older than STALE_SYNC_MS is considered abandoned and is
+  // allowed to be overwritten.
+  const { data: existing } = await supabase
+    .from('sync_status')
+    .select('status, updated_at')
+    .eq('workspace_id', workspace.id)
+    .maybeSingle<Pick<SyncStatusRow, 'status' | 'updated_at'>>();
+  if (existing?.status === 'syncing') {
+    const age = Date.now() - new Date(existing.updated_at).getTime();
+    if (age < STALE_SYNC_MS) {
+      return { ok: false, error: 'Sync already in progress' };
+    }
+  }
 
   const core = await import('@cezar/core');
   let token = user.githubToken || process.env.GITHUB_TOKEN || '';
@@ -47,7 +90,6 @@ export async function syncAndDigest(): Promise<SyncResult> {
   }
   if (!token) return { ok: false, error: 'No GitHub token — sign out and back in to sync' };
 
-  const supabase = createSupabaseAdminClient();
   const adapter = new SupabaseStoreAdapter(supabase, workspace.id);
 
   // The store may be empty for a newly-connected workspace; tolerate that
@@ -90,20 +132,62 @@ export async function syncAndDigest(): Promise<SyncResult> {
 
   const github = new core.GitHubService(config);
 
+  // ── Flip the row to 'syncing' before we return, so the client sees the
+  //    spinner immediately and the concurrency guard above is armed. ──
+  await writeStatus(supabase, workspace.id, {
+    status: 'syncing',
+    phase: 'issues',
+    message: 'Fetching issues…',
+    counts: {},
+    error: null,
+    started_at: new Date().toISOString(),
+    finished_at: null,
+  });
+
+  // ── Run the four phases in the background; do NOT await. ──
+  void runSync({ supabase, workspaceId: workspace.id, store, github, config, llm: core.LLMService }).catch(
+    async (err) => {
+      console.error('[syncAndDigest] background sync crashed:', err);
+      await writeStatus(supabase, workspace.id, {
+        status: 'error',
+        phase: null,
+        error: err instanceof Error ? err.message : String(err),
+        finished_at: new Date().toISOString(),
+      });
+    },
+  );
+
+  return { ok: true };
+}
+
+interface RunSyncArgs {
+  supabase: SupabaseClient<Database>;
+  workspaceId: string;
+  store: Awaited<ReturnType<(typeof import('@cezar/core'))['IssueStore']['fromPort']>>;
+  github: InstanceType<(typeof import('@cezar/core'))['GitHubService']>;
+  config: Awaited<ReturnType<typeof loadWorkspaceConfig>>;
+  llm: (typeof import('@cezar/core'))['LLMService'];
+}
+
+/** The four serial sync phases, each writing its progress into `sync_status`.
+ *  Phase 1 is fatal-on-error; phases 2–4 are best-effort (warn + continue)
+ *  so a digest/comment/PR hiccup still produces a usable sync. */
+async function runSync({ supabase, workspaceId, store, github, config, llm: LLMService }: RunSyncArgs): Promise<void> {
+  const counts: SyncCounts = {};
+
   // ── 1. Fetch issues (incremental when possible) ──
-  let issuesFetched = 0;
-  let issuesCreated = 0;
-  let issuesUpdated = 0;
   try {
     const meta = store.getMeta();
     const issues = meta.lastSyncedAt
       ? await github.fetchIssuesSince(meta.lastSyncedAt, false)
       : await github.fetchAllIssues(false);
-    issuesFetched = issues.length;
+    counts.issuesFetched = issues.length;
+    counts.issuesCreated = 0;
+    counts.issuesUpdated = 0;
     for (const issue of issues) {
       const r = store.upsertIssue(issue);
-      if (r.action === 'created') issuesCreated += 1;
-      if (r.action === 'updated') issuesUpdated += 1;
+      if (r.action === 'created') counts.issuesCreated += 1;
+      if (r.action === 'updated') counts.issuesUpdated += 1;
     }
     store.updateMeta({
       lastSyncedAt: new Date().toISOString(),
@@ -111,41 +195,58 @@ export async function syncAndDigest(): Promise<SyncResult> {
     });
     await store.save();
   } catch (err) {
-    return { ok: false, error: `Issue fetch failed: ${err instanceof Error ? err.message : String(err)}` };
+    await writeStatus(supabase, workspaceId, {
+      status: 'error',
+      phase: null,
+      counts,
+      error: `Issue fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      finished_at: new Date().toISOString(),
+    });
+    return;
   }
 
   // ── 2. Generate digests for issues that don't have one yet ──
-  let digestsCreated = 0;
   try {
     const needDigest = store.getIssues({ hasDigest: false });
     if (needDigest.length > 0) {
-      const llm = new core.LLMService(config);
+      await writeStatus(supabase, workspaceId, {
+        status: 'syncing',
+        phase: 'digests',
+        message: `Digesting ${needDigest.length} issue${needDigest.length === 1 ? '' : 's'}…`,
+        counts,
+      });
+      const service = new LLMService(config);
       const issueData = needDigest.map((i) => ({ number: i.number, title: i.title, body: i.body }));
-      const results = await llm.generateDigests(issueData, config.sync.digestBatchSize);
+      const results = await service.generateDigests(issueData, config.sync.digestBatchSize);
       for (const [number, digest] of results) {
         store.setDigest(number, digest);
       }
-      digestsCreated = results.size;
+      counts.digestsCreated = results.size;
       await store.save();
     }
   } catch (err) {
-    // Digest failure shouldn't abort the whole sync — log via the return
-    // envelope and let the user retry. Comments + PR pull are still useful.
+    // Digest failure shouldn't abort the whole sync — comments + PR pull are
+    // still useful, and the user can retry to fill in the rest.
     console.warn('[syncAndDigest] digest pass failed:', err);
   }
 
   // ── 3. Fetch comments for open issues that need them ──
-  let commentsFetched = 0;
   try {
     const needComments = store
       .getIssues({ state: 'open' })
       .filter((i) => !i.commentsFetchedAt && i.commentCount > 0);
     if (needComments.length > 0) {
+      await writeStatus(supabase, workspaceId, {
+        status: 'syncing',
+        phase: 'comments',
+        message: `Fetching comments for ${needComments.length} issue${needComments.length === 1 ? '' : 's'}…`,
+        counts,
+      });
       const commentMap = await github.fetchCommentsForIssues(needComments.map((i) => i.number));
       for (const [num, comments] of commentMap) {
         store.setComments(num, comments);
       }
-      commentsFetched = commentMap.size;
+      counts.commentsFetched = commentMap.size;
       await store.save();
     }
   } catch (err) {
@@ -153,12 +254,17 @@ export async function syncAndDigest(): Promise<SyncResult> {
   }
 
   // ── 4. Refresh open PRs into the pull_requests table ──
-  let prsUpdated = 0;
   try {
+    await writeStatus(supabase, workspaceId, {
+      status: 'syncing',
+      phase: 'prs',
+      message: 'Refreshing pull requests…',
+      counts,
+    });
     const openPrs = await github.listOpenPullRequests();
     if (openPrs.length > 0) {
       const rows = openPrs.map((p) => ({
-        workspace_id: workspace.id,
+        workspace_id: workspaceId,
         number: p.number,
         title: p.title,
         body: p.body,
@@ -176,23 +282,32 @@ export async function syncAndDigest(): Promise<SyncResult> {
       const { error } = await supabase
         .from('pull_requests')
         .upsert(rows, { onConflict: 'workspace_id,number' });
-      if (!error) prsUpdated = openPrs.length;
+      if (!error) counts.prsUpdated = openPrs.length;
     }
   } catch (err) {
     console.warn('[syncAndDigest] PR sync failed:', err);
   }
 
-  revalidatePath('/inbox');
-  revalidatePath('/issues');
-  revalidatePath('/prs');
+  // ── Done. ──
+  await writeStatus(supabase, workspaceId, {
+    status: 'done',
+    phase: null,
+    message: summarize(counts),
+    counts,
+    error: null,
+    finished_at: new Date().toISOString(),
+  });
+}
 
-  return {
-    ok: true,
-    issuesFetched,
-    issuesCreated,
-    issuesUpdated,
-    digestsCreated,
-    commentsFetched,
-    prsUpdated,
-  };
+function summarize(counts: SyncCounts): string {
+  const bits: string[] = [];
+  if (counts.issuesFetched) {
+    bits.push(
+      `${counts.issuesFetched} issue${counts.issuesFetched === 1 ? '' : 's'} (${counts.issuesCreated ?? 0} new · ${counts.issuesUpdated ?? 0} updated)`,
+    );
+  }
+  if (counts.digestsCreated) bits.push(`${counts.digestsCreated} digested`);
+  if (counts.commentsFetched) bits.push(`${counts.commentsFetched} commented`);
+  if (counts.prsUpdated) bits.push(`${counts.prsUpdated} PR${counts.prsUpdated === 1 ? '' : 's'}`);
+  return bits.length > 0 ? `Synced: ${bits.join(' · ')}` : 'Already up to date';
 }

--- a/packages/gui/src/app/issues/issues-view.tsx
+++ b/packages/gui/src/app/issues/issues-view.tsx
@@ -1,18 +1,16 @@
 'use client';
 
-import { useEffect, useMemo, useState, useTransition } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
 import { cn } from '@/components/ui/cn';
 import {
   SearchIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
-  RefreshIcon,
 } from '@/components/icons';
 import { RunStatusDots } from '@/components/run-status-dots';
 import type { ActionRunSummary, RunStatus } from '@/lib/action-runs-loader';
-import { syncAndDigest } from '@/app/inbox/sync-action';
 import { IssueRowMenu } from './issue-row-menu';
+import { SyncButton, type SyncStatusRow } from './sync-button';
 
 export interface IssueRow {
   number: number;
@@ -35,6 +33,8 @@ interface IssuesViewProps {
   repoLabel: string;
   fetchedAt: string | null;
   readOnly: boolean;
+  workspaceId: string;
+  initialSyncStatus: SyncStatusRow | null;
 }
 
 type StateFilter = 'all' | 'open' | 'closed';
@@ -83,10 +83,14 @@ function topStatus(runs: ActionRunSummary[]): RunStatus | 'none' {
   return best;
 }
 
-export function IssuesView({ rows, repoLabel, fetchedAt, readOnly }: IssuesViewProps) {
-  const router = useRouter();
-  const [syncing, startSync] = useTransition();
-  const [syncMessage, setSyncMessage] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null);
+export function IssuesView({
+  rows,
+  repoLabel,
+  fetchedAt,
+  readOnly,
+  workspaceId,
+  initialSyncStatus,
+}: IssuesViewProps) {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<PageSize>(10);
   const [search, setSearch] = useState('');
@@ -186,51 +190,8 @@ export function IssuesView({ rows, repoLabel, fetchedAt, readOnly }: IssuesViewP
           <p className="mt-1 text-sm text-on-surface-variant">
             <span className="font-mono">{repoLabel}</span> — {totalIssues} issue{totalIssues === 1 ? '' : 's'} synced
           </p>
-          {syncMessage && (
-            <p className={cn(
-              'mt-1 text-xs',
-              syncMessage.kind === 'error' ? 'text-error' : 'text-on-surface-variant',
-            )}>
-              {syncMessage.text}
-            </p>
-          )}
         </div>
-        {!readOnly && (
-          <button
-            type="button"
-            disabled={syncing}
-            onClick={() =>
-              startSync(async () => {
-                setSyncMessage(null);
-                const result = await syncAndDigest();
-                if (!result.ok) {
-                  setSyncMessage({ kind: 'error', text: `Sync failed: ${result.error ?? 'unknown'}` });
-                  return;
-                }
-                const bits: string[] = [];
-                if (result.issuesFetched) {
-                  bits.push(`${result.issuesFetched} issue${result.issuesFetched === 1 ? '' : 's'} (${result.issuesCreated ?? 0} new · ${result.issuesUpdated ?? 0} updated)`);
-                }
-                if (result.digestsCreated) bits.push(`${result.digestsCreated} digested`);
-                if (result.commentsFetched) bits.push(`${result.commentsFetched} commented`);
-                setSyncMessage({
-                  kind: 'ok',
-                  text: bits.length > 0 ? `Synced: ${bits.join(' · ')}` : 'Already up to date',
-                });
-                router.refresh();
-              })
-            }
-            className={cn(
-              'inline-flex h-9 items-center gap-2 rounded-md border px-4 text-sm font-medium transition-colors',
-              syncing
-                ? 'cursor-wait border-outline-variant bg-surface-container text-on-surface-variant'
-                : 'border-primary/40 bg-primary/10 text-primary hover:border-primary/60 hover:bg-primary/15',
-            )}
-          >
-            <RefreshIcon className={cn('h-4 w-4', syncing && 'animate-spin')} />
-            {syncing ? 'Syncing…' : 'Sync & Digest'}
-          </button>
-        )}
+        <SyncButton workspaceId={workspaceId} readOnly={readOnly} initialStatus={initialSyncStatus} />
       </header>
 
       <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/packages/gui/src/app/issues/page.tsx
+++ b/packages/gui/src/app/issues/page.tsx
@@ -4,6 +4,7 @@ import { getActiveWorkspace } from '@/lib/workspace';
 import type { StoredIssue } from '@cezar/core';
 import { fetchRecentActionRuns, type ActionRunSummary } from '@/lib/action-runs-loader';
 import { IssuesView, type IssueRow } from './issues-view';
+import type { SyncStatusRow } from './sync-button';
 
 export default async function IssuesPage() {
   const workspace = await getActiveWorkspace();
@@ -23,17 +24,20 @@ export default async function IssuesPage() {
   let actionRunsByIssue = new Map<number, ActionRunSummary[]>();
   let loadError: string | null = null;
   let fetchedAt: string | null = null;
+  let syncStatus: SyncStatusRow | null = null;
 
   try {
     const supabase = await createSupabaseServerClient();
     const adapter = new SupabaseStoreAdapter(supabase, workspace.id);
-    const [store, runs] = await Promise.all([
+    const [store, runs, sync] = await Promise.all([
       adapter.load(),
       fetchRecentActionRuns(workspace.id, 'issue'),
+      supabase.from('sync_status').select('*').eq('workspace_id', workspace.id).maybeSingle(),
     ]);
     issues = store.issues;
     actionRunsByIssue = runs;
     fetchedAt = store.meta.lastSyncedAt ?? null;
+    syncStatus = sync.data;
   } catch (err) {
     loadError = (err as Error).message;
   }
@@ -68,6 +72,8 @@ export default async function IssuesPage() {
       repoLabel={`${workspace.repoOwner}/${workspace.repoName}`}
       fetchedAt={fetchedAt}
       readOnly={workspace.role !== 'admin'}
+      workspaceId={workspace.id}
+      initialSyncStatus={syncStatus}
     />
   );
 }

--- a/packages/gui/src/app/issues/sync-button.tsx
+++ b/packages/gui/src/app/issues/sync-button.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useRef, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/components/ui/cn';
+import { RefreshIcon } from '@/components/icons';
+import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
+import { syncAndDigest } from '@/app/inbox/sync-action';
+import type { Database, SyncPhase } from '@/lib/supabase/types';
+
+export type SyncStatusRow = Database['public']['Tables']['sync_status']['Row'];
+
+/** A `syncing` row older than this is abandoned (container restarted mid-sync);
+ *  we render the idle button instead of a permanent spinner. Mirrors the
+ *  server-side guard in sync-action.ts. */
+const STALE_SYNC_MS = 10 * 60 * 1000;
+
+const PHASE_LABEL: Record<SyncPhase, string> = {
+  issues: 'issues',
+  digests: 'digests',
+  comments: 'comments',
+  prs: 'pull requests',
+};
+
+interface SyncButtonProps {
+  workspaceId: string;
+  readOnly: boolean;
+  initialStatus: SyncStatusRow | null;
+}
+
+/**
+ * Shared "Sync & Digest" button + live status, used by the Issues and Inbox
+ * headers. The actual sync runs in the background (see sync-action.ts); this
+ * component just kicks it off and reflects the `sync_status` row it writes,
+ * subscribed over Supabase Realtime. The app never blocks waiting on the sync.
+ */
+export function SyncButton({ workspaceId, readOnly, initialStatus }: SyncButtonProps) {
+  const router = useRouter();
+  const [status, setStatus] = useState<SyncStatusRow | null>(initialStatus);
+  const [pending, startKickoff] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  // Remember the last status we saw 'syncing' on, so we can refresh exactly
+  // once when it transitions to a terminal state.
+  const wasSyncing = useRef(initialStatus?.status === 'syncing');
+
+  // ── Realtime: follow this workspace's sync_status row. ──
+  useEffect(() => {
+    if (!workspaceId) return;
+    const supabase = createSupabaseBrowserClient();
+    const channel = supabase
+      .channel(`sync-${workspaceId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'sync_status',
+          filter: `workspace_id=eq.${workspaceId}`,
+        },
+        (payload) => {
+          const row = payload.new as Partial<SyncStatusRow>;
+          // Ignore DELETE / tombstone payloads (no row data).
+          if (!row || !row.workspace_id || !row.status) return;
+          setStatus(row as SyncStatusRow);
+          if (row.status === 'syncing') {
+            wasSyncing.current = true;
+          } else if (wasSyncing.current && (row.status === 'done' || row.status === 'error')) {
+            // Sync just finished — pull the freshly-synced data into the page.
+            wasSyncing.current = false;
+            router.refresh();
+          }
+        },
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [workspaceId, router]);
+
+  const isStale =
+    status?.status === 'syncing' &&
+    Date.now() - new Date(status.updated_at).getTime() > STALE_SYNC_MS;
+  const syncing = (status?.status === 'syncing' && !isStale) || pending;
+
+  function handleClick() {
+    if (syncing) return;
+    setError(null);
+    startKickoff(async () => {
+      const result = await syncAndDigest();
+      if (!result.ok) {
+        setError(result.error ?? 'Sync failed');
+      }
+      // On success the Realtime subscription drives the rest; nothing to await.
+    });
+  }
+
+  if (readOnly) return null;
+
+  const statusText = (() => {
+    if (error) return error;
+    if (syncing) {
+      if (status?.message) return status.message;
+      if (status?.phase) return `Syncing ${PHASE_LABEL[status.phase]}…`;
+      return 'Starting sync…';
+    }
+    if (status?.status === 'error') return status.error ? `Sync failed: ${status.error}` : 'Sync failed';
+    if (status?.status === 'done') return status.message ?? null;
+    return null;
+  })();
+
+  const label = syncing
+    ? status?.phase
+      ? `Syncing — ${PHASE_LABEL[status.phase]}`
+      : 'Syncing…'
+    : 'Sync & Digest';
+
+  return (
+    <div className="flex items-center gap-3">
+      {statusText && (
+        <span
+          className={cn(
+            'max-w-[280px] truncate text-xs',
+            error || status?.status === 'error' ? 'text-error' : 'text-on-surface-variant',
+          )}
+          title={statusText}
+        >
+          {statusText}
+        </span>
+      )}
+      <button
+        type="button"
+        disabled={syncing}
+        onClick={handleClick}
+        className={cn(
+          'inline-flex h-9 items-center gap-2 rounded-md border px-4 text-sm font-medium transition-colors',
+          syncing
+            ? 'cursor-wait border-outline-variant bg-surface-container text-on-surface-variant'
+            : 'border-primary/40 bg-primary/10 text-primary hover:border-primary/60 hover:bg-primary/15',
+        )}
+      >
+        <RefreshIcon className={cn('h-4 w-4', syncing && 'animate-spin')} />
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -31,6 +31,18 @@ export type LabelAnalysisStatus =
 export type WorkspaceLabelScope = 'issue' | 'pr' | 'both';
 export type WorkspaceLabelSource = 'ai-analyzed' | 'user-edited' | 'manual';
 
+// ─── Sync status (0029) ──────────────────────────────────────────────────
+export type SyncStatusState = 'idle' | 'syncing' | 'done' | 'error';
+export type SyncPhase = 'issues' | 'digests' | 'comments' | 'prs';
+export interface SyncCounts {
+  issuesFetched?: number;
+  issuesCreated?: number;
+  issuesUpdated?: number;
+  digestsCreated?: number;
+  commentsFetched?: number;
+  prsUpdated?: number;
+}
+
 // Shape of `workspace_label_analyses.result` once the executor finishes.
 export interface LabelAnalysisDraft {
   name: string;
@@ -195,6 +207,32 @@ export interface Database {
           updated_at?: string;
         };
         Update: Partial<Database['public']['Tables']['pull_requests']['Insert']>;
+      };
+      sync_status: {
+        Row: {
+          workspace_id: string;
+          status: SyncStatusState;
+          phase: SyncPhase | null;
+          message: string | null;
+          /** { issuesFetched, issuesCreated, issuesUpdated, digestsCreated, commentsFetched, prsUpdated } */
+          counts: SyncCounts;
+          error: string | null;
+          started_at: string | null;
+          finished_at: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          workspace_id: string;
+          status?: SyncStatusState;
+          phase?: SyncPhase | null;
+          message?: string | null;
+          counts?: SyncCounts;
+          error?: string | null;
+          started_at?: string | null;
+          finished_at?: string | null;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['sync_status']['Insert']>;
       };
       user_github_tokens: {
         Row: {

--- a/packages/gui/supabase/migrations/0029_sync_status.sql
+++ b/packages/gui/supabase/migrations/0029_sync_status.sql
@@ -1,0 +1,52 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- 0029_sync_status — live status for the user-triggered "Sync & Digest" action.
+--
+-- The sync used to run inline in a server action (blocking the request + the
+-- whole UI for 30s–2min). It now runs as a detached background task that flips
+-- this single per-workspace row through its phases; the client subscribes over
+-- Realtime to render progress and refresh when it finishes. One row per
+-- workspace, upserted on `workspace_id`.
+-- ─────────────────────────────────────────────────────────────────────────
+
+create table sync_status (
+  workspace_id  uuid primary key references workspaces(id) on delete cascade,
+  status        text not null default 'idle'
+                  check (status in ('idle', 'syncing', 'done', 'error')),
+  -- Current phase while status='syncing': matches the 4 phases of syncAndDigest.
+  phase         text check (phase in ('issues', 'digests', 'comments', 'prs')),
+  -- Human-readable one-liner for the button/toast (e.g. "Digesting 42 issues…").
+  message       text,
+  -- Accumulated counts: { issuesFetched, issuesCreated, issuesUpdated,
+  --                       digestsCreated, commentsFetched, prsUpdated }.
+  counts        jsonb not null default '{}'::jsonb,
+  error         text,
+  started_at    timestamptz,
+  finished_at   timestamptz,
+  updated_at    timestamptz not null default now()
+);
+
+-- ─── RLS (mirrors workflow_runs in 0008) ─────────────────────────────────
+-- Members read; admins write. The server action writes via the service-role
+-- key, which bypasses RLS — no special policy needed for it.
+alter table sync_status enable row level security;
+
+create policy "sync_status_member_select" on sync_status
+  for select using (is_workspace_member(workspace_id));
+create policy "sync_status_admin_write" on sync_status
+  for all using (is_workspace_admin(workspace_id)) with check (is_workspace_admin(workspace_id));
+
+-- ─── updated_at trigger (reuse touch_updated_at() from 0001) ─────────────
+create trigger sync_status_touch before update on sync_status
+  for each row execute function touch_updated_at();
+
+-- ─── Realtime ────────────────────────────────────────────────────────────
+-- The Sync button subscribes to this row for live phase/progress updates.
+do $$
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    alter publication supabase_realtime add table sync_status;
+  end if;
+exception when duplicate_object then
+  -- table already in the publication — fine.
+  null;
+end $$;


### PR DESCRIPTION
## Problem

Clicking **Sync & Digest** ran the whole sync — fetch issues → generate digests (LLM) → fetch comments → refresh PRs — **inline in a server action** and `await`ed it on the client. Next.js serializes server actions, so while it ran (30s–2min on a large repo) `router.refresh()` and navigations queued behind it and **the whole app froze**. The only feedback was a spinner with no phase or progress.

## What this does

Sync now runs **in the background** and surfaces **live, phase-by-phase status** via Supabase Realtime:

- The server action does a fast in-request kickoff (auth → concurrency guard → flip a status row to `syncing`) and fires the four phases as a **detached task** that returns immediately. The app stays responsive; you can navigate away.
- Progress is written to a new per-workspace **`sync_status`** row after each phase (`issues → digests → comments → prs`, with counts).
- A shared **`SyncButton`** subscribes to that row over Realtime, shows the live phase/message, and calls `router.refresh()` once exactly when the sync finishes.
- A **concurrency guard** rejects a second sync while one is live, with a **10-min staleness window** so a mid-sync container restart can't permanently wedge the button.

This fits the deployment model (long-lived Node container — `output: 'standalone'`, Docker/Dokploy), so a non-awaited promise keeps running after the response. Sync is intentionally **not** routed through the `jobs`/dispatch queue: it isn't a workflow, and the dispatcher only ticks on cron (~60s latency) — a user-clicked action should start instantly.

## Changes

| File | Change |
|---|---|
| `supabase/migrations/0029_sync_status.sql` | New table (RLS mirrors `workflow_runs`, touch trigger, added to `supabase_realtime` publication) |
| `app/inbox/sync-action.ts` | Kickoff + background `runSync()`; writes `sync_status` per phase; concurrency/staleness guard |
| `app/issues/sync-button.tsx` | New shared Realtime-driven button (Issues + Inbox) |
| `app/issues/{page,issues-view}.tsx`, `app/inbox/{page,inbox-view}.tsx` | Load `sync_status`, thread `workspaceId` + initial status, replace inline buttons |
| `lib/supabase/types.ts` | `sync_status` table + `SyncStatusState`/`SyncPhase`/`SyncCounts` types |

## Migration required

`0029_sync_status.sql` must be applied before deploy. On Supabase Cloud (the Dokploy path), run it in the **SQL editor**, then confirm Realtime is enabled for `sync_status` (the migration adds it to the publication).

## Verification

- `yarn workspace @cezar/gui typecheck` — passes
- `yarn workspace @cezar/gui build` — passes
- Manual end-to-end check still pending against a live DB: app stays responsive during sync, button shows live phases, second tab mirrors status, "already in progress" guard, stale-row recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)