### PR TITLE
fix(docker): install git in the gui runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,11 @@ ENV NODE_ENV=production \
     HOSTNAME=0.0.0.0 \
     HOME=/home/nextjs
 
+# ensureRepoClone() shells out to `git`, which the slim base image omits.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 # `--create-home` materializes /home/nextjs (a --system user gets the passwd
 # entry but not the directory). ensureRepoClone() clones into ~/.cezar/repos via
 # os.homedir(), so without a writable HOME every clone fails with


### PR DESCRIPTION
## Problem

After #257, Skills **Sync from repo** (and every clone-backed triage/autofix job) fails on self-hosted deploys with:

```
Clone failed: spawn git ENOENT
```

`ensureRepoClone()` (`packages/gui/src/lib/repo-clone.ts`) shells out to `git`, but the `node:20-bookworm-slim` base image doesn't include a `git` binary.

#257 originally carried this fix, but the `apt-get install git` block was dropped from the squash-merge, so only the `HOME` fix landed on `main`. This PR re-adds it.

## Fix

Install `git` (plus `ca-certificates` so the HTTPS clone URL validates) in the runner stage of the GUI `Dockerfile`.

No application code changes. Rebuild + redeploy the `gui` image to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)