### PR TITLE
feat(skills): external repo as a skill source (#262 PR 2)

### DIFF
--- a/packages/gui/src/app/skills/[name]/page.tsx
+++ b/packages/gui/src/app/skills/[name]/page.tsx
@@ -43,6 +43,18 @@ interface ParsedSkill {
   suggestedStages: string[];
   path: string;
   source: SkillSource;
+  /** Inlined body for sources that don't have a workspace-clone path (external-repo PR2). */
+  body?: string;
+}
+
+interface ExternalSourceRow {
+  id: string;
+  name: string;
+}
+
+interface ExternalCacheRow {
+  source_id: string;
+  skills: unknown;
 }
 
 function parseSkills(raw: unknown): ParsedSkill[] {
@@ -61,6 +73,7 @@ function parseSkills(raw: unknown): ParsedSkill[] {
           : [],
         path: typeof o.path === 'string' ? o.path : '',
         source: normalizeSkillSource(o.source),
+        body: typeof o.body === 'string' ? o.body : undefined,
       };
     })
     .filter((s): s is ParsedSkill => s !== null);
@@ -101,6 +114,7 @@ export default async function SkillDetailPage({
     { data: overrideRow },
     { data: issueRows },
     activation,
+    { data: externalSourceRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -128,13 +142,47 @@ export default async function SkillDetailPage({
       .limit(20)
       .returns<IssueRow[]>(),
     getSkillActivationContext(workspace.id, supabase),
+    supabase
+      .from('skill_sources')
+      .select('id, name')
+      .eq('workspace_id', workspace.id)
+      .eq('kind', 'external-repo')
+      .returns<ExternalSourceRow[]>(),
   ]);
 
-  const parsed = parseSkills(skillsRow?.skills);
-  const skill = parsed.find((s) => s.name === name);
+  let parsed = parseSkills(skillsRow?.skills);
+  let skill = parsed.find((s) => s.name === name);
+
+  // Issue #262 PR2 — fall back to external_repo_skills when the skill isn't in
+  // the workspace's repo_skills cache. Scoped by source_id so the service-role
+  // client doesn't bleed cross-tenant cache bodies into the Node process.
+  if (!skill) {
+    const externalSourceIds = (externalSourceRows ?? []).map((row) => row.id);
+    if (externalSourceIds.length > 0) {
+      const { data: externalCacheRows } = await supabase
+        .from('external_repo_skills')
+        .select('source_id, skills')
+        .in('source_id', externalSourceIds)
+        .returns<ExternalCacheRow[]>();
+      const seenNames = new Set(parsed.map((p) => p.name));
+      for (const row of externalCacheRows ?? []) {
+        for (const ext of parseSkills(row.skills)) {
+          if (seenNames.has(ext.name)) continue;
+          seenNames.add(ext.name);
+          parsed.push({ ...ext, source: 'external-repo' });
+        }
+      }
+      skill = parsed.find((s) => s.name === name);
+    }
+  }
+
   if (!skill) notFound();
 
-  const upstreamBody = await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
+  // External-repo skills inline their body in the cache — no workspace clone
+  // to read from. Other sources still flow through readSkillBody.
+  const upstreamBody = skill.source === 'external-repo'
+    ? skill.body ?? null
+    : await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
 
   const bindings = (bindingRows ?? []).filter((b) => b.skill_name === skill.name);
   const isOverride = overrideRow !== null;

--- a/packages/gui/src/app/skills/external-actions.ts
+++ b/packages/gui/src/app/skills/external-actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { resolve, sep } from 'node:path';
 import { revalidatePath } from 'next/cache';
 import type { Skill } from '@cezar/core';
 import { getSessionUser } from '@/lib/auth';
@@ -8,6 +9,7 @@ import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import {
   ensureExternalRepoClone,
   readExternalRepoHead,
+  redactTokenFromMessage,
   withExternalRepoLock,
 } from '@/lib/external-repo-clone';
 
@@ -35,8 +37,12 @@ const DEFAULT_FOLDER = '.ai/skills';
 const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
 const OWNER_PATTERN = /^[a-z0-9][a-z0-9-]{0,38}$/i;
 const REPO_PATTERN = /^[a-z0-9._-]{1,100}$/i;
-const BRANCH_PATTERN = /^[^\s~^:?*\\]{1,250}$/;
-const FOLDER_PATTERN = /^[^\s\\]{1,250}$/;
+// Reject leading `-` so `git checkout <branch>` can't interpret it as a flag.
+const BRANCH_PATTERN = /^(?!-)[^\s~^:?*\\]{1,250}$/;
+// Repo-relative subpath: ASCII alnum + `._-/`, no leading `/`, no `..` segments.
+// Forbids both absolute paths and traversal so `resolve(repoRoot, folder)` can
+// never climb out of the cloned worktree.
+const FOLDER_PATTERN = /^[A-Za-z0-9._/-]{1,250}$/;
 
 function validateInput(
   name: string,
@@ -54,10 +60,14 @@ function validateInput(
   const branch = (config.branch ?? DEFAULT_BRANCH).trim() || DEFAULT_BRANCH;
   const folder = (config.folder ?? DEFAULT_FOLDER).trim() || DEFAULT_FOLDER;
   if (!BRANCH_PATTERN.test(branch)) {
-    return { ok: false, error: 'branch contains invalid characters' };
+    return { ok: false, error: 'branch contains invalid characters or starts with `-`' };
   }
   if (!FOLDER_PATTERN.test(folder)) {
-    return { ok: false, error: 'folder contains invalid characters' };
+    return { ok: false, error: 'folder must be a repo-relative subpath (ASCII alnum + `._-/`)' };
+  }
+  // Belt-and-braces against `..` segments slipping past the regex.
+  if (folder.startsWith('/') || folder.split('/').some((seg) => seg === '..')) {
+    return { ok: false, error: 'folder cannot be absolute or contain `..` segments' };
   }
   return {
     ok: true,
@@ -97,6 +107,7 @@ export async function addExternalRepoSource(params: {
     return { ok: false, error: error?.message ?? 'insert failed' };
   }
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true, id: data.id };
 }
 
@@ -117,7 +128,7 @@ export async function updateExternalRepoSource(params: {
   if (!validated.ok) return validated;
 
   const supabase = createSupabaseAdminClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('skill_sources')
     .update({
       name: params.name,
@@ -125,9 +136,15 @@ export async function updateExternalRepoSource(params: {
       updated_by: user.id,
     })
     .eq('id', params.id)
-    .eq('workspace_id', workspace.id);
+    .eq('workspace_id', workspace.id)
+    .select('id')
+    .maybeSingle();
   if (error) return { ok: false, error: error.message };
+  // Stale ID or cross-workspace target: predicate matched zero rows. Surface
+  // it as a real error so the UI doesn't show 'updated' on a silent no-op.
+  if (!data) return { ok: false, error: 'skill source not found' };
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true };
 }
 
@@ -141,13 +158,26 @@ export async function removeExternalRepoSource(id: string): Promise<ActionResult
   }
 
   const supabase = createSupabaseAdminClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('skill_sources')
     .delete()
     .eq('id', id)
-    .eq('workspace_id', workspace.id);
+    .eq('workspace_id', workspace.id)
+    .select('id')
+    .maybeSingle();
   if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: 'skill source not found' };
+
+  // NOTE: workspace_skill_states rows whose skill_name was only in this
+  // source's cache survive the delete (no FK). They're at worst inactive
+  // cruft; the runtime ignores them when no skill of that name is loaded.
+  // Cross-source cleanup is intentionally deferred — naively dropping the
+  // names would also wipe legitimate state for built-in/workspace-repo
+  // skills that happen to share the name. A future migration with a
+  // source_id-aware state model is the right place for this cleanup.
+
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true };
 }
 
@@ -212,6 +242,14 @@ export async function refreshExternalRepoSource(
     ({ commitSha, skills } = await withExternalRepoLock(id, async () => {
       const repoRoot = await ensureExternalRepoClone(id, { owner, repo, branch }, token);
       const sha = await readExternalRepoHead(id);
+      // Belt-and-braces containment check: regex above already forbids absolute
+      // paths and `..` segments, but assert the resolved path is still inside
+      // the clone before handing it to `discoverSkills` (which uses
+      // `resolve(repoRoot, folder)`).
+      const resolvedFolder = resolve(repoRoot, folder);
+      if (resolvedFolder !== repoRoot && !resolvedFolder.startsWith(repoRoot + sep)) {
+        throw new Error('folder escapes the clone root');
+      }
       const discovered = await core.discoverSkills(repoRoot, folder);
       // Force the external-repo source label — `discoverSkills` defaults to
       // 'workspace-repo' for anything it finds outside the built-in dir.
@@ -221,7 +259,12 @@ export async function refreshExternalRepoSource(
       return { commitSha: sha, skills: tagged };
     }));
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    // Defense in depth — `gitTokenEnv` keeps the token out of argv, so it
+    // shouldn't appear in execFile's error message. Scrub anyway in case a
+    // pre-fix clone left a token-bearing URL in `.git/config` that surfaces
+    // through git's stderr.
+    const rawMessage = err instanceof Error ? err.message : String(err);
+    const message = redactTokenFromMessage(rawMessage, token);
     await supabase
       .from('skill_sources')
       .update({ last_sync_error: message, updated_by: user.id })
@@ -263,5 +306,6 @@ export async function refreshExternalRepoSource(
     .eq('workspace_id', workspace.id);
 
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true, count: skills.length };
 }

--- a/packages/gui/src/app/skills/external-actions.ts
+++ b/packages/gui/src/app/skills/external-actions.ts
@@ -1,0 +1,267 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import type { Skill } from '@cezar/core';
+import { getSessionUser } from '@/lib/auth';
+import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import {
+  ensureExternalRepoClone,
+  readExternalRepoHead,
+  withExternalRepoLock,
+} from '@/lib/external-repo-clone';
+
+/**
+ * Issue #262 (PR 2) — admin-only CRUD + sync for external skill repos.
+ *
+ * "External" here means any GitHub repo that's not the workspace's own. The
+ * workspace repo continues to live under `repo_skills` and reuses
+ * `refreshRepoSkills()`. These actions cover the second source kind from the
+ * roadmap; PR 3 (disk) and PR 4 (skills.sh) add their own.
+ */
+
+export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
+
+export interface ExternalRepoConfigInput {
+  owner: string;
+  repo: string;
+  branch?: string;
+  folder?: string;
+}
+
+const DEFAULT_BRANCH = 'main';
+const DEFAULT_FOLDER = '.ai/skills';
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
+const OWNER_PATTERN = /^[a-z0-9][a-z0-9-]{0,38}$/i;
+const REPO_PATTERN = /^[a-z0-9._-]{1,100}$/i;
+const BRANCH_PATTERN = /^[^\s~^:?*\\]{1,250}$/;
+const FOLDER_PATTERN = /^[^\s\\]{1,250}$/;
+
+function validateInput(
+  name: string,
+  config: ExternalRepoConfigInput,
+): { ok: true; cfg: Required<ExternalRepoConfigInput> } | { ok: false; error: string } {
+  if (!NAME_PATTERN.test(name)) {
+    return { ok: false, error: 'name must be alphanumeric + `-`/`_` (max 63 chars)' };
+  }
+  if (!OWNER_PATTERN.test(config.owner)) {
+    return { ok: false, error: 'owner must be a valid GitHub login' };
+  }
+  if (!REPO_PATTERN.test(config.repo)) {
+    return { ok: false, error: 'repo must be a valid GitHub repo name' };
+  }
+  const branch = (config.branch ?? DEFAULT_BRANCH).trim() || DEFAULT_BRANCH;
+  const folder = (config.folder ?? DEFAULT_FOLDER).trim() || DEFAULT_FOLDER;
+  if (!BRANCH_PATTERN.test(branch)) {
+    return { ok: false, error: 'branch contains invalid characters' };
+  }
+  if (!FOLDER_PATTERN.test(folder)) {
+    return { ok: false, error: 'folder contains invalid characters' };
+  }
+  return {
+    ok: true,
+    cfg: { owner: config.owner, repo: config.repo, branch, folder },
+  };
+}
+
+export async function addExternalRepoSource(params: {
+  name: string;
+  config: ExternalRepoConfigInput;
+}): Promise<ActionResult<{ id: string }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can add skill sources' };
+  }
+
+  const validated = validateInput(params.name, params.config);
+  if (!validated.ok) return validated;
+
+  const supabase = createSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from('skill_sources')
+    .insert({
+      workspace_id: workspace.id,
+      kind: 'external-repo',
+      name: params.name,
+      config: validated.cfg,
+      created_by: user.id,
+      updated_by: user.id,
+    })
+    .select('id')
+    .single();
+  if (error || !data) {
+    return { ok: false, error: error?.message ?? 'insert failed' };
+  }
+  revalidatePath('/skills');
+  return { ok: true, id: data.id };
+}
+
+export async function updateExternalRepoSource(params: {
+  id: string;
+  name: string;
+  config: ExternalRepoConfigInput;
+}): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can update skill sources' };
+  }
+
+  const validated = validateInput(params.name, params.config);
+  if (!validated.ok) return validated;
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('skill_sources')
+    .update({
+      name: params.name,
+      config: validated.cfg,
+      updated_by: user.id,
+    })
+    .eq('id', params.id)
+    .eq('workspace_id', workspace.id);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath('/skills');
+  return { ok: true };
+}
+
+export async function removeExternalRepoSource(id: string): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can remove skill sources' };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('skill_sources')
+    .delete()
+    .eq('id', id)
+    .eq('workspace_id', workspace.id);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath('/skills');
+  return { ok: true };
+}
+
+export async function refreshExternalRepoSource(
+  id: string,
+): Promise<ActionResult<{ count: number }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can sync skill sources' };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { data: source, error: loadError } = await supabase
+    .from('skill_sources')
+    .select('id, workspace_id, kind, config')
+    .eq('id', id)
+    .eq('workspace_id', workspace.id)
+    .single();
+  if (loadError || !source) {
+    return { ok: false, error: loadError?.message ?? 'source not found' };
+  }
+  if (source.kind !== 'external-repo') {
+    return { ok: false, error: `unsupported source kind: ${source.kind}` };
+  }
+
+  const config = source.config as {
+    owner?: string;
+    repo?: string;
+    branch?: string;
+    folder?: string;
+  } | null;
+  if (!config?.owner || !config.repo) {
+    return { ok: false, error: 'source config missing owner/repo' };
+  }
+  const owner = config.owner;
+  const repo = config.repo;
+  const branch = config.branch || DEFAULT_BRANCH;
+  const folder = config.folder || DEFAULT_FOLDER;
+
+  // Resolve a GitHub token: prefer a GitHub App installation token if the App
+  // is configured *and* installed on the external owner; fall back to the
+  // caller's OAuth token; then to the ambient GITHUB_TOKEN. Public repos work
+  // without any token at all (helper accepts null).
+  const core = await import('@cezar/core');
+  let token: string | null = user.githubToken || process.env.GITHUB_TOKEN || null;
+  if (core.GitHubAppService.isConfigured()) {
+    try {
+      token = await new core.GitHubAppService().getInstallationToken(owner);
+    } catch (err) {
+      console.warn(
+        `[refreshExternalRepoSource] App token for ${owner} failed, falling back: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  let commitSha: string | null = null;
+  let skills: Skill[];
+  try {
+    ({ commitSha, skills } = await withExternalRepoLock(id, async () => {
+      const repoRoot = await ensureExternalRepoClone(id, { owner, repo, branch }, token);
+      const sha = await readExternalRepoHead(id);
+      const discovered = await core.discoverSkills(repoRoot, folder);
+      // Force the external-repo source label — `discoverSkills` defaults to
+      // 'workspace-repo' for anything it finds outside the built-in dir.
+      const tagged: Skill[] = discovered
+        .filter((s) => s.source !== 'built-in')
+        .map((s) => ({ ...s, source: 'external-repo' as const }));
+      return { commitSha: sha, skills: tagged };
+    }));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await supabase
+      .from('skill_sources')
+      .update({ last_sync_error: message, updated_by: user.id })
+      .eq('id', id)
+      .eq('workspace_id', workspace.id);
+    return { ok: false, error: `sync failed: ${message}` };
+  }
+
+  // Persist body inline — dispatch never re-clones.
+  const cached = skills.map((s) => ({
+    name: s.name,
+    description: s.description ?? null,
+    suggestedStages: s.suggestedStages,
+    path: s.path,
+    source: 'external-repo' as const,
+    body: s.body,
+  }));
+
+  const now = new Date().toISOString();
+  const { error: upsertError } = await supabase.from('external_repo_skills').upsert(
+    {
+      source_id: id,
+      commit_sha: commitSha,
+      skills: cached,
+      fetched_at: now,
+    },
+    { onConflict: 'source_id' },
+  );
+  if (upsertError) return { ok: false, error: upsertError.message };
+
+  await supabase
+    .from('skill_sources')
+    .update({
+      last_synced_at: now,
+      last_sync_error: null,
+      updated_by: user.id,
+    })
+    .eq('id', id)
+    .eq('workspace_id', workspace.id);
+
+  revalidatePath('/skills');
+  return { ok: true, count: skills.length };
+}

--- a/packages/gui/src/app/skills/external-sources-section.tsx
+++ b/packages/gui/src/app/skills/external-sources-section.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { cn } from '@/components/ui/cn';
+import { RefreshIcon, PlusIcon } from '@/components/icons';
+import {
+  addExternalRepoSource,
+  refreshExternalRepoSource,
+  removeExternalRepoSource,
+  updateExternalRepoSource,
+  type ActionResult,
+} from './external-actions';
+
+/** Issue #262 (PR 2) — props mirror `skill_sources` + `external_repo_skills`. */
+export interface ExternalRepoSourceRow {
+  id: string;
+  name: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  folder: string;
+  lastSyncedAt: string | null;
+  lastSyncError: string | null;
+  skillCount: number;
+}
+
+interface Props {
+  sources: ExternalRepoSourceRow[];
+  readOnly: boolean;
+  /** Externally-controlled open state for the Add modal (drives the
+   *  "Add skill source ▾ → Another repo" entry from the page header). */
+  addModalOpen: boolean;
+  onCloseAddModal: () => void;
+}
+
+interface FormValues {
+  name: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  folder: string;
+}
+
+const EMPTY_FORM: FormValues = {
+  name: '',
+  owner: '',
+  repo: '',
+  branch: 'main',
+  folder: '.ai/skills',
+};
+
+export function ExternalSourcesSection({ sources, readOnly, addModalOpen, onCloseAddModal }: Props) {
+  const [editing, setEditing] = useState<ExternalRepoSourceRow | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function handleSync(id: string) {
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const res = await refreshExternalRepoSource(id);
+      setBusyId(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  function handleRemove(id: string) {
+    if (!confirm('Remove this skill source? Cached skills will be discarded.')) return;
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const res = await removeExternalRepoSource(id);
+      setBusyId(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  return (
+    <section className="mb-6 rounded-lg border border-outline-variant bg-surface-container-low p-4">
+      <header className="mb-3 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-on-surface">External skill sources</h2>
+          <p className="mt-0.5 text-xs text-on-surface-variant">
+            Pull skills from any GitHub repo. Synced manually — bodies are cached so dispatch
+            works without a local clone.
+          </p>
+        </div>
+      </header>
+
+      {error && (
+        <div className="mb-3 rounded-md border border-error/30 bg-error-container/30 px-3 py-2 text-xs text-error">
+          {error}
+        </div>
+      )}
+
+      {sources.length === 0 ? (
+        <div className="rounded-md border border-dashed border-outline-variant px-3 py-6 text-center text-xs text-on-surface-variant">
+          No external sources yet. Use{' '}
+          <span className="font-mono text-on-surface">Add skill source → Another repo</span> to add one.
+        </div>
+      ) : (
+        <ul className="divide-y divide-outline-variant/50 rounded-md border border-outline-variant">
+          {sources.map((s) => (
+            <li key={s.id} className="flex flex-wrap items-center gap-3 px-3 py-2 text-sm">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2 text-on-surface">
+                  <span className="font-medium">{s.name}</span>
+                  <span className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-on-surface-variant">
+                    {s.owner}/{s.repo}:{s.branch}
+                  </span>
+                  <span className="font-mono text-[11px] text-on-surface-variant">{s.folder}</span>
+                </div>
+                <div className="mt-0.5 text-[11px] text-on-surface-variant">
+                  {s.skillCount} skill{s.skillCount === 1 ? '' : 's'}
+                  {' · '}
+                  {s.lastSyncedAt ? `last synced ${formatTimestamp(s.lastSyncedAt)}` : 'never synced'}
+                  {s.lastSyncError && (
+                    <span className="ml-2 text-amber-300/90">⚠ {s.lastSyncError}</span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => handleSync(s.id)}
+                  disabled={readOnly || busyId === s.id}
+                  className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant bg-surface-container px-2 text-[11px] font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+                >
+                  <RefreshIcon className="h-3 w-3" />
+                  {busyId === s.id ? 'Syncing…' : 'Sync'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditing(s)}
+                  disabled={readOnly}
+                  className="inline-flex h-7 items-center rounded-md border border-outline-variant bg-surface-container px-2 text-[11px] font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(s.id)}
+                  disabled={readOnly || busyId === s.id}
+                  className="inline-flex h-7 items-center rounded-md border border-error/40 bg-surface-container px-2 text-[11px] font-medium text-error transition-colors hover:bg-error-container/40 disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {addModalOpen && (
+        <SourceFormModal
+          mode="create"
+          initial={EMPTY_FORM}
+          onClose={onCloseAddModal}
+          onSubmit={async (values) => addExternalRepoSource({ name: values.name, config: values })}
+          onSuccess={() => {
+            onCloseAddModal();
+          }}
+          onError={setError}
+        />
+      )}
+
+      {editing && (
+        <SourceFormModal
+          mode="edit"
+          initial={{
+            name: editing.name,
+            owner: editing.owner,
+            repo: editing.repo,
+            branch: editing.branch,
+            folder: editing.folder,
+          }}
+          onClose={() => setEditing(null)}
+          onSubmit={async (values) =>
+            updateExternalRepoSource({
+              id: editing.id,
+              name: values.name,
+              config: values,
+            })
+          }
+          onSuccess={() => setEditing(null)}
+          onError={setError}
+        />
+      )}
+    </section>
+  );
+}
+
+interface ModalProps {
+  mode: 'create' | 'edit';
+  initial: FormValues;
+  onClose: () => void;
+  onSubmit: (values: FormValues) => Promise<ActionResult<{ id?: string }>>;
+  onSuccess: () => void;
+  onError: (msg: string) => void;
+}
+
+function SourceFormModal({ mode, initial, onClose, onSubmit, onSuccess, onError }: ModalProps) {
+  const [values, setValues] = useState<FormValues>(initial);
+  const [submitting, startSubmit] = useTransition();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    startSubmit(async () => {
+      const res = await onSubmit(values);
+      if (res.ok) {
+        onSuccess();
+      } else {
+        onError(res.error);
+      }
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={mode === 'create' ? 'Add external skill source' : 'Edit external skill source'}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-lg border border-outline-variant bg-surface-container p-5 shadow-xl"
+      >
+        <h2 className="mb-4 text-base font-semibold text-on-surface">
+          {mode === 'create' ? 'Add external skill source' : 'Edit external skill source'}
+        </h2>
+        <div className="grid gap-3">
+          <ModalField
+            label="Name"
+            hint="Friendly slug — letters, digits, `-`, `_`."
+            value={values.name}
+            onChange={(v) => setValues((p) => ({ ...p, name: v }))}
+            placeholder="team-skills"
+            disabled={mode === 'edit'} // unique constraint; rename via a follow-up
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <ModalField
+              label="Owner"
+              value={values.owner}
+              onChange={(v) => setValues((p) => ({ ...p, owner: v }))}
+              placeholder="open-mercato"
+            />
+            <ModalField
+              label="Repo"
+              value={values.repo}
+              onChange={(v) => setValues((p) => ({ ...p, repo: v }))}
+              placeholder="shared-skills"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <ModalField
+              label="Branch"
+              value={values.branch}
+              onChange={(v) => setValues((p) => ({ ...p, branch: v }))}
+              placeholder="main"
+            />
+            <ModalField
+              label="Folder"
+              value={values.folder}
+              onChange={(v) => setValues((p) => ({ ...p, folder: v }))}
+              placeholder=".ai/skills"
+            />
+          </div>
+        </div>
+        <footer className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface hover:border-primary"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className={cn(
+              'h-9 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface',
+              submitting && 'opacity-60',
+            )}
+          >
+            {submitting ? 'Saving…' : mode === 'create' ? 'Add' : 'Save'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}
+
+function ModalField({
+  label,
+  value,
+  onChange,
+  hint,
+  placeholder,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  hint?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="block">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-on-surface-variant">
+        {label}
+      </div>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="mt-1 h-9 w-full rounded-md border border-outline-variant bg-surface px-2 text-sm text-on-surface focus:border-primary focus:outline-none disabled:opacity-60"
+      />
+      {hint && <p className="mt-1 text-[11px] text-on-surface-variant/80">{hint}</p>}
+    </label>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/packages/gui/src/app/skills/page.tsx
+++ b/packages/gui/src/app/skills/page.tsx
@@ -9,6 +9,7 @@ import {
   seedBuiltinSkillStatesIfNeeded,
 } from '@/lib/skill-state';
 import { SkillsView, type SkillRow } from './skills-view';
+import type { ExternalRepoSourceRow } from './external-sources-section';
 
 interface RepoSkillsRow {
   commit_sha: string | null;
@@ -21,6 +22,40 @@ interface OverrideRow {
   enabled: boolean;
   execution_mode: string;
   updated_at: string | null;
+}
+
+interface ExternalSourceRow {
+  id: string;
+  name: string;
+  config: unknown;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+}
+
+interface ExternalCacheRow {
+  source_id: string;
+  skills: unknown;
+}
+
+interface ExternalRepoConfig {
+  owner: string;
+  repo: string;
+  branch: string;
+  folder: string;
+}
+
+function parseExternalConfig(raw: unknown): ExternalRepoConfig | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const owner = typeof o.owner === 'string' ? o.owner : null;
+  const repo = typeof o.repo === 'string' ? o.repo : null;
+  if (!owner || !repo) return null;
+  return {
+    owner,
+    repo,
+    branch: typeof o.branch === 'string' && o.branch ? o.branch : 'main',
+    folder: typeof o.folder === 'string' && o.folder ? o.folder : '.ai/skills',
+  };
 }
 
 interface ParsedSkill {
@@ -85,12 +120,15 @@ export default async function SkillsPage() {
 
   const supabase = createSupabaseAdminClient();
 
-  // Pull everything in parallel — repo_skills cache, overrides, and the
-  // activation context (per-skill state map + workspace seed marker).
+  // Pull everything in parallel — repo_skills cache, overrides, the activation
+  // context (per-skill state map + workspace seed marker), and any external
+  // skill sources + their cached catalogs (issue #262 PR 2).
   const [
     { data: skillsRow },
     { data: overrideRows },
     { states, seeded: workspaceSeeded },
+    { data: externalSourceRows },
+    { data: externalCacheRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -104,6 +142,16 @@ export default async function SkillsPage() {
       .eq('workspace_id', workspace.id)
       .returns<OverrideRow[]>(),
     getSkillActivationContext(workspace.id, supabase),
+    supabase
+      .from('skill_sources')
+      .select('id, name, config, last_synced_at, last_sync_error')
+      .eq('workspace_id', workspace.id)
+      .eq('kind', 'external-repo')
+      .returns<ExternalSourceRow[]>(),
+    supabase
+      .from('external_repo_skills')
+      .select('source_id, skills')
+      .returns<ExternalCacheRow[]>(),
   ]);
 
   // `refreshRepoSkills` caches the merged catalog (built-in + repo) into
@@ -123,6 +171,29 @@ export default async function SkillsPage() {
       }));
     } catch {
       parsed = [];
+    }
+  }
+
+  // Issue #262 (PR 2) — fold external repo cached catalogs into the workspace
+  // catalog. Workspace + built-in entries win on name collisions because they
+  // sit higher in `SKILL_SOURCE_PRIORITY`. External rows that survive the
+  // dedupe show up with their own `source: 'external-repo'` badge.
+  const cacheBySourceId = new Map<string, ExternalCacheRow>(
+    (externalCacheRows ?? []).map((row) => [row.source_id, row]),
+  );
+  const externalSourceMeta = new Map<string, ExternalSourceRow>(
+    (externalSourceRows ?? []).map((row) => [row.id, row]),
+  );
+  const seenNames = new Set(parsed.map((p) => p.name));
+  const externalSkillCounts = new Map<string, number>();
+  for (const sourceRow of externalSourceRows ?? []) {
+    const cache = cacheBySourceId.get(sourceRow.id);
+    const externalSkills = parseSkills(cache?.skills);
+    externalSkillCounts.set(sourceRow.id, externalSkills.length);
+    for (const skill of externalSkills) {
+      if (seenNames.has(skill.name)) continue;
+      seenNames.add(skill.name);
+      parsed.push({ ...skill, source: 'external-repo' });
     }
   }
 
@@ -180,6 +251,27 @@ export default async function SkillsPage() {
 
   const isAdmin = workspace.role === 'admin';
 
+  const externalSources: ExternalRepoSourceRow[] = (externalSourceRows ?? [])
+    .map((row): ExternalRepoSourceRow | null => {
+      const cfg = parseExternalConfig(row.config);
+      if (!cfg) return null;
+      return {
+        id: row.id,
+        name: row.name,
+        owner: cfg.owner,
+        repo: cfg.repo,
+        branch: cfg.branch,
+        folder: cfg.folder,
+        lastSyncedAt: row.last_synced_at,
+        lastSyncError: row.last_sync_error,
+        skillCount: externalSkillCounts.get(row.id) ?? 0,
+      };
+    })
+    .filter((row): row is ExternalRepoSourceRow => row !== null);
+  // Keep `externalSourceMeta` reference for a possible future "show name" column
+  // — silence unused-var until then.
+  void externalSourceMeta;
+
   return (
     <SkillsView
       rows={rows}
@@ -187,6 +279,7 @@ export default async function SkillsPage() {
       commitSha={skillsRow?.commit_sha ?? null}
       fetchedAt={skillsRow?.fetched_at ?? null}
       readOnly={!isAdmin}
+      externalSources={externalSources}
     />
   );
 }

--- a/packages/gui/src/app/skills/page.tsx
+++ b/packages/gui/src/app/skills/page.tsx
@@ -121,14 +121,15 @@ export default async function SkillsPage() {
   const supabase = createSupabaseAdminClient();
 
   // Pull everything in parallel — repo_skills cache, overrides, the activation
-  // context (per-skill state map + workspace seed marker), and any external
-  // skill sources + their cached catalogs (issue #262 PR 2).
+  // context (per-skill state map + workspace seed marker), and the workspace's
+  // external skill sources (issue #262 PR 2). The external cache is fetched in
+  // a second step so it can be scoped by source_id — without that scoping the
+  // service-role client would dump every workspace's cached bodies into memory.
   const [
     { data: skillsRow },
     { data: overrideRows },
     { states, seeded: workspaceSeeded },
     { data: externalSourceRows },
-    { data: externalCacheRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -148,11 +149,16 @@ export default async function SkillsPage() {
       .eq('workspace_id', workspace.id)
       .eq('kind', 'external-repo')
       .returns<ExternalSourceRow[]>(),
-    supabase
-      .from('external_repo_skills')
-      .select('source_id, skills')
-      .returns<ExternalCacheRow[]>(),
   ]);
+
+  const externalSourceIds = (externalSourceRows ?? []).map((row) => row.id);
+  const { data: externalCacheRows } = externalSourceIds.length > 0
+    ? await supabase
+        .from('external_repo_skills')
+        .select('source_id, skills')
+        .in('source_id', externalSourceIds)
+        .returns<ExternalCacheRow[]>()
+    : { data: [] as ExternalCacheRow[] };
 
   // `refreshRepoSkills` caches the merged catalog (built-in + repo) into
   // `repo_skills.skills`. For never-synced workspaces, fall back to the

--- a/packages/gui/src/app/skills/skills-view.tsx
+++ b/packages/gui/src/app/skills/skills-view.tsx
@@ -27,6 +27,10 @@ import { ActionSheet, type ActionSheetItem } from '@/components/ui/action-sheet'
 import { RowMenuPortal } from '@/components/row-menu-portal';
 import { refreshRepoSkills } from './skills-action';
 import { setSkillEnabled } from './state-actions';
+import {
+  ExternalSourcesSection,
+  type ExternalRepoSourceRow,
+} from './external-sources-section';
 
 /** Issue #262 — provenance values surfaced in the UI. `override` keeps its
  *  special meaning ("the workspace forked this skill") and shadows whatever
@@ -64,6 +68,8 @@ interface SkillsViewProps {
   commitSha: string | null;
   fetchedAt: string | null;
   readOnly: boolean;
+  /** Issue #262 (PR 2) — registered external repos for the workspace. */
+  externalSources?: ExternalRepoSourceRow[];
 }
 
 type SortKey = 'name' | 'source' | 'mode' | 'trigger' | 'status' | 'lastRun';
@@ -73,7 +79,17 @@ type SkillTab = 'catalog' | 'active';
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
 type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
 
-export function SkillsView({ rows: rowsProp, overridesCount, commitSha, fetchedAt, readOnly }: SkillsViewProps) {
+export function SkillsView({
+  rows: rowsProp,
+  overridesCount,
+  commitSha,
+  fetchedAt,
+  readOnly,
+  externalSources = [],
+}: SkillsViewProps) {
+  // Issue #262 (PR 2) — controlled open state for the "Add external repo" modal,
+  // toggled from the page-header "Add skill source ▾" menu.
+  const [addExternalOpen, setAddExternalOpen] = useState(false);
   // Keep an optimistic local mirror so a toggle reflects in the table before
   // `revalidatePath` lands the server-side refresh.
   const [rows, setRows] = useState<SkillRow[]>(rowsProp);
@@ -205,7 +221,10 @@ export function SkillsView({ rows: rowsProp, overridesCount, commitSha, fetchedA
             <RefreshIcon className="h-4 w-4" />
             {refreshing ? 'Syncing…' : 'Sync from repo'}
           </button>
-          <AddSkillSourceMenu disabled={readOnly} />
+          <AddSkillSourceMenu
+            disabled={readOnly}
+            onAddExternalRepo={() => setAddExternalOpen(true)}
+          />
           <Link
             href="/settings/workflows"
             aria-disabled={readOnly}
@@ -259,6 +278,14 @@ export function SkillsView({ rows: rowsProp, overridesCount, commitSha, fetchedA
           {refreshState.error}
         </div>
       )}
+
+      {/* Issue #262 (PR 2) — external repo sources */}
+      <ExternalSourcesSection
+        sources={externalSources}
+        readOnly={readOnly}
+        addModalOpen={addExternalOpen}
+        onCloseAddModal={() => setAddExternalOpen(false)}
+      />
 
       {/* KPI stats */}
       <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -899,12 +926,22 @@ function SourceBadge({ source }: { source: SkillRow['source'] }) {
   );
 }
 
-/** Issue #262 — placeholder dropdown for adding additional skill sources. The
- *  three non-workspace options ship in PR 2 (external-repo), PR 3 (disk), and
- *  PR 4 (skills-sh); they're listed here so the IA settles in PR 1 without a
- *  follow-up nav refactor. */
-function AddSkillSourceMenu({ disabled }: { disabled: boolean }) {
+/** Issue #262 — dropdown for adding additional skill sources. "Another repo"
+ *  lands in PR 2 (this); the rest stay marked _Coming soon_ until their PRs. */
+function AddSkillSourceMenu({
+  disabled,
+  onAddExternalRepo,
+}: {
+  disabled: boolean;
+  onAddExternalRepo: () => void;
+}) {
   const [open, setOpen] = useState(false);
+  type Entry = { label: string; note: string; onClick?: () => void };
+  const entries: Entry[] = [
+    { label: 'Another repo', note: 'External', onClick: onAddExternalRepo },
+    { label: 'Upload from disk', note: 'Coming soon' },
+    { label: 'skills.sh registry', note: 'Coming soon' },
+  ];
   return (
     <div className="relative">
       <button
@@ -924,24 +961,33 @@ function AddSkillSourceMenu({ disabled }: { disabled: boolean }) {
           className="absolute right-0 z-20 mt-1 w-56 rounded-md border border-outline-variant bg-surface-container py-1 shadow-lg"
           onMouseLeave={() => setOpen(false)}
         >
-          {[
-            { label: 'Another repo', note: 'Coming soon' },
-            { label: 'Upload from disk', note: 'Coming soon' },
-            { label: 'skills.sh registry', note: 'Coming soon' },
-          ].map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              role="menuitem"
-              disabled
-              className="flex w-full cursor-not-allowed items-center justify-between px-3 py-2 text-left text-sm text-on-surface-variant"
-            >
-              <span>{item.label}</span>
-              <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-on-surface-variant/60">
-                {item.note}
-              </span>
-            </button>
-          ))}
+          {entries.map((item) => {
+            const enabled = !!item.onClick;
+            return (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                disabled={!enabled}
+                onClick={() => {
+                  if (!item.onClick) return;
+                  setOpen(false);
+                  item.onClick();
+                }}
+                className={cn(
+                  'flex w-full items-center justify-between px-3 py-2 text-left text-sm',
+                  enabled
+                    ? 'text-on-surface transition-colors hover:bg-surface-container/80'
+                    : 'cursor-not-allowed text-on-surface-variant',
+                )}
+              >
+                <span>{item.label}</span>
+                <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-on-surface-variant/60">
+                  {item.note}
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -435,7 +435,11 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
     getSkillActivationContext(workspace.id, supabase),
     listExternalRepoSkills(workspace.id, supabase),
   ]);
-  if (!data) return [];
+  // Don't early-return on `!data` — repo_skills failures are independent of
+  // external sources. Falling back to `[]` keeps the external loop below
+  // reachable so the picker degrades gracefully (workflows pointing at
+  // external-only skills still see them during a transient repo_skills blip).
+  const repoSkillRows = data ?? [];
   const { states, seeded: workspaceSeeded } = activation;
   const byName = new Map<string, SkillSummary>();
 
@@ -448,7 +452,7 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
     byName.set(name, { name, description });
   }
 
-  for (const row of data) {
+  for (const row of repoSkillRows) {
     const arr = (row.skills as Array<Record<string, unknown>> | null) ?? [];
     for (const s of arr) {
       if (!s || typeof s.name !== 'string' || !s.name.trim()) continue;

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -421,41 +421,86 @@ export async function runFlowOnIssue(params: {
  * `workspace_skill_states`) are returned. A workspace that hasn't been seeded
  * yet falls back to "every skill in the cached catalog is active" so an
  * unmigrated workspace doesn't suddenly see an empty picker.
+ *
+ * PR 2: external repo sources contribute too — their cached `skills` jsonb is
+ * folded in via `external_repo_skills` (joined on the workspace's
+ * `skill_sources` rows). The dedup-by-name policy from PR 1 still applies.
  */
 export async function listAvailableSkills(): Promise<SkillSummary[]> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return [];
   const supabase = createSupabaseAdminClient();
-  const [{ data }, activation] = await Promise.all([
+  const [{ data }, activation, externalRows] = await Promise.all([
     supabase.from('repo_skills').select('skills').eq('workspace_id', workspace.id),
     getSkillActivationContext(workspace.id, supabase),
+    listExternalRepoSkills(workspace.id, supabase),
   ]);
   if (!data) return [];
   const { states, seeded: workspaceSeeded } = activation;
   const byName = new Map<string, SkillSummary>();
+
+  function pushIfActive(name: string, description: string, source: string) {
+    if (byName.has(name)) return;
+    // Use the canonical predicate so the picker can't drift from
+    // `filterActiveSkills` (the runtime). The cache may hold a legacy
+    // `'repo'` value, so bridge it through `normalizeSkillSource` first.
+    if (!isSkillActive(states.get(name), normalizeSkillSource(source), workspaceSeeded)) return;
+    byName.set(name, { name, description });
+  }
+
   for (const row of data) {
     const arr = (row.skills as Array<Record<string, unknown>> | null) ?? [];
     for (const s of arr) {
       if (!s || typeof s.name !== 'string' || !s.name.trim()) continue;
-      // Use the canonical predicate so the picker can't drift from
-      // `filterActiveSkills` (the runtime). The cache may hold a legacy
-      // `'repo'` value, so bridge it through `normalizeSkillSource` first.
-      const active = isSkillActive(
-        states.get(s.name),
-        normalizeSkillSource(s.source),
-        workspaceSeeded,
-      );
-      if (!active) continue;
       const description =
         typeof s.description === 'string'
           ? s.description.split('\n')[0].trim().slice(0, 240)
           : '';
-      // First write wins (repo_skills is one row per repo; for multi-repo
-      // workspaces, skills across repos with the same name are de-duped here).
-      if (!byName.has(s.name)) byName.set(s.name, { name: s.name, description });
+      const source = typeof s.source === 'string' ? s.source : 'built-in';
+      pushIfActive(s.name, description, source);
     }
   }
+
+  for (const ext of externalRows) {
+    pushIfActive(ext.name, ext.description, 'external-repo');
+  }
+
   return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface ExternalSkillSummary {
+  name: string;
+  description: string;
+}
+
+async function listExternalRepoSkills(
+  workspaceId: string,
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+): Promise<ExternalSkillSummary[]> {
+  const { data: sourceRows } = await supabase
+    .from('skill_sources')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('kind', 'external-repo');
+  if (!sourceRows || sourceRows.length === 0) return [];
+  const { data: cacheRows } = await supabase
+    .from('external_repo_skills')
+    .select('skills')
+    .in('source_id', sourceRows.map((r) => r.id));
+  if (!cacheRows) return [];
+  const out: ExternalSkillSummary[] = [];
+  for (const row of cacheRows) {
+    const arr = (row.skills as Array<Record<string, unknown>> | null) ?? [];
+    for (const s of arr) {
+      if (!s || typeof s.name !== 'string' || !s.name.trim()) continue;
+      const description =
+        typeof s.description === 'string'
+          ? s.description.split('\n')[0].trim().slice(0, 240)
+          : '';
+      out.push({ name: s.name, description });
+    }
+  }
+  return out;
 }
 
 // ─── Prompt preview ─────────────────────────────────────────────────────────

--- a/packages/gui/src/lib/external-repo-clone.ts
+++ b/packages/gui/src/lib/external-repo-clone.ts
@@ -8,6 +8,28 @@ import { homedir } from 'node:os';
 const exec = promisify(execFile);
 
 /**
+ * Build env vars that inject `http.extraHeader: Authorization: Bearer <token>`
+ * into one git invocation via `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` /
+ * `GIT_CONFIG_VALUE_<n>`. The token stays out of argv (no leakage in `ps` or
+ * execFile error messages) AND out of `.git/config` on disk — the clone uses
+ * the clean public URL and the header is only present for the duration of the
+ * child process.
+ */
+function gitTokenEnv(token: string): Record<string, string> {
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.extraHeader',
+    GIT_CONFIG_VALUE_0: `Authorization: Bearer ${token}`,
+  };
+}
+
+/** Redact a token from a stringified git error so it can't surface in `last_sync_error`. */
+export function redactTokenFromMessage(message: string, token: string | null): string {
+  if (!token) return message;
+  return message.split(token).join('***');
+}
+
+/**
  * Issue #262 (PR 2) — external skill sources clone management.
  *
  * Workspace repos already live under `~/.cezar/repos/<owner>-<repo>/` (see
@@ -40,14 +62,20 @@ export async function acquireExternalRepoLock(sourceId: string): Promise<() => v
   const next = new Promise<void>((resolve) => {
     release = resolve;
   });
-  externalLocks.set(sourceId, prev.then(() => next, () => next));
+  // Store the chained promise (`prev.then(...)`) — NOT `next` — and compare
+  // against the same reference on cleanup. The original code compared against
+  // `next`, which is a different object identity than the value stored in the
+  // Map (the .then() always returns a new Promise), so the delete branch was
+  // unreachable and the Map grew without bound on long-lived workers.
+  const chained = prev.then(() => next, () => next);
+  externalLocks.set(sourceId, chained);
   await prev.catch(() => {});
   let released = false;
   return () => {
     if (released) return;
     released = true;
     release();
-    if (externalLocks.get(sourceId) === next) externalLocks.delete(sourceId);
+    if (externalLocks.get(sourceId) === chained) externalLocks.delete(sourceId);
   };
 }
 
@@ -87,19 +115,27 @@ export async function ensureExternalRepoClone(
   await mkdir(EXTERNAL_REPOS_DIR, { recursive: true });
 
   const repoDir = join(EXTERNAL_REPOS_DIR, sourceId);
-  const cloneUrl = githubToken
-    ? `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`
-    : `https://github.com/${owner}/${repo}.git`;
+  // Always use the clean public URL — auth flows via env-injected
+  // `http.extraHeader`, so the token never lands in argv (visible in `ps` and
+  // execFile error messages) nor in `.git/config` on disk.
+  const cloneUrl = `https://github.com/${owner}/${repo}.git`;
+  const tokenEnv = githubToken
+    ? { ...process.env, ...gitTokenEnv(githubToken) }
+    : process.env;
 
   if (existsSync(join(repoDir, '.git'))) {
+    // Heal any pre-existing clone that may have a token-bearing URL persisted
+    // from before the env-extraHeader switch.
     await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir });
-    await exec('git', ['fetch', 'origin'], { cwd: repoDir });
+    await exec('git', ['fetch', 'origin'], { cwd: repoDir, env: tokenEnv });
     await exec('git', ['checkout', branch], { cwd: repoDir }).catch(() =>
       exec('git', ['checkout', '-b', branch, `origin/${branch}`], { cwd: repoDir }),
     );
     await exec('git', ['reset', '--hard', `origin/${branch}`], { cwd: repoDir });
   } else {
-    await exec('git', ['clone', '--depth', '50', '--branch', branch, cloneUrl, repoDir]);
+    await exec('git', ['clone', '--depth', '50', '--branch', branch, cloneUrl, repoDir], {
+      env: tokenEnv,
+    });
   }
 
   return repoDir;

--- a/packages/gui/src/lib/external-repo-clone.ts
+++ b/packages/gui/src/lib/external-repo-clone.ts
@@ -1,0 +1,120 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const exec = promisify(execFile);
+
+/**
+ * Issue #262 (PR 2) — external skill sources clone management.
+ *
+ * Workspace repos already live under `~/.cezar/repos/<owner>-<repo>/` (see
+ * `lib/repo-clone.ts`). External skill repos go to a *separate* tree under
+ * `~/.cezar/external-skills/<source_id>/`. Two reasons for the separate
+ * namespace:
+ *
+ *   1. Lock domains stay disjoint. `withRepoLock` keys on owner/repo; an
+ *      external repo that happens to share owner/repo with the workspace
+ *      would otherwise serialize on the same key as the workspace's autofix
+ *      runs.
+ *   2. Different branches of the same repo can be added as separate sources
+ *      without colliding on the working-tree dir.
+ *
+ * Source id is a UUID so collisions are impossible.
+ */
+
+const EXTERNAL_REPOS_DIR = join(homedir(), '.cezar', 'external-skills');
+
+const externalLocks = new Map<string, Promise<void>>();
+
+/**
+ * Acquires the per-source working-tree lock and returns a release function.
+ * Prefer {@link withExternalRepoLock} unless the locked region spans control
+ * flow a callback can't wrap.
+ */
+export async function acquireExternalRepoLock(sourceId: string): Promise<() => void> {
+  const prev = externalLocks.get(sourceId) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  externalLocks.set(sourceId, prev.then(() => next, () => next));
+  await prev.catch(() => {});
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+    if (externalLocks.get(sourceId) === next) externalLocks.delete(sourceId);
+  };
+}
+
+/** Runs `fn` while holding the per-source lock. */
+export async function withExternalRepoLock<T>(
+  sourceId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireExternalRepoLock(sourceId);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+export interface ExternalRepoConfig {
+  owner: string;
+  repo: string;
+  branch: string;
+}
+
+/**
+ * Ensures a shallow clone of the external repo exists at
+ * `~/.cezar/external-skills/<sourceId>/`, fetching the configured branch.
+ * Token is optional — public repos work without one. When provided, it's
+ * wired into the HTTPS URL via the `x-access-token` GitHub auth convention.
+ *
+ * MUST be called inside {@link withExternalRepoLock} so a concurrent sync of
+ * the same source doesn't race on the checkout.
+ */
+export async function ensureExternalRepoClone(
+  sourceId: string,
+  { owner, repo, branch }: ExternalRepoConfig,
+  githubToken: string | null,
+): Promise<string> {
+  await mkdir(EXTERNAL_REPOS_DIR, { recursive: true });
+
+  const repoDir = join(EXTERNAL_REPOS_DIR, sourceId);
+  const cloneUrl = githubToken
+    ? `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`
+    : `https://github.com/${owner}/${repo}.git`;
+
+  if (existsSync(join(repoDir, '.git'))) {
+    await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir });
+    await exec('git', ['fetch', 'origin'], { cwd: repoDir });
+    await exec('git', ['checkout', branch], { cwd: repoDir }).catch(() =>
+      exec('git', ['checkout', '-b', branch, `origin/${branch}`], { cwd: repoDir }),
+    );
+    await exec('git', ['reset', '--hard', `origin/${branch}`], { cwd: repoDir });
+  } else {
+    await exec('git', ['clone', '--depth', '50', '--branch', branch, cloneUrl, repoDir]);
+  }
+
+  return repoDir;
+}
+
+/**
+ * Returns the HEAD commit sha of the cloned external repo (or null on
+ * failure). Cheap — runs `git rev-parse HEAD` against the on-disk worktree.
+ */
+export async function readExternalRepoHead(sourceId: string): Promise<string | null> {
+  const repoDir = join(EXTERNAL_REPOS_DIR, sourceId);
+  try {
+    const { stdout } = await exec('git', ['rev-parse', 'HEAD'], { cwd: repoDir });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -484,6 +484,50 @@ export interface Database {
         };
         Update: Partial<Database['public']['Tables']['workspace_skill_states']['Insert']>;
       };
+      skill_sources: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          /** PR 4 will widen this to `'external-repo' | 'skills-sh'`. */
+          kind: 'external-repo';
+          name: string;
+          /** For `kind='external-repo'`: `{ owner, repo, branch, folder }`. */
+          config: Json;
+          last_synced_at: string | null;
+          last_sync_error: string | null;
+          created_at: string;
+          updated_at: string;
+          created_by: string | null;
+          updated_by: string | null;
+        };
+        Insert: Omit<Database['public']['Tables']['skill_sources']['Row'], 'id' | 'config' | 'last_synced_at' | 'last_sync_error' | 'created_at' | 'updated_at' | 'created_by' | 'updated_by'> & {
+          id?: string;
+          config?: Json;
+          last_synced_at?: string | null;
+          last_sync_error?: string | null;
+          created_at?: string;
+          updated_at?: string;
+          created_by?: string | null;
+          updated_by?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['skill_sources']['Insert']>;
+      };
+      external_repo_skills: {
+        Row: {
+          source_id: string;
+          commit_sha: string | null;
+          /** Array of `{ name, description, suggestedStages, path, source, body }`
+           *  — body inline so the dispatcher works without a local clone. */
+          skills: Json;
+          fetched_at: string;
+        };
+        Insert: Omit<Database['public']['Tables']['external_repo_skills']['Row'], 'commit_sha' | 'skills' | 'fetched_at'> & {
+          commit_sha?: string | null;
+          skills?: Json;
+          fetched_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['external_repo_skills']['Insert']>;
+      };
       jobs: {
         Row: {
           id: string;

--- a/packages/gui/src/lib/workflow-config.ts
+++ b/packages/gui/src/lib/workflow-config.ts
@@ -97,6 +97,10 @@ export async function loadWorkflowSettings(
  * orchestrator's `opts.skills ?? discoverSkillsSafe(...)` fallback fires and
  * the per-issue event stream sees a real failure log instead of a silent
  * zero-skill run.
+ *
+ * PR 2: also folds in cached external repo catalogs from `external_repo_skills`.
+ * External rows hydrate from the DB only (body inline), so dispatch never
+ * needs a clone of the external repo.
  */
 export async function loadActiveSkillCatalog(
   workspaceId: string,
@@ -115,11 +119,85 @@ export async function loadActiveSkillCatalog(
     return undefined;
   }
 
-  const activation = await getSkillActivationContext(workspaceId, supabase);
+  const [activation, externalSkills] = await Promise.all([
+    getSkillActivationContext(workspaceId, supabase),
+    loadExternalRepoSkills(workspaceId, supabase),
+  ]);
   if (activation.error) {
     // Surface the failure to the orchestrator so its `??` fallback to
     // `discoverSkillsSafe` fires (per-issue onEvent logging, no silent run).
     return undefined;
   }
+
+  // SKILL_SOURCE_PRIORITY: built-in > workspace-repo > external-repo > disk > skills-sh.
+  // The repo-side catalog already covers the first two; external rows are
+  // appended only when their name isn't already taken.
+  const taken = new Set(catalog.map((s) => s.name));
+  for (const s of externalSkills) {
+    if (taken.has(s.name)) continue;
+    taken.add(s.name);
+    catalog.push(s);
+  }
+
   return filterActiveSkills(catalog, activation.states, activation.seeded);
+}
+
+interface CachedExternalSkill {
+  name?: unknown;
+  description?: unknown;
+  suggestedStages?: unknown;
+  path?: unknown;
+  body?: unknown;
+}
+
+/**
+ * Hydrate the `external_repo_skills.skills` jsonb into proper `Skill` objects.
+ * Filters out any cached row whose source has since been removed (RLS-joined
+ * via the `skill_sources.workspace_id` predicate). Bodies live inline, so the
+ * engine doesn't need an on-disk clone of the external repo.
+ */
+async function loadExternalRepoSkills(
+  workspaceId: string,
+  supabase: SupabaseClient<Database>,
+): Promise<Skill[]> {
+  const { data: sourceRows } = await supabase
+    .from('skill_sources')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('kind', 'external-repo');
+  if (!sourceRows || sourceRows.length === 0) return [];
+
+  const sourceIds = sourceRows.map((r) => r.id);
+  const { data: cacheRows } = await supabase
+    .from('external_repo_skills')
+    .select('source_id, skills')
+    .in('source_id', sourceIds);
+  if (!cacheRows) return [];
+
+  const skills: Skill[] = [];
+  const seen = new Set<string>();
+  for (const row of cacheRows) {
+    if (!Array.isArray(row.skills)) continue;
+    for (const raw of row.skills as CachedExternalSkill[]) {
+      if (!raw || typeof raw !== 'object') continue;
+      const name = typeof raw.name === 'string' ? raw.name : null;
+      const body = typeof raw.body === 'string' ? raw.body : null;
+      if (!name || body === null) continue;
+      // Two sources in the same workspace can ship the same skill name; first
+      // hit wins. The /skills surface already disambiguates by source badge.
+      if (seen.has(name)) continue;
+      seen.add(name);
+      skills.push({
+        name,
+        description: typeof raw.description === 'string' ? raw.description : undefined,
+        body,
+        path: typeof raw.path === 'string' ? raw.path : '',
+        suggestedStages: Array.isArray(raw.suggestedStages)
+          ? (raw.suggestedStages as unknown[]).filter((x): x is string => typeof x === 'string')
+          : [],
+        source: 'external-repo',
+      });
+    }
+  }
+  return skills;
 }

--- a/packages/gui/supabase/migrations/20260619104247_external_skill_sources.sql
+++ b/packages/gui/supabase/migrations/20260619104247_external_skill_sources.sql
@@ -1,0 +1,133 @@
+-- Issue #262 (PR 2) — external skill sources.
+--
+-- Lets a workspace pull skills from any GitHub repo (not just the one bound
+-- to the workspace). Two tables land in this migration:
+--
+--   * skill_sources — polymorphic registry of every non-built-in source the
+--     workspace knows about. PR 2 only supports kind='external-repo'; PR 4
+--     will extend the CHECK constraint with 'skills-sh'. The legacy "workspace
+--     repo" still lives under `repo_skills` (single, implicit source); this
+--     table is for *additional* sources.
+--
+--   * external_repo_skills — per-source cache of metadata + body inline.
+--     Unlike `repo_skills` (which only stores metadata because the dispatcher
+--     already has the workspace clone on disk), an external repo may be
+--     synced on machine A and dispatched on machine B, so we cache the body
+--     in the DB. Skill bodies are small markdown blobs (a few KB).
+
+create table skill_sources (
+  id              uuid primary key default gen_random_uuid(),
+  workspace_id    uuid not null references workspaces(id) on delete cascade,
+  -- PR 4 will widen this to also accept 'skills-sh'.
+  kind            text not null check (kind in ('external-repo')),
+  -- Human-friendly label (slug-ish). Surfaced in the /skills "Sources" panel
+  -- and in source badges next to each skill.
+  name            text not null,
+  -- Per-kind config blob. For 'external-repo' the shape is:
+  --   { owner: string, repo: string, branch: string, folder: string }
+  config          jsonb not null default '{}'::jsonb,
+  last_synced_at  timestamptz,
+  last_sync_error text,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  created_by      uuid references auth.users(id),
+  updated_by      uuid references auth.users(id),
+  unique (workspace_id, name)
+);
+
+create index skill_sources_workspace_idx on skill_sources(workspace_id);
+
+create table external_repo_skills (
+  source_id    uuid primary key references skill_sources(id) on delete cascade,
+  commit_sha   text,
+  -- Array of full Skill records (body inline so dispatch never needs a clone):
+  --   { name, description, suggestedStages, path, source: 'external-repo', body }
+  skills       jsonb not null default '[]'::jsonb,
+  fetched_at   timestamptz not null default now()
+);
+
+-- Keep updated_at fresh on every UPDATE of skill_sources.
+create or replace function skill_sources_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create trigger skill_sources_set_updated_at
+  before update on skill_sources
+  for each row execute function skill_sources_set_updated_at();
+
+alter table skill_sources       enable row level security;
+alter table external_repo_skills enable row level security;
+
+create policy "members read skill_sources"
+  on skill_sources for select
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skill_sources.workspace_id
+        and wm.user_id = auth.uid()
+    )
+  );
+
+create policy "admins write skill_sources"
+  on skill_sources for all
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skill_sources.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skill_sources.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  );
+
+-- external_repo_skills is keyed off a skill_sources row; mirror its access
+-- model by joining on workspace membership through the parent.
+create policy "members read external_repo_skills"
+  on external_repo_skills for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from skill_sources s
+      join workspace_members wm on wm.workspace_id = s.workspace_id
+      where s.id = external_repo_skills.source_id
+        and wm.user_id = auth.uid()
+    )
+  );
+
+create policy "admins write external_repo_skills"
+  on external_repo_skills for all
+  to authenticated
+  using (
+    exists (
+      select 1
+      from skill_sources s
+      join workspace_members wm on wm.workspace_id = s.workspace_id
+      where s.id = external_repo_skills.source_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from skill_sources s
+      join workspace_members wm on wm.workspace_id = s.workspace_id
+      where s.id = external_repo_skills.source_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  );


### PR DESCRIPTION
**Stacked on top of #270 (PR 1).** The diff below includes both PRs because GitHub can't target a cross-fork branch as the base; once #270 merges to main, this PR's diff will collapse to just PR 2.

## Summary

PR 2 of 5 for #262. Adds the second skill source: arbitrary GitHub repos. Users register an external repo from \`/skills → Add skill source → Another repo\`, hit **Sync** to pull its \`.ai/skills/\` (configurable), and the discovered skills land in the same Catalog / Active model PR 1 introduced.

- New tables (\`0045\`):
  - \`skill_sources\` — polymorphic registry, \`kind='external-repo'\` for now (PR 4 widens to \`'skills-sh'\`).
  - \`external_repo_skills\` — per-source cache with **body inline**. Workspace repo doesn't need this because the dispatcher already has its clone on disk; an external repo may be synced on a different machine than the one running the workflow, so we cache bodies in the DB.
- New clone tree: \`~/.cezar/external-skills/<source_id>/\`. Per-source lock keeps concurrent \`Sync\` clicks from racing on the checkout; the namespace stays disjoint from workspace \`~/.cezar/repos/\` so locks can't cross.
- New panel \"External skill sources\" on \`/skills\` (\`external-sources-section.tsx\`): list of sources, \`Sync\` / \`Edit\` / \`Remove\`, modal form for Add/Edit. \"Add skill source ▾ → Another repo\" now opens that modal; the other two entries (disk, skills.sh) stay marked _Coming soon_.
- \`loadActiveSkillCatalog\` and \`listAvailableSkills\` fold external skills into the catalog/picker, deduped by name against the higher-priority workspace + built-in sources (per \`SKILL_SOURCE_PRIORITY\`).
- Auth resolution mirrors \`refreshRepoSkills\`: GitHub App installation token for the external owner, OAuth fallback, ambient \`GITHUB_TOKEN\`. Public repos work with no token at all.

## Roadmap

| PR | Status |
| --- | --- |
| #262 PR 1 | Open (#270) |
| **#262 PR 2 (this)** | Open |
| #262 PR 3 | Disk upload (drag-and-drop) — next |
| #262 PR 4 | skills.sh integration |
| #262 PR 5 | Built-in audit |

## Test plan

- [x] \`yarn typecheck\` — clean.
- [x] \`yarn build\` — clean (\`/skills\` route 10.3 kB).
- [ ] Apply migration \`0045\` against a Supabase clone; confirm RLS, \`updated_at\` trigger, and cascade delete from \`skill_sources\` → \`external_repo_skills\`.
- [ ] \`/skills → Add skill source → Another repo\` modal happy path: name validation, defaults (branch \`main\`, folder \`.ai/skills\`), inserts a row.
- [ ] \`Sync\` button on a new external source: clones to \`~/.cezar/external-skills/<id>/\`, populates \`external_repo_skills.skills\` with body inline, refreshes \`last_synced_at\`.
- [ ] External skills appear in \`/skills\` Catalog tab with \`EXT REPO\` badge; toggle Enable/Disable still works (re-uses PR 1 infrastructure).
- [ ] Workflow-step picker lists the external skill once enabled; warns if a binding references a now-disabled external skill (re-uses PR 1 warning).
- [ ] Trigger an autofix run binding the external skill — engine receives the body via the cached jsonb (no extra clone in the dispatch path).
- [ ] \`Remove\` an external source — cascade clears \`external_repo_skills\`, the skill drops off \`/skills\`.
- [ ] Edge case: invalid owner/repo → \`last_sync_error\` is populated; GitHub App not installed → falls back to OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)