### PR TITLE
docs(dev): document local GitHub OAuth provider setup

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -3,6 +3,7 @@
 Local development setup, tech stack, and extension points.
 
 - [Commands](#commands)
+- [GitHub login for local dev](#github-login-for-local-dev)
 - [Tech stack](#tech-stack)
 - [Adding a new Action](#adding-a-new-action)
 - [Adding a new effect](#adding-a-new-effect)
@@ -36,6 +37,81 @@ yarn db:reset                                # down -v && up -d (wipes data)
 yarn db:logs                                 # follow logs
 yarn db:psql                                 # psql -U postgres -d postgres
 ```
+
+---
+
+## GitHub login for local dev
+
+The local Supabase stack (`infra/supabase/`) ships with the GitHub auth
+provider **disabled**. Until you enable it, `Sign in with GitHub` returns
+`{"error_code":"validation_failed","msg":"Unsupported provider: provider is
+not enabled"}`. Email/password still works out of the box (GoTrue runs with
+`MAILER_AUTOCONFIRM=true`, so any address auto-confirms).
+
+> **Two different GitHub integrations — don't mix them up.** Local login uses a
+> classic **OAuth App** (`LOCAL_GITHUB_*` below). The webhooks / installation-token
+> path uses a **GitHub App** (`GITHUB_APP_*`, see
+> [`github-app-setup.md`](./github-app-setup.md)). A GitHub App client id
+> (`Iv23li…`) pasted into the OAuth slots fails at the profile fetch with
+> `403 Resource not accessible by integration`, because a GitHub App can't read
+> `/user/emails` via OAuth scopes. Use a real OAuth App here.
+
+### 1. Register a classic OAuth App
+
+Open GitHub → *Settings* → *Developer settings* → *OAuth Apps* → *New OAuth App*
+(<https://github.com/settings/applications/new>) and fill the form:
+
+- **Application name:** anything (e.g. `cezar local`).
+- **Homepage URL:** `http://localhost:3000`
+- **Authorization callback URL:** `http://127.0.0.1:54321/auth/v1/callback`
+  (this is GoTrue's `/callback` on the Supabase gateway, **not** the Next.js
+  `/auth/callback` route — the 54321 port, not 3000).
+- Leave **Enable Device Flow** unchecked.
+
+Click **Register application**, then **Generate a new client secret** and copy
+both the **Client ID** and the **Client secret** (the secret is shown once). A
+classic OAuth App client id is a 20-char hex / `Ov23…`-style string — **not** the
+`Iv23li…` GitHub App form.
+
+**Permissions / scopes.** A classic OAuth App has no per-permission toggles in
+the panel, access is granted through OAuth *scopes* requested at sign-in time.
+Cezar requests `read:user user:email repo` (see
+[`packages/gui/src/app/auth/actions.ts`](../packages/gui/src/app/auth/actions.ts)):
+
+- `read:user` — read the signed-in user's profile.
+- `user:email` — read the account's email addresses (required; without it the
+  profile fetch fails).
+- `repo` — read/write access to repositories so autofix runs can push branches
+  and open PRs.
+
+You approve these on GitHub's consent screen the first time you log in — just
+click **Authorize**. Nothing extra to configure in the OAuth App panel.
+
+### 2. Enable it in the stack
+
+Copy the template and fill it in:
+
+```bash
+cp infra/supabase/.env.example infra/supabase/.env
+```
+
+```dotenv
+LOCAL_GITHUB_ENABLED=true
+LOCAL_GITHUB_CLIENT_ID=<OAuth App client id>
+LOCAL_GITHUB_CLIENT_SECRET=<OAuth App client secret>
+```
+
+GoTrue reads these via `GOTRUE_EXTERNAL_GITHUB_*` in the compose file. The flag
+defaults to `false`, so `LOCAL_GITHUB_ENABLED=true` is required even with the
+id/secret set.
+
+### 3. Restart so compose re-reads `.env`
+
+```bash
+yarn db:stop && yarn db:start
+```
+
+A bare container restart won't pick up `.env` changes — you need `down` + `up`.
 
 ---
 

--- a/infra/supabase/.env.example
+++ b/infra/supabase/.env.example
@@ -2,15 +2,21 @@
 # docker compose auto-loads this file (same directory as the compose file).
 #
 # GitHub OAuth for local dev:
-#   1. Register a NEW OAuth App at https://github.com/settings/applications/new
+#   1. Register a NEW classic OAuth App at
+#      https://github.com/settings/applications/new
 #      (you cannot share the cloud Supabase app — classic GitHub OAuth Apps
-#       allow only one Authorization callback URL).
-#   2. Homepage URL:           http://127.0.0.1:3000
+#       allow only one Authorization callback URL). This is NOT a GitHub App:
+#       a GitHub App client id (Iv23li...) fails at the profile fetch with
+#       "403 Resource not accessible by integration". Use a classic OAuth App.
+#   2. Homepage URL:           http://localhost:3000
 #      Authorization callback: http://127.0.0.1:54321/auth/v1/callback
-#   3. Paste the resulting Client ID + Client Secret below.
+#   3. Set LOCAL_GITHUB_ENABLED=true and paste the Client ID + Client Secret.
 #
-# Leave blank to keep GitHub login disabled — email/password still works via
-# GoTrue's MAILER_AUTOCONFIRM=true (any address auto-confirms).
+# Leave LOCAL_GITHUB_ENABLED=false (or unset) to keep GitHub login disabled —
+# email/password still works via GoTrue's MAILER_AUTOCONFIRM=true (any address
+# auto-confirms). The flag defaults to false, so it must be true even with the
+# id/secret set. Restart with `yarn db:stop && yarn db:start` after editing.
 
+# LOCAL_GITHUB_ENABLED=false
 LOCAL_GITHUB_CLIENT_ID=
 LOCAL_GITHUB_CLIENT_SECRET=

--- a/packages/gui/README.md
+++ b/packages/gui/README.md
@@ -32,6 +32,9 @@ materializes a CEZAR `Store` from Postgres.
 
 4. Enable GitHub OAuth in **Supabase → Authentication → Providers → GitHub**
    (this is the Auth path used in Phase 1 — Phase 0 doesn't yet block on auth).
+   For the **local docker stack** (`yarn db:start`) the provider lives in
+   `infra/supabase/.env` instead — see
+   [GitHub login for local dev](../../docs/DEVELOPMENT.md#github-login-for-local-dev).
 
 5. Install and run:
    ```bash


### PR DESCRIPTION
## Summary

- New section in `docs/DEVELOPMENT.md` walking through enabling GitHub login on the local Supabase stack: classic OAuth App registration, the `Iv23li…` GitHub App vs OAuth App gotcha (which surfaces as `403 Resource not accessible by integration` at the profile fetch), required scopes (`read:user user:email repo`), the GoTrue callback URL on `127.0.0.1:54321` (not the Next.js `:3000`), and the `LOCAL_GITHUB_ENABLED` flag that gates the provider on top of the id/secret.
- `infra/supabase/.env.example` rewritten to match — clearer steps, the new flag, and the `yarn db:stop && yarn db:start` restart note (bare restart won't pick up `.env` changes).
- `packages/gui/README.md` step 4 links into the new section so the local-docker path isn't a dead end.

Motivation: I hit the `Unsupported provider: provider is not enabled` error followed by the `403` from pasting a GitHub App client id into the OAuth slots, and there was nothing in the docs to point at either one. This captures both so the next person doesn't have to rediscover them.

## Test plan

- [ ] Render `docs/DEVELOPMENT.md` and confirm the new TOC entry / anchor work
- [ ] Follow the section end-to-end on a clean checkout: register OAuth App → set `LOCAL_GITHUB_ENABLED=true` + id/secret → `yarn db:stop && yarn db:start` → `Sign in with GitHub` completes
- [ ] Verify leaving `LOCAL_GITHUB_ENABLED=false` keeps the previous email/password-only behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)