### PR TITLE
fix(github): correctly classify write 403s (rate-limit vs permission) + retry secondary limits

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,10 @@ export { loadConfig } from './config/loader.js';
 // Services
 export {
   GitHubService,
+  GitHubApiError,
+  classifyGitHubError,
+  toGitHubApiError,
+  isAuthOrRateLimitError,
   summarizeCi,
   parseCheckRunUrl,
   extractReferencedIssues,
@@ -34,6 +38,8 @@ export {
   type CheckRunSummary,
   type CiOverall,
   type CiSummary,
+  type GitHubErrorKind,
+  type ClassifiedGitHubError,
 } from './services/github.service.js';
 export {
   LLMService,

--- a/packages/core/src/services/github.service.ts
+++ b/packages/core/src/services/github.service.ts
@@ -1003,12 +1003,25 @@ export function toGitHubApiError(
     case 'auth':
       message = 'Invalid or expired GitHub token — re-authenticate (or reinstall the GitHub App).';
       break;
-    case 'permission':
-      message =
-        `GitHub denied this action (403): permission missing${detail}. ` +
-        `The token/GitHub App lacks write access for this operation on ${slug} — ` +
-        `grant "Issues: Read & write" (and "Pull requests" for PRs) and re-accept the install.`;
+    case 'permission': {
+      // Distinguish the two real causes of a write 403, because the fix differs:
+      //   - GitHub App token ("Resource not accessible by integration"): the App
+      //     installation lacks the permission — grant it and re-accept.
+      //   - User OAuth token / PAT: the *account* Cezar is acting as lacks the
+      //     repo role. Crucially, on GitHub a user with read access can COMMENT
+      //     but needs the Triage (or Write/Maintain/Admin) role to add/remove
+      //     LABELS — so "comment worked but labeling 403'd" is expected here and
+      //     is NOT a rate limit. Installing the GitHub App fixes it regardless of
+      //     who connected the workspace.
+      const isApp = /integration/i.test(classified.message);
+      message = isApp
+        ? `GitHub denied this action (403): the GitHub App installation lacks permission${detail}. ` +
+          `Grant "Issues: Read & write" (and "Pull requests: Read & write" for PRs) on ${slug} and re-accept the install.`
+        : `GitHub denied this action (403): the connected GitHub account lacks the repo role for it${detail}. ` +
+          `Commenting only needs read access, but adding/removing labels needs the Triage (or Write) role on ${slug} — ` +
+          `install the Cezar GitHub App (recommended), or give that account Triage+ access.`;
       break;
+    }
     case 'secondary-rate-limit':
       message =
         `GitHub secondary (anti-burst) rate limit hit${detail} — exhausted in-run retries. ` +

--- a/packages/core/src/services/github.service.ts
+++ b/packages/core/src/services/github.service.ts
@@ -259,70 +259,77 @@ export class GitHubService {
   }
 
   async addLabel(issueNumber: number, label: string): Promise<void> {
-    try {
-      // Ensure label exists
+    // Common case is one request: `addLabels` succeeds when the repo label
+    // exists. Only when GitHub rejects a missing repo label (404/422) do we
+    // create it and retry — this drops the unconditional getLabel probe that
+    // used to make every add 2-3 requests (which itself worsened rate limits).
+    // The closure throws the RAW error so `withWriteRetry` can classify it
+    // (retry-after / rate-limit headers intact) and retry secondary limits.
+    await this.withWriteRetry(`addLabel #${issueNumber}`, async () => {
       try {
-        await this.octokit.rest.issues.getLabel({
+        await this.octokit.rest.issues.addLabels({
           owner: this.owner,
           repo: this.repo,
-          name: label,
+          issue_number: issueNumber,
+          labels: [label],
         });
-      } catch {
-        await this.octokit.rest.issues.createLabel({
+      } catch (error) {
+        const status = errorStatus(error);
+        if (status !== 404 && status !== 422) throw error; // rate-limit/permission → withWriteRetry
+        // Repo label missing — create it once (with our color), then add.
+        // createLabel may 422 if a concurrent attempt already created it — ok.
+        try {
+          await this.octokit.rest.issues.createLabel({
+            owner: this.owner,
+            repo: this.repo,
+            name: label,
+            color: 'e4e669',
+            description: 'Managed by cezar',
+          });
+        } catch (createErr) {
+          if (errorStatus(createErr) !== 422) throw createErr;
+        }
+        await this.octokit.rest.issues.addLabels({
           owner: this.owner,
           repo: this.repo,
-          name: label,
-          color: 'e4e669',
-          description: 'Managed by cezar',
+          issue_number: issueNumber,
+          labels: [label],
         });
       }
-
-      await this.octokit.rest.issues.addLabels({
-        owner: this.owner,
-        repo: this.repo,
-        issue_number: issueNumber,
-        labels: [label],
-      });
-    } catch (error) {
-      this.handleError(error);
-      throw error;
-    }
+    });
   }
 
   async removeLabel(issueNumber: number, label: string): Promise<void> {
-    try {
-      await this.octokit.rest.issues.removeLabel({
-        owner: this.owner,
-        repo: this.repo,
-        issue_number: issueNumber,
-        name: label,
-      });
-    } catch (error) {
-      // Ignore 404 — label wasn't on the issue
-      if (error && typeof error === 'object' && 'status' in error && (error as { status: number }).status === 404) {
-        return;
+    await this.withWriteRetry(`removeLabel #${issueNumber}`, async () => {
+      try {
+        await this.octokit.rest.issues.removeLabel({
+          owner: this.owner,
+          repo: this.repo,
+          issue_number: issueNumber,
+          name: label,
+        });
+      } catch (error) {
+        // Ignore 404 — label wasn't on the issue. Everything else (incl. rate
+        // limits) propagates raw to withWriteRetry for classification/retry.
+        if (errorStatus(error) === 404) return;
+        throw error;
       }
-      this.handleError(error);
-      throw error;
-    }
+    });
   }
 
   async setLabels(issueNumber: number, labels: string[]): Promise<void> {
-    try {
-      await this.octokit.rest.issues.setLabels({
+    await this.withWriteRetry(`setLabels #${issueNumber}`, () =>
+      this.octokit.rest.issues.setLabels({
         owner: this.owner,
         repo: this.repo,
         issue_number: issueNumber,
         labels,
-      });
-    } catch (error) {
-      this.handleError(error);
-      throw error;
-    }
+      }).then(() => undefined),
+    );
   }
 
   async addComment(issueNumber: number, body: string): Promise<number> {
-    try {
+    return this.withWriteRetry(`addComment #${issueNumber}`, async () => {
       const resp = await this.octokit.rest.issues.createComment({
         owner: this.owner,
         repo: this.repo,
@@ -330,10 +337,7 @@ export class GitHubService {
         body,
       });
       return resp.data.id;
-    } catch (error) {
-      this.handleError(error);
-      throw error;
-    }
+    });
   }
 
   /** Edit an existing issue/PR comment in place — the "living comment" per run (docs §3.6). */
@@ -829,19 +833,199 @@ export class GitHubService {
   }
 
   private handleError(error: unknown): void {
+    // Only translate the structured Octokit/HTTP errors (those with a numeric
+    // `status`). The classifier distinguishes a genuine permission denial from
+    // a primary/secondary rate limit — historically all of these collapsed into
+    // one misleading "rate limit exceeded or access forbidden" message, which
+    // made a transient anti-burst limit look like a missing App permission.
     if (error && typeof error === 'object' && 'status' in error) {
       const status = (error as { status: number }).status;
-      if (status === 401) {
-        throw new Error('Invalid GitHub token. Check GITHUB_TOKEN env var.');
-      }
-      if (status === 403) {
-        throw new Error('GitHub API rate limit exceeded or access forbidden.');
-      }
-      if (status === 404) {
-        throw new Error(`Repo '${this.owner}/${this.repo}' not found or inaccessible.`);
+      if (status === 401 || status === 403 || status === 404 || status === 429) {
+        throw toGitHubApiError(error, classifyGitHubError(error), { owner: this.owner, repo: this.repo });
       }
     }
   }
+
+  /**
+   * Run a mutating GitHub call, retrying ONLY GitHub's secondary (anti-burst)
+   * rate limit — which is transient and clears within seconds — honoring the
+   * server's `Retry-After` when present, else exponential backoff (capped). A
+   * genuine permission denial, auth failure, primary-budget exhaustion, or any
+   * other error fails fast: retrying those just wastes a job's time. On final
+   * failure throws a {@link GitHubApiError} carrying the real cause so the
+   * effect audit can say *why* instead of "apply manually".
+   */
+  private async withWriteRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const MAX_ATTEMPTS = 4;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        const classified = classifyGitHubError(error);
+        if (classified.kind === 'secondary-rate-limit' && attempt < MAX_ATTEMPTS) {
+          const waitMs = Math.min(60_000, classified.retryAfterMs ?? 1000 * 2 ** (attempt - 1));
+          console.warn(
+            `[github] secondary rate limit on ${label} (attempt ${attempt}/${MAX_ATTEMPTS}); ` +
+              `retrying in ${Math.round(waitMs / 1000)}s ` +
+              `[remaining=${classified.rateLimitRemaining ?? '?'} retry-after=${classified.retryAfterMs != null ? Math.round(classified.retryAfterMs / 1000) + 's' : 'n/a'}]`,
+          );
+          await delay(waitMs);
+          continue;
+        }
+        if (classified.kind === 'primary-rate-limit') {
+          console.warn(
+            `[github] primary rate limit on ${label} ` +
+              `[remaining=${classified.rateLimitRemaining ?? '?'} resets-in=${classified.retryAfterMs != null ? Math.round(classified.retryAfterMs / 1000) + 's' : 'n/a'}]`,
+          );
+        }
+        throw toGitHubApiError(error, classified, { owner: this.owner, repo: this.repo });
+      }
+    }
+  }
+}
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Extract the numeric HTTP status off a raw Octokit/HTTP error, if present. */
+function errorStatus(error: unknown): number | undefined {
+  return error && typeof error === 'object' && 'status' in error
+    ? (error as { status: number }).status
+    : undefined;
+}
+
+/** Distinct failure modes that a 401/403/404/429 from GitHub can actually mean. */
+export type GitHubErrorKind =
+  | 'auth'
+  | 'permission'
+  | 'primary-rate-limit'
+  | 'secondary-rate-limit'
+  | 'not-found'
+  | 'other';
+
+export interface ClassifiedGitHubError {
+  kind: GitHubErrorKind;
+  status?: number;
+  /** ms to wait before retrying — from `Retry-After` (secondary) or `x-ratelimit-reset` (primary). */
+  retryAfterMs?: number;
+  /** `x-ratelimit-remaining` header, when present. */
+  rateLimitRemaining?: string;
+  /** The raw message GitHub returned (e.g. "Resource not accessible by integration"). */
+  message: string;
+}
+
+/** A GitHub failure with the real cause preserved (status + classified kind). */
+export class GitHubApiError extends Error {
+  readonly status?: number;
+  readonly kind: GitHubErrorKind;
+  readonly retryAfterMs?: number;
+  constructor(message: string, classified: ClassifiedGitHubError) {
+    super(message);
+    this.name = 'GitHubApiError';
+    this.status = classified.status;
+    this.kind = classified.kind;
+    this.retryAfterMs = classified.retryAfterMs;
+  }
+}
+
+function headerValue(headers: Record<string, unknown> | undefined, name: string): string | undefined {
+  if (!headers) return undefined;
+  const v = headers[name] ?? headers[name.toLowerCase()];
+  return v == null ? undefined : String(v);
+}
+
+/**
+ * Classify a raw Octokit error into the cause GitHub actually signaled.
+ *
+ * The key distinctions, all of which arrive as HTTP 403 (or 429):
+ *   - secondary rate limit → message contains "secondary rate limit", or a
+ *     `Retry-After` header is present while budget remains. Transient; retry.
+ *   - primary rate limit    → `x-ratelimit-remaining: 0` (resets on the hour).
+ *   - permission            → a 403 with no rate-limit signal, typically
+ *     "Resource not accessible by integration" (the App lacks the permission).
+ */
+export function classifyGitHubError(error: unknown): ClassifiedGitHubError {
+  if (!error || typeof error !== 'object') {
+    return { kind: 'other', message: String(error) };
+  }
+  const e = error as {
+    status?: number;
+    message?: string;
+    response?: { headers?: Record<string, unknown>; data?: { message?: string } };
+  };
+  const status = e.status;
+  const headers = e.response?.headers;
+  const apiMessage = e.response?.data?.message ?? e.message ?? '';
+  const lower = apiMessage.toLowerCase();
+  const remaining = headerValue(headers, 'x-ratelimit-remaining');
+
+  const retryAfterRaw = headerValue(headers, 'retry-after');
+  const retryAfterMs = retryAfterRaw != null && Number.isFinite(Number(retryAfterRaw))
+    ? Number(retryAfterRaw) * 1000
+    : undefined;
+  const resetRaw = headerValue(headers, 'x-ratelimit-reset');
+  const resetMs = resetRaw != null && Number.isFinite(Number(resetRaw))
+    ? Math.max(0, Number(resetRaw) * 1000 - Date.now())
+    : undefined;
+
+  if (status === 401) return { kind: 'auth', status, message: apiMessage, rateLimitRemaining: remaining };
+
+  if (status === 403 || status === 429) {
+    // Secondary (anti-burst) limit: explicit message, or a Retry-After while
+    // the primary budget is NOT exhausted.
+    if (lower.includes('secondary rate limit') || (retryAfterMs != null && remaining !== '0')) {
+      return { kind: 'secondary-rate-limit', status, retryAfterMs, rateLimitRemaining: remaining, message: apiMessage };
+    }
+    // Primary budget exhausted.
+    if (remaining === '0' || (lower.includes('rate limit') && remaining !== undefined)) {
+      return { kind: 'primary-rate-limit', status, retryAfterMs: resetMs, rateLimitRemaining: remaining, message: apiMessage };
+    }
+    if (lower.includes('rate limit')) {
+      return { kind: 'primary-rate-limit', status, retryAfterMs: resetMs, rateLimitRemaining: remaining, message: apiMessage };
+    }
+    // A 403 with no rate-limit signal is a real permission denial.
+    return { kind: 'permission', status, message: apiMessage, rateLimitRemaining: remaining };
+  }
+
+  if (status === 404) return { kind: 'not-found', status, message: apiMessage };
+  return { kind: 'other', status, message: apiMessage };
+}
+
+/** Build a human-readable {@link GitHubApiError} from a classified error. */
+export function toGitHubApiError(
+  error: unknown,
+  classified: ClassifiedGitHubError,
+  repo?: { owner: string; repo: string },
+): GitHubApiError {
+  const detail = classified.message ? ` (${classified.message})` : '';
+  const slug = repo ? `${repo.owner}/${repo.repo}` : 'the repo';
+  let message: string;
+  switch (classified.kind) {
+    case 'auth':
+      message = 'Invalid or expired GitHub token — re-authenticate (or reinstall the GitHub App).';
+      break;
+    case 'permission':
+      message =
+        `GitHub denied this action (403): permission missing${detail}. ` +
+        `The token/GitHub App lacks write access for this operation on ${slug} — ` +
+        `grant "Issues: Read & write" (and "Pull requests" for PRs) and re-accept the install.`;
+      break;
+    case 'secondary-rate-limit':
+      message =
+        `GitHub secondary (anti-burst) rate limit hit${detail} — exhausted in-run retries. ` +
+        `This is transient (not a permission problem); re-run the action shortly.`;
+      break;
+    case 'primary-rate-limit': {
+      const resets = classified.retryAfterMs != null ? ` (resets in ~${Math.round(classified.retryAfterMs / 1000)}s)` : '';
+      message = `GitHub API rate limit exhausted${resets}${detail}.`;
+      break;
+    }
+    case 'not-found':
+      message = `'${slug}' or the target resource was not found or is inaccessible${detail}.`;
+      break;
+    default:
+      message = error instanceof Error ? error.message : String(error);
+  }
+  return new GitHubApiError(message, classified);
 }
 
 // Auth (401) and access/rate-limit (403) failures are not transient per-item
@@ -850,9 +1034,14 @@ export class GitHubService {
 // silently dropping every item. Matches both the raw Octokit error shape
 // (`.status`) and the normalized Error messages thrown by `handleError`.
 export function isAuthOrRateLimitError(error: unknown): boolean {
+  // GitHubApiError carries the classified kind directly.
+  if (error instanceof GitHubApiError) {
+    return error.kind === 'auth' || error.kind === 'permission'
+      || error.kind === 'primary-rate-limit' || error.kind === 'secondary-rate-limit';
+  }
   if (error && typeof error === 'object' && 'status' in error) {
     const status = (error as { status: unknown }).status;
-    if (status === 401 || status === 403) return true;
+    if (status === 401 || status === 403 || status === 429) return true;
   }
   if (error instanceof Error) {
     return (

--- a/packages/core/tests/services/github-error.test.ts
+++ b/packages/core/tests/services/github-error.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { classifyGitHubError, toGitHubApiError, GitHubApiError, isAuthOrRateLimitError } from '@cezar/core';
+
+// Octokit RequestError-shaped fixtures: `.status` plus `.response.headers` /
+// `.response.data.message`. These mirror the real signals GitHub sends so the
+// classifier can tell a transient anti-burst limit from a missing permission —
+// the distinction that the old single "rate limit exceeded or access forbidden"
+// message erased.
+function ghError(opts: {
+  status: number;
+  headers?: Record<string, string>;
+  message?: string;
+}): unknown {
+  return {
+    status: opts.status,
+    message: opts.message ?? '',
+    response: { headers: opts.headers ?? {}, data: { message: opts.message ?? '' } },
+  };
+}
+
+describe('classifyGitHubError', () => {
+  it('classifies 401 as auth', () => {
+    expect(classifyGitHubError(ghError({ status: 401 })).kind).toBe('auth');
+  });
+
+  it('classifies a secondary rate limit by message', () => {
+    const c = classifyGitHubError(
+      ghError({ status: 403, message: 'You have exceeded a secondary rate limit', headers: { 'retry-after': '30' } }),
+    );
+    expect(c.kind).toBe('secondary-rate-limit');
+    expect(c.retryAfterMs).toBe(30_000);
+  });
+
+  it('classifies a Retry-After 403 with remaining budget as secondary', () => {
+    const c = classifyGitHubError(
+      ghError({ status: 403, headers: { 'retry-after': '5', 'x-ratelimit-remaining': '4999' } }),
+    );
+    expect(c.kind).toBe('secondary-rate-limit');
+    expect(c.retryAfterMs).toBe(5_000);
+  });
+
+  it('classifies x-ratelimit-remaining: 0 as a primary rate limit', () => {
+    const c = classifyGitHubError(
+      ghError({ status: 403, headers: { 'x-ratelimit-remaining': '0' }, message: 'API rate limit exceeded' }),
+    );
+    expect(c.kind).toBe('primary-rate-limit');
+  });
+
+  it('classifies a bare 403 (no rate-limit signal) as a permission denial', () => {
+    const c = classifyGitHubError(ghError({ status: 403, message: 'Resource not accessible by integration' }));
+    expect(c.kind).toBe('permission');
+  });
+
+  it('classifies 404 as not-found', () => {
+    expect(classifyGitHubError(ghError({ status: 404 })).kind).toBe('not-found');
+  });
+});
+
+describe('toGitHubApiError', () => {
+  it('produces a permission message that does NOT mention rate limits', () => {
+    const err = toGitHubApiError(
+      ghError({ status: 403, message: 'Resource not accessible by integration' }),
+      classifyGitHubError(ghError({ status: 403, message: 'Resource not accessible by integration' })),
+      { owner: 'o', repo: 'r' },
+    );
+    expect(err).toBeInstanceOf(GitHubApiError);
+    expect(err.kind).toBe('permission');
+    expect(err.message).toMatch(/permission missing/);
+    expect(err.message).not.toMatch(/rate limit/i);
+  });
+
+  it('preserves the classified kind + status for callers', () => {
+    const classified = classifyGitHubError(ghError({ status: 403, message: 'secondary rate limit' }));
+    const err = toGitHubApiError(new Error('x'), classified);
+    expect(err.kind).toBe('secondary-rate-limit');
+    expect(err.status).toBe(403);
+  });
+});
+
+describe('isAuthOrRateLimitError', () => {
+  it('recognizes a GitHubApiError permission as fatal-for-the-token', () => {
+    const err = new GitHubApiError('nope', { kind: 'permission', status: 403, message: '' });
+    expect(isAuthOrRateLimitError(err)).toBe(true);
+  });
+
+  it('recognizes a raw 429', () => {
+    expect(isAuthOrRateLimitError({ status: 429 })).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isAuthOrRateLimitError(new Error('boom'))).toBe(false);
+  });
+});

--- a/packages/core/tests/services/github-error.test.ts
+++ b/packages/core/tests/services/github-error.test.ts
@@ -65,8 +65,22 @@ describe('toGitHubApiError', () => {
     );
     expect(err).toBeInstanceOf(GitHubApiError);
     expect(err.kind).toBe('permission');
-    expect(err.message).toMatch(/permission missing/);
+    expect(err.message).toMatch(/denied this action/);
     expect(err.message).not.toMatch(/rate limit/i);
+  });
+
+  it('an App-token 403 ("integration") blames the App installation', () => {
+    const raw = ghError({ status: 403, message: 'Resource not accessible by integration' });
+    const err = toGitHubApiError(raw, classifyGitHubError(raw), { owner: 'o', repo: 'r' });
+    expect(err.message).toMatch(/GitHub App installation lacks permission/);
+  });
+
+  it('a user-token 403 (no "integration") points at the missing Triage role', () => {
+    // A read-access user can comment but not label — exactly the contributor case.
+    const raw = ghError({ status: 403, message: 'Must have triage permission' });
+    const err = toGitHubApiError(raw, classifyGitHubError(raw), { owner: 'o', repo: 'r' });
+    expect(err.message).toMatch(/Triage/);
+    expect(err.message).toMatch(/install the Cezar GitHub App/);
   });
 
   it('preserves the classified kind + status for callers', () => {

--- a/packages/core/tests/services/github.service.test.ts
+++ b/packages/core/tests/services/github.service.test.ts
@@ -179,7 +179,7 @@ describe('GitHubService', () => {
       const service = new GitHubService(makeConfig());
       // No longer the misleading "rate limit exceeded" — a 403 without any
       // rate-limit headers/message is a real permission problem.
-      await expect(service.fetchAllIssues()).rejects.toThrow(/permission missing/);
+      await expect(service.fetchAllIssues()).rejects.toThrow(/denied this action/);
     });
 
     it('reports a primary rate limit (x-ratelimit-remaining: 0) distinctly', async () => {
@@ -247,7 +247,7 @@ describe('GitHubService', () => {
       const { addLabels } = await labelMocks();
       addLabels.mockRejectedValue({ status: 403, response: { headers: {}, data: { message: 'Resource not accessible by integration' } } });
 
-      await expect(new GitHubService(makeConfig()).addLabel(7, 'priority-high')).rejects.toThrow(/permission missing/);
+      await expect(new GitHubService(makeConfig()).addLabel(7, 'priority-high')).rejects.toThrow(/GitHub App installation lacks permission/);
       // One real attempt — permission denials are fatal, not retried.
       expect(addLabels).toHaveBeenCalledTimes(1);
     });

--- a/packages/core/tests/services/github.service.test.ts
+++ b/packages/core/tests/services/github.service.test.ts
@@ -163,21 +163,93 @@ describe('GitHubService', () => {
       mockPaginate.mockRejectedValue({ status: 401 });
 
       const service = new GitHubService(makeConfig());
-      await expect(service.fetchAllIssues()).rejects.toThrow('Invalid GitHub token');
+      await expect(service.fetchAllIssues()).rejects.toThrow(/Invalid or expired GitHub token/);
     });
 
     it('throws descriptive error on 404', async () => {
       mockPaginate.mockRejectedValue({ status: 404 });
 
       const service = new GitHubService(makeConfig());
-      await expect(service.fetchAllIssues()).rejects.toThrow('not found or inaccessible');
+      await expect(service.fetchAllIssues()).rejects.toThrow(/not found or is inaccessible/);
     });
 
-    it('throws descriptive error on 403', async () => {
+    it('treats a bare 403 (no rate-limit signal) as a permission denial', async () => {
       mockPaginate.mockRejectedValue({ status: 403 });
 
       const service = new GitHubService(makeConfig());
-      await expect(service.fetchAllIssues()).rejects.toThrow('rate limit exceeded');
+      // No longer the misleading "rate limit exceeded" — a 403 without any
+      // rate-limit headers/message is a real permission problem.
+      await expect(service.fetchAllIssues()).rejects.toThrow(/permission missing/);
+    });
+
+    it('reports a primary rate limit (x-ratelimit-remaining: 0) distinctly', async () => {
+      mockPaginate.mockRejectedValue({
+        status: 403,
+        response: { headers: { 'x-ratelimit-remaining': '0' }, data: { message: 'API rate limit exceeded' } },
+      });
+
+      const service = new GitHubService(makeConfig());
+      await expect(service.fetchAllIssues()).rejects.toThrow(/API rate limit exhausted/);
+    });
+  });
+
+  describe('label writes', () => {
+    async function labelMocks() {
+      const mod = (await import('@octokit/rest')) as unknown as {
+        __mockGetLabel: ReturnType<typeof vi.fn>;
+        __mockCreateLabel: ReturnType<typeof vi.fn>;
+        __mockAddLabels: ReturnType<typeof vi.fn>;
+      };
+      return { getLabel: mod.__mockGetLabel, createLabel: mod.__mockCreateLabel, addLabels: mod.__mockAddLabels };
+    }
+
+    it('adds a label in a single request when it already exists (no getLabel probe)', async () => {
+      const { getLabel, createLabel, addLabels } = await labelMocks();
+      addLabels.mockResolvedValue({});
+
+      await new GitHubService(makeConfig()).addLabel(42, 'priority-high');
+
+      expect(addLabels).toHaveBeenCalledTimes(1);
+      expect(getLabel).not.toHaveBeenCalled();
+      expect(createLabel).not.toHaveBeenCalled();
+    });
+
+    it('creates the repo label then retries when addLabels 404s', async () => {
+      const { createLabel, addLabels } = await labelMocks();
+      addLabels.mockRejectedValueOnce({ status: 404 }).mockResolvedValueOnce({});
+      createLabel.mockResolvedValue({});
+
+      await new GitHubService(makeConfig()).addLabel(42, 'brand-new');
+
+      expect(createLabel).toHaveBeenCalledTimes(1);
+      expect(addLabels).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a secondary rate limit and succeeds (self-heals)', async () => {
+      const { addLabels } = await labelMocks();
+      // retry-after: 0 → instant retry, keeps the test fast.
+      addLabels
+        .mockRejectedValueOnce({
+          status: 403,
+          response: {
+            headers: { 'retry-after': '0', 'x-ratelimit-remaining': '4999' },
+            data: { message: 'You have exceeded a secondary rate limit' },
+          },
+        })
+        .mockResolvedValueOnce({});
+
+      await new GitHubService(makeConfig()).addLabel(7, 'priority-high');
+
+      expect(addLabels).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry a permission 403 and surfaces a permission error', async () => {
+      const { addLabels } = await labelMocks();
+      addLabels.mockRejectedValue({ status: 403, response: { headers: {}, data: { message: 'Resource not accessible by integration' } } });
+
+      await expect(new GitHubService(makeConfig()).addLabel(7, 'priority-high')).rejects.toThrow(/permission missing/);
+      // One real attempt — permission denials are fatal, not retried.
+      expect(addLabels).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/gui/src/lib/sync/classify-sync-error.ts
+++ b/packages/gui/src/lib/sync/classify-sync-error.ts
@@ -1,20 +1,38 @@
+import { GitHubApiError } from '@cezar/core';
 import type { SyncErrorKind } from '@/lib/supabase/types';
 
 // ─────────────────────────────────────────────────────────────────────
 // §3: Stale & actionable states — classify a caught sync error into a
 // `SyncErrorKind` so the indicator can show a recovery CTA instead of a raw
-// message. We string-match the *normalized* error messages thrown by core's
-// `GitHubService#handleError` (401/403/404) and `GitHubAppService
-// #getInstallationToken` ("App is not installed …"), and also tolerate the raw
-// Octokit `.status` shape in case an un-normalized error bubbles up.
+// message. Core now throws a `GitHubApiError` carrying the precise `kind`
+// (auth / permission / primary- & secondary-rate-limit / not-found), so we map
+// that directly; the `.status` and message fallbacks cover any un-normalized
+// error that bubbles up (`GitHubAppService#getInstallationToken` etc.).
 // ─────────────────────────────────────────────────────────────────────
 export function classifySyncError(err: unknown): SyncErrorKind {
-  // Raw Octokit errors carry a numeric `.status`; map it directly when present
-  // (a 403 here is GitHub's combined rate-limit/forbidden, matching handleError).
+  // Precise path: core's classified GitHub error.
+  if (err instanceof GitHubApiError) {
+    switch (err.kind) {
+      case 'auth':
+      // A permission gap (App lacks Issues/PRs write) is recovered the same
+      // way as auth — reconnect / re-accept the install — so route it to 'auth'.
+      case 'permission':
+        return 'auth';
+      case 'primary-rate-limit':
+      case 'secondary-rate-limit':
+        return 'rate_limit';
+      case 'not-found':
+        return 'not_found';
+      default:
+        return 'unknown';
+    }
+  }
+
+  // Raw Octokit errors carry a numeric `.status`; map it when present.
   if (err && typeof err === 'object' && 'status' in err) {
     const status = (err as { status: unknown }).status;
     if (status === 401) return 'auth';
-    if (status === 403) return 'rate_limit';
+    if (status === 403 || status === 429) return 'rate_limit';
     if (status === 404) return 'not_found';
   }
 
@@ -23,16 +41,22 @@ export function classifySyncError(err: unknown): SyncErrorKind {
   // 401 → invalid/revoked token; App-uninstalled is also an auth-recovery case.
   if (
     message.includes('Invalid GitHub token') ||
+    message.includes('Invalid or expired GitHub token') ||
+    message.includes('permission missing') ||
     message.includes('GitHub App is not installed')
   ) {
     return 'auth';
   }
-  // 403 → GitHub's "rate limit exceeded or access forbidden" (treat as transient).
-  if (message.includes('rate limit exceeded or access forbidden')) {
+  // Rate limits (new precise messages + the legacy combined one).
+  if (
+    message.includes('rate limit exceeded or access forbidden') ||
+    message.includes('secondary (anti-burst) rate limit') ||
+    message.includes('API rate limit exhausted')
+  ) {
     return 'rate_limit';
   }
-  // 404 → "Repo '…' not found or inaccessible."
-  if (message.includes('not found or inaccessible')) {
+  // 404 → "… not found or is inaccessible." (legacy: "not found or inaccessible")
+  if (message.includes('not found or inaccessible') || message.includes('not found or is inaccessible')) {
     return 'not_found';
   }
   return 'unknown';


### PR DESCRIPTION
## Problem

Label changes from the triage/duplicates action failed with **"GitHub API rate limit exceeded or access forbidden."** and the audit told the user to *apply manually* — while the bot had just **successfully posted a comment** in the same run.

## Two possible root causes — and the message couldn't tell them apart

`GitHubService#handleError` collapsed **every** 403 (secondary rate limit, primary rate limit, *and* genuine permission denial) into one string, and there was **no retry**. So both of these looked identical:

1. **Secondary (anti-burst) rate limit** — transient 403s on a burst of mutating requests; clears in seconds. Real if Cezar is using a **GitHub App token** (where commenting and labeling are the *same* `Issues: write` permission, so a successful comment ⟹ labels should work).
2. **Permission denial** — real if Cezar fell back to a **user OAuth token** (App not installed/configured). On GitHub a *user* with read access **can comment but needs the Triage role to add/remove labels** — so "comment worked, labeling 403'd" is expected and is **not** a rate limit. (Thanks to the reviewer who flagged that external contributors can comment but not label — that's exactly this case.)

Which one applies depends on the token: the cron path prefers the App installation token but **falls back to a workspace admin's OAuth token** (`execute-workflow-job.ts` / `execute-action-job.ts` → `resolveWorkspaceToken`) when the App isn't installed.

## Fix

- **`classifyGitHubError`** — inspects `status` + `response.headers`/`message` to distinguish `auth` / `permission` / `primary-rate-limit` / `secondary-rate-limit` / `not-found`.
- **`GitHubApiError`** carries the classified `kind` + `status`; **`toGitHubApiError`** builds accurate messages. The **permission** message now branches:
  - *App token* (`Resource not accessible by integration`) → "the GitHub App installation lacks permission — grant Issues/PRs write and re-accept."
  - *User token* → "the connected account lacks the repo role; commenting needs read, labeling needs Triage — install the Cezar GitHub App (recommended) or grant Triage+."
- **`withWriteRetry`** wraps label/comment writes — retries **only** secondary rate limits (honors `Retry-After`, capped backoff, 4 attempts), fails fast on permission/auth/primary, logs `x-ratelimit-*` so the cause is visible.
- **`addLabel`** drops the unconditional `getLabel` probe (2-3 requests → 1); creates the repo label only on 404/422.
- GUI `classifySyncError` + `isAuthOrRateLimitError` understand the new kinds (permission → 'auth' recovery CTA).

Net effect: the audit comment now states the **real** cause instead of the misleading "rate limit OR forbidden", and transient secondary limits self-heal.

## Recommended operational fix
Install the **Cezar GitHub App** on the org/repo. Its `Issues: Read & write` applies regardless of which user connected the workspace — so labeling no longer depends on the connecting account's repo role.

## Tests
`tests/services/github-error.test.ts` (new) + `github.service.test.ts`: classifier; App-vs-user permission messages; addLabel single-request path; 404→create+retry; secondary-limit retry self-heals; permission 403 not retried. Core build + vitest green (26/26 in the two GitHub files). Pre-existing `tests/store/*` failures are unrelated (fail on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)