### PR TITLE
fix(sync): backfill closed issues — full sync until first complete sync

### DIFF
--- a/packages/core/src/store/store.model.ts
+++ b/packages/core/src/store/store.model.ts
@@ -147,6 +147,11 @@ export const StoreMetaSchema = z.object({
   owner: z.string(),
   repo: z.string(),
   lastSyncedAt: z.string().nullable().default(null),
+  /** Set once a *complete* (all-states, including closed) sync has succeeded.
+   *  Until then, sync does a full fetch rather than an incremental `since`
+   *  fetch — this backfills closed issues for stores first synced by an older
+   *  open-only sync, and bootstraps freshly-connected workspaces. */
+  fullSyncedAt: z.string().nullable().default(null),
   totalFetched: z.number().default(0),
   version: z.literal(1).default(1),
   orgMembers: z.array(z.string()).default([]),

--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -52,6 +52,7 @@ export class IssueStore {
         owner: meta.owner,
         repo: meta.repo,
         lastSyncedAt: null,
+        fullSyncedAt: null,
         totalFetched: 0,
         version: 1,
         orgMembers: [],

--- a/packages/gui/src/app/inbox/sync-action.ts
+++ b/packages/gui/src/app/inbox/sync-action.ts
@@ -105,6 +105,7 @@ export async function syncAndDigest(): Promise<SyncResult> {
             owner: workspace.repoOwner,
             repo: workspace.repoName,
             lastSyncedAt: null,
+            fullSyncedAt: null,
             totalFetched: 0,
             version: 1 as const,
             orgMembers: [],
@@ -175,12 +176,17 @@ interface RunSyncArgs {
 async function runSync({ supabase, workspaceId, store, github, config, llm: LLMService }: RunSyncArgs): Promise<void> {
   const counts: SyncCounts = {};
 
-  // ── 1. Fetch issues (incremental when possible) ──
+  // ── 1. Fetch issues ──
+  // Do a full (all-states, incl. closed) fetch until a complete sync has
+  // succeeded, then switch to incremental `since` fetches. The full fetch
+  // backfills closed issues — and corrects issues closed upstream — for stores
+  // first synced by the older open-only path, and bootstraps new workspaces.
   try {
     const meta = store.getMeta();
-    const issues = meta.lastSyncedAt
-      ? await github.fetchIssuesSince(meta.lastSyncedAt, false)
-      : await github.fetchAllIssues(false);
+    const fullSync = !meta.fullSyncedAt || !meta.lastSyncedAt;
+    const issues = fullSync
+      ? await github.fetchAllIssues(true)
+      : await github.fetchIssuesSince(meta.lastSyncedAt as string, true);
     counts.issuesFetched = issues.length;
     counts.issuesCreated = 0;
     counts.issuesUpdated = 0;
@@ -189,9 +195,13 @@ async function runSync({ supabase, workspaceId, store, github, config, llm: LLMS
       if (r.action === 'created') counts.issuesCreated += 1;
       if (r.action === 'updated') counts.issuesUpdated += 1;
     }
+    const nowIso = new Date().toISOString();
     store.updateMeta({
-      lastSyncedAt: new Date().toISOString(),
+      lastSyncedAt: nowIso,
       totalFetched: issues.length,
+      // Mark the store complete once the first all-states fetch lands, so
+      // later syncs go incremental.
+      ...(fullSync ? { fullSyncedAt: nowIso } : {}),
     });
     await store.save();
   } catch (err) {
@@ -205,9 +215,11 @@ async function runSync({ supabase, workspaceId, store, github, config, llm: LLMS
     return;
   }
 
-  // ── 2. Generate digests for issues that don't have one yet ──
+  // ── 2. Generate digests for OPEN issues that don't have one yet ──
+  // Scoped to open issues: a full backfill can pull in hundreds of historical
+  // closed issues, and digesting those would be a large, low-value LLM spend.
   try {
-    const needDigest = store.getIssues({ hasDigest: false });
+    const needDigest = store.getIssues({ state: 'open', hasDigest: false });
     if (needDigest.length > 0) {
       await writeStatus(supabase, workspaceId, {
         status: 'syncing',

--- a/packages/gui/src/lib/adapters/supabase-store.ts
+++ b/packages/gui/src/lib/adapters/supabase-store.ts
@@ -45,6 +45,7 @@ export class SupabaseStoreAdapter implements StorePort {
       .update({
         meta: {
           lastSyncedAt: store.meta.lastSyncedAt,
+          fullSyncedAt: store.meta.fullSyncedAt,
           totalFetched: store.meta.totalFetched,
           version: store.meta.version,
           orgMembers: store.meta.orgMembers,
@@ -70,6 +71,7 @@ function metaFromWorkspace(ws: WorkspaceRow): Store['meta'] {
     owner: ws.repo_owner,
     repo: ws.repo_name,
     lastSyncedAt: raw.lastSyncedAt ?? null,
+    fullSyncedAt: raw.fullSyncedAt ?? null,
     totalFetched: raw.totalFetched ?? 0,
     version: 1,
     orgMembers: raw.orgMembers ?? [],


### PR DESCRIPTION
## Problem

The Issues page under-counts badly: Cezar shows **425 total / 420 open / ~5 closed**, while the GitHub repo has **344 open + 594 closed = 938 issues** — and ~76 issues that are closed upstream still show as open.

**Root cause:** the full sync only fetched *open* issues. `sync-action.ts` called `github.fetchAllIssues(false)`, which maps to `state: 'open'` in `github.service.ts:118-119`, so the 594 closed issues were never loaded.

**Why it couldn't self-correct:** once a workspace has `lastSyncedAt` set, every later sync takes the incremental `fetchIssuesSince(since)` branch, which only returns issues *updated since* the last sync. Historical closed issues (untouched) are never returned, so they never backfill and stale-open issues never get corrected. A naive "fetch closed on first sync" fix does nothing for an already-synced workspace.

## Fix

1. **`fullSyncedAt` marker** in store meta (`store.model.ts`, persisted via the Supabase adapter). Sync does a **full all-states fetch** (`fetchAllIssues(true)`) until one complete sync has succeeded, then switches to incremental.
2. This **self-heals already-synced workspaces** on the next sync: a full fetch returns every issue's current state, and `upsertIssue` applies it — backfilling closed issues and correcting issues closed upstream.
3. **Digests scoped to open issues** so the one-time backfill of ~594 historical closed issues doesn't trigger a large, low-value LLM spend.

## Not a bug
The **BUGS = 0** stat counts `analysis.issueType === 'bug'`, set by the **triage runner**, not the digest pass — unrelated to sync.

## Verification
- `@cezar/core` tests: 202/202 pass
- `@cezar/gui` typecheck + production build: green
- No new migration (rides on existing `issues` / `workspaces` tables).

After deploy, one **Sync & Digest** click runs a full backfill: closed jumps to ~594, total to ~938, open drops to ~344; later syncs go incremental again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)