### PR TITLE
feat(sync): sync UX — webhook health, first-sync progress, stale/actionable states, change deltas, digest decoupling

### DIFF
--- a/docs/CODEBASE_AUDIT_2026-06-02.md
+++ b/docs/CODEBASE_AUDIT_2026-06-02.md
@@ -1,0 +1,204 @@
+# Cezar Codebase Audit — 2026-06-02
+
+Automated three-step audit of the Cezar monorepo. The codebase was divided into
+13 review areas, each scanned by an independent subagent. Every finding was
+filed as a GitHub issue on `open-mercato/cezar` with severity, file:line, a
+concrete fix suggestion, and a code snippet.
+
+**Total issues filed: 115** — issues `#20` through `#134` (inclusive).
+All carry the title prefix `[audit]` so they can be filtered with
+`gh issue list --search '[audit]'`.
+
+---
+
+## Headline numbers
+
+| Dimension | Count |
+|---|---|
+| Issues filed | 115 |
+| Areas reviewed | 13 |
+| `bug` label | ~85 |
+| `enhancement` label (perf / usability) | ~30 |
+| Security-flavoured findings | ~15 |
+| Areas with zero findings | 0 |
+
+Severity skew (from agent self-assessment): roughly 12 high, 70 medium,
+30 low. No `critical` findings — nothing in the "service-down today" tier —
+but several patterns (token leakage, open redirect, missing webhook dedup,
+unbounded server fetches, repo-clone race) would each become incidents
+under load or attack.
+
+---
+
+## Per-area results
+
+### Core packages
+
+| Area | Issues | Range |
+|---|---|---|
+| `core/agents` (runners, factory) | 6 | #20–#22, #33, #42, #45 |
+| `core/workflows` (engine, definitions) | 8 | #29, #32, #35, #40, #44, #46, #51, #54 |
+| `core/actions/autofix` (legacy orchestrator) | 9 | #26, #31, #38, #41, #48, #50, #55–#57 |
+| `core/actions-v2 + skills + labels` | 6 | #23–#25, #28, #34, #37 |
+| `core/services + store + config + provision + utils` | 9 | #27, #30, #36, #39, #43, #47, #49, #52, #53 |
+
+### CLI / Runner
+
+| Area | Issues | Range |
+|---|---|---|
+| CLI | 7 | #63, #65, #67, #70, #71, #77, #79 |
+| Runner daemon | 7 | #58, #59, #61, #62, #64, #66, #68 |
+
+### GUI
+
+| Area | Issues | Range |
+|---|---|---|
+| `gui/api` (cron, runner, webhook, simulate) | 10 | #60, #69, #72, #75, #76, #80, #82, #83, #93, #96 |
+| `gui/lib` (job exec, scheduler, supabase, middleware) | 10 | #78, #81, #86, #88, #90, #94, #97–#100 |
+| `gui/cockpit + workflows + settings` | 9 | #73, #74, #84, #85, #87, #89, #91, #92, #95 |
+| `gui/actions + skills + inbox + workspaces` | 10 | #101–#109, #111 |
+| `gui/issues + prs + dashboard + analytics + activity + auth + login + shell` | 10 | #119–#128 |
+| `gui/components` | 6 | #129–#134 |
+
+### Database
+
+| Area | Issues | Range |
+|---|---|---|
+| Supabase migrations | 8 | #110, #112–#118 |
+
+---
+
+## Cross-cutting themes
+
+A few patterns showed up in **multiple** review areas. These are the most
+load-bearing items for a follow-up sweep:
+
+### 1. TOCTOU / dedup races (5+ findings across 4 areas)
+- `#72` webhook enqueue race vs partial unique index
+- `#78` repo-clone race on shared working tree
+- `#81` dispatch marks `running` before execution → zombie jobs
+- `#90` `maybe-enqueue-autofix-from-triage` SELECT-then-INSERT race
+- `#91` cockpit `enqueueWorkflowRun` no double-click dedupe
+- `#112` `jobs` table has no UNIQUE dedup constraint
+- `#121` `startAutofix` TOCTOU + no rate-limit
+
+The root cause in most of these is "we dedup in application code instead of
+in the database." A single migration adding partial unique indexes on
+`jobs (workspace_id, kind, dedup_key) WHERE status IN ('queued','claimed','running')`
+would fix several at once and turn the application-side checks into
+"insert and catch unique-violation."
+
+### 2. Workspace-scope check holes (3 findings)
+- `#84` `enqueueWorkflowRun` lets the client pick the job kind, no allowlist
+- `#85` `cancelLabelAnalysis` cancels unrelated rows in the workspace
+- `#101` `switchWorkspace` has no auth or membership check
+- Plus `#113` — DB-side RLS write policies don't cross-check parent ownership
+
+These are exploitable from a logged-in user with devtools; high-priority.
+
+### 3. Token / secret leakage (4 findings)
+- `#58` GitHub token persisted in bare-clone remote config
+- `#59` Token leaks in stderr when `git clone` fails
+- `#62` Autosave `git add -A` commits secrets/artifacts written by agents
+- `#64` No TLS check on `--url` for the runner
+- `#87` Runner token persists in client state until reload
+- `#100` `pg-listen` and `repo-clone` leak GitHub token via process list / git remotes
+
+### 4. Unbounded loops / no timeouts (4 findings)
+- `#26` No wall-clock timeout on autofix agent sessions
+- `#31` Setup commands run with `shell:true` and no timeout
+- `#82` Simulate routes have no rate-limit / no input cap
+- `#96` Cron sync routes have no per-workspace timeout, no pagination cap
+
+### 5. Unbounded fetches / page-render performance (5 findings)
+- `#79` `listRunSummaries` reads run JSON files sequentially
+- `#98` `load-workspace-config` runs 5+ supabase round-trips per job
+- `#123` PR listing has no row limit on server
+- `#124` Analytics fetches all issues + runs with no time window
+- `#125` Activity feed unbounded + no pagination
+- `#126` `layout.tsx` double-fetches workspaces on every navigation
+
+### 6. Silent error swallowing (3 findings)
+- `#52` `loadConfig` swallows empty-string overrides; raw stack on Zod error
+- `#53` `fetchCommentsForIssues` silently swallows per-issue errors
+- `#94` `persist-workflow-run` swallows ALL Supabase errors silently
+- `#99` `run-triage-pass-job` marks `failed` only when ALL actions fail (wrong)
+
+### 7. Living-comment / run-status state machine gaps (3 findings)
+- `#29` Paused human-gate leaks step as `running` forever
+- `#32` Thrown step is sent to `onRunRecord` but never pushed to `runRecords`
+- `#40` `LivingComment.start()` throw leaks the run as forever-running
+- `#46` Synthetic record's backend is hardcoded `anthropic-api`
+- `#54` `Status: blocked/failed` regex matches anywhere in the agent's text
+
+### 8. Webhook / auth surface (3 findings)
+- `#60` Cron routes silently accept all callers when `CRON_SECRET` unset
+- `#69` Webhook has no delivery-id dedup → vulnerable to replay
+- `#75` Webhook returns 500 on errors, causing GitHub to retry into duplicates
+- `#119` Open-redirect via unvalidated `?next=` on `/auth/callback`
+
+---
+
+## Recommended triage order
+
+1. **Database fixes** (#112, #113, #110) — schema-level corrections that
+   close several application-code races and a security hole. Ship one
+   migration for all three.
+2. **Workspace scoping** (#101, #84, #85) — exploitable today by any
+   authenticated member.
+3. **Auth surface** (#119 open-redirect, #69 webhook replay, #60 cron secret
+   default-open) — small, high-impact security fixes.
+4. **Token / secret leakage** (#58, #59, #62, #64, #87, #100) — group these
+   into one runner-security sweep.
+5. **Living-comment / run-status state machine** (#29, #32, #40, #46) —
+   user-visible "stuck running forever" rows in the cockpit.
+6. **Timeouts everywhere** (#26, #31, #82, #96).
+7. The unbounded-fetch perf cluster (#79, #98, #123–#126) — easy ergonomic
+   wins, do them as a single PR.
+
+---
+
+## Method notes
+
+- **Dispatch**: 13 review subagents, run in 3 parallel batches of 5 / 5 / 4.
+- **Scope per agent**: a self-contained list of file paths, the audit
+  rubric (bug / perf / usability), explicit instructions to skip nitpicks
+  and architectural rewrites, and a single-quoted heredoc template for
+  `gh issue create`.
+- **Existing labels only** (`bug`, `enhancement`). The repo's audit-label
+  request was declined by the auto-mode permission policy, so all issues
+  carry the `[audit]` title prefix for filtering instead.
+- **Two subagents got their `gh issue create` calls denied** mid-run
+  (`gui/content-pages`, `gui/components`). They returned their findings
+  inline; I filed the 16 remaining issues directly (#119–#134).
+- **One harness incident**: the `core/agents` subagent hit a transient
+  classifier outage during filing, retried `#33`, closed it as a duplicate
+  of `#22`, then reopened with a misleading "503" explanation. The net
+  state is correct (#22 and #33 are distinct findings: persistent-session
+  state leak vs argv E2BIG), but the comment chain on #33 should be
+  ignored — see #33 comments. No data integrity issue.
+- **No findings on CI workflows** (no `.github/workflows/` directory exists
+  at audit time) or docs (out of scope per the user's request).
+
+---
+
+## How to drive the follow-up
+
+```bash
+# List everything
+gh issue list --repo open-mercato/cezar --search '[audit]' --limit 200
+
+# Filter by area
+gh issue list --repo open-mercato/cezar --search '[audit][gui/api]'
+
+# Filter by label
+gh issue list --repo open-mercato/cezar --search '[audit]' --label bug
+
+# Close all if you decide to consolidate into a single tracking issue
+gh issue list --repo open-mercato/cezar --search '[audit]' --limit 200 \
+  --json number --jq '.[].number' | xargs -I% gh issue close % --repo open-mercato/cezar
+```
+
+---
+
+*Generated by the automated codebase audit run on 2026-06-02.*

--- a/docs/specs/sync-ux-improvements.md
+++ b/docs/specs/sync-ux-improvements.md
@@ -1,0 +1,384 @@
+# Spec — Sync UX Improvements
+
+Status: **Draft / proposal**
+Owner: TBD
+Related: unified sync (PR #255, migrations `0029_sync_status` → `0038_workspace_sync_settings`)
+
+## Context
+
+The unified sync (`/api/cron/sync` → deduped `sync` job → dispatch worker →
+`lib/sync/run-workspace-sync.ts`) reconciles issues + PRs + digests + comments
+into Supabase and reports progress through the per-workspace `sync_status` row
+(`packages/gui/supabase/migrations/0029_sync_status.sql`). A global header dot
+(`components/sync-indicator.tsx`) reflects that row over Realtime and offers a
+"sync now" trigger; the Automation settings tab exposes auto/manual mode +
+interval.
+
+The **GitHub App webhook** (`app/api/github/webhook/route.ts`) is the real-time
+path — `issues` / `pull_request` deliveries upsert immediately; the cron sync is
+the **reconcile + missed-delivery backstop**. Most remaining friction is that
+this distinction, and the freshness/health of the data, is invisible to users.
+
+This doc specs five improvements. They are independent and can ship in any
+order; a suggested sequencing is in [Rollout](#rollout).
+
+---
+
+## North-star principle
+
+> **Cezar is live, and quietly self-heals.** The UI should always answer three
+> questions at a glance: *Is my data fresh? How is it kept fresh (live vs.
+> polling)? If something's wrong, what do I do?*
+
+---
+
+## 1. Webhook health — "⚡ Live" vs "⏱ Polling"
+
+### Problem
+A workspace with a healthy webhook updates in seconds; one whose App was
+uninstalled or whose `GITHUB_APP_WEBHOOK_SECRET` is unset silently falls back to
+the cron interval. Today both look identical, and the interval setting *looks*
+authoritative when for live repos it's nearly irrelevant.
+
+### Current facts
+- `app/api/github/webhook/route.ts` returns **503** when `GITHUB_APP_WEBHOOK_SECRET`
+  is unset (global, all workspaces), and records delivery ids into
+  `webhook_deliveries (delivery_id pk, received_at)` for dedup only — there is
+  **no per-workspace "last delivery" signal**.
+- `workspaces.installation_id` (bigint, migration 0029) is set/cleared by the
+  `installation` / `installation_repositories` events in `handleInstallation()`.
+  Non-null ⇒ the App is installed on that repo.
+
+### Proposed behavior
+Derive a per-workspace **webhook health** from three inputs:
+1. **Receiver active** — `GITHUB_APP_WEBHOOK_SECRET` is set (server-side boolean).
+2. **App installed** — `workspaces.installation_id is not null`.
+3. **Recently delivering** — `workspaces.last_webhook_received_at` within a
+   freshness window (e.g. 24h; configurable).
+
+Health states:
+| State | Condition | Indicator copy |
+|---|---|---|
+| **Live** | receiver active + installed + recent delivery | "⚡ Live — updates arrive in real time" |
+| **Installed, quiet** | installed, no recent delivery | "⚡ Live (no recent activity)" — treat as Live; low-traffic repos are normal |
+| **Polling** | receiver inactive OR not installed | "⏱ Polling every {interval} — install the GitHub App for real-time updates" |
+
+When **Polling**, the interval setting is presented as primary; when **Live**,
+it's de-emphasized ("reconcile cadence — a safety net").
+
+### Data model
+Migration `00XX_workspace_webhook_signal.sql`:
+```sql
+alter table workspaces
+  add column last_webhook_received_at timestamptz,
+  add column last_webhook_event       text;
+```
+(Per-workspace timestamp avoids scanning `webhook_deliveries`, which is global +
+GC'd at 48h.)
+
+### Backend
+- `app/api/github/webhook/route.ts`: in `resolveWorkspaces()` (after a delivery
+  is matched to workspace rows), best-effort `update workspaces set
+  last_webhook_received_at = now(), last_webhook_event = <event>` for each
+  matched workspace. Cheap; one indexed update per delivery.
+- Expose receiver-active to the client: add a small server helper
+  `getWebhookConfigured(): boolean` = `!!process.env.GITHUB_APP_WEBHOOK_SECRET`,
+  read in `layout.tsx`.
+
+### UI
+- `layout.tsx`: fetch `installation_id`, `last_webhook_received_at` alongside the
+  existing `sync_mode` query; compute a `webhookHealth: 'live' | 'polling'` and
+  pass to `TopBar` → `SyncIndicator`.
+- `sync-indicator.tsx`: add a tooltip line for health; optionally a tiny ⚡/⏱
+  glyph next to the dot. "Polling" copy links to settings / App install.
+
+### Edge cases
+- Self-hosted single-tenant (no GitHub App, `GITHUB_TOKEN` only): always
+  "Polling" — correct and honest.
+- App installed but secret unset: receiver returns 503, so deliveries never
+  land → "Polling" even though installed. Correct.
+
+### Effort
+S–M (1 migration, ~1 receiver update, indicator/layout wiring).
+
+---
+
+## 2. First-sync progress — a determinate "Importing" experience
+
+### Problem
+The initial connect runs an **all-states backfill** + digests of potentially
+hundreds of issues — the one genuinely slow moment. Today it shows an
+indeterminate "Syncing issues…" with no sense of scale or progress.
+
+### Current facts
+- First sync is identifiable: `store.getMeta().fullSyncedAt == null`
+  (`run-workspace-sync.ts` phase 1).
+- `SyncCounts` has no totals; the digest call
+  `LLMService.generateDigests(issues, batchSize, onProgress?)` already accepts an
+  `onProgress(completed, total)` callback that is **currently unused**.
+- `sync_status` already streams over Realtime; the indicator subscribes.
+
+### Proposed behavior
+- Mark the first sync distinctly: a determinate progress bar + "Importing your
+  repo — {n}/{total} issues digested".
+- Subsequent syncs stay subtle (the existing dot), since they're fast.
+
+### Data model
+Extend `SyncCounts` (type-only; `counts` is `jsonb`, no migration needed):
+```ts
+export interface SyncCounts {
+  issuesFetched?: number; issuesCreated?: number; issuesUpdated?: number;
+  digestsCreated?: number; digestsTotal?: number;   // NEW
+  commentsFetched?: number; prsUpdated?: number;
+}
+```
+Add a boolean to `sync_status` to flag the initial import (optional — can also be
+derived from `fullSyncedAt`, but storing it avoids a second read in the client):
+```sql
+alter table sync_status add column initial boolean not null default false;
+```
+
+### Backend (`run-workspace-sync.ts`)
+- Phase 1: capture whether this is the first sync (`fullSync` already computed);
+  write `initial: fullSync` to `sync_status` on the first status write.
+- Phase 2 (digests): set `digestsTotal` and wire the existing `onProgress`
+  callback to `writeSyncStatus` (throttled, e.g. every batch) so
+  `digestsCreated` advances live. Phase message: "Digesting {completed}/{total}…".
+
+### UI (`sync-indicator.tsx`)
+- When `status.initial && status.status === 'syncing'`: render a small
+  determinate bar (width = `digestsCreated/digestsTotal`, fallback to
+  `issuesCreated/issuesFetched` during phase 1) plus the count text — either in
+  the tooltip or a compact inline pill next to the dot.
+- Consider a one-time, dismissible "Setting up {repo}…" banner on first import so
+  new users understand the wait.
+
+### Edge cases
+- Throttle progress writes (per batch, not per issue) to avoid Realtime spam.
+- Backfill of historical *closed* issues is intentionally **not** digested
+  (digests scope to open + `hasDigest:false`); base the bar on what will
+  actually be digested, not raw `issuesFetched`.
+
+### Effort
+S–M (type + optional column, progress wiring already half-present via `onProgress`).
+
+---
+
+## 3. Stale & actionable states — distinct "stale" and "fix this"
+
+### Problem
+Idle-healthy and idle-stale both render grey; errors are red but show a raw
+message with no recovery path. The most common real failure — an expired/revoked
+token or uninstalled App — should tell the user exactly what to do.
+
+### Current facts
+- `github.service.ts#handleError` normalizes **401** (invalid token), **403**
+  (rate limit / forbidden), **404** (repo not found).
+- `github-app.service.ts#getInstallationToken` throws "GitHub App is not
+  installed on …" when the install is gone.
+- OAuth tokens (`user_github_tokens`) have **no refresh logic** — revocation
+  surfaces as a 401 on the next call.
+- The indicator already has interval available *in settings* but **not** passed
+  to the component; "fresh" = synced < 5 min ago, else grey.
+
+### Proposed behavior
+**Staleness (amber):** when the last *successful* sync is older than
+`max(2 × sync_interval_minutes, 30 min)` (and not currently syncing), show an
+**amber** dot + "Data may be stale — last synced {rel}".
+
+**Actionable errors:** classify the failure and show a CTA:
+| `error_kind` | Cause | Indicator copy + CTA |
+|---|---|---|
+| `auth` | 401 / App uninstalled | "GitHub access expired — **Reconnect**" → OAuth re-auth / App install |
+| `rate_limit` | 403 rate limit | "GitHub rate limit — will retry automatically" (transient, no CTA) |
+| `not_found` | 404 repo | "Repo not accessible — check the GitHub App's repo access" |
+| `unknown` | other | raw message (today's behavior) |
+
+### Data model
+```sql
+alter table sync_status
+  add column error_kind text
+    check (error_kind in ('auth','rate_limit','not_found','unknown'));
+```
+
+### Backend
+- `lib/execute-sync-job.ts` + `run-workspace-sync.ts` error paths: classify the
+  caught error (string-match the normalized messages from `handleError` /
+  `getInstallationToken`, or thread a typed error) and write `error_kind`
+  alongside `status:'error'`.
+- Pass `sync_interval_minutes` to the indicator (already loaded in `layout.tsx`'s
+  workspaces query — add the column) for the staleness threshold.
+
+### UI (`sync-indicator.tsx`)
+- Add an **amber** dot state (`bg-tertiary` or a warning token) for stale.
+- Error tooltip renders the mapped copy; for `auth`, render a real link/button
+  (Reconnect → existing OAuth flow; Install → GitHub App install URL).
+- Distinguish transient (`rate_limit`) visually from permanent (`auth`) — e.g.
+  amber vs red.
+
+### Edge cases
+- Don't show "stale" while a sync is in progress or queued.
+- Manual-mode workspaces are *expected* to be stale; suppress the amber warning
+  there (manual already has its own tooltip line) or soften the copy.
+
+### Effort
+M (1 column, error classification, indicator states + CTA wiring).
+
+---
+
+## 4. "What changed" — deltas, not cumulative totals
+
+### Problem
+The tooltip shows cumulative totals ("346 issues · 65 PRs"), which never conveys
+that *this* sync did anything. Trust comes from deltas.
+
+### Current facts
+- `issuesCreated` / `issuesUpdated` are already true per-run deltas
+  (`run-workspace-sync.ts` phase 1, derived from upsert action).
+- `prsUpdated` is the **count fetched** (500-cap window), **not** a delta — PR
+  created/closed/merged deltas are not computed.
+- The indicator already calls `router.refresh()` on `done`; no toast today.
+
+### Proposed behavior
+On sync completion, surface a brief, dismissible **toast**: e.g.
+"Synced — 3 new issues · 1 reopened · 2 PRs merged · 1 PR opened". Falls back to
+"No changes" (or stays silent) when all deltas are zero.
+
+### Data model
+Extend `SyncCounts` with PR deltas (type-only, `jsonb`):
+```ts
+prsCreated?: number; prsClosed?: number; prsMerged?: number; prsReopened?: number;
+issuesClosed?: number; issuesReopened?: number;   // optional finer issue deltas
+```
+
+### Backend (`run-workspace-sync.ts`)
+- Phase 4: the `pull_requests` upsert currently overwrites blindly. To compute
+  deltas, fetch the existing `(number, state, draft)` for the affected PRs first
+  (one indexed select), diff against incoming, and tally
+  created/closed/merged/reopened. (Merged ⇒ incoming `state==='closed'` with a
+  merge signal; if merge isn't tracked, treat closed transitions as "closed".)
+- Phase 1: optionally split `issuesUpdated` into closed/reopened using prior
+  state, same diff approach.
+
+### UI
+- `sync-indicator.tsx`: on the syncing→`done` transition, build a delta string
+  from `counts` and fire a toast (reuse any existing toast system; else a small
+  transient popover anchored to the dot). Keep `router.refresh()`.
+- Suppress toast when all deltas are 0 to avoid noise on routine no-op syncs.
+
+### Edge cases
+- The PR diff select adds one query per sync — bounded by the 500-cap window;
+  acceptable. Skip it entirely on the initial import (everything is "new" — a
+  toast of "340 new" is noise; the first-sync experience in §2 covers that).
+- Don't toast for cron-driven background syncs the user didn't initiate? →
+  Decision: toast only when the **user clicked "sync now"** (the component knows
+  via its `pending`/`wasSyncing` state), so background reconciles stay silent.
+
+### Effort
+M (PR delta computation + toast).
+
+---
+
+## 5. Decouple metadata sync from AI digests (cost + cadence control)
+
+### Problem
+Issue/PR metadata is cheap to pull; **digests are LLM spend**. Bundling them
+means "sync more often" silently means "spend more often", and the interval
+setting is implicitly a billing dial. `generateDigests` surfaces **no token/cost
+data** today, so spend is invisible.
+
+### Current facts
+- Phases 1/3/4 (issues, comments, PRs) are cheap API I/O; phase 2 (digests) is
+  the only LLM cost, scoped to open + un-digested issues.
+- No usage/cost is returned by `LLMService.generateDigests`.
+
+### Proposed behavior
+Treat **data sync** and **digest generation** as two cadences:
+- **Data sync** (issues + PRs + comments): the fast reconcile cadence
+  (`sync_interval_minutes`), unchanged.
+- **Digests**: a separate control — `auto` on a slower cadence
+  (`digest_interval_minutes`, default e.g. 60), `on-demand` only, or `off`.
+
+This makes the frequent cadence cheap and gives cost-conscious workspaces an
+explicit lever, without losing always-fresh metadata.
+
+### Data model
+```sql
+alter table workspaces
+  add column digest_mode text not null default 'auto'
+    check (digest_mode in ('auto','manual','off')),
+  add column digest_interval_minutes integer not null default 60
+    check (digest_interval_minutes >= 15);
+```
+
+### Backend
+- `run-workspace-sync.ts`: gate phase 2 on `digest_mode` + a digest-cadence
+  check. Two options:
+  - **(a)** Keep one job; inside `runSyncPhases`, skip digests unless
+    `digest_mode==='auto'` and the last digest run is older than
+    `digest_interval_minutes` (track `last_digested_at` in `sync_status` or
+    workspaces).
+  - **(b)** Split into a separate `digest` job kind enqueued on its own cadence
+    by the sweep. Cleaner separation, more moving parts. **Recommend (a)** first.
+- "Generate digests now" action for `manual`/`on-demand` mode (admin-only),
+  reachable from settings and/or the inbox.
+- **Cost visibility (stretch):** have `generateDigests` return token usage
+  (`@anthropic-ai/sdk` responses include `usage`); thread it into `counts`
+  (`digestTokens`) and show an estimate ("~{n}k tokens this run") — the start of
+  real spend transparency.
+
+### UI (`settings/automation-section.tsx`)
+- Add a "AI digests" sub-block under the sync controls: a mode select
+  (Auto / On-demand / Off) and, for Auto, a digest-frequency select. Mirror the
+  existing toggle+select pattern.
+- Copy clarifies the cost tradeoff: "Digests are AI-generated summaries (uses
+  your Anthropic key). Metadata sync stays on your sync schedule regardless."
+
+### Edge cases
+- `digest_mode='off'`: inbox shows raw issue titles/bodies without summaries —
+  ensure the UI degrades gracefully (it already tolerates missing digests).
+- Initial import: still digest once on first sync regardless of cadence (so a new
+  workspace isn't empty), then follow `digest_mode`.
+
+### Effort
+M–L (2 columns, phase gating, on-demand action, settings UI; cost surfacing is a
+stretch add-on).
+
+---
+
+## Cross-cutting notes
+
+- **No new heavy infra**: every item reuses `sync_status` + Realtime + the
+  indicator + the Automation settings pattern. New columns are small and
+  additive.
+- **Indicator is getting busy.** After §1–§4 the dot encodes: syncing / fresh /
+  stale / error(auth|rate|other) / live-vs-polling / manual. Consider promoting
+  it from a bare dot to a small status chip ("⚡ Synced 4m ago") on wide screens
+  for discoverability, collapsing to the dot on narrow ones.
+- **Settings self-containment**: add "Sync now" + "Last synced …" to the
+  Automation tab (cheap, complements §1/§5).
+
+## Migrations summary (if all five ship)
+| # | Migration | For |
+|---|---|---|
+| 1 | `workspaces.last_webhook_received_at`, `last_webhook_event` | §1 |
+| 2 | `sync_status.initial` (optional) | §2 |
+| 3 | `sync_status.error_kind` | §3 |
+| 4 | — (SyncCounts type-only) | §2, §4 |
+| 5 | `workspaces.digest_mode`, `digest_interval_minutes` | §5 |
+
+(§3 also needs `sync_interval_minutes` passed to the indicator — already a
+column, just plumb it through `layout.tsx` → `TopBar` → `SyncIndicator`.)
+
+## Rollout
+
+Suggested order by trust-per-effort:
+
+1. **§1 Webhook health** — reframes the feature; highest trust-per-effort.
+2. **§3 Stale & actionable states** — covers the "is it fresh / why broken"
+   moments; pairs naturally with §1.
+3. **§2 First-sync progress** — fixes the scariest single moment (onboarding).
+4. **§4 What changed** — ongoing trust/delight once the basics are solid.
+5. **§5 Digest decoupling** — the cost lever; larger, do once usage is real.
+
+Each is independently shippable behind the existing `sync_status` plumbing.

--- a/packages/gui/src/app/api/github/webhook/route.ts
+++ b/packages/gui/src/app/api/github/webhook/route.ts
@@ -89,11 +89,11 @@ export async function POST(req: Request): Promise<NextResponse> {
       case 'ping':
         return NextResponse.json({ ok: true });
       case 'issues':
-        return await handleIssues(admin, payload);
+        return await handleIssues(admin, payload, event);
       case 'check_run':
-        return await handleCheckRun(admin, payload);
+        return await handleCheckRun(admin, payload, event);
       case 'pull_request':
-        return await handlePullRequest(admin, payload);
+        return await handlePullRequest(admin, payload, event);
       case 'installation':
       case 'installation_repositories':
         return await handleInstallation(admin, payload);
@@ -180,7 +180,7 @@ interface WebhookPullRequest {
 
 const TRIAGE_ACTIONS = new Set(['opened', 'reopened']);
 
-async function handleIssues(admin: SupabaseAdmin, payload: WebhookPayload): Promise<NextResponse> {
+async function handleIssues(admin: SupabaseAdmin, payload: WebhookPayload, event: string): Promise<NextResponse> {
   const action = payload.action ?? '';
   const isTriageRelevant =
     TRIAGE_ACTIONS.has(action) ||
@@ -194,7 +194,7 @@ async function handleIssues(admin: SupabaseAdmin, payload: WebhookPayload): Prom
   const repo = payload.repository;
   if (!issue || !repo) return NextResponse.json({ ok: true, ignored: 'issues event missing issue/repository' });
 
-  const workspaces = await resolveWorkspaces(admin, payload, repo);
+  const workspaces = await resolveWorkspaces(admin, payload, repo, event);
   if (workspaces.length === 0) return NextResponse.json({ ok: true, ignored: 'no matching workspace' });
 
   const repoSlug = `${repo.owner.login}/${repo.name}`;
@@ -371,7 +371,7 @@ async function enqueueFlowsForIssueEvent(
  */
 const CHECK_RUN_FAIL_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required', 'startup_failure']);
 
-async function handleCheckRun(admin: SupabaseAdmin, payload: WebhookPayload): Promise<NextResponse> {
+async function handleCheckRun(admin: SupabaseAdmin, payload: WebhookPayload, event: string): Promise<NextResponse> {
   if (payload.action !== 'completed') return NextResponse.json({ ok: true, ignored: `check_run.${payload.action}` });
   const cr = payload.check_run;
   const repo = payload.repository;
@@ -384,7 +384,7 @@ async function handleCheckRun(admin: SupabaseAdmin, payload: WebhookPayload): Pr
     return NextResponse.json({ ok: true, ignored: 'check_run not linked to any PR' });
   }
 
-  const workspaces = await resolveWorkspaces(admin, payload, repo);
+  const workspaces = await resolveWorkspaces(admin, payload, repo, event);
   if (workspaces.length === 0) return NextResponse.json({ ok: true, ignored: 'no matching workspace' });
 
   const repoSlug = `${repo.owner.login}/${repo.name}`;
@@ -504,7 +504,7 @@ const PR_UPSERT_ACTIONS = new Set([
 ]);
 const PR_CLOSE_ACTIONS = new Set(['closed']);
 
-async function handlePullRequest(admin: SupabaseAdmin, payload: WebhookPayload): Promise<NextResponse> {
+async function handlePullRequest(admin: SupabaseAdmin, payload: WebhookPayload, event: string): Promise<NextResponse> {
   const action = payload.action ?? '';
   const pr = payload.pull_request;
   const repo = payload.repository;
@@ -514,7 +514,7 @@ async function handlePullRequest(admin: SupabaseAdmin, payload: WebhookPayload):
     return NextResponse.json({ ok: true, ignored: `pull_request.${action}` });
   }
 
-  const workspaces = await resolveWorkspaces(admin, payload, repo);
+  const workspaces = await resolveWorkspaces(admin, payload, repo, event);
   if (workspaces.length === 0) return NextResponse.json({ ok: true, ignored: 'no matching workspace' });
 
   const labels = Array.isArray(pr.labels)
@@ -585,24 +585,53 @@ async function handleInstallation(admin: SupabaseAdmin, payload: WebhookPayload)
 type SupabaseAdmin = ReturnType<typeof createSupabaseAdminClient>;
 type WorkspaceMatch = Pick<Database['public']['Tables']['workspaces']['Row'], 'id' | 'auto_triage_enabled'>;
 
-/** Match by `installation_id` first (preferred), else by `repo_owner`/`repo_name`. */
+/**
+ * Match by `installation_id` first (preferred), else by `repo_owner`/`repo_name`.
+ *
+ * This is the single chokepoint every real (non-ping) per-workspace delivery
+ * flows through, so it's also where we stamp the per-workspace "last webhook
+ * delivery" signal (`last_webhook_received_at` / `last_webhook_event`,
+ * migration 0039) that powers the indicator's Live-vs-Polling state. The stamp
+ * is best-effort: a failure logs and continues — it must never affect dispatch
+ * or the 200/503 response.
+ */
 async function resolveWorkspaces(
   admin: SupabaseAdmin,
   payload: WebhookPayload,
   repo: { name: string; owner: { login: string } },
+  event: string,
 ): Promise<WorkspaceMatch[]> {
+  let matched: WorkspaceMatch[] = [];
   const installationId = payload.installation?.id;
   if (installationId != null) {
     const { data } = await admin
       .from('workspaces')
       .select('id, auto_triage_enabled')
       .eq('installation_id', installationId);
-    if (data && data.length > 0) return data;
+    if (data && data.length > 0) matched = data;
   }
-  const { data } = await admin
-    .from('workspaces')
-    .select('id, auto_triage_enabled')
-    .eq('repo_owner', repo.owner.login)
-    .eq('repo_name', repo.name);
-  return data ?? [];
+  if (matched.length === 0) {
+    const { data } = await admin
+      .from('workspaces')
+      .select('id, auto_triage_enabled')
+      .eq('repo_owner', repo.owner.login)
+      .eq('repo_name', repo.name);
+    matched = data ?? [];
+  }
+
+  if (matched.length > 0) {
+    try {
+      await admin
+        .from('workspaces')
+        .update({ last_webhook_received_at: new Date().toISOString(), last_webhook_event: event })
+        .in(
+          'id',
+          matched.map((ws) => ws.id),
+        );
+    } catch (err) {
+      console.error('[github-webhook] webhook signal stamp failed:', err instanceof Error ? err.message : err);
+    }
+  }
+
+  return matched;
 }

--- a/packages/gui/src/app/inbox/sync-action.ts
+++ b/packages/gui/src/app/inbox/sync-action.ts
@@ -94,7 +94,10 @@ export async function syncAndDigest(): Promise<SyncResult> {
   });
 
   // ── Run the four phases in the background; do NOT await. ──
-  void runSyncPhases({ supabase, workspaceId: workspace.id, store: ctx.store, github: ctx.github, config: ctx.config }).catch(
+  // "Sync now" is a metadata refresh: digests follow the workspace's digest
+  // policy (auto cadence / manual / off), not forced. The dedicated
+  // `generateDigestsNow` action is the explicit "spend now" path.
+  void runSyncPhases({ supabase, workspaceId: workspace.id, store: ctx.store, github: ctx.github, config: ctx.config, digestPolicy: ctx.digestPolicy }).catch(
     async (err) => {
       console.error('[syncAndDigest] background sync crashed:', err);
       await writeSyncStatus(supabase, workspace.id, {
@@ -105,6 +108,95 @@ export async function syncAndDigest(): Promise<SyncResult> {
       });
     },
   );
+
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Generate digests now — the on-demand "spend now" action (spec §5).
+//
+// For `manual`/`off` digest workspaces, this is how an admin produces AI
+// summaries on demand. It runs the SAME background sync pipeline as
+// `syncAndDigest` but with `forceDigests: true`, so phase 2 runs regardless of
+// the workspace's digest mode/cadence. Metadata phases run too (cheap), keeping
+// everything fresh. Admin-only; writes `sync_status` exactly like the normal
+// path, so the existing indicator reflects progress.
+// ─────────────────────────────────────────────────────────────────────
+export async function generateDigestsNow(): Promise<SyncResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') return { ok: false, error: 'Only admins can generate digests' };
+
+  const supabase = createSupabaseAdminClient();
+
+  // Same concurrency guard as syncAndDigest — refuse to start while a sync is
+  // live (a fresh `syncing` row), since both write the same `sync_status`.
+  const { data: existing } = await supabase
+    .from('sync_status')
+    .select('status, updated_at')
+    .eq('workspace_id', workspace.id)
+    .maybeSingle<Pick<SyncStatusRow, 'status' | 'updated_at'>>();
+  if (existing?.status === 'syncing') {
+    const age = Date.now() - new Date(existing.updated_at).getTime();
+    if (age < STALE_SYNC_MS) {
+      return { ok: false, error: 'Sync already in progress' };
+    }
+  }
+
+  const core = await import('@cezar/core');
+  let token = user.githubToken || process.env.GITHUB_TOKEN || '';
+  if (core.GitHubAppService.isConfigured()) {
+    try {
+      token = await new core.GitHubAppService().getInstallationToken(workspace.repoOwner);
+    } catch (err) {
+      console.warn('[generateDigestsNow] GitHub App token failed, falling back to OAuth:', err);
+    }
+  }
+  if (!token) return { ok: false, error: 'No GitHub token — sign out and back in to sync' };
+
+  let ctx: Awaited<ReturnType<typeof buildSyncContext>>;
+  try {
+    ctx = await buildSyncContext({
+      supabase,
+      workspaceId: workspace.id,
+      repoOwner: workspace.repoOwner,
+      repoName: workspace.repoName,
+      token,
+    });
+  } catch (err) {
+    return { ok: false, error: `Config load failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  await writeSyncStatus(supabase, workspace.id, {
+    status: 'syncing',
+    phase: 'issues',
+    message: 'Fetching issues…',
+    counts: {},
+    error: null,
+    started_at: new Date().toISOString(),
+    finished_at: null,
+  });
+
+  // forceDigests: true ⇒ phase 2 runs whatever the workspace's digest mode is.
+  void runSyncPhases({
+    supabase,
+    workspaceId: workspace.id,
+    store: ctx.store,
+    github: ctx.github,
+    config: ctx.config,
+    digestPolicy: ctx.digestPolicy,
+    forceDigests: true,
+  }).catch(async (err) => {
+    console.error('[generateDigestsNow] background sync crashed:', err);
+    await writeSyncStatus(supabase, workspace.id, {
+      status: 'error',
+      phase: null,
+      error: err instanceof Error ? err.message : String(err),
+      finished_at: new Date().toISOString(),
+    });
+  });
 
   return { ok: true };
 }

--- a/packages/gui/src/app/layout.tsx
+++ b/packages/gui/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { TopBar } from '@/components/topbar';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace, listWorkspaces } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { isWebhookConfigured } from '@/lib/webhook-config';
 import type { Database } from '@/lib/supabase/types';
 
 type SyncStatusRow = Database['public']['Tables']['sync_status']['Row'];
@@ -38,14 +39,27 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   // workspaces.
   let initialSyncStatus: SyncStatusRow | null = null;
   let syncMode: 'auto' | 'manual' = 'auto';
+  // Webhook health drives the indicator's "⚡ Live" vs "⏱ Polling" line (spec
+  // §1). Live = the receiver is active (secret set) AND the GitHub App is
+  // installed on this repo; we treat installed-but-quiet as Live too (low-traffic
+  // repos are normal), passing the last-delivery time through so the tooltip can
+  // note "no recent activity".
+  let webhookHealth: 'live' | 'polling' = 'polling';
+  let lastWebhookAt: string | null = null;
   if (workspace) {
     const supabase = createSupabaseAdminClient();
     const [{ data: status }, { data: ws }] = await Promise.all([
       supabase.from('sync_status').select('*').eq('workspace_id', workspace.id).maybeSingle<SyncStatusRow>(),
-      supabase.from('workspaces').select('sync_mode').eq('id', workspace.id).maybeSingle<{ sync_mode: 'auto' | 'manual' }>(),
+      supabase
+        .from('workspaces')
+        .select('sync_mode, installation_id, last_webhook_received_at')
+        .eq('id', workspace.id)
+        .maybeSingle<{ sync_mode: 'auto' | 'manual'; installation_id: number | null; last_webhook_received_at: string | null }>(),
     ]);
     initialSyncStatus = status ?? null;
     syncMode = ws?.sync_mode ?? 'auto';
+    lastWebhookAt = ws?.last_webhook_received_at ?? null;
+    webhookHealth = isWebhookConfigured() && ws?.installation_id != null ? 'live' : 'polling';
   }
 
   return (
@@ -65,6 +79,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               readOnly={workspace ? workspace.role !== 'admin' : true}
               initialSyncStatus={initialSyncStatus}
               syncMode={syncMode}
+              webhookHealth={webhookHealth}
+              lastWebhookAt={lastWebhookAt}
             />
             <main className="flex-1">{children}</main>
           </div>

--- a/packages/gui/src/app/layout.tsx
+++ b/packages/gui/src/app/layout.tsx
@@ -39,6 +39,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   // workspaces.
   let initialSyncStatus: SyncStatusRow | null = null;
   let syncMode: 'auto' | 'manual' = 'auto';
+  // The reconcile cadence — passed to the indicator so it can compute the
+  // staleness threshold (spec §3: max(2 × interval, 30 min)).
+  let syncIntervalMinutes = 30;
   // Webhook health drives the indicator's "⚡ Live" vs "⏱ Polling" line (spec
   // §1). Live = the receiver is active (secret set) AND the GitHub App is
   // installed on this repo; we treat installed-but-quiet as Live too (low-traffic
@@ -52,12 +55,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       supabase.from('sync_status').select('*').eq('workspace_id', workspace.id).maybeSingle<SyncStatusRow>(),
       supabase
         .from('workspaces')
-        .select('sync_mode, installation_id, last_webhook_received_at')
+        .select('sync_mode, sync_interval_minutes, installation_id, last_webhook_received_at')
         .eq('id', workspace.id)
-        .maybeSingle<{ sync_mode: 'auto' | 'manual'; installation_id: number | null; last_webhook_received_at: string | null }>(),
+        .maybeSingle<{ sync_mode: 'auto' | 'manual'; sync_interval_minutes: number | null; installation_id: number | null; last_webhook_received_at: string | null }>(),
     ]);
     initialSyncStatus = status ?? null;
     syncMode = ws?.sync_mode ?? 'auto';
+    syncIntervalMinutes = ws?.sync_interval_minutes ?? 30;
     lastWebhookAt = ws?.last_webhook_received_at ?? null;
     webhookHealth = isWebhookConfigured() && ws?.installation_id != null ? 'live' : 'polling';
   }
@@ -79,6 +83,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               readOnly={workspace ? workspace.role !== 'admin' : true}
               initialSyncStatus={initialSyncStatus}
               syncMode={syncMode}
+              syncIntervalMinutes={syncIntervalMinutes}
               webhookHealth={webhookHealth}
               lastWebhookAt={lastWebhookAt}
             />

--- a/packages/gui/src/app/settings/automation-actions.ts
+++ b/packages/gui/src/app/settings/automation-actions.ts
@@ -13,6 +13,13 @@ export interface SaveAutomationState {
 const SYNC_INTERVAL_MIN = 5;
 const SYNC_INTERVAL_MAX = 1440;
 
+/** Allowed digest cadences (minutes); floored at 15 — digests are LLM spend, so
+ *  the minimum is coarser than the metadata-sync floor. */
+const DIGEST_INTERVAL_MIN = 15;
+const DIGEST_INTERVAL_MAX = 1440;
+
+const DIGEST_MODES = ['auto', 'manual', 'off'] as const;
+
 /**
  * The automation toggles on `workspaces`:
  *   - `auto_triage_enabled` — run the triage workflow on new/edited issues.
@@ -23,6 +30,9 @@ const SYNC_INTERVAL_MAX = 1440;
  *   - `action_auto_comment` — post a summary comment after each action.
  *   - `sync_mode` / `sync_interval_minutes` — auto vs. manual GitHub sync and,
  *     for auto, the minimum gap between automatic syncs.
+ *   - `digest_mode` / `digest_interval_minutes` — AI-digest cadence (spec §5),
+ *     decoupled from metadata sync: auto (own cadence) / manual (on-demand) /
+ *     off. Cheap metadata sync stays on `sync_interval_minutes` regardless.
  * Admin-only.
  */
 export async function saveAutomationToggles(
@@ -50,6 +60,25 @@ export async function saveAutomationToggles(
     const parsed = Number(rawInterval);
     if (Number.isFinite(parsed)) {
       update.sync_interval_minutes = Math.min(SYNC_INTERVAL_MAX, Math.max(SYNC_INTERVAL_MIN, Math.round(parsed)));
+    }
+  }
+
+  // ── AI-digest cadence (spec §5) ──
+  const rawDigestMode = formData.get('digestMode');
+  if (typeof rawDigestMode === 'string' && (DIGEST_MODES as readonly string[]).includes(rawDigestMode)) {
+    update.digest_mode = rawDigestMode;
+  }
+  // The digest-interval field is only rendered in `auto` mode; clamp when
+  // present, leave the stored value untouched when hidden (manual/off) — mirrors
+  // the sync_interval_minutes handling above.
+  const rawDigestInterval = formData.get('digestIntervalMinutes');
+  if (rawDigestInterval != null) {
+    const parsed = Number(rawDigestInterval);
+    if (Number.isFinite(parsed)) {
+      update.digest_interval_minutes = Math.min(
+        DIGEST_INTERVAL_MAX,
+        Math.max(DIGEST_INTERVAL_MIN, Math.round(parsed)),
+      );
     }
   }
 

--- a/packages/gui/src/app/settings/automation-section.tsx
+++ b/packages/gui/src/app/settings/automation-section.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useActionState, useState } from 'react';
+import { useActionState, useState, useTransition } from 'react';
 import { cn } from '@/components/ui/cn';
 import { saveAutomationToggles, type SaveAutomationState } from './automation-actions';
+import { generateDigestsNow } from '@/app/inbox/sync-action';
+import type { DigestMode } from '@/lib/supabase/types';
 
 const SYNC_INTERVAL_OPTIONS = [5, 15, 30, 60, 120, 360] as const;
+const DIGEST_INTERVAL_OPTIONS = [15, 30, 60, 120, 360] as const;
 
 function formatInterval(min: number): string {
   if (min < 60) return `Every ${min} minutes`;
@@ -19,6 +22,8 @@ interface AutomationSectionProps {
   actionAutoComment: boolean;
   syncMode: 'auto' | 'manual';
   syncIntervalMinutes: number;
+  digestMode: DigestMode;
+  digestIntervalMinutes: number;
   readOnly: boolean;
 }
 
@@ -29,11 +34,28 @@ export function AutomationSection({
   actionAutoComment,
   syncMode,
   syncIntervalMinutes,
+  digestMode,
+  digestIntervalMinutes,
   readOnly,
 }: AutomationSectionProps) {
   const [state, formAction, pending] = useActionState<SaveAutomationState, FormData>(saveAutomationToggles, {});
   const [autofix, setAutofix] = useState(autofixEnabled);
   const [syncAuto, setSyncAuto] = useState(syncMode === 'auto');
+  const [digest, setDigest] = useState<DigestMode>(digestMode);
+  const [genPending, startGen] = useTransition();
+  const [genMsg, setGenMsg] = useState<{ tone: 'ok' | 'error'; text: string } | null>(null);
+
+  function onGenerateDigests() {
+    setGenMsg(null);
+    startGen(async () => {
+      const res = await generateDigestsNow();
+      setGenMsg(
+        res.ok
+          ? { tone: 'ok', text: 'Generating digests… watch the sync indicator for progress.' }
+          : { tone: 'error', text: res.error ?? 'Failed to start' },
+      );
+    });
+  }
 
   return (
     <form action={formAction} className="space-y-4">
@@ -120,6 +142,80 @@ export function AutomationSection({
           </select>
         </label>
       )}
+
+      {/* ── AI digests (spec §5): a separate cadence from metadata sync, since
+          digests are the only LLM spend. Metadata stays on the sync schedule. ── */}
+      <div className="space-y-4 rounded-md border border-outline-variant bg-surface-container/40 p-4">
+        <div className="space-y-1">
+          <span className="block text-sm font-medium text-on-surface">AI digests</span>
+          <span className="block text-xs leading-relaxed text-on-surface-variant">
+            Digests are AI-generated issue summaries (uses your Anthropic key). They&rsquo;re the only
+            LLM spend in a sync, so they have their own cadence — metadata sync (issues, PRs, comments)
+            stays on your sync schedule regardless. <span className="font-medium">Auto</span> digests on
+            their own slower schedule, <span className="font-medium">On-demand</span> only when you click
+            below, <span className="font-medium">Off</span> never (the inbox shows raw issue titles).
+          </span>
+        </div>
+
+        <label className="flex items-center justify-between gap-3">
+          <span className="text-sm text-on-surface">Mode</span>
+          <select
+            name="digestMode"
+            value={digest}
+            onChange={(e) => setDigest(e.target.value as DigestMode)}
+            disabled={readOnly}
+            className="h-9 shrink-0 rounded-md border border-outline-variant bg-surface px-2 text-sm text-on-surface focus:border-primary focus:outline-none disabled:opacity-70"
+          >
+            <option value="auto">Auto</option>
+            <option value="manual">On-demand</option>
+            <option value="off">Off</option>
+          </select>
+        </label>
+
+        {digest === 'auto' && (
+          <label className="flex items-center justify-between gap-3">
+            <span className="min-w-0 flex-1 space-y-1">
+              <span className="block text-sm text-on-surface">Digest frequency</span>
+              <span className="block text-xs leading-relaxed text-on-surface-variant">
+                How often Cezar generates digests during a sync. Metadata still syncs on every sync;
+                digests only run once this much time has passed.
+              </span>
+            </span>
+            <select
+              name="digestIntervalMinutes"
+              defaultValue={String(digestIntervalMinutes)}
+              disabled={readOnly}
+              className="h-9 shrink-0 rounded-md border border-outline-variant bg-surface px-2 text-sm text-on-surface focus:border-primary focus:outline-none disabled:opacity-70"
+            >
+              {(DIGEST_INTERVAL_OPTIONS.includes(digestIntervalMinutes as (typeof DIGEST_INTERVAL_OPTIONS)[number])
+                ? DIGEST_INTERVAL_OPTIONS
+                : [digestIntervalMinutes, ...DIGEST_INTERVAL_OPTIONS]
+              ).map((min) => (
+                <option key={min} value={min}>
+                  {formatInterval(min)}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {!readOnly && (
+          <div className="space-y-2 border-t border-outline-variant pt-3">
+            {genMsg && <Banner tone={genMsg.tone}>{genMsg.text}</Banner>}
+            <button
+              type="button"
+              onClick={onGenerateDigests}
+              disabled={genPending}
+              className="inline-flex h-9 items-center rounded-md border border-outline-variant bg-surface px-4 text-sm font-medium text-on-surface transition-colors hover:border-outline disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {genPending ? 'Starting…' : 'Generate digests now'}
+            </button>
+            <span className="block text-xs text-on-surface-variant">
+              Runs a digest pass immediately, regardless of mode. Useful for On-demand / Off workspaces.
+            </span>
+          </div>
+        )}
+      </div>
 
       {!readOnly && (
         <div className="flex justify-end pt-2">

--- a/packages/gui/src/app/settings/page.tsx
+++ b/packages/gui/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { AutomationSection } from './automation-section';
 import { LabelsSection, type AcceptedLabelRow } from './labels-section';
 import { SettingsTabs, SettingsCard } from './settings-tabs';
 import type {
+  DigestMode,
   LabelAnalysisInputsSummary,
   LabelAnalysisResult,
   LabelAnalysisStatus,
@@ -21,11 +22,13 @@ async function loadWorkspaceConfig(workspaceId: string): Promise<{
   actionAutoComment: boolean;
   syncMode: 'auto' | 'manual';
   syncIntervalMinutes: number;
+  digestMode: DigestMode;
+  digestIntervalMinutes: number;
 }> {
   const supabase = createSupabaseAdminClient();
   const { data } = await supabase
     .from('workspaces')
-    .select('config, auto_triage_enabled, autofix_enabled, separate_comment_per_step, action_auto_comment, sync_mode, sync_interval_minutes')
+    .select('config, auto_triage_enabled, autofix_enabled, separate_comment_per_step, action_auto_comment, sync_mode, sync_interval_minutes, digest_mode, digest_interval_minutes')
     .eq('id', workspaceId)
     .single();
   return {
@@ -36,6 +39,8 @@ async function loadWorkspaceConfig(workspaceId: string): Promise<{
     actionAutoComment: data?.action_auto_comment ?? true,
     syncMode: data?.sync_mode ?? 'auto',
     syncIntervalMinutes: data?.sync_interval_minutes ?? 15,
+    digestMode: data?.digest_mode ?? 'auto',
+    digestIntervalMinutes: data?.digest_interval_minutes ?? 60,
   };
 }
 
@@ -92,7 +97,7 @@ export default async function SettingsPage() {
     );
   }
 
-  const [{ config, autoTriageEnabled, autofixEnabled, separateCommentPerStep, actionAutoComment, syncMode, syncIntervalMinutes }, members, labelsInitial, acceptedLabels] = await Promise.all([
+  const [{ config, autoTriageEnabled, autofixEnabled, separateCommentPerStep, actionAutoComment, syncMode, syncIntervalMinutes, digestMode, digestIntervalMinutes }, members, labelsInitial, acceptedLabels] = await Promise.all([
     loadWorkspaceConfig(workspace.id),
     loadMembers(workspace.id),
     loadLabelsInitial(workspace.id),
@@ -120,6 +125,8 @@ export default async function SettingsPage() {
             actionAutoComment={actionAutoComment}
             syncMode={syncMode}
             syncIntervalMinutes={syncIntervalMinutes}
+            digestMode={digestMode}
+            digestIntervalMinutes={digestIntervalMinutes}
             readOnly={!isAdmin}
           />
         </SettingsCard>

--- a/packages/gui/src/components/sync-indicator.tsx
+++ b/packages/gui/src/components/sync-indicator.tsx
@@ -39,6 +39,25 @@ function summarize(counts: SyncCounts | null | undefined): string | null {
   return bits.length > 0 ? bits.join(' · ') : null;
 }
 
+/** Build the "what changed" delta string (spec §4) from the per-run `counts`,
+ *  e.g. "3 new issues · 1 reopened · 2 PRs closed · 1 PR opened". Returns null
+ *  when every delta is zero/absent so a no-op sync stays silent. PR merges fold
+ *  into `prsClosed` (no merge signal in the sync fetch today), so we render that
+ *  bucket as "closed". */
+function deltaSummary(counts: SyncCounts | null | undefined): string | null {
+  if (!counts) return null;
+  const bits: string[] = [];
+  const plural = (n: number, one: string, many: string) => `${n} ${n === 1 ? one : many}`;
+  if (counts.issuesCreated) bits.push(plural(counts.issuesCreated, 'new issue', 'new issues'));
+  if (counts.issuesClosed) bits.push(`${counts.issuesClosed} closed`);
+  if (counts.issuesReopened) bits.push(`${counts.issuesReopened} reopened`);
+  if (counts.prsCreated) bits.push(plural(counts.prsCreated, 'PR opened', 'PRs opened'));
+  if (counts.prsMerged) bits.push(plural(counts.prsMerged, 'PR merged', 'PRs merged'));
+  if (counts.prsClosed) bits.push(plural(counts.prsClosed, 'PR closed', 'PRs closed'));
+  if (counts.prsReopened) bits.push(plural(counts.prsReopened, 'PR reopened', 'PRs reopened'));
+  return bits.length > 0 ? bits.join(' · ') : null;
+}
+
 /** "5 minutes ago", "2 hours ago", etc. — coarse relative time. */
 function relativeTime(iso: string | null | undefined): string | null {
   if (!iso) return null;
@@ -83,6 +102,13 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
   const [error, setError] = useState<string | null>(null);
   // Refresh exactly once when a sync transitions to a terminal state.
   const wasSyncing = useRef(initialStatus?.status === 'syncing');
+  // ── "What changed" toast (spec §4). ──
+  // `userInitiated` remembers that the *most recent* run was started by this
+  // user's "sync now" click (set in `handleClick`), distinct from a background
+  // cron reconcile that merely flips the row over Realtime. We only toast for
+  // user-initiated runs so background syncs stay silent.
+  const userInitiated = useRef(false);
+  const [toast, setToast] = useState<string | null>(null);
 
   // ── Realtime: follow this workspace's sync_status row. ──
   useEffect(() => {
@@ -108,6 +134,14 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
           } else if (wasSyncing.current && (row.status === 'done' || row.status === 'error')) {
             // Sync just finished — pull the freshly-synced data into every page.
             wasSyncing.current = false;
+            // "What changed" toast (spec §4): only for a user-initiated run that
+            // completed (not background reconciles, not the §2 initial import —
+            // its progress bar already covers that). No deltas ⇒ "no changes".
+            if (userInitiated.current && row.status === 'done' && !row.initial) {
+              const deltas = deltaSummary(row.counts);
+              setToast(deltas ? `Synced — ${deltas}` : 'Synced — no changes');
+            }
+            userInitiated.current = false;
             router.refresh();
           }
         },
@@ -117,6 +151,13 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
       supabase.removeChannel(channel);
     };
   }, [workspaceId, router]);
+
+  // ── "What changed" toast auto-dismiss (spec §4): clears ~5s after it shows. ──
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 5000);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   const isStale =
     status?.status === 'syncing' &&
@@ -186,6 +227,9 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
   function handleClick() {
     if (syncing || readOnly) return;
     setError(null);
+    // Mark this run as user-initiated so the syncing→done transition fires the
+    // "what changed" toast (background reconciles leave this false).
+    userInitiated.current = true;
     startKickoff(async () => {
       const result = await syncAndDigest();
       if (!result.ok) {
@@ -351,6 +395,19 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
           </a>
         )}
       </div>
+
+      {/* "What changed" toast (spec §4) — a transient popover anchored under the
+       *  dot, shown only after a user-initiated "sync now" completes. Auto-
+       *  dismisses after ~5s; dismissable on click. */}
+      {toast && (
+        <div
+          role="status"
+          onClick={() => setToast(null)}
+          className="absolute right-0 top-full z-30 mt-1 w-max max-w-[280px] cursor-pointer rounded-md border border-outline-variant bg-surface-container-high px-3 py-2 text-xs text-on-surface shadow-ambient"
+        >
+          {toast}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/gui/src/components/sync-indicator.tsx
+++ b/packages/gui/src/components/sync-indicator.tsx
@@ -17,6 +17,10 @@ const STALE_SYNC_MS = 10 * 60 * 1000;
 /** Synced within this window → render a subtle "fresh" tint on the dot. */
 const FRESH_SYNC_MS = 5 * 60 * 1000;
 
+/** A webhook delivery within this window counts as "recent activity" — older
+ *  than this and a Live workspace's tooltip softens to "(no recent activity)". */
+const WEBHOOK_FRESH_MS = 24 * 60 * 60 * 1000;
+
 const PHASE_LABEL: Record<SyncPhase, string> = {
   issues: 'issues',
   digests: 'digests',
@@ -56,6 +60,11 @@ interface SyncIndicatorProps {
   readOnly: boolean;
   /** 'manual' workspaces don't auto-sync — the tooltip flags it. */
   syncMode: 'auto' | 'manual';
+  /** Live = GitHub App installed + webhook secret set (updates arrive in real
+   *  time); Polling = otherwise (falls back to the cron reconcile interval). */
+  webhookHealth: 'live' | 'polling';
+  /** Last matched webhook delivery — lets the Live line note "no recent activity". */
+  lastWebhookAt?: string | null;
 }
 
 /**
@@ -64,7 +73,7 @@ interface SyncIndicatorProps {
  * is clickable to trigger a "sync now", and shows a tooltip with the last-sync
  * time + status + counts on hover.
  */
-export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode }: SyncIndicatorProps) {
+export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, webhookHealth, lastWebhookAt }: SyncIndicatorProps) {
   const router = useRouter();
   const [status, setStatus] = useState<SyncStatusRow | null>(initialStatus);
   const [pending, startKickoff] = useTransition();
@@ -149,6 +158,15 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode }
     else lines.push('Not synced yet');
     const counts = summarize(status?.counts);
     if (counts) lines.push(counts);
+    // Live-vs-Polling: how the data is kept fresh (spec §1). Live = GitHub App
+    // installed + receiver active; quiet live repos still count as Live.
+    if (webhookHealth === 'live') {
+      const recent =
+        lastWebhookAt != null && Date.now() - new Date(lastWebhookAt).getTime() < WEBHOOK_FRESH_MS;
+      lines.push(recent ? '⚡ Live — updates arrive in real time' : '⚡ Live (no recent activity)');
+    } else {
+      lines.push('⏱ Polling — install the GitHub App for real-time updates');
+    }
     // Flag manual workspaces — the cron won't auto-sync; the user drives it.
     if (syncMode === 'manual') {
       lines.push(readOnly ? 'Auto-sync off' : 'Auto-sync off — click to sync');

--- a/packages/gui/src/components/sync-indicator.tsx
+++ b/packages/gui/src/components/sync-indicator.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { cn } from '@/components/ui/cn';
 import { createSupabaseBrowserClient } from '@/lib/supabase/browser';
 import { syncAndDigest } from '@/app/inbox/sync-action';
-import type { Database, SyncCounts, SyncPhase } from '@/lib/supabase/types';
+import type { Database, SyncCounts, SyncPhase, SyncErrorKind } from '@/lib/supabase/types';
 
 type SyncStatusRow = Database['public']['Tables']['sync_status']['Row'];
 
@@ -60,6 +60,9 @@ interface SyncIndicatorProps {
   readOnly: boolean;
   /** 'manual' workspaces don't auto-sync — the tooltip flags it. */
   syncMode: 'auto' | 'manual';
+  /** The reconcile cadence (minutes) — sets the staleness threshold
+   *  `max(2 × interval, 30)` for the amber "stale" state (spec §3). */
+  syncIntervalMinutes: number;
   /** Live = GitHub App installed + webhook secret set (updates arrive in real
    *  time); Polling = otherwise (falls back to the cron reconcile interval). */
   webhookHealth: 'live' | 'polling';
@@ -73,7 +76,7 @@ interface SyncIndicatorProps {
  * is clickable to trigger a "sync now", and shows a tooltip with the last-sync
  * time + status + counts on hover.
  */
-export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, webhookHealth, lastWebhookAt }: SyncIndicatorProps) {
+export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, syncIntervalMinutes, webhookHealth, lastWebhookAt }: SyncIndicatorProps) {
   const router = useRouter();
   const [status, setStatus] = useState<SyncStatusRow | null>(initialStatus);
   const [pending, startKickoff] = useTransition();
@@ -159,6 +162,27 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
     Boolean(lastSyncedAt) &&
     Date.now() - new Date(lastSyncedAt as string).getTime() < FRESH_SYNC_MS;
 
+  // ── Staleness (spec §3): amber when the last successful sync is older than
+  // max(2 × interval, 30 min) and nothing is in flight. Suppressed for manual
+  // workspaces — they're *expected* to be stale and carry their own tooltip
+  // line. Errors take precedence over stale (handled by the `!isError` guard).
+  const staleThresholdMs = Math.max(2 * syncIntervalMinutes, 30) * 60 * 1000;
+  const isStaleData =
+    !syncing &&
+    !isError &&
+    syncMode !== 'manual' &&
+    Boolean(lastSyncedAt) &&
+    Date.now() - new Date(lastSyncedAt as string).getTime() > staleThresholdMs;
+
+  // ── Actionable errors (spec §3): map the persisted `error_kind` to copy + an
+  // optional CTA. `rate_limit` is transient (amber, no CTA); `auth` is permanent
+  // (red, Reconnect); `not_found` is a repo-access problem; unknown/null fall
+  // back to the raw message.
+  const errorKind: SyncErrorKind | null = (status?.error_kind as SyncErrorKind | null) ?? null;
+  // `rate_limit` is transient — render it amber like stale, distinct from the
+  // red permanent-failure states (auth / not_found / unknown).
+  const isTransientError = isError && errorKind === 'rate_limit';
+
   function handleClick() {
     if (syncing || readOnly) return;
     setError(null);
@@ -172,21 +196,43 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
   }
 
   // ── Tooltip lines. ──
-  const tooltip = (() => {
+  // `cta` is an optional recovery action rendered as a real link below the
+  // lines (spec §3 — e.g. an `auth` failure → "Reconnect").
+  const { lines: tooltip, cta } = ((): { lines: string[]; cta: { label: string; href: string } | null } => {
     const lines: string[] = [];
     if (syncing) {
       if (importProgress) lines.push(importProgress.label);
       else if (status?.message) lines.push(status.message);
       else if (status?.phase) lines.push(`Syncing ${PHASE_LABEL[status.phase]}…`);
       else lines.push('Starting sync…');
-      return lines;
+      return { lines, cta: null };
     }
     if (isError) {
-      lines.push(error ?? status?.error ?? 'Sync failed');
-      return lines;
+      // Actionable copy keyed off the persisted classification. A live `error`
+      // from a just-failed kickoff has no kind yet, so fall back to the raw text.
+      switch (errorKind) {
+        case 'auth':
+          lines.push('GitHub access expired');
+          // Reconnect → the GitHub OAuth sign-in flow (signInWithGitHub), which
+          // re-mints the OAuth token the sync falls back to when the App token
+          // is unavailable.
+          return { lines, cta: { label: 'Reconnect', href: '/login' } };
+        case 'rate_limit':
+          lines.push('GitHub rate limit — will retry automatically');
+          return { lines, cta: null };
+        case 'not_found':
+          lines.push("Repo not accessible — check the GitHub App's repo access");
+          return { lines, cta: null };
+        default:
+          lines.push(error ?? status?.error ?? 'Sync failed');
+          return { lines, cta: null };
+      }
     }
     const rel = relativeTime(lastSyncedAt);
-    if (rel) lines.push(`Last synced ${rel}`);
+    // Stale (spec §3): amber warning when the last successful sync is too old.
+    if (isStaleData) {
+      lines.push(`Data may be stale — last synced ${rel ?? 'a while ago'}`);
+    } else if (rel) lines.push(`Last synced ${rel}`);
     else lines.push('Not synced yet');
     const counts = summarize(status?.counts);
     if (counts) lines.push(counts);
@@ -203,16 +249,22 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
     if (syncMode === 'manual') {
       lines.push(readOnly ? 'Auto-sync off' : 'Auto-sync off — click to sync');
     }
-    return lines;
+    return { lines, cta: null };
   })();
 
+  // Dot color: amber (tertiary) for transient errors + stale data; red for
+  // permanent failures; primary tints for syncing/fresh; outline otherwise.
   const dotColor = syncing
     ? 'bg-primary animate-pulse'
-    : isError
-      ? 'bg-error'
-      : isFresh
-        ? 'bg-primary/60'
-        : 'bg-outline';
+    : isTransientError
+      ? 'bg-tertiary'
+      : isError
+        ? 'bg-error'
+        : isStaleData
+          ? 'bg-tertiary'
+          : isFresh
+            ? 'bg-primary/60'
+            : 'bg-outline';
 
   const aria = syncing ? 'Syncing…' : isError ? 'Sync failed' : 'Sync now';
 
@@ -261,19 +313,43 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
         )}
       </button>
 
-      {/* Tooltip — appears on hover, right-aligned under the dot. */}
+      {/* Tooltip — appears on hover, right-aligned under the dot. When it carries
+       *  a CTA (e.g. Reconnect) it becomes interactive so the link is clickable. */}
       <div
         role="tooltip"
-        className="pointer-events-none absolute right-0 top-full z-20 mt-1 hidden w-max max-w-[260px] rounded-md border border-outline-variant bg-surface-container-high px-3 py-2 text-xs shadow-ambient group-hover:block"
+        className={cn(
+          'absolute right-0 top-full z-20 mt-1 hidden w-max max-w-[260px] rounded-md border border-outline-variant bg-surface-container-high px-3 py-2 text-xs shadow-ambient group-hover:block',
+          cta ? 'pointer-events-auto' : 'pointer-events-none',
+        )}
       >
         <div className="font-medium text-on-surface">
-          {syncing ? 'Syncing' : isError ? 'Sync failed' : readOnly ? 'Sync status' : 'Sync now'}
+          {syncing ? 'Syncing' : isError ? 'Sync failed' : isStaleData ? 'Data may be stale' : readOnly ? 'Sync status' : 'Sync now'}
         </div>
         {tooltip.map((line, i) => (
-          <div key={i} className={cn('mt-0.5', isError && i === 0 ? 'text-error' : 'text-on-surface-variant')}>
+          <div
+            key={i}
+            className={cn(
+              'mt-0.5',
+              i === 0 && isTransientError
+                ? 'text-tertiary'
+                : i === 0 && isError
+                  ? 'text-error'
+                  : i === 0 && isStaleData
+                    ? 'text-tertiary'
+                    : 'text-on-surface-variant',
+            )}
+          >
             {line}
           </div>
         ))}
+        {cta && (
+          <a
+            href={cta.href}
+            className="mt-1.5 inline-flex items-center rounded-md bg-primary-container px-2 py-1 text-xs font-medium text-primary-on-container hover:bg-primary-container/90"
+          >
+            {cta.label}
+          </a>
+        )}
       </div>
     </div>
   );

--- a/packages/gui/src/components/sync-indicator.tsx
+++ b/packages/gui/src/components/sync-indicator.tsx
@@ -121,6 +121,37 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
   const syncing = (status?.status === 'syncing' && !isStale) || pending;
   const isError = !syncing && (Boolean(error) || status?.status === 'error');
 
+  // ── First-import (spec §2): a determinate "Importing" bar. ──
+  // `initial` flags the workspace's first full backfill; while it's syncing we
+  // surface real progress (n/total digested) instead of the subtle dot.
+  const isInitialImport = syncing && Boolean(status?.initial);
+  const importProgress = (() => {
+    if (!isInitialImport) return null;
+    const counts = status?.counts;
+    const digestsTotal = counts?.digestsTotal ?? 0;
+    const digestsCreated = counts?.digestsCreated ?? 0;
+    // Prefer digest progress (the slow phase); fall back to issue fetch during
+    // phase 1 before any digest total is known.
+    if (digestsTotal > 0) {
+      return {
+        fraction: Math.min(1, digestsCreated / digestsTotal),
+        label: `Importing — ${digestsCreated}/${digestsTotal} digested`,
+        indeterminate: false,
+      };
+    }
+    const issuesFetched = counts?.issuesFetched ?? 0;
+    const issuesCreated = counts?.issuesCreated ?? 0;
+    if (issuesFetched > 0) {
+      return {
+        fraction: Math.min(1, issuesCreated / issuesFetched),
+        label: `Importing — ${issuesCreated}/${issuesFetched} issues`,
+        indeterminate: false,
+      };
+    }
+    // No totals yet (very start of phase 1) — show an indeterminate bar.
+    return { fraction: 0, label: 'Importing your repo…', indeterminate: true };
+  })();
+
   const lastSyncedAt = status?.finished_at ?? (status?.status === 'done' ? status?.updated_at : null);
   const isFresh =
     !syncing &&
@@ -144,7 +175,8 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
   const tooltip = (() => {
     const lines: string[] = [];
     if (syncing) {
-      if (status?.message) lines.push(status.message);
+      if (importProgress) lines.push(importProgress.label);
+      else if (status?.message) lines.push(status.message);
       else if (status?.phase) lines.push(`Syncing ${PHASE_LABEL[status.phase]}…`);
       else lines.push('Starting sync…');
       return lines;
@@ -192,12 +224,41 @@ export function SyncIndicator({ workspaceId, initialStatus, readOnly, syncMode, 
         onClick={handleClick}
         aria-label={aria}
         className={cn(
-          'flex h-9 w-9 items-center justify-center rounded-md text-on-surface-variant transition-colors',
+          'flex h-9 items-center justify-center gap-2 rounded-md px-2 text-on-surface-variant transition-colors',
+          // Initial import gets extra width for the inline bar; otherwise stay
+          // a compact 9×9 dot button.
+          importProgress ? '' : 'w-9 px-0',
           readOnly ? 'cursor-default' : 'hover:bg-surface-container hover:text-on-surface',
           syncing && 'cursor-wait',
         )}
       >
-        <span className={cn('h-2 w-2 rounded-full transition-colors', dotColor)} aria-hidden />
+        <span className={cn('h-2 w-2 shrink-0 rounded-full transition-colors', dotColor)} aria-hidden />
+        {/* First-import (spec §2): a thin determinate bar + count, replacing the
+         *  bare pulsing dot so the slow onboarding import shows real progress. */}
+        {importProgress && (
+          <span className="flex items-center gap-1.5" aria-hidden>
+            <span className="h-1 w-16 overflow-hidden rounded-full bg-surface-container-highest">
+              <span
+                className={cn(
+                  'block h-full rounded-full bg-primary',
+                  importProgress.indeterminate
+                    ? 'w-1/3 animate-pulse'
+                    : 'transition-[width] duration-500',
+                )}
+                style={
+                  importProgress.indeterminate
+                    ? undefined
+                    : { width: `${Math.round(importProgress.fraction * 100)}%` }
+                }
+              />
+            </span>
+            <span className="whitespace-nowrap text-[10px] tabular-nums text-on-surface-variant">
+              {(status?.counts?.digestsTotal ?? 0) > 0
+                ? `${status?.counts?.digestsCreated ?? 0}/${status?.counts?.digestsTotal}`
+                : 'Importing'}
+            </span>
+          </span>
+        )}
       </button>
 
       {/* Tooltip — appears on hover, right-aligned under the dot. */}

--- a/packages/gui/src/components/topbar.tsx
+++ b/packages/gui/src/components/topbar.tsx
@@ -13,11 +13,12 @@ interface TopBarProps {
   readOnly: boolean;
   initialSyncStatus: SyncStatusRow | null;
   syncMode: 'auto' | 'manual';
+  syncIntervalMinutes: number;
   webhookHealth: 'live' | 'polling';
   lastWebhookAt: string | null;
 }
 
-export function TopBar({ user, workspaceId, readOnly, initialSyncStatus, syncMode, webhookHealth, lastWebhookAt }: TopBarProps) {
+export function TopBar({ user, workspaceId, readOnly, initialSyncStatus, syncMode, syncIntervalMinutes, webhookHealth, lastWebhookAt }: TopBarProps) {
   const initials = useMemo(
     () =>
       (user.name || user.email || '?')
@@ -39,6 +40,7 @@ export function TopBar({ user, workspaceId, readOnly, initialSyncStatus, syncMod
             readOnly={readOnly}
             initialStatus={initialSyncStatus}
             syncMode={syncMode}
+            syncIntervalMinutes={syncIntervalMinutes}
             webhookHealth={webhookHealth}
             lastWebhookAt={lastWebhookAt}
           />

--- a/packages/gui/src/components/topbar.tsx
+++ b/packages/gui/src/components/topbar.tsx
@@ -13,9 +13,11 @@ interface TopBarProps {
   readOnly: boolean;
   initialSyncStatus: SyncStatusRow | null;
   syncMode: 'auto' | 'manual';
+  webhookHealth: 'live' | 'polling';
+  lastWebhookAt: string | null;
 }
 
-export function TopBar({ user, workspaceId, readOnly, initialSyncStatus, syncMode }: TopBarProps) {
+export function TopBar({ user, workspaceId, readOnly, initialSyncStatus, syncMode, webhookHealth, lastWebhookAt }: TopBarProps) {
   const initials = useMemo(
     () =>
       (user.name || user.email || '?')
@@ -37,6 +39,8 @@ export function TopBar({ user, workspaceId, readOnly, initialSyncStatus, syncMod
             readOnly={readOnly}
             initialStatus={initialSyncStatus}
             syncMode={syncMode}
+            webhookHealth={webhookHealth}
+            lastWebhookAt={lastWebhookAt}
           />
         )}
 

--- a/packages/gui/src/lib/execute-sync-job.ts
+++ b/packages/gui/src/lib/execute-sync-job.ts
@@ -80,14 +80,17 @@ export async function executeSyncJob(
       error: null,
     });
 
-    const { store, github, config } = await buildSyncContext({
+    const { store, github, config, digestPolicy } = await buildSyncContext({
       supabase,
       workspaceId,
       repoOwner,
       repoName,
       token,
     });
-    await runSyncPhases({ supabase, workspaceId, store, github, config });
+    // Cron path: pass the digest policy but DON'T force — digests follow their
+    // own cadence (auto) / on-demand-only (manual) / off, except on the initial
+    // import which `runSyncPhases` always digests.
+    await runSyncPhases({ supabase, workspaceId, store, github, config, digestPolicy });
 
     await finishJob('done');
   } catch (err) {

--- a/packages/gui/src/lib/execute-sync-job.ts
+++ b/packages/gui/src/lib/execute-sync-job.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { buildSyncContext, runSyncPhases, writeSyncStatus } from './sync/run-workspace-sync';
+import { classifySyncError } from './sync/classify-sync-error';
 import { resolveWorkspaceToken } from './sync/resolve-workspace-token';
 import type { Database } from './supabase/types';
 
@@ -55,6 +56,8 @@ export async function executeSyncJob(
       status: 'error',
       phase: null,
       error: 'no github token available for workspace',
+      // No usable token ⇒ an auth-recovery case (Reconnect / reinstall the App).
+      error_kind: 'auth',
       finished_at: new Date().toISOString(),
     });
     await supabase
@@ -94,6 +97,7 @@ export async function executeSyncJob(
       status: 'error',
       phase: null,
       error: message,
+      error_kind: classifySyncError(err),
       finished_at: new Date().toISOString(),
     });
     await supabase

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -49,6 +49,24 @@ export interface SyncCounts {
   digestsTotal?: number;
   commentsFetched?: number;
   prsUpdated?: number;
+  // ── Per-run PR deltas (spec §4) — computed from a pre-upsert state diff,
+  // so the "what changed" toast reflects *this* sync rather than cumulative
+  // totals. Skipped on the initial import (everything would be "new"). ──
+  /** PRs not previously present in the store. */
+  prsCreated?: number;
+  /** PRs that went open → closed this run. Merges fold in here when no merge
+   *  signal is available (`RawPullRequest` carries none today). */
+  prsClosed?: number;
+  /** PRs closed *as merged* this run. Unset while the fetch lacks a merge
+   *  signal — merges are counted under `prsClosed` instead. */
+  prsMerged?: number;
+  /** PRs that went closed → open this run. */
+  prsReopened?: number;
+  // ── Finer issue deltas (spec §4), split out of `issuesUpdated`. ──
+  /** Issues that went open → closed this run. */
+  issuesClosed?: number;
+  /** Issues that went closed → open this run. */
+  issuesReopened?: number;
 }
 
 // Shape of `workspace_label_analyses.result` once the executor finishes.

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -31,6 +31,11 @@ export type LabelAnalysisStatus =
 export type WorkspaceLabelScope = 'issue' | 'pr' | 'both';
 export type WorkspaceLabelSource = 'ai-analyzed' | 'user-edited' | 'manual';
 
+/** Per-workspace AI-digest cadence (migration 0042 / spec §5). `auto` runs
+ *  digests on their own `digest_interval_minutes` cadence; `manual` only on the
+ *  initial import or the admin "Generate digests now" action; `off` never. */
+export type DigestMode = 'auto' | 'manual' | 'off';
+
 // ─── Sync status (0029) ──────────────────────────────────────────────────
 export type SyncStatusState = 'idle' | 'syncing' | 'done' | 'error';
 export type SyncPhase = 'issues' | 'digests' | 'comments' | 'prs';
@@ -160,11 +165,16 @@ export interface Database {
           sync_interval_minutes: number;
           last_webhook_received_at: string | null;
           last_webhook_event: string | null;
+          // §5 (migration 0042) — AI-digest cadence, decoupled from the
+          // metadata-sync cadence so "sync often" doesn't mean "spend often".
+          digest_mode: DigestMode;
+          digest_interval_minutes: number;
+          last_digested_at: string | null;
           auto_triage_action_id: string | null;
           created_at: string;
           updated_at: string;
         };
-        Insert: Omit<Database['public']['Tables']['workspaces']['Row'], 'id' | 'created_at' | 'updated_at' | 'auto_triage_action_id' | 'action_auto_comment' | 'sync_mode' | 'sync_interval_minutes' | 'last_webhook_received_at' | 'last_webhook_event'> & {
+        Insert: Omit<Database['public']['Tables']['workspaces']['Row'], 'id' | 'created_at' | 'updated_at' | 'auto_triage_action_id' | 'action_auto_comment' | 'sync_mode' | 'sync_interval_minutes' | 'last_webhook_received_at' | 'last_webhook_event' | 'digest_mode' | 'digest_interval_minutes' | 'last_digested_at'> & {
           id?: string;
           auto_triage_action_id?: string | null;
           action_auto_comment?: boolean;
@@ -172,6 +182,9 @@ export interface Database {
           sync_interval_minutes?: number;
           last_webhook_received_at?: string | null;
           last_webhook_event?: string | null;
+          digest_mode?: DigestMode;
+          digest_interval_minutes?: number;
+          last_digested_at?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -132,16 +132,20 @@ export interface Database {
           action_auto_comment: boolean;
           sync_mode: 'auto' | 'manual';
           sync_interval_minutes: number;
+          last_webhook_received_at: string | null;
+          last_webhook_event: string | null;
           auto_triage_action_id: string | null;
           created_at: string;
           updated_at: string;
         };
-        Insert: Omit<Database['public']['Tables']['workspaces']['Row'], 'id' | 'created_at' | 'updated_at' | 'auto_triage_action_id' | 'action_auto_comment' | 'sync_mode' | 'sync_interval_minutes'> & {
+        Insert: Omit<Database['public']['Tables']['workspaces']['Row'], 'id' | 'created_at' | 'updated_at' | 'auto_triage_action_id' | 'action_auto_comment' | 'sync_mode' | 'sync_interval_minutes' | 'last_webhook_received_at' | 'last_webhook_event'> & {
           id?: string;
           auto_triage_action_id?: string | null;
           action_auto_comment?: boolean;
           sync_mode?: 'auto' | 'manual';
           sync_interval_minutes?: number;
+          last_webhook_received_at?: string | null;
+          last_webhook_event?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -34,6 +34,11 @@ export type WorkspaceLabelSource = 'ai-analyzed' | 'user-edited' | 'manual';
 // ─── Sync status (0029) ──────────────────────────────────────────────────
 export type SyncStatusState = 'idle' | 'syncing' | 'done' | 'error';
 export type SyncPhase = 'issues' | 'digests' | 'comments' | 'prs';
+/** Classification of a sync failure (migration 0041) — drives the indicator's
+ *  actionable error copy + recovery CTA. `auth` ⇒ expired/revoked token or an
+ *  uninstalled App (→ Reconnect); `rate_limit` is transient; `not_found` is a
+ *  repo-access problem; `unknown` falls back to the raw message. */
+export type SyncErrorKind = 'auth' | 'rate_limit' | 'not_found' | 'unknown';
 export interface SyncCounts {
   issuesFetched?: number;
   issuesCreated?: number;
@@ -228,6 +233,9 @@ export interface Database {
           /** { issuesFetched, issuesCreated, issuesUpdated, digestsCreated, digestsTotal, commentsFetched, prsUpdated } */
           counts: SyncCounts;
           error: string | null;
+          /** Classification of the last failure (migration 0041), set with
+           *  status='error' so the indicator can show a recovery CTA. */
+          error_kind: SyncErrorKind | null;
           /** True during the workspace's first full import (migration 0040) —
            *  flips the indicator to a determinate "Importing" bar. */
           initial: boolean;
@@ -242,6 +250,7 @@ export interface Database {
           message?: string | null;
           counts?: SyncCounts;
           error?: string | null;
+          error_kind?: SyncErrorKind | null;
           initial?: boolean;
           started_at?: string | null;
           finished_at?: string | null;

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -39,6 +39,9 @@ export interface SyncCounts {
   issuesCreated?: number;
   issuesUpdated?: number;
   digestsCreated?: number;
+  /** Total issues slated for digesting this run (open + un-digested), captured
+   *  before the LLM call so the first-import bar has a denominator. */
+  digestsTotal?: number;
   commentsFetched?: number;
   prsUpdated?: number;
 }
@@ -222,9 +225,12 @@ export interface Database {
           status: SyncStatusState;
           phase: SyncPhase | null;
           message: string | null;
-          /** { issuesFetched, issuesCreated, issuesUpdated, digestsCreated, commentsFetched, prsUpdated } */
+          /** { issuesFetched, issuesCreated, issuesUpdated, digestsCreated, digestsTotal, commentsFetched, prsUpdated } */
           counts: SyncCounts;
           error: string | null;
+          /** True during the workspace's first full import (migration 0040) —
+           *  flips the indicator to a determinate "Importing" bar. */
+          initial: boolean;
           started_at: string | null;
           finished_at: string | null;
           updated_at: string;
@@ -236,6 +242,7 @@ export interface Database {
           message?: string | null;
           counts?: SyncCounts;
           error?: string | null;
+          initial?: boolean;
           started_at?: string | null;
           finished_at?: string | null;
           updated_at?: string;

--- a/packages/gui/src/lib/sync/classify-sync-error.ts
+++ b/packages/gui/src/lib/sync/classify-sync-error.ts
@@ -1,0 +1,39 @@
+import type { SyncErrorKind } from '@/lib/supabase/types';
+
+// ─────────────────────────────────────────────────────────────────────
+// §3: Stale & actionable states — classify a caught sync error into a
+// `SyncErrorKind` so the indicator can show a recovery CTA instead of a raw
+// message. We string-match the *normalized* error messages thrown by core's
+// `GitHubService#handleError` (401/403/404) and `GitHubAppService
+// #getInstallationToken` ("App is not installed …"), and also tolerate the raw
+// Octokit `.status` shape in case an un-normalized error bubbles up.
+// ─────────────────────────────────────────────────────────────────────
+export function classifySyncError(err: unknown): SyncErrorKind {
+  // Raw Octokit errors carry a numeric `.status`; map it directly when present
+  // (a 403 here is GitHub's combined rate-limit/forbidden, matching handleError).
+  if (err && typeof err === 'object' && 'status' in err) {
+    const status = (err as { status: unknown }).status;
+    if (status === 401) return 'auth';
+    if (status === 403) return 'rate_limit';
+    if (status === 404) return 'not_found';
+  }
+
+  const message = err instanceof Error ? err.message : String(err ?? '');
+
+  // 401 → invalid/revoked token; App-uninstalled is also an auth-recovery case.
+  if (
+    message.includes('Invalid GitHub token') ||
+    message.includes('GitHub App is not installed')
+  ) {
+    return 'auth';
+  }
+  // 403 → GitHub's "rate limit exceeded or access forbidden" (treat as transient).
+  if (message.includes('rate limit exceeded or access forbidden')) {
+    return 'rate_limit';
+  }
+  // 404 → "Repo '…' not found or inaccessible."
+  if (message.includes('not found or inaccessible')) {
+    return 'not_found';
+  }
+  return 'unknown';
+}

--- a/packages/gui/src/lib/sync/run-workspace-sync.ts
+++ b/packages/gui/src/lib/sync/run-workspace-sync.ts
@@ -27,6 +27,10 @@ export async function writeSyncStatus(
     message?: string | null;
     counts?: SyncCounts;
     error?: string | null;
+    /** Flags the first full import (migration 0040) so the indicator shows a
+     *  determinate progress bar. Threaded from `runSyncPhases` once phase 1
+     *  has computed `fullSync`. */
+    initial?: boolean;
     started_at?: string | null;
     finished_at?: string | null;
   },
@@ -124,6 +128,10 @@ export async function runSyncPhases({
 }: RunSyncPhasesArgs): Promise<void> {
   const { LLMService } = await import('@cezar/core');
   const counts: SyncCounts = {};
+  // Whether this run is the workspace's first full (all-states) import. Set in
+  // phase 1 and threaded into every `sync_status` write from there on, so the
+  // indicator can switch to a determinate "Importing" bar.
+  let initial = false;
 
   // ── 1. Fetch issues ──
   // Do a full (all-states, incl. closed) fetch until a complete sync has
@@ -133,6 +141,7 @@ export async function runSyncPhases({
   try {
     const meta = store.getMeta();
     const fullSync = !meta.fullSyncedAt || !meta.lastSyncedAt;
+    initial = fullSync;
     const issues = fullSync
       ? await github.fetchAllIssues(true)
       : await github.fetchIssuesSince(meta.lastSyncedAt as string, true);
@@ -158,6 +167,7 @@ export async function runSyncPhases({
       status: 'error',
       phase: null,
       counts,
+      initial,
       error: `Issue fetch failed: ${err instanceof Error ? err.message : String(err)}`,
       finished_at: new Date().toISOString(),
     });
@@ -170,15 +180,37 @@ export async function runSyncPhases({
   try {
     const needDigest = store.getIssues({ state: 'open', hasDigest: false });
     if (needDigest.length > 0) {
+      // Seed the denominator BEFORE the LLM call so the first-import bar has a
+      // total to measure against; the bar advances as `onProgress` fires.
+      counts.digestsTotal = needDigest.length;
+      counts.digestsCreated = 0;
       await writeSyncStatus(supabase, workspaceId, {
         status: 'syncing',
         phase: 'digests',
-        message: `Digesting ${needDigest.length} issue${needDigest.length === 1 ? '' : 's'}…`,
+        message: `Digesting 0/${needDigest.length}…`,
         counts,
+        initial,
       });
       const service = new LLMService(config);
       const issueData = needDigest.map((i) => ({ number: i.number, title: i.title, body: i.body }));
-      const results = await service.generateDigests(issueData, config.sync.digestBatchSize);
+      // Wire the (previously-unused) per-batch progress callback to a throttled
+      // Realtime write — once per batch, never per-issue — so the import bar
+      // advances live without spamming `sync_status`.
+      const results = await service.generateDigests(
+        issueData,
+        config.sync.digestBatchSize,
+        (completed, total) => {
+          counts.digestsCreated = completed;
+          counts.digestsTotal = total;
+          void writeSyncStatus(supabase, workspaceId, {
+            status: 'syncing',
+            phase: 'digests',
+            message: `Digesting ${completed}/${total}…`,
+            counts,
+            initial,
+          });
+        },
+      );
       for (const [number, digest] of results) {
         store.setDigest(number, digest);
       }
@@ -202,6 +234,7 @@ export async function runSyncPhases({
         phase: 'comments',
         message: `Fetching comments for ${needComments.length} issue${needComments.length === 1 ? '' : 's'}…`,
         counts,
+        initial,
       });
       const commentMap = await github.fetchCommentsForIssues(needComments.map((i) => i.number));
       for (const [num, comments] of commentMap) {
@@ -221,6 +254,7 @@ export async function runSyncPhases({
       phase: 'prs',
       message: 'Refreshing pull requests…',
       counts,
+      initial,
     });
     // All states, newest-activity first, so PRs closed/merged upstream get
     // their state corrected; cap the walk so a repo with thousands of historical
@@ -258,6 +292,7 @@ export async function runSyncPhases({
     phase: null,
     message: summarize(counts),
     counts,
+    initial,
     error: null,
     finished_at: new Date().toISOString(),
   });

--- a/packages/gui/src/lib/sync/run-workspace-sync.ts
+++ b/packages/gui/src/lib/sync/run-workspace-sync.ts
@@ -1,7 +1,7 @@
 import { SupabaseStoreAdapter } from '@/lib/adapters/supabase-store';
 import { loadWorkspaceConfig } from '@/lib/load-workspace-config';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Database, SyncCounts, SyncErrorKind, SyncPhase, SyncStatusState } from '@/lib/supabase/types';
+import type { Database, DigestMode, SyncCounts, SyncErrorKind, SyncPhase, SyncStatusState } from '@/lib/supabase/types';
 import { classifySyncError } from './classify-sync-error';
 
 // ─────────────────────────────────────────────────────────────────────
@@ -53,10 +53,22 @@ export interface BuildSyncContextArgs {
   token: string;
 }
 
+/** The AI-digest cadence policy (spec §5), read from the workspace row in
+ *  `buildSyncContext` and threaded into `runSyncPhases` to gate phase 2. */
+export interface DigestPolicy {
+  mode: DigestMode;
+  intervalMinutes: number;
+  /** When the digest phase last actually ran (ISO), or null. The auto-mode
+   *  cadence gate compares this against `intervalMinutes`. */
+  lastDigestedAt: string | null;
+}
+
 export interface SyncContext {
   store: Awaited<ReturnType<(typeof import('@cezar/core'))['IssueStore']['fromPort']>>;
   github: InstanceType<(typeof import('@cezar/core'))['GitHubService']>;
   config: Awaited<ReturnType<typeof loadWorkspaceConfig>>;
+  /** Digest cadence + last-run marker for this workspace. */
+  digestPolicy: DigestPolicy;
 }
 
 /** Build the store / config / github trio used to run a workspace sync.
@@ -109,7 +121,21 @@ export async function buildSyncContext({
 
   const github = new core.GitHubService(config);
 
-  return { store, github, config };
+  // Read the digest cadence + last-run marker (migration 0042) so phase 2 can
+  // gate on it. One small indexed select; tolerate a missing row / pre-migration
+  // workspace by defaulting to the SQL defaults (auto / 60 / never-digested).
+  const { data: ws } = await supabase
+    .from('workspaces')
+    .select('digest_mode, digest_interval_minutes, last_digested_at')
+    .eq('id', workspaceId)
+    .maybeSingle();
+  const digestPolicy: DigestPolicy = {
+    mode: ws?.digest_mode ?? 'auto',
+    intervalMinutes: ws?.digest_interval_minutes ?? 60,
+    lastDigestedAt: ws?.last_digested_at ?? null,
+  };
+
+  return { store, github, config, digestPolicy };
 }
 
 export interface RunSyncPhasesArgs {
@@ -118,6 +144,36 @@ export interface RunSyncPhasesArgs {
   store: Awaited<ReturnType<(typeof import('@cezar/core'))['IssueStore']['fromPort']>>;
   github: InstanceType<(typeof import('@cezar/core'))['GitHubService']>;
   config: Awaited<ReturnType<typeof loadWorkspaceConfig>>;
+  /** Digest cadence policy (spec §5). Phase 2 runs only when this allows it;
+   *  defaults to always-on (auto / 0-interval) when omitted, preserving the
+   *  pre-§5 behavior for any caller that doesn't thread it. */
+  digestPolicy?: DigestPolicy;
+  /** Force the digest phase to run regardless of mode/cadence — used by the
+   *  on-demand "Generate digests now" action. The initial import forces digests
+   *  on its own (see `shouldRunDigests`), so this is for explicit user intent. */
+  forceDigests?: boolean;
+}
+
+/** Decide whether phase 2 (digests) should run this sync, per spec §5:
+ *   - `off`    → never.
+ *   - initial  → ALWAYS (a new workspace must not be empty), any mode but off.
+ *   - forced   → always (on-demand "Generate digests now"), any mode but off.
+ *   - `manual` → only when initial/forced (handled above) — i.e. not on cron.
+ *   - `auto`   → only when last_digested_at is null or older than the interval.
+ */
+export function shouldRunDigests(
+  policy: DigestPolicy | undefined,
+  opts: { initial: boolean; force: boolean },
+): boolean {
+  const mode = policy?.mode ?? 'auto';
+  if (mode === 'off') return false;
+  if (opts.initial || opts.force) return true;
+  if (mode === 'manual') return false;
+  // auto: cadence gate.
+  const last = policy?.lastDigestedAt;
+  if (!last) return true;
+  const intervalMs = Math.max(15, policy?.intervalMinutes ?? 60) * 60 * 1000;
+  return Date.now() - new Date(last).getTime() >= intervalMs;
 }
 
 /** The four serial sync phases, each writing its progress into `sync_status`.
@@ -129,6 +185,8 @@ export async function runSyncPhases({
   store,
   github,
   config,
+  digestPolicy,
+  forceDigests = false,
 }: RunSyncPhasesArgs): Promise<void> {
   const { LLMService } = await import('@cezar/core');
   const counts: SyncCounts = {};
@@ -197,8 +255,14 @@ export async function runSyncPhases({
   // ── 2. Generate digests for OPEN issues that don't have one yet ──
   // Scoped to open issues: a full backfill can pull in hundreds of historical
   // closed issues, and digesting those would be a large, low-value LLM spend.
+  //
+  // Digests are the only LLM cost in a sync (spec §5), so they run on their own
+  // cadence — gated by `digestPolicy`. The initial import always digests (so a
+  // new workspace isn't empty); `forceDigests` is the on-demand override. When
+  // the gate says "skip", phases 3/4 still run, so metadata stays fresh for free.
+  const runDigests = shouldRunDigests(digestPolicy, { initial, force: forceDigests });
   try {
-    const needDigest = store.getIssues({ state: 'open', hasDigest: false });
+    const needDigest = runDigests ? store.getIssues({ state: 'open', hasDigest: false }) : [];
     if (needDigest.length > 0) {
       // Seed the denominator BEFORE the LLM call so the first-import bar has a
       // total to measure against; the bar advances as `onProgress` fires.
@@ -236,6 +300,17 @@ export async function runSyncPhases({
       }
       counts.digestsCreated = results.size;
       await store.save();
+    }
+    // Stamp the cadence marker whenever the digest phase actually ran (even if
+    // it found nothing to digest) so the auto-mode gate advances. Skipped only
+    // when the gate suppressed the phase entirely. Best-effort — a marker write
+    // failing shouldn't fail the sync.
+    if (runDigests) {
+      const { error: stampErr } = await supabase
+        .from('workspaces')
+        .update({ last_digested_at: new Date().toISOString() })
+        .eq('id', workspaceId);
+      if (stampErr) console.warn('[sync] last_digested_at write failed:', stampErr.message);
     }
   } catch (err) {
     // Digest failure shouldn't abort the whole sync — comments + PR pull are

--- a/packages/gui/src/lib/sync/run-workspace-sync.ts
+++ b/packages/gui/src/lib/sync/run-workspace-sync.ts
@@ -136,6 +136,9 @@ export async function runSyncPhases({
   // phase 1 and threaded into every `sync_status` write from there on, so the
   // indicator can switch to a determinate "Importing" bar.
   let initial = false;
+  // Mirror of `initial` (the first all-states import) used to guard the §4
+  // delta computation — on a full backfill every PR/issue would count as "new".
+  let fullSync = false;
 
   // ── 1. Fetch issues ──
   // Do a full (all-states, incl. closed) fetch until a complete sync has
@@ -144,7 +147,7 @@ export async function runSyncPhases({
   // first synced by the older open-only path, and bootstraps new workspaces.
   try {
     const meta = store.getMeta();
-    const fullSync = !meta.fullSyncedAt || !meta.lastSyncedAt;
+    fullSync = !meta.fullSyncedAt || !meta.lastSyncedAt;
     initial = fullSync;
     const issues = fullSync
       ? await github.fetchAllIssues(true)
@@ -152,10 +155,22 @@ export async function runSyncPhases({
     counts.issuesFetched = issues.length;
     counts.issuesCreated = 0;
     counts.issuesUpdated = 0;
+    // Per-run open↔closed deltas (spec §4) — only on incremental syncs; the
+    // initial import marks everything as "new" so close/reopen tallies are noise.
+    if (!fullSync) {
+      counts.issuesClosed = 0;
+      counts.issuesReopened = 0;
+    }
     for (const issue of issues) {
       const r = store.upsertIssue(issue);
       if (r.action === 'created') counts.issuesCreated += 1;
       if (r.action === 'updated') counts.issuesUpdated += 1;
+      // `upsertIssue` reports `stateChanged`; pair it with the incoming state to
+      // get the direction. Cheap — no extra read, the diff is already done here.
+      if (!fullSync && r.stateChanged) {
+        if (issue.state === 'closed') counts.issuesClosed! += 1;
+        else counts.issuesReopened! += 1;
+      }
     }
     const nowIso = new Date().toISOString();
     store.updateMeta({
@@ -266,6 +281,41 @@ export async function runSyncPhases({
     // PRs doesn't bloat this background pass.
     const prs = await github.listPullRequests(500);
     if (prs.length > 0) {
+      // Per-run PR deltas (spec §4) — diff the incoming set against the stored
+      // `(number, state)` BEFORE the upsert overwrites it. One indexed select
+      // (bounded by the 500-cap window). Skipped on the initial import, where
+      // every PR would register as "new". `RawPullRequest` carries no merge
+      // signal today, so merges fold into `prsClosed` and `prsMerged` is left
+      // unset (see report).
+      if (!fullSync) {
+        const numbers = prs.map((p) => p.number);
+        const { data: priorRows, error: priorErr } = await supabase
+          .from('pull_requests')
+          .select('number, state')
+          .eq('workspace_id', workspaceId)
+          .in('number', numbers);
+        if (!priorErr) {
+          const priorState = new Map<number, 'open' | 'closed'>(
+            (priorRows ?? []).map((r) => [r.number, r.state]),
+          );
+          let created = 0;
+          let closed = 0;
+          let reopened = 0;
+          for (const p of prs) {
+            const prev = priorState.get(p.number);
+            if (prev === undefined) {
+              created += 1;
+            } else if (prev === 'open' && p.state === 'closed') {
+              closed += 1; // includes merges — no merge flag available
+            } else if (prev === 'closed' && p.state === 'open') {
+              reopened += 1;
+            }
+          }
+          counts.prsCreated = created;
+          counts.prsClosed = closed;
+          counts.prsReopened = reopened;
+        }
+      }
       const rows = prs.map((p) => ({
         workspace_id: workspaceId,
         number: p.number,

--- a/packages/gui/src/lib/sync/run-workspace-sync.ts
+++ b/packages/gui/src/lib/sync/run-workspace-sync.ts
@@ -1,7 +1,8 @@
 import { SupabaseStoreAdapter } from '@/lib/adapters/supabase-store';
 import { loadWorkspaceConfig } from '@/lib/load-workspace-config';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Database, SyncCounts, SyncPhase, SyncStatusState } from '@/lib/supabase/types';
+import type { Database, SyncCounts, SyncErrorKind, SyncPhase, SyncStatusState } from '@/lib/supabase/types';
+import { classifySyncError } from './classify-sync-error';
 
 // ─────────────────────────────────────────────────────────────────────
 // Shared workspace-sync core — the four-phase "pull from GitHub" pipeline
@@ -27,6 +28,9 @@ export async function writeSyncStatus(
     message?: string | null;
     counts?: SyncCounts;
     error?: string | null;
+    /** Classification of the failure (migration 0041), written alongside
+     *  status='error' so the indicator can show a recovery CTA. */
+    error_kind?: SyncErrorKind | null;
     /** Flags the first full import (migration 0040) so the indicator shows a
      *  determinate progress bar. Threaded from `runSyncPhases` once phase 1
      *  has computed `fullSync`. */
@@ -169,6 +173,7 @@ export async function runSyncPhases({
       counts,
       initial,
       error: `Issue fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      error_kind: classifySyncError(err),
       finished_at: new Date().toISOString(),
     });
     return;
@@ -294,6 +299,7 @@ export async function runSyncPhases({
     counts,
     initial,
     error: null,
+    error_kind: null,
     finished_at: new Date().toISOString(),
   });
 }

--- a/packages/gui/src/lib/webhook-config.ts
+++ b/packages/gui/src/lib/webhook-config.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether the GitHub App webhook receiver is active server-side. The receiver
+ * (`app/api/github/webhook/route.ts`) returns 503 — i.e. deliveries never land —
+ * unless `GITHUB_APP_WEBHOOK_SECRET` is set. The layout reads this (with the
+ * workspace's `installation_id` + `last_webhook_received_at`) to decide whether
+ * the header indicator shows "⚡ Live" or "⏱ Polling" (spec §1). Server-only.
+ */
+export function isWebhookConfigured(): boolean {
+  return !!process.env.GITHUB_APP_WEBHOOK_SECRET;
+}

--- a/packages/gui/supabase/migrations/0039_workspace_webhook_signal.sql
+++ b/packages/gui/supabase/migrations/0039_workspace_webhook_signal.sql
@@ -1,0 +1,22 @@
+-- Per-workspace "last webhook delivery" signal — powers the header sync
+-- indicator's "⚡ Live" vs "⏱ Polling" state (spec §1).
+--
+-- A workspace with a healthy GitHub App webhook updates in seconds; one whose
+-- App was uninstalled or whose `GITHUB_APP_WEBHOOK_SECRET` is unset silently
+-- falls back to the cron reconcile interval. The receiver stamps these columns
+-- on every matched (non-ping) delivery so the UI can tell the two apart without
+-- scanning the global, 48h-GC'd `webhook_deliveries` table.
+
+alter table workspaces
+  add column last_webhook_received_at timestamptz,
+  add column last_webhook_event       text;
+
+comment on column workspaces.last_webhook_received_at is
+  'Timestamp of the most recent GitHub App webhook delivery matched to this
+   workspace. Non-null + recent ⇒ the live path is healthy; the sync indicator
+   reads it (with installation_id + the receiver-active flag) to show Live vs
+   Polling. Set best-effort by app/api/github/webhook/route.ts.';
+
+comment on column workspaces.last_webhook_event is
+  'The `X-GitHub-Event` name of the most recent matched webhook delivery
+   (e.g. `issues`, `pull_request`) — companion to last_webhook_received_at.';

--- a/packages/gui/supabase/migrations/0040_sync_status_initial.sql
+++ b/packages/gui/supabase/migrations/0040_sync_status_initial.sql
@@ -1,0 +1,11 @@
+-- §2: First-sync progress — flag the initial full import so the UI can show a
+-- determinate "Importing" progress bar (n/total digested) instead of an
+-- indeterminate spinner. Subsequent (incremental) syncs leave this false and
+-- keep the subtle pulsing dot. Derivable from `store.getMeta().fullSyncedAt`,
+-- but stored here so the indicator doesn't need a second read.
+alter table sync_status add column initial boolean not null default false;
+
+comment on column sync_status.initial is
+  'True while the workspace''s first full (all-states) import is running, so the '
+  'sync indicator renders a determinate import bar (n/total digested) rather '
+  'than the subtle pulsing dot used for fast incremental syncs.';

--- a/packages/gui/supabase/migrations/0041_sync_status_error_kind.sql
+++ b/packages/gui/supabase/migrations/0041_sync_status_error_kind.sql
@@ -1,0 +1,12 @@
+-- §3: Stale & actionable states — classify sync failures so the indicator can
+-- show a recovery CTA instead of a raw error string. The most common real
+-- failures (expired/revoked OAuth token or an uninstalled GitHub App) map to
+-- `auth`, which the indicator surfaces with a "Reconnect" action.
+alter table sync_status add column error_kind text
+  check (error_kind in ('auth', 'rate_limit', 'not_found', 'unknown'));
+
+comment on column sync_status.error_kind is
+  'Classification of the most recent sync failure (auth | rate_limit | '
+  'not_found | unknown), set alongside status=''error'' so the sync indicator '
+  'can render actionable copy + a recovery CTA (e.g. auth → Reconnect). Null '
+  'when the last sync did not fail.';

--- a/packages/gui/supabase/migrations/0042_workspace_digest_settings.sql
+++ b/packages/gui/supabase/migrations/0042_workspace_digest_settings.sql
@@ -1,0 +1,40 @@
+-- 0042_workspace_digest_settings.sql
+-- §5: Decouple metadata sync from AI digests (cost + cadence control).
+--
+-- Issue/PR metadata is cheap to pull; digests are the only LLM spend in a sync.
+-- Bundling them meant "sync more often" silently meant "spend more often". This
+-- gives digests their OWN cadence, independent of `sync_interval_minutes`:
+--
+--   * digest_mode = 'auto'   — digests run on their own (typically slower)
+--                              cadence, gated by digest_interval_minutes.
+--   * digest_mode = 'manual' — digests never run during cron/auto syncs; only
+--                              an admin's "Generate digests now" (or the initial
+--                              import) produces them.
+--   * digest_mode = 'off'    — digests never run; the inbox shows raw titles.
+--
+-- `last_digested_at` is the per-workspace cadence marker the gate compares
+-- against: in auto mode the digest phase runs only when it's null or older than
+-- digest_interval_minutes ago. Stored on `workspaces` (not `sync_status`) so the
+-- sync engine reads mode + interval + marker in the single workspace SELECT it
+-- already issues, and updates the marker in one indexed write when digests run.
+
+alter table workspaces
+  add column digest_mode text not null default 'auto'
+    check (digest_mode in ('auto', 'manual', 'off')),
+  add column digest_interval_minutes integer not null default 60
+    check (digest_interval_minutes >= 15),
+  add column last_digested_at timestamptz;
+
+comment on column workspaces.digest_mode is
+  'auto (default): the digest phase of a sync runs on its own cadence
+   (digest_interval_minutes), independent of sync_interval_minutes. manual:
+   digests run only on the initial import or via the admin "Generate digests
+   now" action. off: digests never run (inbox shows raw issue titles/bodies).';
+comment on column workspaces.digest_interval_minutes is
+  'Minimum minutes between automatic digest passes (digest_mode=auto). The
+   digest phase is skipped when last_digested_at is newer than this. Floored at
+   15 — digests are LLM spend, so the minimum cadence is coarser than sync.';
+comment on column workspaces.last_digested_at is
+  'When the digest phase last actually ran (regardless of mode). The auto-mode
+   cadence gate compares this against digest_interval_minutes. Null until the
+   first digest pass.';


### PR DESCRIPTION
Implements all 5 improvements from `docs/specs/sync-ux-improvements.md`. **Stacked on #255** (`feat/unified-sync`) — review/merge that first; this branch's base will retarget to `main` once #255 lands.

Each feature was built as its own checkpoint (typecheck-green between each); the full stack passes `@cezar/gui` + `@cezar/core` typecheck **and a production build**.

## Features

### §1 — Webhook health: "⚡ Live" vs "⏱ Polling" (`4aecbdb`)
Reframes the feature around the real-time webhook path vs. the cron backstop. Migration `0039` adds `workspaces.last_webhook_received_at` / `last_webhook_event`, stamped best-effort at the receiver's `resolveWorkspaces` chokepoint. The indicator tooltip shows Live (App installed + secret set) vs Polling.

### §2 — Determinate first-import progress (`5701d92`)
The initial all-states backfill + digest is the one slow moment — now a real progress bar instead of an indeterminate spinner. Migration `0040` adds `sync_status.initial`; wires `generateDigests`' previously-unused `onProgress` callback (throttled per batch) to advance `digestsCreated/digestsTotal`.

### §3 — Stale (amber) + actionable errors (`d12ffb4`)
Distinguishes fresh / stale / broken-with-a-fix. Migration `0041` adds `sync_status.error_kind`; a classifier maps GitHub 401/403/404 + "App not installed" to `auth`/`rate_limit`/`not_found`. Amber dot + "Data may be stale" past `max(2×interval, 30m)` (suppressed in manual mode); `auth` errors show a **Reconnect** link to `/login`.

### §4 — "What changed" toast (`cae6063`)
Per-run deltas instead of cumulative totals. Phase 1 splits `issuesClosed/issuesReopened` from the store's `stateChanged`; phase 4 diffs incoming PRs against a pre-upsert select for `prsCreated/prsClosed/prsReopened`. A toast fires **only on user-initiated** "sync now" (background/initial/no-change stay silent).

### §5 — Decouple AI digests from metadata sync (`15fa747`)
Digests are the only LLM spend, so they get their own cadence (single-job gating). Migration `0042` adds `digest_mode` (auto/on-demand/off) + `digest_interval_minutes` + `last_digested_at`. `shouldRunDigests` gates phase 2; metadata phases always run. Adds a "Generate digests now" action + an "AI digests" settings block.

## Migrations to apply
`0039` → `0042` (on top of `0037`/`0038` from #255).

## Deferred (noted in commits)
- True PR **merged** detection (§4) — needs `RawPullRequest` to map `merged_at` in `packages/core`; merges currently count as `prsClosed`.
- Per-run digest **token/cost** surfacing (§5) — needs a `generateDigests` return-shape change in `packages/core`.

## Notes
- The header indicator now encodes a lot (syncing / import-progress / fresh / stale / error+CTA / live-vs-polling / manual / change-toast). The spec flags a possible future "status chip" promotion for discoverability — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)