### PR TITLE
fix(prs): sync all PR states so closed/merged stop showing as open

### DIFF
--- a/packages/core/src/services/github.service.ts
+++ b/packages/core/src/services/github.service.ts
@@ -188,7 +188,18 @@ export class GitHubService {
     }
   }
 
-  async listOpenPullRequests(maxItems?: number): Promise<RawPullRequest[]> {
+  /**
+   * Lists pull requests for the repo, newest-activity first, across *all*
+   * states (open + closed/merged). Fetching `state: 'all'` sorted by `updated`
+   * descending is what lets the periodic sync self-heal: closing or merging a
+   * PR bumps its `updated_at`, so every PR that recently changed state surfaces
+   * near the top and gets re-upserted with its current state — without it,
+   * a PR synced while open and later closed upstream stays `open` in the store
+   * forever (the webhook covers live transitions; this is the backfill +
+   * missed-delivery safety net). `maxItems` caps the walk so a repo with
+   * thousands of historical PRs can't blow the request budget.
+   */
+  async listPullRequests(maxItems?: number): Promise<RawPullRequest[]> {
     const mapPr = (
       p: Awaited<ReturnType<Octokit['rest']['pulls']['list']>>['data'][number],
     ): RawPullRequest => ({
@@ -218,7 +229,9 @@ export class GitHubService {
         const iterator = this.octokit.paginate.iterator(this.octokit.rest.pulls.list, {
           owner: this.owner,
           repo: this.repo,
-          state: 'open',
+          state: 'all',
+          sort: 'updated',
+          direction: 'desc',
           per_page: 100,
         });
         for await (const { data } of iterator) {
@@ -233,7 +246,9 @@ export class GitHubService {
       const prs = await this.octokit.paginate(this.octokit.rest.pulls.list, {
         owner: this.owner,
         repo: this.repo,
-        state: 'open',
+        state: 'all',
+        sort: 'updated',
+        direction: 'desc',
         per_page: 100,
       });
       return prs.map(mapPr);

--- a/packages/gui/src/app/api/cron/prs-sync/route.ts
+++ b/packages/gui/src/app/api/cron/prs-sync/route.ts
@@ -11,7 +11,8 @@ const MAX_WORKSPACES_PER_TICK = 10;
 // window) must not hold the whole tick hostage.
 const PER_WORKSPACE_TIMEOUT_MS = 20_000;
 // Bound how many PRs a single tick pulls into memory so a mega-repo with
-// thousands of open PRs can't OOM/timeout the cron.
+// thousands of PRs can't OOM/timeout the cron. We walk all states newest-
+// activity first, so recently closed/merged PRs land within this budget.
 const MAX_PRS_PER_TICK = 1_000;
 
 type Workspace = {
@@ -36,8 +37,9 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
  * The webhook receiver upserts on `pull_request` events in real time; this
  * cron is the backfill + missed-delivery safety net.
  *
- * Pulls open PRs via Octokit and upserts them into the `pull_requests` table.
- * Per-workspace gated by the same `auto_triage_enabled` flag — repos opted
+ * Pulls PRs (all states, newest-activity first) via Octokit and upserts them
+ * into the `pull_requests` table — so PRs closed/merged upstream stop showing
+ * as open. Per-workspace gated by the same `auto_triage_enabled` flag — repos opted
  * out of automated work still get a /prs page, so we sync regardless of that
  * flag and require only that a workspace exists.
  */
@@ -95,10 +97,10 @@ async function syncOne(
     github: { owner: ws.repo_owner, repo: ws.repo_name, token },
   } as never);
 
-  const openPrs = await github.listOpenPullRequests(MAX_PRS_PER_TICK);
+  const prs = await github.listPullRequests(MAX_PRS_PER_TICK);
 
-  if (openPrs.length > 0) {
-    const rows = openPrs.map((p) => ({
+  if (prs.length > 0) {
+    const rows = prs.map((p) => ({
       workspace_id: ws.id,
       number: p.number,
       title: p.title,
@@ -120,7 +122,7 @@ async function syncOne(
     if (upsertErr) throw new Error(`pull_requests upsert failed: ${upsertErr.message}`);
   }
 
-  return { workspaceId: ws.id, ok: true, prs: openPrs.length };
+  return { workspaceId: ws.id, ok: true, prs: prs.length };
 }
 
 // Picks a workable GitHub token for the workspace: walk admins, return the

--- a/packages/gui/src/app/inbox/sync-action.ts
+++ b/packages/gui/src/app/inbox/sync-action.ts
@@ -265,7 +265,7 @@ async function runSync({ supabase, workspaceId, store, github, config, llm: LLMS
     console.warn('[syncAndDigest] comments pass failed:', err);
   }
 
-  // ── 4. Refresh open PRs into the pull_requests table ──
+  // ── 4. Refresh PRs (all states) into the pull_requests table ──
   try {
     await writeStatus(supabase, workspaceId, {
       status: 'syncing',
@@ -273,9 +273,12 @@ async function runSync({ supabase, workspaceId, store, github, config, llm: LLMS
       message: 'Refreshing pull requests…',
       counts,
     });
-    const openPrs = await github.listOpenPullRequests();
-    if (openPrs.length > 0) {
-      const rows = openPrs.map((p) => ({
+    // All states, newest-activity first, so PRs closed/merged upstream get
+    // their state corrected; cap the walk so a repo with thousands of historical
+    // PRs doesn't bloat this background pass.
+    const prs = await github.listPullRequests(500);
+    if (prs.length > 0) {
+      const rows = prs.map((p) => ({
         workspace_id: workspaceId,
         number: p.number,
         title: p.title,
@@ -294,7 +297,7 @@ async function runSync({ supabase, workspaceId, store, github, config, llm: LLMS
       const { error } = await supabase
         .from('pull_requests')
         .upsert(rows, { onConflict: 'workspace_id,number' });
-      if (!error) counts.prsUpdated = openPrs.length;
+      if (!error) counts.prsUpdated = prs.length;
     }
   } catch (err) {
     console.warn('[syncAndDigest] PR sync failed:', err);

--- a/packages/gui/src/app/prs/prs-action.ts
+++ b/packages/gui/src/app/prs/prs-action.ts
@@ -14,15 +14,16 @@ export interface SyncPrsResult {
 }
 
 // Hard cap on the GitHub round-trip from the interactive server action: 500
-// open PRs (~5 pages of 100). Busy repos can't block the route handler
+// PRs (~5 pages of 100). Busy repos can't block the route handler
 // indefinitely (or time the action out); the background `prs-sync` cron does
-// the uncapped walk. listOpenPullRequests stops fetching once the cap is hit.
+// the larger walk. listPullRequests stops fetching once the cap is hit.
 const MAX_SYNC_ITEMS = 500;
 
 /**
- * On-demand counterpart to the `prs-sync` cron — fetches open PRs from
- * GitHub and upserts them into `pull_requests` for the active workspace.
- * Prefers a GitHub App installation token (§3.9), falling back to the
+ * On-demand counterpart to the `prs-sync` cron — fetches PRs (all states,
+ * newest-activity first) from GitHub and upserts them into `pull_requests`
+ * for the active workspace, so PRs closed/merged upstream stop showing as
+ * open. Prefers a GitHub App installation token (§3.9), falling back to the
  * caller's per-user OAuth token. Admin-only (matches the skills sync).
  */
 export async function syncPullRequests(): Promise<SyncPrsResult> {
@@ -43,27 +44,27 @@ export async function syncPullRequests(): Promise<SyncPrsResult> {
   }
   if (!token) return { ok: false, error: 'No GitHub token — sign out and back in to sync' };
 
-  let openPrs: Awaited<ReturnType<InstanceType<typeof core.GitHubService>['listOpenPullRequests']>>;
+  let prs: Awaited<ReturnType<InstanceType<typeof core.GitHubService>['listPullRequests']>>;
   try {
     const github = new core.GitHubService({
       github: { owner: workspace.repoOwner, repo: workspace.repoName, token },
     } as never);
-    openPrs = await github.listOpenPullRequests(MAX_SYNC_ITEMS);
+    prs = await github.listPullRequests(MAX_SYNC_ITEMS);
   } catch (err) {
     return { ok: false, error: `GitHub fetch failed: ${err instanceof Error ? err.message : String(err)}` };
   }
 
   // Hitting the cap means more PRs exist than we walked — flag it so the UI
   // can tell the user the cron will backfill the remainder.
-  const capped = openPrs.length >= MAX_SYNC_ITEMS;
+  const capped = prs.length >= MAX_SYNC_ITEMS;
 
-  if (openPrs.length === 0) {
+  if (prs.length === 0) {
     revalidatePath('/prs');
     return { ok: true, count: 0 };
   }
 
   const supabase = createSupabaseAdminClient();
-  const rows = openPrs.map((p) => ({
+  const rows = prs.map((p) => ({
     workspace_id: workspace.id,
     number: p.number,
     title: p.title,
@@ -86,5 +87,5 @@ export async function syncPullRequests(): Promise<SyncPrsResult> {
   if (error) return { ok: false, error: `Upsert failed: ${error.message}` };
 
   revalidatePath('/prs');
-  return { ok: true, count: openPrs.length, capped };
+  return { ok: true, count: prs.length, capped };
 }

--- a/packages/gui/src/app/prs/prs-view.tsx
+++ b/packages/gui/src/app/prs/prs-view.tsx
@@ -187,7 +187,7 @@ export function PrsView({ rows, repoLabel, fetchedAt, readOnly }: PrsViewProps) 
 
       {syncState?.ok && (
         <div className="mb-4 rounded-md border border-primary/30 bg-primary-container/20 px-4 py-2 text-sm text-primary">
-          Synced {syncState.count ?? 0} open PR{(syncState.count ?? 0) === 1 ? '' : 's'} from GitHub.
+          Synced {syncState.count ?? 0} PR{(syncState.count ?? 0) === 1 ? '' : 's'} from GitHub.
           {syncState.capped && (
             <> Page cap reached — the background sync will backfill the rest.</>
           )}
@@ -550,11 +550,14 @@ function BranchCell({ head, base }: { head: string | null; base: string | null }
   if (!head && !base) {
     return <span className="font-mono text-[13px] text-on-surface-variant">—</span>;
   }
+  // Each side caps its own width and truncates with an ellipsis — the table is
+  // auto-layout, so a `max-width` on the <td> alone is ignored and a long head
+  // ref would otherwise push into the labels column.
   return (
-    <span className="inline-flex items-center gap-1 truncate font-mono text-[12px] text-on-surface-variant" title={`${head ?? '?'} → ${base ?? '?'}`}>
-      <span className="truncate">{head ?? '?'}</span>
-      <span className="text-outline-variant">→</span>
-      <span className="truncate">{base ?? '?'}</span>
+    <span className="flex items-center gap-1 font-mono text-[12px] text-on-surface-variant" title={`${head ?? '?'} → ${base ?? '?'}`}>
+      <span className="max-w-[150px] truncate">{head ?? '?'}</span>
+      <span className="shrink-0 text-outline-variant">→</span>
+      <span className="max-w-[90px] truncate">{base ?? '?'}</span>
     </span>
   );
 }


### PR DESCRIPTION
## Problem

The /prs page showed **65 PRs all "open"** while GitHub had only **20 open** (the rest closed/merged) — see screenshots in the originating request. Long branch names also overflowed their column into the labels column.

## Root cause

The PR sync only ever queried GitHub with `state: 'open'`. A PR synced while open and later closed/merged upstream was never re-fetched, so it stayed `open` in the `pull_requests` table forever. The webhook upserts live transitions, but the periodic sync — the missed-delivery + backfill safety net — was blind to closed PRs.

## Fix

**Sync all states.** Rename `GitHubService.listOpenPullRequests` → `listPullRequests` and fetch `state: 'all'` sorted by `updated desc`. Closing/merging a PR bumps its `updated_at`, so every recently-transitioned PR surfaces near the top and gets re-upserted with its current state — self-healing stale-open rows within the existing per-fetch caps. Callers updated:
- interactive "Sync from GitHub" action (`prs-action.ts`)
- `prs-sync` cron
- inbox sync-and-digest (gains a 500 cap so the all-states walk doesn't bloat the background pass)
- "Synced N open PRs" → "Synced N PRs" copy

The OPEN/DRAFT/RUNNING stat cards are derived client-side from the rows, so correcting stored state fixes the counts automatically.

**Branch-name truncation.** The branch cell used `truncate` with no width constraint, but the table is auto-layout so the `<td>` `max-w` was ignored and long head refs pushed into the labels column. Each side (head/base) now caps its own width and ellipsizes; the full ref stays on hover via `title`.

## Notes

- Server-side data correction: a "Sync from GitHub" click (or the next `prs-sync` cron tick) backfills the corrected states into the table.
- `@cezar/core` and `@cezar/gui` both typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)