### PR TITLE
fix(security): use GIT_ASKPASS to avoid leaking token in remote URL (#100)

### DIFF
--- a/packages/gui/src/lib/repo-clone.ts
+++ b/packages/gui/src/lib/repo-clone.ts
@@ -1,13 +1,28 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, writeFile, chmod, rm } from 'node:fs/promises';
 import { join } from 'node:path';
-import { tmpdir, homedir } from 'node:os';
+import { homedir } from 'node:os';
+import { randomBytes } from 'node:crypto';
 
 const exec = promisify(execFile);
 
 const REPOS_DIR = join(homedir(), '.cezar', 'repos');
+
+/**
+ * Creates a temporary GIT_ASKPASS script that outputs the token.
+ * This avoids embedding the token in the remote URL (which leaks via
+ * process listing and persists in .git/config on disk).
+ */
+async function createAskPassScript(token: string): Promise<string> {
+  const scriptPath = join(REPOS_DIR, `.askpass-${randomBytes(8).toString('hex')}`);
+  // The script outputs the token when git asks for credentials
+  // On Windows this would need to be a .cmd file, but this is a server-side lib
+  await writeFile(scriptPath, `#!/bin/sh\necho "${token}"\n`, { mode: 0o700 });
+  await chmod(scriptPath, 0o700);
+  return scriptPath;
+}
 
 /**
  * Ensures a local clone of the repo exists and is up-to-date.
@@ -15,6 +30,9 @@ const REPOS_DIR = join(homedir(), '.cezar', 'repos');
  *
  * Clones to ~/.cezar/repos/<owner>-<repo>. If already cloned,
  * fetches latest from origin.
+ *
+ * Uses GIT_ASKPASS to inject the token securely — the token is never
+ * embedded in the remote URL or visible in process listings.
  */
 export async function ensureRepoClone(
   owner: string,
@@ -25,18 +43,35 @@ export async function ensureRepoClone(
   await mkdir(REPOS_DIR, { recursive: true });
 
   const repoDir = join(REPOS_DIR, `${owner}-${repo}`);
-  const cloneUrl = `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`;
+  // Clean URL — no credentials embedded
+  const cloneUrl = `https://github.com/${owner}/${repo}.git`;
 
-  if (existsSync(join(repoDir, '.git'))) {
-    await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir });
-    await exec('git', ['fetch', 'origin'], { cwd: repoDir });
-    await exec('git', ['checkout', baseBranch], { cwd: repoDir }).catch(() => {
-      // branch might not exist locally yet
-      return exec('git', ['checkout', '-b', baseBranch, `origin/${baseBranch}`], { cwd: repoDir });
-    });
-    await exec('git', ['reset', '--hard', `origin/${baseBranch}`], { cwd: repoDir });
-  } else {
-    await exec('git', ['clone', '--depth', '50', '--branch', baseBranch, cloneUrl, repoDir]);
+  // Create temporary askpass script for secure token injection
+  const askPassPath = await createAskPassScript(githubToken);
+
+  const gitEnv = {
+    ...process.env,
+    GIT_ASKPASS: askPassPath,
+    // Also set these to prevent git from falling back to other credential helpers
+    GIT_TERMINAL_PROMPT: '0',
+    GCM_INTERACTIVE: 'never',
+  };
+
+  try {
+    if (existsSync(join(repoDir, '.git'))) {
+      // Ensure the remote URL doesn't contain embedded credentials
+      await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir, env: gitEnv });
+      await exec('git', ['fetch', 'origin'], { cwd: repoDir, env: gitEnv });
+      await exec('git', ['checkout', baseBranch], { cwd: repoDir, env: gitEnv }).catch(() => {
+        return exec('git', ['checkout', '-b', baseBranch, `origin/${baseBranch}`], { cwd: repoDir, env: gitEnv });
+      });
+      await exec('git', ['reset', '--hard', `origin/${baseBranch}`], { cwd: repoDir, env: gitEnv });
+    } else {
+      await exec('git', ['clone', '--depth', '50', '--branch', baseBranch, cloneUrl, repoDir], { env: gitEnv });
+    }
+  } finally {
+    // Always clean up the askpass script
+    await rm(askPassPath, { force: true }).catch(() => {});
   }
 
   return repoDir;


### PR DESCRIPTION
Fixes #100

## Problem
`ensureRepoClone` embeds the GitHub token directly in the remote URL:
```
https://x-access-token:TOKEN@github.com/owner/repo.git
```
This leaks the token via:
- **Process listing** (`ps aux` shows the token in `git clone` / `git fetch` args)
- **`.git/config` on disk** (persists the token in plaintext after clone)

## Solution
Use `GIT_ASKPASS` environment variable with a temporary script to inject the token securely. The token is never embedded in the URL or visible in process arguments.

### Changes:
- Created `createAskPassScript()` helper that generates a temporary executable script
- Clone URL is now clean: `https://github.com/owner/repo.git` (no credentials)
- Token injected via `GIT_ASKPASS` env var passed to all git commands
- Askpass script is always cleaned up in `finally` block
- Added `GIT_TERMINAL_PROMPT=0` and `GCM_INTERACTIVE=never` to prevent fallback