### PR TITLE
fix(core): repair main build — derive synthetic-record backend from bindings

### DIFF
--- a/packages/core/src/workflows/workflow-engine.ts
+++ b/packages/core/src/workflows/workflow-engine.ts
@@ -283,8 +283,10 @@ export class WorkflowEngine {
     // The workspace's effective default backend, used to stamp non-agent steps'
     // synthetic records so the cockpit's per-row backend icon matches where the
     // run actually executes (claude-cli / codex-cli) instead of always reading
-    // 'anthropic-api'. Falls back to the API path when no default is configured.
-    const workspaceBackend: AgentBackend = ctx.config.autofix?.runner?.backend ?? 'anthropic-api';
+    // 'anthropic-api'. Derived from the per-step bindings — the same source the
+    // agent steps resolve their backend from (see resolveStepConfig) — using the
+    // first binding that pins one. Falls back to the API path when none do.
+    const workspaceBackend: AgentBackend = bindings.find((b) => b.backend != null)?.backend ?? 'anthropic-api';
 
     // Issue data — repo-less workflows still want title/body for prompts.
     let issueTitle = `#${ctx.issueNumber}`;


### PR DESCRIPTION
## Problem

`main` currently fails `@cezar/core` typecheck/build:

```
packages/core/src/workflows/workflow-engine.ts(287,72):
  error TS2339: Property 'backend' does not exist on type '{ transport: "print" | "stream-json"; mode: "staged" | "unified"; }'.
```

`runWorkflow` stamped non-agent steps' synthetic run records with `ctx.config.autofix?.runner?.backend` (added by #166 / issue #46). But the `autofix.runner` config object only declares `{ transport, mode }` — the `backend` / `model` fields live under `workflow.bindings[]`, not `autofix.runner`. So the property access is invalid and breaks the build.

## Fix

Derive `workspaceBackend` from the per-step `bindings` — the **same source agent steps already resolve their backend from** (`resolveStepConfig`: `binding?.backend ?? … ?? 'anthropic-api'`) — using the first binding that pins one, falling back to `'anthropic-api'`:

```ts
const workspaceBackend: AgentBackend =
  bindings.find((b) => b.backend != null)?.backend ?? 'anthropic-api';
```

This preserves #166's intent (the cockpit's per-row backend icon should reflect where the run actually executes, e.g. `claude-cli`) against a source that actually exists.

## Verification

- `yarn workspace @cezar/core typecheck` — clean
- `yarn workspace @cezar/core build` — clean
- `npx vitest run tests/workflows` — 65/65 pass

No new test added: this re-points an existing computation to an already-covered source (`bindings`), and the synthetic-record path needs effect-step scaffolding (git/github/store deps) that would add fragility without commensurate value. Happy to add one if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)