### PR TITLE
feat(skills): skills.sh registry as a skill source (#262 PR 4)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -68,6 +68,15 @@ GITHUB_APP_ID=123456
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n"
 GITHUB_APP_WEBHOOK_SECRET=replace-me
 
+# ─── skills.sh (optional — issue #262 PR 4) ───────────────────────────────────
+# Required to install or refresh skills from https://skills.sh. Without it the
+# "Install from skills.sh" modal is disabled and existing imports keep working
+# but can't be refreshed. Use a Vercel OIDC bearer token (or a long-lived API
+# key if skills.sh issues one for your account). API base override is for
+# testing — leave commented to use the public skills.sh endpoint.
+# SKILLS_SH_TOKEN=
+# SKILLS_SH_API_BASE=https://skills.sh
+
 # ─── Workflow engine ──────────────────────────────────────────────────────────
 # `true` flips the engine on globally (recommended for self-hosted).
 CEZAR_USE_WORKFLOW_ENGINE=true

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,9 +129,11 @@ export {
   discoverBuiltinSkills,
   skillsForStage,
   normalizeSkillSource,
+  parseSkillMarkdown,
   SKILL_SOURCE_PRIORITY,
   type Skill,
   type SkillSource,
+  type ParsedSkillMarkdown,
 } from './skills/skill-catalog.js';
 
 // Data-driven actions runtime — system prompt + skill_refs + effects/tools.

--- a/packages/core/src/skills/skill-catalog.ts
+++ b/packages/core/src/skills/skill-catalog.ts
@@ -175,6 +175,44 @@ function loadBuiltinSkills(): Promise<Skill[]> {
   );
 }
 
+/**
+ * Issue #262 (PR 3) — public adapter around the internal `parseFrontmatter`
+ * parser, used by GUI when ingesting markdown that didn't come through
+ * `discoverSkills`. Pasting a skill into the upload modal or dropping a
+ * `.md` file goes through this so the parsing rules stay identical to what
+ * the dispatcher applies when reading skills off disk.
+ *
+ * `fallbackName` is consulted only when the markdown's frontmatter omits a
+ * `name:` field — typically the filename (without `.md`) for file uploads, or
+ * a user-supplied label when pasting raw text.
+ */
+export interface ParsedSkillMarkdown {
+  name: string | null;
+  description?: string;
+  suggestedStages: string[];
+  body: string;
+}
+
+export function parseSkillMarkdown(
+  raw: string,
+  fallbackName?: string,
+): ParsedSkillMarkdown {
+  const { frontmatter, body } = parseFrontmatter(raw);
+  const frontmatterName =
+    typeof frontmatter.name === 'string' && frontmatter.name.trim()
+      ? frontmatter.name.trim()
+      : null;
+  const description =
+    typeof frontmatter.description === 'string' && frontmatter.description.trim()
+      ? frontmatter.description.trim()
+      : undefined;
+  const suggestedStages = Array.isArray(frontmatter['cezar-stages'])
+    ? frontmatter['cezar-stages'].filter((s): s is string => typeof s === 'string')
+    : [];
+  const name = frontmatterName ?? (fallbackName?.trim() ? fallbackName.trim() : null);
+  return { name, description, suggestedStages, body };
+}
+
 /** Partition skills by whether their `suggestedStages` includes `stageId`. */
 export function skillsForStage(skills: Skill[], stageId: string): { suggested: Skill[]; others: Skill[] } {
   const suggested: Skill[] = [];

--- a/packages/core/src/skills/skill-catalog.ts
+++ b/packages/core/src/skills/skill-catalog.ts
@@ -235,7 +235,10 @@ function parseFrontmatter(
   raw: string,
   sourcePath?: string,
 ): { frontmatter: Record<string, FrontmatterValue>; body: string } {
-  const text = raw.replace(/\r\n/g, '\n');
+  // Normalize CRLF AND lone CR (legacy-Mac line endings) — otherwise a file
+  // with `\r`-only newlines fails `text.startsWith('---\n')`, frontmatter is
+  // silently dropped, and the whole document ends up dumped into `body`.
+  const text = raw.replace(/\r\n?/g, '\n');
   if (!text.startsWith('---\n')) return { frontmatter: {}, body: raw };
 
   // Match the closing delimiter only on its own line (`\n---\n`, or `\n---` at

--- a/packages/gui/src/app/skills/[name]/page.tsx
+++ b/packages/gui/src/app/skills/[name]/page.tsx
@@ -65,6 +65,16 @@ interface UploadedSkillRow {
   updated_at: string;
 }
 
+interface SkillsShRow {
+  name: string;
+  source_slug: string;
+  body: string;
+  description: string | null;
+  suggested_stages: unknown;
+  install_url: string | null;
+  last_synced_at: string;
+}
+
 function parseSkills(raw: unknown): ParsedSkill[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -124,6 +134,7 @@ export default async function SkillDetailPage({
     activation,
     { data: externalSourceRows },
     { data: uploadedRow },
+    { data: skillsShRow },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -165,6 +176,13 @@ export default async function SkillDetailPage({
       .eq('workspace_id', workspace.id)
       .eq('name', name)
       .maybeSingle<UploadedSkillRow>(),
+    // Issue #262 (PR 4) — same fallback for skills.sh imports.
+    supabase
+      .from('skills_sh_skills')
+      .select('name, source_slug, body, description, suggested_stages, install_url, last_synced_at')
+      .eq('workspace_id', workspace.id)
+      .eq('name', name)
+      .maybeSingle<SkillsShRow>(),
   ]);
 
   let parsed = parseSkills(skillsRow?.skills);
@@ -193,8 +211,7 @@ export default async function SkillDetailPage({
     }
   }
 
-  // Issue #262 PR3 — disk uploads are the last fallback when the name isn't
-  // anywhere else in the catalog.
+  // Issue #262 PR3 — disk uploads come next in the fallback chain.
   const isDisk = !skill && uploadedRow !== null;
   if (isDisk) {
     skill = {
@@ -206,19 +223,31 @@ export default async function SkillDetailPage({
     };
   }
 
+  // Issue #262 PR4 — skills.sh registry imports are the last fallback.
+  const isSkillsSh = !skill && skillsShRow !== null;
+  if (isSkillsSh) {
+    skill = {
+      name: skillsShRow!.name,
+      description: skillsShRow!.description,
+      suggestedStages: parseStringArray(skillsShRow!.suggested_stages),
+      path: '',
+      source: 'skills-sh',
+    };
+  }
+
   if (!skill) notFound();
 
-  // Resolve the body source per provenance: disk + external inline it in the
-  // DB cache; everything else still flows through `readSkillBody` against
-  // the workspace clone.
-  const upstreamBody = isDisk
+  // Resolve the body source per provenance: disk / skills.sh / external all
+  // inline the body in their DB cache; the legacy workspace/built-in/override
+  // path still flows through `readSkillBody` against the workspace clone.
+  const upstreamBody = isDisk || isSkillsSh
     ? null
     : skill.source === 'external-repo'
       ? skill.body ?? null
       : await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
 
   const bindings = (bindingRows ?? []).filter((b) => b.skill_name === skill.name);
-  const isOverride = !isDisk && overrideRow !== null;
+  const isOverride = !isDisk && !isSkillsSh && overrideRow !== null;
 
   // Issue #262 — runtime activation lives in `workspace_skill_states`, not
   // `skill_overrides.enabled`. Use the canonical predicate so the detail page
@@ -236,15 +265,29 @@ export default async function SkillDetailPage({
     name: skill.name,
     description: skill.description,
     path: skill.path,
-    body: isDisk ? uploadedRow!.body : isOverride ? overrideRow!.body : upstreamBody,
+    body: isDisk
+      ? uploadedRow!.body
+      : isSkillsSh
+        ? skillsShRow!.body
+        : isOverride
+          ? overrideRow!.body
+          : upstreamBody,
     upstreamBody,
-    source: isDisk ? 'disk' : isOverride ? 'override' : 'repo',
+    source: isDisk
+      ? 'disk'
+      : isSkillsSh
+        ? 'skills-sh'
+        : isOverride
+          ? 'override'
+          : 'repo',
     enabled,
     overrideUpdatedAt: isDisk
       ? uploadedRow!.updated_at
-      : isOverride
-        ? overrideRow!.updated_at
-        : null,
+      : isSkillsSh
+        ? skillsShRow!.last_synced_at
+        : isOverride
+          ? overrideRow!.updated_at
+          : null,
     metadata: {
       executionMode: isOverride ? overrideRow!.execution_mode : 'continuous',
       triggers: isOverride ? parseStringArray(overrideRow!.triggers) : ['issue-created'],

--- a/packages/gui/src/app/skills/[name]/page.tsx
+++ b/packages/gui/src/app/skills/[name]/page.tsx
@@ -43,6 +43,18 @@ interface ParsedSkill {
   suggestedStages: string[];
   path: string;
   source: SkillSource;
+  /** Inlined body for sources that don't have a workspace-clone path (external-repo PR2). */
+  body?: string;
+}
+
+interface ExternalSourceRow {
+  id: string;
+  name: string;
+}
+
+interface ExternalCacheRow {
+  source_id: string;
+  skills: unknown;
 }
 
 function parseSkills(raw: unknown): ParsedSkill[] {
@@ -61,6 +73,7 @@ function parseSkills(raw: unknown): ParsedSkill[] {
           : [],
         path: typeof o.path === 'string' ? o.path : '',
         source: normalizeSkillSource(o.source),
+        body: typeof o.body === 'string' ? o.body : undefined,
       };
     })
     .filter((s): s is ParsedSkill => s !== null);
@@ -101,6 +114,7 @@ export default async function SkillDetailPage({
     { data: overrideRow },
     { data: issueRows },
     activation,
+    { data: externalSourceRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -128,13 +142,47 @@ export default async function SkillDetailPage({
       .limit(20)
       .returns<IssueRow[]>(),
     getSkillActivationContext(workspace.id, supabase),
+    supabase
+      .from('skill_sources')
+      .select('id, name')
+      .eq('workspace_id', workspace.id)
+      .eq('kind', 'external-repo')
+      .returns<ExternalSourceRow[]>(),
   ]);
 
-  const parsed = parseSkills(skillsRow?.skills);
-  const skill = parsed.find((s) => s.name === name);
+  let parsed = parseSkills(skillsRow?.skills);
+  let skill = parsed.find((s) => s.name === name);
+
+  // Issue #262 PR2 — fall back to external_repo_skills when the skill isn't in
+  // the workspace's repo_skills cache. Scoped by source_id so the service-role
+  // client doesn't bleed cross-tenant cache bodies into the Node process.
+  if (!skill) {
+    const externalSourceIds = (externalSourceRows ?? []).map((row) => row.id);
+    if (externalSourceIds.length > 0) {
+      const { data: externalCacheRows } = await supabase
+        .from('external_repo_skills')
+        .select('source_id, skills')
+        .in('source_id', externalSourceIds)
+        .returns<ExternalCacheRow[]>();
+      const seenNames = new Set(parsed.map((p) => p.name));
+      for (const row of externalCacheRows ?? []) {
+        for (const ext of parseSkills(row.skills)) {
+          if (seenNames.has(ext.name)) continue;
+          seenNames.add(ext.name);
+          parsed.push({ ...ext, source: 'external-repo' });
+        }
+      }
+      skill = parsed.find((s) => s.name === name);
+    }
+  }
+
   if (!skill) notFound();
 
-  const upstreamBody = await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
+  // External-repo skills inline their body in the cache — no workspace clone
+  // to read from. Other sources still flow through readSkillBody.
+  const upstreamBody = skill.source === 'external-repo'
+    ? skill.body ?? null
+    : await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
 
   const bindings = (bindingRows ?? []).filter((b) => b.skill_name === skill.name);
   const isOverride = overrideRow !== null;

--- a/packages/gui/src/app/skills/[name]/page.tsx
+++ b/packages/gui/src/app/skills/[name]/page.tsx
@@ -57,6 +57,14 @@ interface ExternalCacheRow {
   skills: unknown;
 }
 
+interface UploadedSkillRow {
+  name: string;
+  body: string;
+  description: string | null;
+  suggested_stages: unknown;
+  updated_at: string;
+}
+
 function parseSkills(raw: unknown): ParsedSkill[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -115,6 +123,7 @@ export default async function SkillDetailPage({
     { data: issueRows },
     activation,
     { data: externalSourceRows },
+    { data: uploadedRow },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -148,6 +157,14 @@ export default async function SkillDetailPage({
       .eq('workspace_id', workspace.id)
       .eq('kind', 'external-repo')
       .returns<ExternalSourceRow[]>(),
+    // Issue #262 (PR 3) — disk uploads can shadow workspace skills on
+    // collision-free names; check if this `name` came from disk.
+    supabase
+      .from('uploaded_skills')
+      .select('name, body, description, suggested_stages, updated_at')
+      .eq('workspace_id', workspace.id)
+      .eq('name', name)
+      .maybeSingle<UploadedSkillRow>(),
   ]);
 
   let parsed = parseSkills(skillsRow?.skills);
@@ -176,16 +193,32 @@ export default async function SkillDetailPage({
     }
   }
 
+  // Issue #262 PR3 — disk uploads are the last fallback when the name isn't
+  // anywhere else in the catalog.
+  const isDisk = !skill && uploadedRow !== null;
+  if (isDisk) {
+    skill = {
+      name: uploadedRow!.name,
+      description: uploadedRow!.description,
+      suggestedStages: parseStringArray(uploadedRow!.suggested_stages),
+      path: '',
+      source: 'disk',
+    };
+  }
+
   if (!skill) notFound();
 
-  // External-repo skills inline their body in the cache — no workspace clone
-  // to read from. Other sources still flow through readSkillBody.
-  const upstreamBody = skill.source === 'external-repo'
-    ? skill.body ?? null
-    : await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
+  // Resolve the body source per provenance: disk + external inline it in the
+  // DB cache; everything else still flows through `readSkillBody` against
+  // the workspace clone.
+  const upstreamBody = isDisk
+    ? null
+    : skill.source === 'external-repo'
+      ? skill.body ?? null
+      : await readSkillBody(workspace.repoOwner, workspace.repoName, skill.path);
 
   const bindings = (bindingRows ?? []).filter((b) => b.skill_name === skill.name);
-  const isOverride = overrideRow !== null;
+  const isOverride = !isDisk && overrideRow !== null;
 
   // Issue #262 — runtime activation lives in `workspace_skill_states`, not
   // `skill_overrides.enabled`. Use the canonical predicate so the detail page
@@ -203,11 +236,15 @@ export default async function SkillDetailPage({
     name: skill.name,
     description: skill.description,
     path: skill.path,
-    body: isOverride ? overrideRow!.body : upstreamBody,
+    body: isDisk ? uploadedRow!.body : isOverride ? overrideRow!.body : upstreamBody,
     upstreamBody,
-    source: isOverride ? 'override' : 'repo',
+    source: isDisk ? 'disk' : isOverride ? 'override' : 'repo',
     enabled,
-    overrideUpdatedAt: isOverride ? overrideRow!.updated_at : null,
+    overrideUpdatedAt: isDisk
+      ? uploadedRow!.updated_at
+      : isOverride
+        ? overrideRow!.updated_at
+        : null,
     metadata: {
       executionMode: isOverride ? overrideRow!.execution_mode : 'continuous',
       triggers: isOverride ? parseStringArray(overrideRow!.triggers) : ['issue-created'],

--- a/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
+++ b/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
@@ -26,6 +26,10 @@ import {
   autosaveUploadedSkillBody,
   deleteUploadedSkill,
 } from './uploaded-actions';
+import {
+  refreshSkillsShSkillByName,
+  removeSkillsShSkillByName,
+} from './skills-sh-actions';
 
 export interface SkillDetail {
   name: string;
@@ -33,7 +37,7 @@ export interface SkillDetail {
   path: string;
   body: string | null;
   upstreamBody: string | null;
-  source: 'override' | 'repo' | 'built-in' | 'disk';
+  source: 'override' | 'repo' | 'built-in' | 'disk' | 'skills-sh';
   enabled: boolean;
   overrideUpdatedAt: string | null;
   metadata: {
@@ -86,10 +90,14 @@ export function SkillDetailView({ skill, readOnly }: Props) {
   // `uploaded_skills`, so they bypass the "fork upstream → override" handshake
   // entirely. `isDisk` toggles those branches throughout the component.
   const isDisk = skill.source === 'disk';
-  // Disk skills have no metadata save path — execution-mode / triggers /
-  // outputs / capabilities are derived from the uploaded file's frontmatter.
-  // Lock the controls so the user can't dirty state that has nowhere to land.
-  const metaReadOnly = readOnly || isDisk;
+  // Issue #262 (PR 4) — skills.sh imports are read-only mirrors of the
+  // remote registry; we expose Refresh + Remove instead of any save handshake.
+  const isSkillsSh = skill.source === 'skills-sh';
+  // Disk + skills.sh skills have no metadata save path — execution-mode /
+  // triggers / outputs / capabilities are derived from upstream (uploaded
+  // file's frontmatter or the registry payload). Lock the controls so the
+  // user can't dirty state that has nowhere to land.
+  const metaReadOnly = readOnly || isDisk || isSkillsSh;
   const router = useRouter();
   const [executionMode, setExecutionMode] = useState(skill.metadata.executionMode);
   const [triggers, setTriggers] = useState<Set<string>>(() => new Set(skill.metadata.triggers));
@@ -146,6 +154,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
   const bodyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (!bodyDirty || readOnly) return;
+    if (isSkillsSh) return; // skills.sh imports are read-only mirrors.
     if (!isDisk && !hasOverride) return;
     if (bodyTimerRef.current) clearTimeout(bodyTimerRef.current);
     bodyTimerRef.current = setTimeout(async () => {
@@ -169,7 +178,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
     return () => {
       if (bodyTimerRef.current) clearTimeout(bodyTimerRef.current);
     };
-  }, [body, bodyDirty, readOnly, hasOverride, isDisk, skill.name]);
+  }, [body, bodyDirty, readOnly, hasOverride, isDisk, isSkillsSh, skill.name]);
 
   const buildPayload = useCallback(
     (): OverridePayload => ({
@@ -202,6 +211,22 @@ export function SkillDetailView({ skill, readOnly }: Props) {
 
   async function handleDiscard() {
     if (readOnly) return;
+    // skills.sh imports — Discard means uninstall. Re-install brings them back.
+    if (isSkillsSh) {
+      const ok = window.confirm(
+        `Remove the skills.sh import "${skill.name}"? Re-install it from /skills to bring it back.`,
+      );
+      if (!ok) return;
+      setSaveState('saving');
+      const result = await removeSkillsShSkillByName(skill.name);
+      if (result.ok) {
+        router.push('/skills');
+      } else {
+        setSaveState('error');
+        setSaveError(result.error ?? 'Could not remove skills.sh import');
+      }
+      return;
+    }
     // Disk uploads have no upstream to fall back to — "Discard" deletes the
     // skill outright (no recovery from this side; user can re-upload).
     if (isDisk) {
@@ -340,13 +365,15 @@ export function SkillDetailView({ skill, readOnly }: Props) {
   }
 
   const dirty = bodyDirty || metaDirty;
-  const headerBadge: { label: string; tone: 'tertiary' | 'primary' | 'muted' } = isDisk
-    ? { label: 'DISK · UPLOADED', tone: 'tertiary' }
-    : hasOverride
-      ? enabled
-        ? { label: 'OVERRIDE · ACTIVE', tone: 'primary' }
-        : { label: 'OVERRIDE · DISABLED', tone: 'muted' }
-      : { label: 'AI_ASSISTED', tone: 'tertiary' };
+  const headerBadge: { label: string; tone: 'tertiary' | 'primary' | 'muted' } = isSkillsSh
+    ? { label: 'SKILLS.SH · SYNCED', tone: 'tertiary' }
+    : isDisk
+      ? { label: 'DISK · UPLOADED', tone: 'tertiary' }
+      : hasOverride
+        ? enabled
+          ? { label: 'OVERRIDE · ACTIVE', tone: 'primary' }
+          : { label: 'OVERRIDE · DISABLED', tone: 'muted' }
+        : { label: 'AI_ASSISTED', tone: 'tertiary' };
 
   return (
     <div className="flex min-h-[calc(100vh-56px)] flex-col">
@@ -636,16 +663,46 @@ export function SkillDetailView({ skill, readOnly }: Props) {
         <button
           type="button"
           onClick={handleDiscard}
-          disabled={readOnly || (!dirty && !hasOverride && !isDisk)}
+          disabled={readOnly || (!dirty && !hasOverride && !isDisk && !isSkillsSh)}
           className="inline-flex h-9 items-center gap-2 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface-variant transition-colors hover:border-primary hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {isDisk ? 'Delete uploaded skill' : hasOverride ? 'Delete override' : 'Discard changes'}
+          {isSkillsSh
+            ? 'Remove import'
+            : isDisk
+              ? 'Delete uploaded skill'
+              : hasOverride
+                ? 'Delete override'
+                : 'Discard changes'}
         </button>
         <div className="flex flex-wrap items-center gap-2">
           {saveError && <span className="text-xs text-error">{saveError}</span>}
+          {isSkillsSh && (
+            <button
+              type="button"
+              onClick={async () => {
+                setSaveState('saving');
+                const result = await refreshSkillsShSkillByName(skill.name);
+                if (result.ok) {
+                  setSaveState('saved');
+                  setSaveError(null);
+                  // The page-level loader will re-fetch on revalidatePath;
+                  // body state stays mirrored from the latest snapshot.
+                } else {
+                  setSaveState('error');
+                  setSaveError(result.error ?? 'Refresh failed');
+                }
+              }}
+              disabled={readOnly || saveState === 'saving'}
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-outline-variant bg-surface px-3 text-sm font-medium text-on-surface transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <RotateLeftIcon className="h-4 w-4" />
+              Refresh from skills.sh
+            </button>
+          )}
           {/* Save handshake only makes sense for repo/built-in skills — disk
-              uploads autosave directly into their own table. */}
-          {!isDisk && (
+              uploads autosave directly into their own table; skills.sh imports
+              are read-only mirrors. */}
+          {!isDisk && !isSkillsSh && (
             <>
               <button
                 type="button"

--- a/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
+++ b/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
@@ -86,6 +86,10 @@ export function SkillDetailView({ skill, readOnly }: Props) {
   // `uploaded_skills`, so they bypass the "fork upstream → override" handshake
   // entirely. `isDisk` toggles those branches throughout the component.
   const isDisk = skill.source === 'disk';
+  // Disk skills have no metadata save path — execution-mode / triggers /
+  // outputs / capabilities are derived from the uploaded file's frontmatter.
+  // Lock the controls so the user can't dirty state that has nowhere to land.
+  const metaReadOnly = readOnly || isDisk;
   const router = useRouter();
   const [executionMode, setExecutionMode] = useState(skill.metadata.executionMode);
   const [triggers, setTriggers] = useState<Set<string>>(() => new Set(skill.metadata.triggers));
@@ -407,7 +411,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                 setExecutionMode(v);
                 setMetaDirty(true);
               }}
-              disabled={readOnly}
+              disabled={metaReadOnly}
               options={EXECUTION_MODES}
             />
           </Field>
@@ -420,7 +424,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                   className={cn(
                     'flex cursor-pointer items-center justify-between px-3 py-2 text-sm text-on-surface',
                     i !== 0 && 'border-t border-outline-variant/60',
-                    readOnly && 'cursor-not-allowed opacity-60',
+                    metaReadOnly && 'cursor-not-allowed opacity-60',
                   )}
                 >
                   <span>{t.label}</span>
@@ -428,7 +432,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                     type="checkbox"
                     checked={triggers.has(t.id)}
                     onChange={() => toggleTrigger(t.id)}
-                    disabled={readOnly}
+                    disabled={metaReadOnly}
                     className="h-4 w-4 accent-primary"
                   />
                 </label>
@@ -447,7 +451,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                     <CodeIcon className="h-4 w-4 text-on-surface-variant" />
                     {o}
                   </span>
-                  {!readOnly && (
+                  {!metaReadOnly && (
                     <button
                       type="button"
                       onClick={() => removeOutput(o)}
@@ -459,7 +463,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                   )}
                 </div>
               ))}
-              {!readOnly && (
+              {!metaReadOnly && (
                 <div className="flex items-center gap-2">
                   <input
                     type="text"
@@ -498,7 +502,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                     key={cap.id}
                     type="button"
                     onClick={() => toggleCapability(cap.id)}
-                    disabled={readOnly}
+                    disabled={metaReadOnly}
                     className={cn(
                       'flex flex-col items-center justify-center gap-2 rounded-md border bg-surface px-3 py-4 text-center transition-colors disabled:cursor-not-allowed disabled:opacity-60',
                       active

--- a/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
+++ b/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDownIcon,
   ChevronLeftIcon,
 } from '@/components/icons';
+import { useRouter } from 'next/navigation';
 import {
   saveSkillOverride,
   autosaveSkillOverrideBody,
@@ -21,6 +22,10 @@ import {
   deleteSkillOverride,
   type OverridePayload,
 } from './override-actions';
+import {
+  autosaveUploadedSkillBody,
+  deleteUploadedSkill,
+} from './uploaded-actions';
 
 export interface SkillDetail {
   name: string;
@@ -28,7 +33,7 @@ export interface SkillDetail {
   path: string;
   body: string | null;
   upstreamBody: string | null;
-  source: 'override' | 'repo' | 'built-in';
+  source: 'override' | 'repo' | 'built-in' | 'disk';
   enabled: boolean;
   overrideUpdatedAt: string | null;
   metadata: {
@@ -77,6 +82,11 @@ const AUTOSAVE_DEBOUNCE_MS = 800;
 type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 
 export function SkillDetailView({ skill, readOnly }: Props) {
+  // Issue #262 (PR 3) — disk-uploaded skills edit their body directly in
+  // `uploaded_skills`, so they bypass the "fork upstream → override" handshake
+  // entirely. `isDisk` toggles those branches throughout the component.
+  const isDisk = skill.source === 'disk';
+  const router = useRouter();
   const [executionMode, setExecutionMode] = useState(skill.metadata.executionMode);
   const [triggers, setTriggers] = useState<Set<string>>(() => new Set(skill.metadata.triggers));
   const [outputs, setOutputs] = useState<string[]>(skill.metadata.outputs);
@@ -125,23 +135,28 @@ export function SkillDetailView({ skill, readOnly }: Props) {
     skill.metadata.capabilities,
   ]);
 
-  // Debounced body autosave. Only runs once an override already exists —
-  // editing an upstream (repo/built-in) skill must NOT silently fork it on the
-  // first keystroke. Until then the body stays "Unsaved" and the user opts in
-  // explicitly via "Save as override" / "Save & Enable Skill".
+  // Debounced body autosave. For overrides, only runs once an override already
+  // exists — editing an upstream (repo/built-in) skill must NOT silently fork
+  // it on the first keystroke. For disk uploads, the skill *is* the canonical
+  // version, so we autosave from the first keystroke.
   const bodyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (!bodyDirty || readOnly || !hasOverride) return;
+    if (!bodyDirty || readOnly) return;
+    if (!isDisk && !hasOverride) return;
     if (bodyTimerRef.current) clearTimeout(bodyTimerRef.current);
     bodyTimerRef.current = setTimeout(async () => {
       setSaveState('saving');
-      const result = await autosaveSkillOverrideBody(skill.name, body);
+      const result = isDisk
+        ? await autosaveUploadedSkillBody(skill.name, body)
+        : await autosaveSkillOverrideBody(skill.name, body);
       if (result.ok) {
         setSaveState('saved');
         setSaveError(null);
         setBodyDirty(false);
         if (result.updatedAt) setOverrideUpdatedAt(result.updatedAt);
-        if (typeof result.enabled === 'boolean') setEnabled(result.enabled);
+        if (!isDisk && 'enabled' in result && typeof result.enabled === 'boolean') {
+          setEnabled(result.enabled);
+        }
       } else {
         setSaveState('error');
         setSaveError(result.error ?? 'Save failed');
@@ -150,7 +165,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
     return () => {
       if (bodyTimerRef.current) clearTimeout(bodyTimerRef.current);
     };
-  }, [body, bodyDirty, readOnly, hasOverride, skill.name]);
+  }, [body, bodyDirty, readOnly, hasOverride, isDisk, skill.name]);
 
   const buildPayload = useCallback(
     (): OverridePayload => ({
@@ -183,6 +198,23 @@ export function SkillDetailView({ skill, readOnly }: Props) {
 
   async function handleDiscard() {
     if (readOnly) return;
+    // Disk uploads have no upstream to fall back to — "Discard" deletes the
+    // skill outright (no recovery from this side; user can re-upload).
+    if (isDisk) {
+      const ok = window.confirm(
+        `Delete the uploaded skill "${skill.name}"? You'll need to re-upload it to bring it back.`,
+      );
+      if (!ok) return;
+      setSaveState('saving');
+      const result = await deleteUploadedSkill(skill.name);
+      if (result.ok) {
+        router.push('/skills');
+      } else {
+        setSaveState('error');
+        setSaveError(result.error ?? 'Could not delete uploaded skill');
+      }
+      return;
+    }
     // If we have an override, "Discard" should revert to upstream entirely.
     if (hasOverride) {
       const ok = window.confirm(
@@ -304,11 +336,13 @@ export function SkillDetailView({ skill, readOnly }: Props) {
   }
 
   const dirty = bodyDirty || metaDirty;
-  const headerBadge: { label: string; tone: 'tertiary' | 'primary' | 'muted' } = hasOverride
-    ? enabled
-      ? { label: 'OVERRIDE · ACTIVE', tone: 'primary' }
-      : { label: 'OVERRIDE · DISABLED', tone: 'muted' }
-    : { label: 'AI_ASSISTED', tone: 'tertiary' };
+  const headerBadge: { label: string; tone: 'tertiary' | 'primary' | 'muted' } = isDisk
+    ? { label: 'DISK · UPLOADED', tone: 'tertiary' }
+    : hasOverride
+      ? enabled
+        ? { label: 'OVERRIDE · ACTIVE', tone: 'primary' }
+        : { label: 'OVERRIDE · DISABLED', tone: 'muted' }
+      : { label: 'AI_ASSISTED', tone: 'tertiary' };
 
   return (
     <div className="flex min-h-[calc(100vh-56px)] flex-col">
@@ -598,31 +632,37 @@ export function SkillDetailView({ skill, readOnly }: Props) {
         <button
           type="button"
           onClick={handleDiscard}
-          disabled={readOnly || (!dirty && !hasOverride)}
+          disabled={readOnly || (!dirty && !hasOverride && !isDisk)}
           className="inline-flex h-9 items-center gap-2 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface-variant transition-colors hover:border-primary hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {hasOverride ? 'Delete override' : 'Discard changes'}
+          {isDisk ? 'Delete uploaded skill' : hasOverride ? 'Delete override' : 'Discard changes'}
         </button>
         <div className="flex flex-wrap items-center gap-2">
           {saveError && <span className="text-xs text-error">{saveError}</span>}
-          <button
-            type="button"
-            onClick={() => handleSave(false)}
-            disabled={readOnly || saveState === 'saving'}
-            className="inline-flex h-9 items-center gap-2 rounded-md border border-outline-variant bg-surface px-3 text-sm font-medium text-on-surface transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <RotateLeftIcon className="h-4 w-4" />
-            Save as override
-          </button>
-          <button
-            type="button"
-            onClick={() => handleSave(true)}
-            disabled={readOnly || saveState === 'saving'}
-            className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <CheckIcon className="h-4 w-4" />
-            Save &amp; Enable Skill
-          </button>
+          {/* Save handshake only makes sense for repo/built-in skills — disk
+              uploads autosave directly into their own table. */}
+          {!isDisk && (
+            <>
+              <button
+                type="button"
+                onClick={() => handleSave(false)}
+                disabled={readOnly || saveState === 'saving'}
+                className="inline-flex h-9 items-center gap-2 rounded-md border border-outline-variant bg-surface px-3 text-sm font-medium text-on-surface transition-colors hover:border-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RotateLeftIcon className="h-4 w-4" />
+                Save as override
+              </button>
+              <button
+                type="button"
+                onClick={() => handleSave(true)}
+                disabled={readOnly || saveState === 'saving'}
+                className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <CheckIcon className="h-4 w-4" />
+                Save &amp; Enable Skill
+              </button>
+            </>
+          )}
         </div>
       </footer>
     </div>

--- a/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
+++ b/packages/gui/src/app/skills/[name]/skill-detail-view.tsx
@@ -606,7 +606,7 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                   setBodyDirty(true);
                   setSaveState('idle');
                 }}
-                readOnly={readOnly}
+                readOnly={readOnly || isSkillsSh}
                 spellCheck={false}
                 className="block h-full min-h-[240px] w-full resize-none bg-surface-container-lowest p-5 font-mono text-base leading-[20px] text-on-surface focus:outline-none lg:min-h-[420px] lg:text-[13px]"
               />
@@ -685,8 +685,12 @@ export function SkillDetailView({ skill, readOnly }: Props) {
                 if (result.ok) {
                   setSaveState('saved');
                   setSaveError(null);
-                  // The page-level loader will re-fetch on revalidatePath;
-                  // body state stays mirrored from the latest snapshot.
+                  // `revalidatePath` invalidates the server cache, but our
+                  // local `body`/`description` state lives in client useState
+                  // and won't re-hydrate without an explicit router refresh.
+                  // Without this the textarea keeps showing the pre-refresh
+                  // snapshot even though the badge says 'saved'.
+                  router.refresh();
                 } else {
                   setSaveState('error');
                   setSaveError(result.error ?? 'Refresh failed');

--- a/packages/gui/src/app/skills/[name]/skills-sh-actions.ts
+++ b/packages/gui/src/app/skills/[name]/skills-sh-actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import {
@@ -16,9 +17,21 @@ import {
 
 export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
 
+/**
+ * Gate the name→id resolver on the same admin role that the underlying
+ * id-keyed actions require. Without this an authenticated non-admin member
+ * could probe the existence of skills.sh imports by name (the resolver runs
+ * the admin client which bypasses RLS) before being told they don't have
+ * permission.
+ */
 async function resolveIdByName(name: string): Promise<{ id: string } | { error: string }> {
+  const user = await getSessionUser();
+  if (!user) return { error: 'Not authenticated' };
   const workspace = await getActiveWorkspace();
   if (!workspace) return { error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { error: 'Only admins can manage skills.sh imports' };
+  }
   const supabase = createSupabaseAdminClient();
   const { data, error } = await supabase
     .from('skills_sh_skills')
@@ -38,6 +51,9 @@ export async function refreshSkillsShSkillByName(
   if ('error' in resolved) return { ok: false, error: resolved.error };
   const result = await refreshById(resolved.id);
   if (!result.ok) return result;
+  // refreshById already covers `/skills`, `/skills/[name]`, and the
+  // `/workflows` layout; we re-revalidate the detail route under the
+  // caller-supplied name in case the admin sat on an old URL.
   revalidatePath(`/skills/${encodeURIComponent(name)}`);
   return { ok: true, changed: result.changed };
 }
@@ -45,5 +61,10 @@ export async function refreshSkillsShSkillByName(
 export async function removeSkillsShSkillByName(name: string): Promise<ActionResult> {
   const resolved = await resolveIdByName(name);
   if ('error' in resolved) return { ok: false, error: resolved.error };
-  return removeById(resolved.id);
+  const result = await removeById(resolved.id);
+  if (!result.ok) return result;
+  // Mirror the surface set the id-keyed action revalidates, plus the
+  // detail route under the caller-supplied name.
+  revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  return { ok: true };
 }

--- a/packages/gui/src/app/skills/[name]/skills-sh-actions.ts
+++ b/packages/gui/src/app/skills/[name]/skills-sh-actions.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import {
+  refreshSkillsShSkill as refreshById,
+  removeSkillsShSkill as removeById,
+} from '../skills-sh-actions';
+
+/**
+ * Issue #262 (PR 4) — convenience wrappers around the id-keyed actions that
+ * the detail page reaches by skill name. Resolves `name → id` against the
+ * active workspace, then delegates to the canonical action.
+ */
+
+export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
+
+async function resolveIdByName(name: string): Promise<{ id: string } | { error: string }> {
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { error: 'No workspace selected' };
+  const supabase = createSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from('skills_sh_skills')
+    .select('id')
+    .eq('workspace_id', workspace.id)
+    .eq('name', name)
+    .maybeSingle<{ id: string }>();
+  if (error) return { error: error.message };
+  if (!data) return { error: 'skills.sh skill not found for this name' };
+  return { id: data.id };
+}
+
+export async function refreshSkillsShSkillByName(
+  name: string,
+): Promise<ActionResult<{ changed: boolean }>> {
+  const resolved = await resolveIdByName(name);
+  if ('error' in resolved) return { ok: false, error: resolved.error };
+  const result = await refreshById(resolved.id);
+  if (!result.ok) return result;
+  revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  return { ok: true, changed: result.changed };
+}
+
+export async function removeSkillsShSkillByName(name: string): Promise<ActionResult> {
+  const resolved = await resolveIdByName(name);
+  if ('error' in resolved) return { ok: false, error: resolved.error };
+  return removeById(resolved.id);
+}

--- a/packages/gui/src/app/skills/[name]/uploaded-actions.ts
+++ b/packages/gui/src/app/skills/[name]/uploaded-actions.ts
@@ -1,0 +1,73 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getSessionUser } from '@/lib/auth';
+import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+
+/**
+ * Issue #262 (PR 3) — autosave + delete for uploaded (disk) skills.
+ *
+ * Disk skills are first-class catalog entries: their bodies live in the
+ * `uploaded_skills.body` column, the skill detail page edits that directly.
+ * No "fork upstream first" handshake like the override editor — uploaded
+ * skills *are* the canonical version.
+ */
+
+export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
+
+const MAX_BODY_BYTES = 100 * 1024;
+
+export async function autosaveUploadedSkillBody(
+  name: string,
+  body: string,
+): Promise<ActionResult<{ updatedAt: string }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can edit uploaded skills' };
+  }
+  if (!name.trim()) return { ok: false, error: 'name is required' };
+  if (body.length > MAX_BODY_BYTES) {
+    return { ok: false, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from('uploaded_skills')
+    .update({ body, updated_by: user.id })
+    .eq('workspace_id', workspace.id)
+    .eq('name', name)
+    .select('updated_at')
+    .maybeSingle<{ updated_at: string }>();
+  if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: 'uploaded skill not found' };
+
+  revalidatePath('/skills');
+  revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  return { ok: true, updatedAt: data.updated_at };
+}
+
+export async function deleteUploadedSkill(name: string): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can remove uploaded skills' };
+  }
+  if (!name.trim()) return { ok: false, error: 'name is required' };
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('uploaded_skills')
+    .delete()
+    .eq('workspace_id', workspace.id)
+    .eq('name', name);
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath('/skills');
+  return { ok: true };
+}

--- a/packages/gui/src/app/skills/[name]/uploaded-actions.ts
+++ b/packages/gui/src/app/skills/[name]/uploaded-actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { parseSkillMarkdown } from '@cezar/core';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
@@ -18,6 +19,12 @@ export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: stri
 
 const MAX_BODY_BYTES = 100 * 1024;
 
+function revalidateAfterMutation(name: string) {
+  revalidatePath('/skills');
+  revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  revalidatePath('/workflows', 'layout');
+}
+
 export async function autosaveUploadedSkillBody(
   name: string,
   body: string,
@@ -30,14 +37,30 @@ export async function autosaveUploadedSkillBody(
     return { ok: false, error: 'Only admins can edit uploaded skills' };
   }
   if (!name.trim()) return { ok: false, error: 'name is required' };
-  if (body.length > MAX_BODY_BYTES) {
+  // Reject empty/whitespace-only body — an admin who Ctrl+A-deletes the editor
+  // would otherwise autosave `body=''` and the workflow engine would silently
+  // run the next dispatch with an empty prompt.
+  if (!body.trim()) return { ok: false, error: 'body is empty' };
+  // Byte-length, not `.length` — multi-byte glyphs would otherwise pass under
+  // a 4× larger payload than the constant implies.
+  if (Buffer.byteLength(body, 'utf8') > MAX_BODY_BYTES) {
     return { ok: false, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` };
   }
 
+  // Re-parse the frontmatter so derived columns stay in sync with the body.
+  // Without this, editing `description:` or `cezar-stages:` in the editor
+  // leaves the catalog row showing the old values forever — the workflow
+  // picker / list page read `description` and `suggested_stages` directly.
+  const parsed = parseSkillMarkdown(body, name);
   const supabase = createSupabaseAdminClient();
   const { data, error } = await supabase
     .from('uploaded_skills')
-    .update({ body, updated_by: user.id })
+    .update({
+      body,
+      description: parsed.description ?? null,
+      suggested_stages: parsed.suggestedStages,
+      updated_by: user.id,
+    })
     .eq('workspace_id', workspace.id)
     .eq('name', name)
     .select('updated_at')
@@ -45,8 +68,7 @@ export async function autosaveUploadedSkillBody(
   if (error) return { ok: false, error: error.message };
   if (!data) return { ok: false, error: 'uploaded skill not found' };
 
-  revalidatePath('/skills');
-  revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  revalidateAfterMutation(name);
   return { ok: true, updatedAt: data.updated_at };
 }
 
@@ -68,6 +90,6 @@ export async function deleteUploadedSkill(name: string): Promise<ActionResult> {
     .eq('name', name);
   if (error) return { ok: false, error: error.message };
 
-  revalidatePath('/skills');
+  revalidateAfterMutation(name);
   return { ok: true };
 }

--- a/packages/gui/src/app/skills/external-actions.ts
+++ b/packages/gui/src/app/skills/external-actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { resolve, sep } from 'node:path';
 import { revalidatePath } from 'next/cache';
 import type { Skill } from '@cezar/core';
 import { getSessionUser } from '@/lib/auth';
@@ -8,6 +9,7 @@ import { createSupabaseAdminClient } from '@/lib/supabase/server';
 import {
   ensureExternalRepoClone,
   readExternalRepoHead,
+  redactTokenFromMessage,
   withExternalRepoLock,
 } from '@/lib/external-repo-clone';
 
@@ -35,8 +37,12 @@ const DEFAULT_FOLDER = '.ai/skills';
 const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
 const OWNER_PATTERN = /^[a-z0-9][a-z0-9-]{0,38}$/i;
 const REPO_PATTERN = /^[a-z0-9._-]{1,100}$/i;
-const BRANCH_PATTERN = /^[^\s~^:?*\\]{1,250}$/;
-const FOLDER_PATTERN = /^[^\s\\]{1,250}$/;
+// Reject leading `-` so `git checkout <branch>` can't interpret it as a flag.
+const BRANCH_PATTERN = /^(?!-)[^\s~^:?*\\]{1,250}$/;
+// Repo-relative subpath: ASCII alnum + `._-/`, no leading `/`, no `..` segments.
+// Forbids both absolute paths and traversal so `resolve(repoRoot, folder)` can
+// never climb out of the cloned worktree.
+const FOLDER_PATTERN = /^[A-Za-z0-9._/-]{1,250}$/;
 
 function validateInput(
   name: string,
@@ -54,10 +60,14 @@ function validateInput(
   const branch = (config.branch ?? DEFAULT_BRANCH).trim() || DEFAULT_BRANCH;
   const folder = (config.folder ?? DEFAULT_FOLDER).trim() || DEFAULT_FOLDER;
   if (!BRANCH_PATTERN.test(branch)) {
-    return { ok: false, error: 'branch contains invalid characters' };
+    return { ok: false, error: 'branch contains invalid characters or starts with `-`' };
   }
   if (!FOLDER_PATTERN.test(folder)) {
-    return { ok: false, error: 'folder contains invalid characters' };
+    return { ok: false, error: 'folder must be a repo-relative subpath (ASCII alnum + `._-/`)' };
+  }
+  // Belt-and-braces against `..` segments slipping past the regex.
+  if (folder.startsWith('/') || folder.split('/').some((seg) => seg === '..')) {
+    return { ok: false, error: 'folder cannot be absolute or contain `..` segments' };
   }
   return {
     ok: true,
@@ -97,6 +107,7 @@ export async function addExternalRepoSource(params: {
     return { ok: false, error: error?.message ?? 'insert failed' };
   }
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true, id: data.id };
 }
 
@@ -117,7 +128,7 @@ export async function updateExternalRepoSource(params: {
   if (!validated.ok) return validated;
 
   const supabase = createSupabaseAdminClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('skill_sources')
     .update({
       name: params.name,
@@ -125,9 +136,15 @@ export async function updateExternalRepoSource(params: {
       updated_by: user.id,
     })
     .eq('id', params.id)
-    .eq('workspace_id', workspace.id);
+    .eq('workspace_id', workspace.id)
+    .select('id')
+    .maybeSingle();
   if (error) return { ok: false, error: error.message };
+  // Stale ID or cross-workspace target: predicate matched zero rows. Surface
+  // it as a real error so the UI doesn't show 'updated' on a silent no-op.
+  if (!data) return { ok: false, error: 'skill source not found' };
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true };
 }
 
@@ -141,13 +158,26 @@ export async function removeExternalRepoSource(id: string): Promise<ActionResult
   }
 
   const supabase = createSupabaseAdminClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('skill_sources')
     .delete()
     .eq('id', id)
-    .eq('workspace_id', workspace.id);
+    .eq('workspace_id', workspace.id)
+    .select('id')
+    .maybeSingle();
   if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: 'skill source not found' };
+
+  // NOTE: workspace_skill_states rows whose skill_name was only in this
+  // source's cache survive the delete (no FK). They're at worst inactive
+  // cruft; the runtime ignores them when no skill of that name is loaded.
+  // Cross-source cleanup is intentionally deferred — naively dropping the
+  // names would also wipe legitimate state for built-in/workspace-repo
+  // skills that happen to share the name. A future migration with a
+  // source_id-aware state model is the right place for this cleanup.
+
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true };
 }
 
@@ -212,6 +242,14 @@ export async function refreshExternalRepoSource(
     ({ commitSha, skills } = await withExternalRepoLock(id, async () => {
       const repoRoot = await ensureExternalRepoClone(id, { owner, repo, branch }, token);
       const sha = await readExternalRepoHead(id);
+      // Belt-and-braces containment check: regex above already forbids absolute
+      // paths and `..` segments, but assert the resolved path is still inside
+      // the clone before handing it to `discoverSkills` (which uses
+      // `resolve(repoRoot, folder)`).
+      const resolvedFolder = resolve(repoRoot, folder);
+      if (resolvedFolder !== repoRoot && !resolvedFolder.startsWith(repoRoot + sep)) {
+        throw new Error('folder escapes the clone root');
+      }
       const discovered = await core.discoverSkills(repoRoot, folder);
       // Force the external-repo source label — `discoverSkills` defaults to
       // 'workspace-repo' for anything it finds outside the built-in dir.
@@ -221,7 +259,12 @@ export async function refreshExternalRepoSource(
       return { commitSha: sha, skills: tagged };
     }));
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    // Defense in depth — `gitTokenEnv` keeps the token out of argv, so it
+    // shouldn't appear in execFile's error message. Scrub anyway in case a
+    // pre-fix clone left a token-bearing URL in `.git/config` that surfaces
+    // through git's stderr.
+    const rawMessage = err instanceof Error ? err.message : String(err);
+    const message = redactTokenFromMessage(rawMessage, token);
     await supabase
       .from('skill_sources')
       .update({ last_sync_error: message, updated_by: user.id })
@@ -263,5 +306,6 @@ export async function refreshExternalRepoSource(
     .eq('workspace_id', workspace.id);
 
   revalidatePath('/skills');
+  revalidatePath('/workflows', 'layout');
   return { ok: true, count: skills.length };
 }

--- a/packages/gui/src/app/skills/external-actions.ts
+++ b/packages/gui/src/app/skills/external-actions.ts
@@ -1,0 +1,267 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import type { Skill } from '@cezar/core';
+import { getSessionUser } from '@/lib/auth';
+import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import {
+  ensureExternalRepoClone,
+  readExternalRepoHead,
+  withExternalRepoLock,
+} from '@/lib/external-repo-clone';
+
+/**
+ * Issue #262 (PR 2) — admin-only CRUD + sync for external skill repos.
+ *
+ * "External" here means any GitHub repo that's not the workspace's own. The
+ * workspace repo continues to live under `repo_skills` and reuses
+ * `refreshRepoSkills()`. These actions cover the second source kind from the
+ * roadmap; PR 3 (disk) and PR 4 (skills.sh) add their own.
+ */
+
+export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
+
+export interface ExternalRepoConfigInput {
+  owner: string;
+  repo: string;
+  branch?: string;
+  folder?: string;
+}
+
+const DEFAULT_BRANCH = 'main';
+const DEFAULT_FOLDER = '.ai/skills';
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
+const OWNER_PATTERN = /^[a-z0-9][a-z0-9-]{0,38}$/i;
+const REPO_PATTERN = /^[a-z0-9._-]{1,100}$/i;
+const BRANCH_PATTERN = /^[^\s~^:?*\\]{1,250}$/;
+const FOLDER_PATTERN = /^[^\s\\]{1,250}$/;
+
+function validateInput(
+  name: string,
+  config: ExternalRepoConfigInput,
+): { ok: true; cfg: Required<ExternalRepoConfigInput> } | { ok: false; error: string } {
+  if (!NAME_PATTERN.test(name)) {
+    return { ok: false, error: 'name must be alphanumeric + `-`/`_` (max 63 chars)' };
+  }
+  if (!OWNER_PATTERN.test(config.owner)) {
+    return { ok: false, error: 'owner must be a valid GitHub login' };
+  }
+  if (!REPO_PATTERN.test(config.repo)) {
+    return { ok: false, error: 'repo must be a valid GitHub repo name' };
+  }
+  const branch = (config.branch ?? DEFAULT_BRANCH).trim() || DEFAULT_BRANCH;
+  const folder = (config.folder ?? DEFAULT_FOLDER).trim() || DEFAULT_FOLDER;
+  if (!BRANCH_PATTERN.test(branch)) {
+    return { ok: false, error: 'branch contains invalid characters' };
+  }
+  if (!FOLDER_PATTERN.test(folder)) {
+    return { ok: false, error: 'folder contains invalid characters' };
+  }
+  return {
+    ok: true,
+    cfg: { owner: config.owner, repo: config.repo, branch, folder },
+  };
+}
+
+export async function addExternalRepoSource(params: {
+  name: string;
+  config: ExternalRepoConfigInput;
+}): Promise<ActionResult<{ id: string }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can add skill sources' };
+  }
+
+  const validated = validateInput(params.name, params.config);
+  if (!validated.ok) return validated;
+
+  const supabase = createSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from('skill_sources')
+    .insert({
+      workspace_id: workspace.id,
+      kind: 'external-repo',
+      name: params.name,
+      config: validated.cfg,
+      created_by: user.id,
+      updated_by: user.id,
+    })
+    .select('id')
+    .single();
+  if (error || !data) {
+    return { ok: false, error: error?.message ?? 'insert failed' };
+  }
+  revalidatePath('/skills');
+  return { ok: true, id: data.id };
+}
+
+export async function updateExternalRepoSource(params: {
+  id: string;
+  name: string;
+  config: ExternalRepoConfigInput;
+}): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can update skill sources' };
+  }
+
+  const validated = validateInput(params.name, params.config);
+  if (!validated.ok) return validated;
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('skill_sources')
+    .update({
+      name: params.name,
+      config: validated.cfg,
+      updated_by: user.id,
+    })
+    .eq('id', params.id)
+    .eq('workspace_id', workspace.id);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath('/skills');
+  return { ok: true };
+}
+
+export async function removeExternalRepoSource(id: string): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can remove skill sources' };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('skill_sources')
+    .delete()
+    .eq('id', id)
+    .eq('workspace_id', workspace.id);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath('/skills');
+  return { ok: true };
+}
+
+export async function refreshExternalRepoSource(
+  id: string,
+): Promise<ActionResult<{ count: number }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can sync skill sources' };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { data: source, error: loadError } = await supabase
+    .from('skill_sources')
+    .select('id, workspace_id, kind, config')
+    .eq('id', id)
+    .eq('workspace_id', workspace.id)
+    .single();
+  if (loadError || !source) {
+    return { ok: false, error: loadError?.message ?? 'source not found' };
+  }
+  if (source.kind !== 'external-repo') {
+    return { ok: false, error: `unsupported source kind: ${source.kind}` };
+  }
+
+  const config = source.config as {
+    owner?: string;
+    repo?: string;
+    branch?: string;
+    folder?: string;
+  } | null;
+  if (!config?.owner || !config.repo) {
+    return { ok: false, error: 'source config missing owner/repo' };
+  }
+  const owner = config.owner;
+  const repo = config.repo;
+  const branch = config.branch || DEFAULT_BRANCH;
+  const folder = config.folder || DEFAULT_FOLDER;
+
+  // Resolve a GitHub token: prefer a GitHub App installation token if the App
+  // is configured *and* installed on the external owner; fall back to the
+  // caller's OAuth token; then to the ambient GITHUB_TOKEN. Public repos work
+  // without any token at all (helper accepts null).
+  const core = await import('@cezar/core');
+  let token: string | null = user.githubToken || process.env.GITHUB_TOKEN || null;
+  if (core.GitHubAppService.isConfigured()) {
+    try {
+      token = await new core.GitHubAppService().getInstallationToken(owner);
+    } catch (err) {
+      console.warn(
+        `[refreshExternalRepoSource] App token for ${owner} failed, falling back: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  let commitSha: string | null = null;
+  let skills: Skill[];
+  try {
+    ({ commitSha, skills } = await withExternalRepoLock(id, async () => {
+      const repoRoot = await ensureExternalRepoClone(id, { owner, repo, branch }, token);
+      const sha = await readExternalRepoHead(id);
+      const discovered = await core.discoverSkills(repoRoot, folder);
+      // Force the external-repo source label — `discoverSkills` defaults to
+      // 'workspace-repo' for anything it finds outside the built-in dir.
+      const tagged: Skill[] = discovered
+        .filter((s) => s.source !== 'built-in')
+        .map((s) => ({ ...s, source: 'external-repo' as const }));
+      return { commitSha: sha, skills: tagged };
+    }));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await supabase
+      .from('skill_sources')
+      .update({ last_sync_error: message, updated_by: user.id })
+      .eq('id', id)
+      .eq('workspace_id', workspace.id);
+    return { ok: false, error: `sync failed: ${message}` };
+  }
+
+  // Persist body inline — dispatch never re-clones.
+  const cached = skills.map((s) => ({
+    name: s.name,
+    description: s.description ?? null,
+    suggestedStages: s.suggestedStages,
+    path: s.path,
+    source: 'external-repo' as const,
+    body: s.body,
+  }));
+
+  const now = new Date().toISOString();
+  const { error: upsertError } = await supabase.from('external_repo_skills').upsert(
+    {
+      source_id: id,
+      commit_sha: commitSha,
+      skills: cached,
+      fetched_at: now,
+    },
+    { onConflict: 'source_id' },
+  );
+  if (upsertError) return { ok: false, error: upsertError.message };
+
+  await supabase
+    .from('skill_sources')
+    .update({
+      last_synced_at: now,
+      last_sync_error: null,
+      updated_by: user.id,
+    })
+    .eq('id', id)
+    .eq('workspace_id', workspace.id);
+
+  revalidatePath('/skills');
+  return { ok: true, count: skills.length };
+}

--- a/packages/gui/src/app/skills/external-sources-section.tsx
+++ b/packages/gui/src/app/skills/external-sources-section.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { cn } from '@/components/ui/cn';
+import { RefreshIcon, PlusIcon } from '@/components/icons';
+import {
+  addExternalRepoSource,
+  refreshExternalRepoSource,
+  removeExternalRepoSource,
+  updateExternalRepoSource,
+  type ActionResult,
+} from './external-actions';
+
+/** Issue #262 (PR 2) — props mirror `skill_sources` + `external_repo_skills`. */
+export interface ExternalRepoSourceRow {
+  id: string;
+  name: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  folder: string;
+  lastSyncedAt: string | null;
+  lastSyncError: string | null;
+  skillCount: number;
+}
+
+interface Props {
+  sources: ExternalRepoSourceRow[];
+  readOnly: boolean;
+  /** Externally-controlled open state for the Add modal (drives the
+   *  "Add skill source ▾ → Another repo" entry from the page header). */
+  addModalOpen: boolean;
+  onCloseAddModal: () => void;
+}
+
+interface FormValues {
+  name: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  folder: string;
+}
+
+const EMPTY_FORM: FormValues = {
+  name: '',
+  owner: '',
+  repo: '',
+  branch: 'main',
+  folder: '.ai/skills',
+};
+
+export function ExternalSourcesSection({ sources, readOnly, addModalOpen, onCloseAddModal }: Props) {
+  const [editing, setEditing] = useState<ExternalRepoSourceRow | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function handleSync(id: string) {
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const res = await refreshExternalRepoSource(id);
+      setBusyId(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  function handleRemove(id: string) {
+    if (!confirm('Remove this skill source? Cached skills will be discarded.')) return;
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const res = await removeExternalRepoSource(id);
+      setBusyId(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  return (
+    <section className="mb-6 rounded-lg border border-outline-variant bg-surface-container-low p-4">
+      <header className="mb-3 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-on-surface">External skill sources</h2>
+          <p className="mt-0.5 text-xs text-on-surface-variant">
+            Pull skills from any GitHub repo. Synced manually — bodies are cached so dispatch
+            works without a local clone.
+          </p>
+        </div>
+      </header>
+
+      {error && (
+        <div className="mb-3 rounded-md border border-error/30 bg-error-container/30 px-3 py-2 text-xs text-error">
+          {error}
+        </div>
+      )}
+
+      {sources.length === 0 ? (
+        <div className="rounded-md border border-dashed border-outline-variant px-3 py-6 text-center text-xs text-on-surface-variant">
+          No external sources yet. Use{' '}
+          <span className="font-mono text-on-surface">Add skill source → Another repo</span> to add one.
+        </div>
+      ) : (
+        <ul className="divide-y divide-outline-variant/50 rounded-md border border-outline-variant">
+          {sources.map((s) => (
+            <li key={s.id} className="flex flex-wrap items-center gap-3 px-3 py-2 text-sm">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2 text-on-surface">
+                  <span className="font-medium">{s.name}</span>
+                  <span className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-on-surface-variant">
+                    {s.owner}/{s.repo}:{s.branch}
+                  </span>
+                  <span className="font-mono text-[11px] text-on-surface-variant">{s.folder}</span>
+                </div>
+                <div className="mt-0.5 text-[11px] text-on-surface-variant">
+                  {s.skillCount} skill{s.skillCount === 1 ? '' : 's'}
+                  {' · '}
+                  {s.lastSyncedAt ? `last synced ${formatTimestamp(s.lastSyncedAt)}` : 'never synced'}
+                  {s.lastSyncError && (
+                    <span className="ml-2 text-amber-300/90">⚠ {s.lastSyncError}</span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => handleSync(s.id)}
+                  disabled={readOnly || busyId === s.id}
+                  className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant bg-surface-container px-2 text-[11px] font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+                >
+                  <RefreshIcon className="h-3 w-3" />
+                  {busyId === s.id ? 'Syncing…' : 'Sync'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditing(s)}
+                  disabled={readOnly}
+                  className="inline-flex h-7 items-center rounded-md border border-outline-variant bg-surface-container px-2 text-[11px] font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(s.id)}
+                  disabled={readOnly || busyId === s.id}
+                  className="inline-flex h-7 items-center rounded-md border border-error/40 bg-surface-container px-2 text-[11px] font-medium text-error transition-colors hover:bg-error-container/40 disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {addModalOpen && (
+        <SourceFormModal
+          mode="create"
+          initial={EMPTY_FORM}
+          onClose={onCloseAddModal}
+          onSubmit={async (values) => addExternalRepoSource({ name: values.name, config: values })}
+          onSuccess={() => {
+            onCloseAddModal();
+          }}
+          onError={setError}
+        />
+      )}
+
+      {editing && (
+        <SourceFormModal
+          mode="edit"
+          initial={{
+            name: editing.name,
+            owner: editing.owner,
+            repo: editing.repo,
+            branch: editing.branch,
+            folder: editing.folder,
+          }}
+          onClose={() => setEditing(null)}
+          onSubmit={async (values) =>
+            updateExternalRepoSource({
+              id: editing.id,
+              name: values.name,
+              config: values,
+            })
+          }
+          onSuccess={() => setEditing(null)}
+          onError={setError}
+        />
+      )}
+    </section>
+  );
+}
+
+interface ModalProps {
+  mode: 'create' | 'edit';
+  initial: FormValues;
+  onClose: () => void;
+  onSubmit: (values: FormValues) => Promise<ActionResult<{ id?: string }>>;
+  onSuccess: () => void;
+  onError: (msg: string) => void;
+}
+
+function SourceFormModal({ mode, initial, onClose, onSubmit, onSuccess, onError }: ModalProps) {
+  const [values, setValues] = useState<FormValues>(initial);
+  const [submitting, startSubmit] = useTransition();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    startSubmit(async () => {
+      const res = await onSubmit(values);
+      if (res.ok) {
+        onSuccess();
+      } else {
+        onError(res.error);
+      }
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={mode === 'create' ? 'Add external skill source' : 'Edit external skill source'}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-lg border border-outline-variant bg-surface-container p-5 shadow-xl"
+      >
+        <h2 className="mb-4 text-base font-semibold text-on-surface">
+          {mode === 'create' ? 'Add external skill source' : 'Edit external skill source'}
+        </h2>
+        <div className="grid gap-3">
+          <ModalField
+            label="Name"
+            hint="Friendly slug — letters, digits, `-`, `_`."
+            value={values.name}
+            onChange={(v) => setValues((p) => ({ ...p, name: v }))}
+            placeholder="team-skills"
+            disabled={mode === 'edit'} // unique constraint; rename via a follow-up
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <ModalField
+              label="Owner"
+              value={values.owner}
+              onChange={(v) => setValues((p) => ({ ...p, owner: v }))}
+              placeholder="open-mercato"
+            />
+            <ModalField
+              label="Repo"
+              value={values.repo}
+              onChange={(v) => setValues((p) => ({ ...p, repo: v }))}
+              placeholder="shared-skills"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <ModalField
+              label="Branch"
+              value={values.branch}
+              onChange={(v) => setValues((p) => ({ ...p, branch: v }))}
+              placeholder="main"
+            />
+            <ModalField
+              label="Folder"
+              value={values.folder}
+              onChange={(v) => setValues((p) => ({ ...p, folder: v }))}
+              placeholder=".ai/skills"
+            />
+          </div>
+        </div>
+        <footer className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface hover:border-primary"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className={cn(
+              'h-9 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface',
+              submitting && 'opacity-60',
+            )}
+          >
+            {submitting ? 'Saving…' : mode === 'create' ? 'Add' : 'Save'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}
+
+function ModalField({
+  label,
+  value,
+  onChange,
+  hint,
+  placeholder,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  hint?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="block">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-on-surface-variant">
+        {label}
+      </div>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="mt-1 h-9 w-full rounded-md border border-outline-variant bg-surface px-2 text-sm text-on-surface focus:border-primary focus:outline-none disabled:opacity-60"
+      />
+      {hint && <p className="mt-1 text-[11px] text-on-surface-variant/80">{hint}</p>}
+    </label>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/packages/gui/src/app/skills/page.tsx
+++ b/packages/gui/src/app/skills/page.tsx
@@ -9,6 +9,7 @@ import {
   seedBuiltinSkillStatesIfNeeded,
 } from '@/lib/skill-state';
 import { SkillsView, type SkillRow } from './skills-view';
+import type { ExternalRepoSourceRow } from './external-sources-section';
 
 interface RepoSkillsRow {
   commit_sha: string | null;
@@ -21,6 +22,40 @@ interface OverrideRow {
   enabled: boolean;
   execution_mode: string;
   updated_at: string | null;
+}
+
+interface ExternalSourceRow {
+  id: string;
+  name: string;
+  config: unknown;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+}
+
+interface ExternalCacheRow {
+  source_id: string;
+  skills: unknown;
+}
+
+interface ExternalRepoConfig {
+  owner: string;
+  repo: string;
+  branch: string;
+  folder: string;
+}
+
+function parseExternalConfig(raw: unknown): ExternalRepoConfig | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const owner = typeof o.owner === 'string' ? o.owner : null;
+  const repo = typeof o.repo === 'string' ? o.repo : null;
+  if (!owner || !repo) return null;
+  return {
+    owner,
+    repo,
+    branch: typeof o.branch === 'string' && o.branch ? o.branch : 'main',
+    folder: typeof o.folder === 'string' && o.folder ? o.folder : '.ai/skills',
+  };
 }
 
 interface ParsedSkill {
@@ -85,12 +120,15 @@ export default async function SkillsPage() {
 
   const supabase = createSupabaseAdminClient();
 
-  // Pull everything in parallel — repo_skills cache, overrides, and the
-  // activation context (per-skill state map + workspace seed marker).
+  // Pull everything in parallel — repo_skills cache, overrides, the activation
+  // context (per-skill state map + workspace seed marker), and any external
+  // skill sources + their cached catalogs (issue #262 PR 2).
   const [
     { data: skillsRow },
     { data: overrideRows },
     { states, seeded: workspaceSeeded },
+    { data: externalSourceRows },
+    { data: externalCacheRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -104,6 +142,16 @@ export default async function SkillsPage() {
       .eq('workspace_id', workspace.id)
       .returns<OverrideRow[]>(),
     getSkillActivationContext(workspace.id, supabase),
+    supabase
+      .from('skill_sources')
+      .select('id, name, config, last_synced_at, last_sync_error')
+      .eq('workspace_id', workspace.id)
+      .eq('kind', 'external-repo')
+      .returns<ExternalSourceRow[]>(),
+    supabase
+      .from('external_repo_skills')
+      .select('source_id, skills')
+      .returns<ExternalCacheRow[]>(),
   ]);
 
   // `refreshRepoSkills` caches the merged catalog (built-in + repo) into
@@ -123,6 +171,29 @@ export default async function SkillsPage() {
       }));
     } catch {
       parsed = [];
+    }
+  }
+
+  // Issue #262 (PR 2) — fold external repo cached catalogs into the workspace
+  // catalog. Workspace + built-in entries win on name collisions because they
+  // sit higher in `SKILL_SOURCE_PRIORITY`. External rows that survive the
+  // dedupe show up with their own `source: 'external-repo'` badge.
+  const cacheBySourceId = new Map<string, ExternalCacheRow>(
+    (externalCacheRows ?? []).map((row) => [row.source_id, row]),
+  );
+  const externalSourceMeta = new Map<string, ExternalSourceRow>(
+    (externalSourceRows ?? []).map((row) => [row.id, row]),
+  );
+  const seenNames = new Set(parsed.map((p) => p.name));
+  const externalSkillCounts = new Map<string, number>();
+  for (const sourceRow of externalSourceRows ?? []) {
+    const cache = cacheBySourceId.get(sourceRow.id);
+    const externalSkills = parseSkills(cache?.skills);
+    externalSkillCounts.set(sourceRow.id, externalSkills.length);
+    for (const skill of externalSkills) {
+      if (seenNames.has(skill.name)) continue;
+      seenNames.add(skill.name);
+      parsed.push({ ...skill, source: 'external-repo' });
     }
   }
 
@@ -180,6 +251,27 @@ export default async function SkillsPage() {
 
   const isAdmin = workspace.role === 'admin';
 
+  const externalSources: ExternalRepoSourceRow[] = (externalSourceRows ?? [])
+    .map((row): ExternalRepoSourceRow | null => {
+      const cfg = parseExternalConfig(row.config);
+      if (!cfg) return null;
+      return {
+        id: row.id,
+        name: row.name,
+        owner: cfg.owner,
+        repo: cfg.repo,
+        branch: cfg.branch,
+        folder: cfg.folder,
+        lastSyncedAt: row.last_synced_at,
+        lastSyncError: row.last_sync_error,
+        skillCount: externalSkillCounts.get(row.id) ?? 0,
+      };
+    })
+    .filter((row): row is ExternalRepoSourceRow => row !== null);
+  // Keep `externalSourceMeta` reference for a possible future "show name" column
+  // — silence unused-var until then.
+  void externalSourceMeta;
+
   return (
     <SkillsView
       rows={rows}
@@ -187,6 +279,7 @@ export default async function SkillsPage() {
       commitSha={skillsRow?.commit_sha ?? null}
       fetchedAt={skillsRow?.fetched_at ?? null}
       readOnly={!isAdmin}
+      externalSources={externalSources}
     />
   );
 }

--- a/packages/gui/src/app/skills/page.tsx
+++ b/packages/gui/src/app/skills/page.tsx
@@ -121,14 +121,15 @@ export default async function SkillsPage() {
   const supabase = createSupabaseAdminClient();
 
   // Pull everything in parallel — repo_skills cache, overrides, the activation
-  // context (per-skill state map + workspace seed marker), and any external
-  // skill sources + their cached catalogs (issue #262 PR 2).
+  // context (per-skill state map + workspace seed marker), and the workspace's
+  // external skill sources (issue #262 PR 2). The external cache is fetched in
+  // a second step so it can be scoped by source_id — without that scoping the
+  // service-role client would dump every workspace's cached bodies into memory.
   const [
     { data: skillsRow },
     { data: overrideRows },
     { states, seeded: workspaceSeeded },
     { data: externalSourceRows },
-    { data: externalCacheRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -148,11 +149,16 @@ export default async function SkillsPage() {
       .eq('workspace_id', workspace.id)
       .eq('kind', 'external-repo')
       .returns<ExternalSourceRow[]>(),
-    supabase
-      .from('external_repo_skills')
-      .select('source_id, skills')
-      .returns<ExternalCacheRow[]>(),
   ]);
+
+  const externalSourceIds = (externalSourceRows ?? []).map((row) => row.id);
+  const { data: externalCacheRows } = externalSourceIds.length > 0
+    ? await supabase
+        .from('external_repo_skills')
+        .select('source_id, skills')
+        .in('source_id', externalSourceIds)
+        .returns<ExternalCacheRow[]>()
+    : { data: [] as ExternalCacheRow[] };
 
   // `refreshRepoSkills` caches the merged catalog (built-in + repo) into
   // `repo_skills.skills`. For never-synced workspaces, fall back to the

--- a/packages/gui/src/app/skills/page.tsx
+++ b/packages/gui/src/app/skills/page.tsx
@@ -8,9 +8,11 @@ import {
   isSkillDefaultActive,
   seedBuiltinSkillStatesIfNeeded,
 } from '@/lib/skill-state';
+import { isSkillsShConfigured } from '@/lib/skills-sh-api';
 import { SkillsView, type SkillRow } from './skills-view';
 import type { ExternalRepoSourceRow } from './external-sources-section';
 import type { UploadedSkillRow } from './uploaded-skills-section';
+import type { SkillsShImportRow } from './skills-sh-section';
 
 interface RepoSkillsRow {
   commit_sha: string | null;
@@ -45,6 +47,17 @@ interface UploadedSkillsDbRow {
   suggested_stages: unknown;
   uploaded_at: string;
   updated_at: string;
+}
+
+interface SkillsShDbRow {
+  id: string;
+  name: string;
+  source_slug: string;
+  description: string | null;
+  suggested_stages: unknown;
+  install_url: string | null;
+  last_synced_at: string;
+  last_sync_error: string | null;
 }
 
 interface ExternalRepoConfig {
@@ -141,6 +154,7 @@ export default async function SkillsPage() {
     { states, seeded: workspaceSeeded },
     { data: externalSourceRows },
     { data: uploadedRows },
+    { data: skillsShRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -166,6 +180,12 @@ export default async function SkillsPage() {
       .eq('workspace_id', workspace.id)
       .order('uploaded_at', { ascending: false })
       .returns<UploadedSkillsDbRow[]>(),
+    supabase
+      .from('skills_sh_skills')
+      .select('id, name, source_slug, description, suggested_stages, install_url, last_synced_at, last_sync_error')
+      .eq('workspace_id', workspace.id)
+      .order('imported_at', { ascending: false })
+      .returns<SkillsShDbRow[]>(),
   ]);
 
   const externalSourceIds = (externalSourceRows ?? []).map((row) => row.id);
@@ -236,6 +256,23 @@ export default async function SkillsPage() {
         : [],
       path: '',
       source: 'disk',
+    });
+  }
+
+  // Issue #262 (PR 4) — skills.sh imports. Lowest priority — only surface in
+  // the main catalog if nothing higher claimed the name. The Imports section
+  // shows shadowed entries so they can still be managed (Refresh / Remove).
+  for (const row of skillsShRows ?? []) {
+    if (seenNames.has(row.name)) continue;
+    seenNames.add(row.name);
+    parsed.push({
+      name: row.name,
+      description: row.description,
+      suggestedStages: Array.isArray(row.suggested_stages)
+        ? (row.suggested_stages as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [],
+      path: '',
+      source: 'skills-sh',
     });
   }
 
@@ -321,6 +358,15 @@ export default async function SkillsPage() {
     updatedAt: row.updated_at,
   }));
 
+  const skillsShImports: SkillsShImportRow[] = (skillsShRows ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    sourceSlug: row.source_slug,
+    installUrl: row.install_url,
+    lastSyncedAt: row.last_synced_at,
+    lastSyncError: row.last_sync_error,
+  }));
+
   return (
     <SkillsView
       rows={rows}
@@ -330,6 +376,8 @@ export default async function SkillsPage() {
       readOnly={!isAdmin}
       externalSources={externalSources}
       uploadedSkills={uploadedSkills}
+      skillsShImports={skillsShImports}
+      skillsShConfigured={isSkillsShConfigured()}
     />
   );
 }

--- a/packages/gui/src/app/skills/page.tsx
+++ b/packages/gui/src/app/skills/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/skill-state';
 import { SkillsView, type SkillRow } from './skills-view';
 import type { ExternalRepoSourceRow } from './external-sources-section';
+import type { UploadedSkillRow } from './uploaded-skills-section';
 
 interface RepoSkillsRow {
   commit_sha: string | null;
@@ -35,6 +36,15 @@ interface ExternalSourceRow {
 interface ExternalCacheRow {
   source_id: string;
   skills: unknown;
+}
+
+interface UploadedSkillsDbRow {
+  name: string;
+  body: string;
+  description: string | null;
+  suggested_stages: unknown;
+  uploaded_at: string;
+  updated_at: string;
 }
 
 interface ExternalRepoConfig {
@@ -130,6 +140,7 @@ export default async function SkillsPage() {
     { data: overrideRows },
     { states, seeded: workspaceSeeded },
     { data: externalSourceRows },
+    { data: uploadedRows },
   ] = await Promise.all([
     supabase
       .from('repo_skills')
@@ -149,6 +160,12 @@ export default async function SkillsPage() {
       .eq('workspace_id', workspace.id)
       .eq('kind', 'external-repo')
       .returns<ExternalSourceRow[]>(),
+    supabase
+      .from('uploaded_skills')
+      .select('name, body, description, suggested_stages, uploaded_at, updated_at')
+      .eq('workspace_id', workspace.id)
+      .order('uploaded_at', { ascending: false })
+      .returns<UploadedSkillsDbRow[]>(),
   ]);
 
   const externalSourceIds = (externalSourceRows ?? []).map((row) => row.id);
@@ -201,6 +218,25 @@ export default async function SkillsPage() {
       seenNames.add(skill.name);
       parsed.push({ ...skill, source: 'external-repo' });
     }
+  }
+
+  // Issue #262 (PR 3) — disk uploads. Sit below external in
+  // `SKILL_SOURCE_PRIORITY`, so they get dedup-shadowed by anything already
+  // surfaced above. UI still lists them in the dedicated Uploaded section so
+  // the user can manage shadowed uploads even when they don't show up in the
+  // main catalog.
+  for (const row of uploadedRows ?? []) {
+    if (seenNames.has(row.name)) continue;
+    seenNames.add(row.name);
+    parsed.push({
+      name: row.name,
+      description: row.description,
+      suggestedStages: Array.isArray(row.suggested_stages)
+        ? (row.suggested_stages as unknown[]).filter((x): x is string => typeof x === 'string')
+        : [],
+      path: '',
+      source: 'disk',
+    });
   }
 
   // Lazy seed: first time a workspace opens /skills, populate `enabled=true`
@@ -278,6 +314,13 @@ export default async function SkillsPage() {
   // — silence unused-var until then.
   void externalSourceMeta;
 
+  const uploadedSkills: UploadedSkillRow[] = (uploadedRows ?? []).map((row) => ({
+    name: row.name,
+    description: row.description,
+    uploadedAt: row.uploaded_at,
+    updatedAt: row.updated_at,
+  }));
+
   return (
     <SkillsView
       rows={rows}
@@ -286,6 +329,7 @@ export default async function SkillsPage() {
       fetchedAt={skillsRow?.fetched_at ?? null}
       readOnly={!isAdmin}
       externalSources={externalSources}
+      uploadedSkills={uploadedSkills}
     />
   );
 }

--- a/packages/gui/src/app/skills/skills-sh-actions.ts
+++ b/packages/gui/src/app/skills/skills-sh-actions.ts
@@ -2,15 +2,19 @@
 
 import { revalidatePath } from 'next/cache';
 import { parseSkillMarkdown } from '@cezar/core';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import type { Database } from '@/lib/supabase/types';
 import {
   fetchSkillsShSkill,
   parseSkillsShIdentifier,
   SkillsShAuthError,
   SkillsShNotConfiguredError,
   SkillsShNotFoundError,
+  SkillsShPayloadTooLargeError,
+  SkillsShTimeoutError,
   type SkillsShSkill,
 } from '@/lib/skills-sh-api';
 
@@ -26,6 +30,7 @@ import {
 export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
+const MAX_BODY_BYTES = 100 * 1024;
 
 interface InstallSummary {
   slug: string;
@@ -43,7 +48,61 @@ function describeError(err: unknown): string {
   if (err instanceof SkillsShNotFoundError) {
     return err.message;
   }
+  if (err instanceof SkillsShTimeoutError || err instanceof SkillsShPayloadTooLargeError) {
+    return err.message;
+  }
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Revalidate every surface that consumes the skills.sh catalog:
+ *   - `/skills` list
+ *   - `/skills/[name]` detail page
+ *   - `/workflows` layout (covers the dynamic `/workflows/[id]` editor whose
+ *     `listAvailableSkills` picker now folds in skills.sh imports)
+ */
+function revalidateSkillsShSurfaces(name?: string) {
+  revalidatePath('/skills');
+  if (name) revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  revalidatePath('/workflows', 'layout');
+}
+
+/**
+ * Match Postgres unique_violation (23505) to a friendly message. The table
+ * declares unique constraints on BOTH (workspace_id, source_slug) AND
+ * (workspace_id, name); persistSkill resolves conflicts on source_slug only,
+ * so a cross-slug name collision still surfaces as a raw 23505.
+ */
+function describeUpsertError(err: { code?: string; message?: string }, finalName: string): string {
+  if (err.code === '23505' && err.message?.includes('workspace_id_name')) {
+    return `a skill named "${finalName}" is already imported from a different skills.sh source — remove the existing one first`;
+  }
+  return err.message ?? 'database upsert failed';
+}
+
+/**
+ * First-install seed for `workspace_skill_states` so a freshly imported
+ * skills.sh skill is immediately visible in the workflow picker and dispatch.
+ * Skipped on Refresh — `existed === true` means the admin already chose an
+ * enabled/disabled state at some point, which we must preserve.
+ */
+async function enableSkillsShSkillState(
+  supabase: SupabaseClient<Database>,
+  workspaceId: string,
+  skillName: string,
+  userId: string,
+) {
+  await supabase.from('workspace_skill_states').upsert(
+    {
+      workspace_id: workspaceId,
+      skill_name: skillName,
+      enabled: true,
+      pinned_source: 'skills-sh',
+      created_by: userId,
+      updated_by: userId,
+    },
+    { onConflict: 'workspace_id,skill_name', ignoreDuplicates: true },
+  );
 }
 
 async function persistSkill(
@@ -51,7 +110,7 @@ async function persistSkill(
   userId: string,
   slug: string,
   api: SkillsShSkill,
-  supabase: ReturnType<typeof createSupabaseAdminClient>,
+  supabase: SupabaseClient<Database>,
 ): Promise<ActionResult<InstallSummary>> {
   // Pull `cezar-stages` and a friendlier name out of the body's frontmatter,
   // falling back to the API's name if the body has none.
@@ -59,6 +118,15 @@ async function persistSkill(
   const finalName = (parsed.name ?? api.name).trim();
   if (!NAME_PATTERN.test(finalName)) {
     return { ok: false, error: `name "${finalName}" must be alphanumeric + \`-\`/\`_\` (max 63 chars)` };
+  }
+  // Belt-and-braces against a compromised / oversized registry response —
+  // mirrors the PR3 cap on disk uploads. Buffer.byteLength counts UTF-8
+  // bytes, not UTF-16 code units, so multi-byte glyphs can't slip past.
+  if (Buffer.byteLength(api.body, 'utf8') > MAX_BODY_BYTES) {
+    return {
+      ok: false,
+      error: `skill body exceeds ${MAX_BODY_BYTES / 1024}KB — skills.sh payload too large`,
+    };
   }
 
   const { data: existing } = await supabase
@@ -84,7 +152,13 @@ async function persistSkill(
     },
     { onConflict: 'workspace_id,source_slug' },
   );
-  if (error) return { ok: false, error: error.message };
+  if (error) return { ok: false, error: describeUpsertError(error, finalName) };
+
+  // Only seed the activation row on first install. On Refresh we must
+  // preserve whatever enabled/disabled state the admin set in the meantime.
+  if (!existing) {
+    await enableSkillsShSkillState(supabase, workspaceId, finalName, userId);
+  }
 
   return { ok: true, slug, name: finalName, replaced: existing !== null };
 }
@@ -113,7 +187,7 @@ export async function addSkillsShSkill(input: {
 
   const supabase = createSupabaseAdminClient();
   const persisted = await persistSkill(workspace.id, user.id, slug, api, supabase);
-  if (persisted.ok) revalidatePath('/skills');
+  if (persisted.ok) revalidateSkillsShSurfaces(persisted.name);
   return persisted;
 }
 
@@ -131,7 +205,7 @@ export async function refreshSkillsShSkill(
   const supabase = createSupabaseAdminClient();
   const { data: row, error: loadError } = await supabase
     .from('skills_sh_skills')
-    .select('source_slug, content_hash')
+    .select('source_slug, content_hash, name')
     .eq('id', id)
     .eq('workspace_id', workspace.id)
     .single();
@@ -158,13 +232,18 @@ export async function refreshSkillsShSkill(
       .update({ last_synced_at: new Date().toISOString(), last_sync_error: null })
       .eq('id', id)
       .eq('workspace_id', workspace.id);
-    revalidatePath('/skills');
+    revalidateSkillsShSurfaces(row.name);
     return { ok: true, slug: row.source_slug, changed: false };
   }
 
   const persisted = await persistSkill(workspace.id, user.id, row.source_slug, api, supabase);
   if (!persisted.ok) return persisted;
-  revalidatePath('/skills');
+  // Surface both the old and the new name (rename case) so revalidatePath
+  // hits the right detail route after an upstream rename.
+  revalidateSkillsShSurfaces(persisted.name);
+  if (persisted.name !== row.name) {
+    revalidatePath(`/skills/${encodeURIComponent(row.name)}`);
+  }
   return { ok: true, slug: row.source_slug, changed: true };
 }
 
@@ -178,12 +257,18 @@ export async function removeSkillsShSkill(id: string): Promise<ActionResult> {
   }
 
   const supabase = createSupabaseAdminClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('skills_sh_skills')
     .delete()
     .eq('id', id)
-    .eq('workspace_id', workspace.id);
+    .eq('workspace_id', workspace.id)
+    .select('name')
+    .maybeSingle<{ name: string }>();
   if (error) return { ok: false, error: error.message };
-  revalidatePath('/skills');
+  // Stale id or cross-workspace target: predicate matched zero rows. Surface
+  // as a real error so the UI doesn't show 'removed' on a silent no-op.
+  if (!data) return { ok: false, error: 'skills.sh import not found' };
+
+  revalidateSkillsShSurfaces(data.name);
   return { ok: true };
 }

--- a/packages/gui/src/app/skills/skills-sh-actions.ts
+++ b/packages/gui/src/app/skills/skills-sh-actions.ts
@@ -1,0 +1,189 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { parseSkillMarkdown } from '@cezar/core';
+import { getSessionUser } from '@/lib/auth';
+import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import {
+  fetchSkillsShSkill,
+  parseSkillsShIdentifier,
+  SkillsShAuthError,
+  SkillsShNotConfiguredError,
+  SkillsShNotFoundError,
+  type SkillsShSkill,
+} from '@/lib/skills-sh-api';
+
+/**
+ * Issue #262 (PR 4) — install / refresh / remove for skills.sh imports.
+ *
+ * The API gives us a skill record with its body inline; we persist it into
+ * `skills_sh_skills` so dispatch reads bodies from the DB without ever
+ * touching skills.sh at run time. Refresh compares the API's `contentHash`
+ * to short-circuit when nothing changed.
+ */
+
+export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
+
+interface InstallSummary {
+  slug: string;
+  name: string;
+  replaced: boolean;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof SkillsShNotConfiguredError) {
+    return 'skills.sh requires SKILLS_SH_TOKEN in env';
+  }
+  if (err instanceof SkillsShAuthError) {
+    return 'skills.sh rejected the token — refresh SKILLS_SH_TOKEN';
+  }
+  if (err instanceof SkillsShNotFoundError) {
+    return err.message;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function persistSkill(
+  workspaceId: string,
+  userId: string,
+  slug: string,
+  api: SkillsShSkill,
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+): Promise<ActionResult<InstallSummary>> {
+  // Pull `cezar-stages` and a friendlier name out of the body's frontmatter,
+  // falling back to the API's name if the body has none.
+  const parsed = parseSkillMarkdown(api.body, api.name);
+  const finalName = (parsed.name ?? api.name).trim();
+  if (!NAME_PATTERN.test(finalName)) {
+    return { ok: false, error: `name "${finalName}" must be alphanumeric + \`-\`/\`_\` (max 63 chars)` };
+  }
+
+  const { data: existing } = await supabase
+    .from('skills_sh_skills')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('source_slug', slug)
+    .maybeSingle<{ id: string }>();
+
+  const { error } = await supabase.from('skills_sh_skills').upsert(
+    {
+      workspace_id: workspaceId,
+      source_slug: slug,
+      name: finalName,
+      body: api.body,
+      description: parsed.description ?? api.description ?? null,
+      suggested_stages: parsed.suggestedStages,
+      content_hash: api.contentHash,
+      install_url: api.installUrl,
+      last_synced_at: new Date().toISOString(),
+      last_sync_error: null,
+      imported_by: userId,
+    },
+    { onConflict: 'workspace_id,source_slug' },
+  );
+  if (error) return { ok: false, error: error.message };
+
+  return { ok: true, slug, name: finalName, replaced: existing !== null };
+}
+
+export async function addSkillsShSkill(input: {
+  identifier: string;
+}): Promise<ActionResult<InstallSummary>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can install skills.sh skills' };
+  }
+  const slug = parseSkillsShIdentifier(input.identifier);
+  if (!slug) {
+    return { ok: false, error: 'invalid identifier — expected `source/slug` or skills.sh URL' };
+  }
+
+  let api: SkillsShSkill;
+  try {
+    api = await fetchSkillsShSkill(slug);
+  } catch (err) {
+    return { ok: false, error: describeError(err) };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const persisted = await persistSkill(workspace.id, user.id, slug, api, supabase);
+  if (persisted.ok) revalidatePath('/skills');
+  return persisted;
+}
+
+export async function refreshSkillsShSkill(
+  id: string,
+): Promise<ActionResult<{ slug: string; changed: boolean }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can refresh skills.sh skills' };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { data: row, error: loadError } = await supabase
+    .from('skills_sh_skills')
+    .select('source_slug, content_hash')
+    .eq('id', id)
+    .eq('workspace_id', workspace.id)
+    .single();
+  if (loadError || !row) return { ok: false, error: loadError?.message ?? 'skill not found' };
+
+  let api: SkillsShSkill;
+  try {
+    api = await fetchSkillsShSkill(row.source_slug);
+  } catch (err) {
+    const message = describeError(err);
+    await supabase
+      .from('skills_sh_skills')
+      .update({ last_sync_error: message })
+      .eq('id', id)
+      .eq('workspace_id', workspace.id);
+    return { ok: false, error: message };
+  }
+
+  const sameHash =
+    api.contentHash !== null && row.content_hash !== null && api.contentHash === row.content_hash;
+  if (sameHash) {
+    await supabase
+      .from('skills_sh_skills')
+      .update({ last_synced_at: new Date().toISOString(), last_sync_error: null })
+      .eq('id', id)
+      .eq('workspace_id', workspace.id);
+    revalidatePath('/skills');
+    return { ok: true, slug: row.source_slug, changed: false };
+  }
+
+  const persisted = await persistSkill(workspace.id, user.id, row.source_slug, api, supabase);
+  if (!persisted.ok) return persisted;
+  revalidatePath('/skills');
+  return { ok: true, slug: row.source_slug, changed: true };
+}
+
+export async function removeSkillsShSkill(id: string): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can remove skills.sh imports' };
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('skills_sh_skills')
+    .delete()
+    .eq('id', id)
+    .eq('workspace_id', workspace.id);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath('/skills');
+  return { ok: true };
+}

--- a/packages/gui/src/app/skills/skills-sh-modal.tsx
+++ b/packages/gui/src/app/skills/skills-sh-modal.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { cn } from '@/components/ui/cn';
+import { addSkillsShSkill } from './skills-sh-actions';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Surfaced from the server so we can disable submit when the env-var is missing. */
+  configured: boolean;
+}
+
+interface SuccessSummary {
+  slug: string;
+  name: string;
+  replaced: boolean;
+}
+
+/**
+ * Issue #262 (PR 4) — install a skill from skills.sh by pasting its identifier
+ * (`source/slug`) or its skills.sh URL. The server action fetches metadata +
+ * body in one call and writes them to `skills_sh_skills` with the body inline.
+ */
+export function SkillsShModal({ open, onClose, configured }: Props) {
+  const [identifier, setIdentifier] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<SuccessSummary | null>(null);
+  const [submitting, startSubmit] = useTransition();
+
+  if (!open) return null;
+
+  function reset() {
+    setIdentifier('');
+    setError(null);
+    setSuccess(null);
+  }
+
+  function closeAndReset() {
+    reset();
+    onClose();
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!configured) {
+      setError('skills.sh requires SKILLS_SH_TOKEN in env — ask an admin to configure it.');
+      return;
+    }
+    setError(null);
+    setSuccess(null);
+    startSubmit(async () => {
+      const res = await addSkillsShSkill({ identifier });
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      setSuccess({ slug: res.slug, name: res.name, replaced: res.replaced });
+      setIdentifier('');
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Install skill from skills.sh"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeAndReset();
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-lg border border-outline-variant bg-surface-container p-5 shadow-xl"
+      >
+        <header className="mb-4">
+          <h2 className="text-base font-semibold text-on-surface">Install from skills.sh</h2>
+          <p className="mt-1 text-xs text-on-surface-variant">
+            Paste a <code className="font-mono">source/slug</code> identifier (e.g.{' '}
+            <code className="font-mono">vercel-labs/skills/find-skills</code>) or the full
+            skills.sh URL.
+          </p>
+        </header>
+
+        {!configured && (
+          <div className="mb-3 rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-amber-300">
+            ⚠ Skills.sh integration is disabled — set <code className="font-mono">SKILLS_SH_TOKEN</code>{' '}
+            in the deployment environment.
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-3 rounded-md border border-error/30 bg-error-container/30 px-3 py-2 text-xs text-error">
+            {error}
+          </div>
+        )}
+
+        {success && (
+          <div className="mb-3 rounded-md border border-primary/30 bg-primary-container/20 px-3 py-2 text-xs text-primary">
+            {success.replaced ? 'Replaced' : 'Installed'}{' '}
+            <span className="font-mono">{success.name}</span>{' '}
+            <span className="text-on-surface-variant">({success.slug})</span>.
+          </div>
+        )}
+
+        <label className="block">
+          <div className="text-[11px] font-medium uppercase tracking-wide text-on-surface-variant">
+            Skill ID or URL
+          </div>
+          <input
+            type="text"
+            value={identifier}
+            onChange={(e) => setIdentifier(e.target.value)}
+            placeholder="vercel-labs/skills/find-skills"
+            disabled={!configured || submitting}
+            className="mt-1 h-9 w-full rounded-md border border-outline-variant bg-surface px-2 font-mono text-xs text-on-surface focus:border-primary focus:outline-none disabled:opacity-60"
+          />
+        </label>
+
+        <footer className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={closeAndReset}
+            className="h-9 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface hover:border-primary"
+          >
+            {success ? 'Close' : 'Cancel'}
+          </button>
+          <button
+            type="submit"
+            disabled={!configured || submitting || !identifier.trim()}
+            className={cn(
+              'h-9 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface',
+              (!configured || submitting || !identifier.trim()) && 'opacity-60',
+            )}
+          >
+            {submitting ? 'Installing…' : 'Fetch & install'}
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}

--- a/packages/gui/src/app/skills/skills-sh-section.tsx
+++ b/packages/gui/src/app/skills/skills-sh-section.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import { RefreshIcon } from '@/components/icons';
+import { refreshSkillsShSkill, removeSkillsShSkill } from './skills-sh-actions';
+
+export interface SkillsShImportRow {
+  id: string;
+  name: string;
+  sourceSlug: string;
+  installUrl: string | null;
+  lastSyncedAt: string;
+  lastSyncError: string | null;
+}
+
+interface Props {
+  imports: SkillsShImportRow[];
+  readOnly: boolean;
+  configured: boolean;
+  onOpenInstall: () => void;
+}
+
+/**
+ * Issue #262 (PR 4) — list of skills.sh imports. Mirrors the layout of the
+ * external sources panel (PR 2) and uploaded skills panel (PR 3).
+ */
+export function SkillsShSection({ imports, readOnly, configured, onOpenInstall }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function handleRefresh(id: string) {
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const res = await refreshSkillsShSkill(id);
+      setBusyId(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  function handleRemove(id: string, name: string) {
+    if (!confirm(`Remove the skills.sh import "${name}"?`)) return;
+    setError(null);
+    setBusyId(id);
+    startTransition(async () => {
+      const res = await removeSkillsShSkill(id);
+      setBusyId(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  return (
+    <section className="mb-6 rounded-lg border border-outline-variant bg-surface-container-low p-4">
+      <header className="mb-3 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-on-surface">skills.sh imports</h2>
+          <p className="mt-0.5 text-xs text-on-surface-variant">
+            Skills installed from the public registry. Refresh pulls a new snapshot when the API&apos;s
+            content hash changes.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenInstall}
+          disabled={readOnly || !configured}
+          className="inline-flex h-8 items-center rounded-md border border-outline-variant bg-surface-container px-2 text-xs font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+          title={!configured ? 'skills.sh requires SKILLS_SH_TOKEN' : undefined}
+        >
+          Install
+        </button>
+      </header>
+
+      {!configured && (
+        <div className="mb-3 rounded-md border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs text-amber-300">
+          ⚠ Set <code className="font-mono">SKILLS_SH_TOKEN</code> in env to install or refresh
+          skills from skills.sh.
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-3 rounded-md border border-error/30 bg-error-container/30 px-3 py-2 text-xs text-error">
+          {error}
+        </div>
+      )}
+
+      {imports.length === 0 ? (
+        <div className="rounded-md border border-dashed border-outline-variant px-3 py-6 text-center text-xs text-on-surface-variant">
+          No skills.sh imports yet. Use{' '}
+          <span className="font-mono text-on-surface">Add skill source → skills.sh registry</span>{' '}
+          or the Install button above.
+        </div>
+      ) : (
+        <ul className="divide-y divide-outline-variant/50 rounded-md border border-outline-variant">
+          {imports.map((row) => (
+            <li key={row.id} className="flex flex-wrap items-center gap-3 px-3 py-2 text-sm">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2 text-on-surface">
+                  <Link
+                    href={`/skills/${encodeURIComponent(row.name)}`}
+                    className="font-medium hover:text-primary"
+                  >
+                    {row.name}
+                  </Link>
+                  <span className="font-mono text-[11px] text-on-surface-variant">{row.sourceSlug}</span>
+                </div>
+                <div className="mt-0.5 text-[11px] text-on-surface-variant">
+                  last synced {formatTimestamp(row.lastSyncedAt)}
+                  {row.installUrl && (
+                    <>
+                      {' · '}
+                      <a
+                        href={row.installUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="underline underline-offset-2 hover:text-on-surface"
+                      >
+                        View on skills.sh
+                      </a>
+                    </>
+                  )}
+                  {row.lastSyncError && (
+                    <span className="ml-2 text-amber-300/90">⚠ {row.lastSyncError}</span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => handleRefresh(row.id)}
+                  disabled={readOnly || !configured || busyId === row.id}
+                  className="inline-flex h-7 items-center gap-1.5 rounded-md border border-outline-variant bg-surface-container px-2 text-[11px] font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+                >
+                  <RefreshIcon className="h-3 w-3" />
+                  {busyId === row.id ? 'Syncing…' : 'Refresh'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(row.id, row.name)}
+                  disabled={readOnly || busyId === row.id}
+                  className="inline-flex h-7 items-center rounded-md border border-error/40 bg-surface-container px-2 text-[11px] font-medium text-error transition-colors hover:bg-error-container/40 disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/packages/gui/src/app/skills/skills-view.tsx
+++ b/packages/gui/src/app/skills/skills-view.tsx
@@ -27,6 +27,10 @@ import { ActionSheet, type ActionSheetItem } from '@/components/ui/action-sheet'
 import { RowMenuPortal } from '@/components/row-menu-portal';
 import { refreshRepoSkills } from './skills-action';
 import { setSkillEnabled } from './state-actions';
+import {
+  ExternalSourcesSection,
+  type ExternalRepoSourceRow,
+} from './external-sources-section';
 
 /** Issue #262 — provenance values surfaced in the UI. `override` keeps its
  *  special meaning ("the workspace forked this skill") and shadows whatever
@@ -64,6 +68,8 @@ interface SkillsViewProps {
   commitSha: string | null;
   fetchedAt: string | null;
   readOnly: boolean;
+  /** Issue #262 (PR 2) — registered external repos for the workspace. */
+  externalSources?: ExternalRepoSourceRow[];
 }
 
 type SortKey = 'name' | 'source' | 'mode' | 'trigger' | 'status' | 'lastRun';
@@ -73,7 +79,17 @@ type SkillTab = 'catalog' | 'active';
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100] as const;
 type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
 
-export function SkillsView({ rows: rowsProp, overridesCount, commitSha, fetchedAt, readOnly }: SkillsViewProps) {
+export function SkillsView({
+  rows: rowsProp,
+  overridesCount,
+  commitSha,
+  fetchedAt,
+  readOnly,
+  externalSources = [],
+}: SkillsViewProps) {
+  // Issue #262 (PR 2) — controlled open state for the "Add external repo" modal,
+  // toggled from the page-header "Add skill source ▾" menu.
+  const [addExternalOpen, setAddExternalOpen] = useState(false);
   // Keep an optimistic local mirror so a toggle reflects in the table before
   // `revalidatePath` lands the server-side refresh.
   const [rows, setRows] = useState<SkillRow[]>(rowsProp);
@@ -205,7 +221,10 @@ export function SkillsView({ rows: rowsProp, overridesCount, commitSha, fetchedA
             <RefreshIcon className="h-4 w-4" />
             {refreshing ? 'Syncing…' : 'Sync from repo'}
           </button>
-          <AddSkillSourceMenu disabled={readOnly} />
+          <AddSkillSourceMenu
+            disabled={readOnly}
+            onAddExternalRepo={() => setAddExternalOpen(true)}
+          />
           <Link
             href="/settings/workflows"
             aria-disabled={readOnly}
@@ -259,6 +278,14 @@ export function SkillsView({ rows: rowsProp, overridesCount, commitSha, fetchedA
           {refreshState.error}
         </div>
       )}
+
+      {/* Issue #262 (PR 2) — external repo sources */}
+      <ExternalSourcesSection
+        sources={externalSources}
+        readOnly={readOnly}
+        addModalOpen={addExternalOpen}
+        onCloseAddModal={() => setAddExternalOpen(false)}
+      />
 
       {/* KPI stats */}
       <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -899,12 +926,22 @@ function SourceBadge({ source }: { source: SkillRow['source'] }) {
   );
 }
 
-/** Issue #262 — placeholder dropdown for adding additional skill sources. The
- *  three non-workspace options ship in PR 2 (external-repo), PR 3 (disk), and
- *  PR 4 (skills-sh); they're listed here so the IA settles in PR 1 without a
- *  follow-up nav refactor. */
-function AddSkillSourceMenu({ disabled }: { disabled: boolean }) {
+/** Issue #262 — dropdown for adding additional skill sources. "Another repo"
+ *  lands in PR 2 (this); the rest stay marked _Coming soon_ until their PRs. */
+function AddSkillSourceMenu({
+  disabled,
+  onAddExternalRepo,
+}: {
+  disabled: boolean;
+  onAddExternalRepo: () => void;
+}) {
   const [open, setOpen] = useState(false);
+  type Entry = { label: string; note: string; onClick?: () => void };
+  const entries: Entry[] = [
+    { label: 'Another repo', note: 'External', onClick: onAddExternalRepo },
+    { label: 'Upload from disk', note: 'Coming soon' },
+    { label: 'skills.sh registry', note: 'Coming soon' },
+  ];
   return (
     <div className="relative">
       <button
@@ -924,24 +961,33 @@ function AddSkillSourceMenu({ disabled }: { disabled: boolean }) {
           className="absolute right-0 z-20 mt-1 w-56 rounded-md border border-outline-variant bg-surface-container py-1 shadow-lg"
           onMouseLeave={() => setOpen(false)}
         >
-          {[
-            { label: 'Another repo', note: 'Coming soon' },
-            { label: 'Upload from disk', note: 'Coming soon' },
-            { label: 'skills.sh registry', note: 'Coming soon' },
-          ].map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              role="menuitem"
-              disabled
-              className="flex w-full cursor-not-allowed items-center justify-between px-3 py-2 text-left text-sm text-on-surface-variant"
-            >
-              <span>{item.label}</span>
-              <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-on-surface-variant/60">
-                {item.note}
-              </span>
-            </button>
-          ))}
+          {entries.map((item) => {
+            const enabled = !!item.onClick;
+            return (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                disabled={!enabled}
+                onClick={() => {
+                  if (!item.onClick) return;
+                  setOpen(false);
+                  item.onClick();
+                }}
+                className={cn(
+                  'flex w-full items-center justify-between px-3 py-2 text-left text-sm',
+                  enabled
+                    ? 'text-on-surface transition-colors hover:bg-surface-container/80'
+                    : 'cursor-not-allowed text-on-surface-variant',
+                )}
+              >
+                <span>{item.label}</span>
+                <span className="font-mono text-[10px] uppercase tracking-[0.05em] text-on-surface-variant/60">
+                  {item.note}
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/gui/src/app/skills/skills-view.tsx
+++ b/packages/gui/src/app/skills/skills-view.tsx
@@ -31,6 +31,11 @@ import {
   ExternalSourcesSection,
   type ExternalRepoSourceRow,
 } from './external-sources-section';
+import { UploadModal } from './upload-modal';
+import {
+  UploadedSkillsSection,
+  type UploadedSkillRow,
+} from './uploaded-skills-section';
 
 /** Issue #262 — provenance values surfaced in the UI. `override` keeps its
  *  special meaning ("the workspace forked this skill") and shadows whatever
@@ -70,6 +75,8 @@ interface SkillsViewProps {
   readOnly: boolean;
   /** Issue #262 (PR 2) — registered external repos for the workspace. */
   externalSources?: ExternalRepoSourceRow[];
+  /** Issue #262 (PR 3) — disk-uploaded skills for the workspace. */
+  uploadedSkills?: UploadedSkillRow[];
 }
 
 type SortKey = 'name' | 'source' | 'mode' | 'trigger' | 'status' | 'lastRun';
@@ -86,10 +93,13 @@ export function SkillsView({
   fetchedAt,
   readOnly,
   externalSources = [],
+  uploadedSkills = [],
 }: SkillsViewProps) {
   // Issue #262 (PR 2) — controlled open state for the "Add external repo" modal,
   // toggled from the page-header "Add skill source ▾" menu.
   const [addExternalOpen, setAddExternalOpen] = useState(false);
+  // Issue #262 (PR 3) — same pattern for the disk upload modal.
+  const [uploadOpen, setUploadOpen] = useState(false);
   // Keep an optimistic local mirror so a toggle reflects in the table before
   // `revalidatePath` lands the server-side refresh.
   const [rows, setRows] = useState<SkillRow[]>(rowsProp);
@@ -224,6 +234,7 @@ export function SkillsView({
           <AddSkillSourceMenu
             disabled={readOnly}
             onAddExternalRepo={() => setAddExternalOpen(true)}
+            onUploadFromDisk={() => setUploadOpen(true)}
           />
           <Link
             href="/settings/workflows"
@@ -286,6 +297,14 @@ export function SkillsView({
         addModalOpen={addExternalOpen}
         onCloseAddModal={() => setAddExternalOpen(false)}
       />
+
+      {/* Issue #262 (PR 3) — uploaded (disk) skills */}
+      <UploadedSkillsSection
+        uploaded={uploadedSkills}
+        readOnly={readOnly}
+        onOpenUpload={() => setUploadOpen(true)}
+      />
+      <UploadModal open={uploadOpen} onClose={() => setUploadOpen(false)} />
 
       {/* KPI stats */}
       <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -927,19 +946,22 @@ function SourceBadge({ source }: { source: SkillRow['source'] }) {
 }
 
 /** Issue #262 — dropdown for adding additional skill sources. "Another repo"
- *  lands in PR 2 (this); the rest stay marked _Coming soon_ until their PRs. */
+ *  landed in PR 2, "Upload from disk" lands here in PR 3; the skills.sh entry
+ *  stays marked _Coming soon_ until PR 4. */
 function AddSkillSourceMenu({
   disabled,
   onAddExternalRepo,
+  onUploadFromDisk,
 }: {
   disabled: boolean;
   onAddExternalRepo: () => void;
+  onUploadFromDisk: () => void;
 }) {
   const [open, setOpen] = useState(false);
   type Entry = { label: string; note: string; onClick?: () => void };
   const entries: Entry[] = [
     { label: 'Another repo', note: 'External', onClick: onAddExternalRepo },
-    { label: 'Upload from disk', note: 'Coming soon' },
+    { label: 'Upload from disk', note: 'Disk', onClick: onUploadFromDisk },
     { label: 'skills.sh registry', note: 'Coming soon' },
   ];
   return (

--- a/packages/gui/src/app/skills/skills-view.tsx
+++ b/packages/gui/src/app/skills/skills-view.tsx
@@ -36,6 +36,11 @@ import {
   UploadedSkillsSection,
   type UploadedSkillRow,
 } from './uploaded-skills-section';
+import { SkillsShModal } from './skills-sh-modal';
+import {
+  SkillsShSection,
+  type SkillsShImportRow,
+} from './skills-sh-section';
 
 /** Issue #262 — provenance values surfaced in the UI. `override` keeps its
  *  special meaning ("the workspace forked this skill") and shadows whatever
@@ -77,6 +82,11 @@ interface SkillsViewProps {
   externalSources?: ExternalRepoSourceRow[];
   /** Issue #262 (PR 3) — disk-uploaded skills for the workspace. */
   uploadedSkills?: UploadedSkillRow[];
+  /** Issue #262 (PR 4) — skills.sh imports for the workspace. */
+  skillsShImports?: SkillsShImportRow[];
+  /** Issue #262 (PR 4) — whether the deployment has `SKILLS_SH_TOKEN` set.
+   *  Drives whether Install / Refresh buttons are clickable. */
+  skillsShConfigured?: boolean;
 }
 
 type SortKey = 'name' | 'source' | 'mode' | 'trigger' | 'status' | 'lastRun';
@@ -94,12 +104,16 @@ export function SkillsView({
   readOnly,
   externalSources = [],
   uploadedSkills = [],
+  skillsShImports = [],
+  skillsShConfigured = false,
 }: SkillsViewProps) {
   // Issue #262 (PR 2) — controlled open state for the "Add external repo" modal,
   // toggled from the page-header "Add skill source ▾" menu.
   const [addExternalOpen, setAddExternalOpen] = useState(false);
   // Issue #262 (PR 3) — same pattern for the disk upload modal.
   const [uploadOpen, setUploadOpen] = useState(false);
+  // Issue #262 (PR 4) — same pattern for the skills.sh install modal.
+  const [skillsShOpen, setSkillsShOpen] = useState(false);
   // Keep an optimistic local mirror so a toggle reflects in the table before
   // `revalidatePath` lands the server-side refresh.
   const [rows, setRows] = useState<SkillRow[]>(rowsProp);
@@ -235,6 +249,7 @@ export function SkillsView({
             disabled={readOnly}
             onAddExternalRepo={() => setAddExternalOpen(true)}
             onUploadFromDisk={() => setUploadOpen(true)}
+            onInstallSkillsSh={() => setSkillsShOpen(true)}
           />
           <Link
             href="/settings/workflows"
@@ -305,6 +320,19 @@ export function SkillsView({
         onOpenUpload={() => setUploadOpen(true)}
       />
       <UploadModal open={uploadOpen} onClose={() => setUploadOpen(false)} />
+
+      {/* Issue #262 (PR 4) — skills.sh imports */}
+      <SkillsShSection
+        imports={skillsShImports}
+        readOnly={readOnly}
+        configured={skillsShConfigured}
+        onOpenInstall={() => setSkillsShOpen(true)}
+      />
+      <SkillsShModal
+        open={skillsShOpen}
+        onClose={() => setSkillsShOpen(false)}
+        configured={skillsShConfigured}
+      />
 
       {/* KPI stats */}
       <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -945,24 +973,26 @@ function SourceBadge({ source }: { source: SkillRow['source'] }) {
   );
 }
 
-/** Issue #262 — dropdown for adding additional skill sources. "Another repo"
- *  landed in PR 2, "Upload from disk" lands here in PR 3; the skills.sh entry
- *  stays marked _Coming soon_ until PR 4. */
+/** Issue #262 — dropdown for adding additional skill sources. PR 2 added
+ *  "Another repo", PR 3 added "Upload from disk", PR 4 adds the skills.sh
+ *  registry entry; all three are now live. */
 function AddSkillSourceMenu({
   disabled,
   onAddExternalRepo,
   onUploadFromDisk,
+  onInstallSkillsSh,
 }: {
   disabled: boolean;
   onAddExternalRepo: () => void;
   onUploadFromDisk: () => void;
+  onInstallSkillsSh: () => void;
 }) {
   const [open, setOpen] = useState(false);
   type Entry = { label: string; note: string; onClick?: () => void };
   const entries: Entry[] = [
     { label: 'Another repo', note: 'External', onClick: onAddExternalRepo },
     { label: 'Upload from disk', note: 'Disk', onClick: onUploadFromDisk },
-    { label: 'skills.sh registry', note: 'Coming soon' },
+    { label: 'skills.sh registry', note: 'Registry', onClick: onInstallSkillsSh },
   ];
   return (
     <div className="relative">

--- a/packages/gui/src/app/skills/upload-actions.ts
+++ b/packages/gui/src/app/skills/upload-actions.ts
@@ -1,0 +1,212 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { parseSkillMarkdown } from '@cezar/core';
+import { getSessionUser } from '@/lib/auth';
+import { getActiveWorkspace } from '@/lib/workspace';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+
+/**
+ * Issue #262 (PR 3) — disk uploads as a skill source.
+ *
+ * The upload modal posts either a `files` FormData (drag-and-drop) or a
+ * `{ name, body }` paste payload. Both flows go through `parseSkillMarkdown`
+ * (shared with `discoverSkills`) so the YAML frontmatter rules stay identical
+ * between dispatch-on-disk and disk uploads.
+ */
+
+export type ActionResult<T = {}> = (T & { ok: true }) | { ok: false; error: string };
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,62}$/i;
+const MAX_BODY_BYTES = 100 * 1024;
+
+export interface UploadFailure {
+  filename: string;
+  error: string;
+}
+
+export interface UploadFilesSummary {
+  added: number;
+  replaced: number;
+  failed: UploadFailure[];
+}
+
+/**
+ * Accepts a FormData with one or more `file` entries (each a `.md` upload),
+ * parses YAML frontmatter, and upserts into `uploaded_skills`. Errors per file
+ * are returned in the summary so the user can fix the bad ones without losing
+ * the good ones.
+ */
+export async function uploadSkillsFromFiles(
+  formData: FormData,
+): Promise<ActionResult<UploadFilesSummary>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can upload skills' };
+  }
+
+  const files = formData.getAll('files').filter((entry): entry is File => entry instanceof File);
+  if (files.length === 0) return { ok: false, error: 'no files provided' };
+
+  const supabase = createSupabaseAdminClient();
+
+  const summary: UploadFilesSummary = { added: 0, replaced: 0, failed: [] };
+  // Look up existing names once so we can report `added` vs. `replaced`
+  // without round-tripping per upload.
+  const { data: existingRows } = await supabase
+    .from('uploaded_skills')
+    .select('name')
+    .eq('workspace_id', workspace.id);
+  const existingNames = new Set((existingRows ?? []).map((r) => r.name));
+
+  for (const file of files) {
+    const filename = file.name || 'untitled.md';
+    if (file.size > MAX_BODY_BYTES) {
+      summary.failed.push({ filename, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` });
+      continue;
+    }
+    let raw: string;
+    try {
+      raw = await file.text();
+    } catch (err) {
+      summary.failed.push({
+        filename,
+        error: `read failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    const fallbackName = filename.replace(/\.md$/i, '');
+    const parsed = parseSkillMarkdown(raw, fallbackName);
+    if (!parsed.name) {
+      summary.failed.push({ filename, error: 'no `name` in frontmatter and filename was unusable' });
+      continue;
+    }
+    if (!NAME_PATTERN.test(parsed.name)) {
+      summary.failed.push({
+        filename,
+        error: `name "${parsed.name}" must be alphanumeric + \`-\`/\`_\` (max 63 chars)`,
+      });
+      continue;
+    }
+    if (!parsed.body.trim()) {
+      summary.failed.push({ filename, error: 'body is empty' });
+      continue;
+    }
+
+    const wasExisting = existingNames.has(parsed.name);
+    const { error: upsertError } = await supabase.from('uploaded_skills').upsert(
+      {
+        workspace_id: workspace.id,
+        name: parsed.name,
+        body: parsed.body,
+        description: parsed.description ?? null,
+        suggested_stages: parsed.suggestedStages,
+        uploaded_by: user.id,
+        updated_by: user.id,
+      },
+      { onConflict: 'workspace_id,name' },
+    );
+    if (upsertError) {
+      summary.failed.push({ filename, error: upsertError.message });
+      continue;
+    }
+    if (wasExisting) summary.replaced += 1;
+    else {
+      summary.added += 1;
+      existingNames.add(parsed.name);
+    }
+  }
+
+  revalidatePath('/skills');
+  return { ok: true, ...summary };
+}
+
+export interface UploadFromTextInput {
+  /** Optional — when omitted, must be present in the markdown's frontmatter. */
+  name?: string;
+  body: string;
+}
+
+/**
+ * Paste-from-textarea fallback. Mirrors the per-file branch of
+ * `uploadSkillsFromFiles` but expects a single payload and returns a clearer
+ * error when the name can't be resolved.
+ */
+export async function uploadSkillFromText(
+  input: UploadFromTextInput,
+): Promise<ActionResult<{ name: string; replaced: boolean }>> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can upload skills' };
+  }
+
+  if (!input.body || !input.body.trim()) return { ok: false, error: 'body is empty' };
+  if (input.body.length > MAX_BODY_BYTES) {
+    return { ok: false, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` };
+  }
+
+  const parsed = parseSkillMarkdown(input.body, input.name?.trim() || undefined);
+  if (!parsed.name) {
+    return {
+      ok: false,
+      error: 'name is required — set `name:` in frontmatter or fill the Name field',
+    };
+  }
+  if (!NAME_PATTERN.test(parsed.name)) {
+    return { ok: false, error: 'name must be alphanumeric + `-`/`_` (max 63 chars)' };
+  }
+  if (!parsed.body.trim()) return { ok: false, error: 'body is empty' };
+
+  const supabase = createSupabaseAdminClient();
+  const { data: existing } = await supabase
+    .from('uploaded_skills')
+    .select('id')
+    .eq('workspace_id', workspace.id)
+    .eq('name', parsed.name)
+    .maybeSingle<{ id: string }>();
+
+  const { error: upsertError } = await supabase.from('uploaded_skills').upsert(
+    {
+      workspace_id: workspace.id,
+      name: parsed.name,
+      body: parsed.body,
+      description: parsed.description ?? null,
+      suggested_stages: parsed.suggestedStages,
+      uploaded_by: user.id,
+      updated_by: user.id,
+    },
+    { onConflict: 'workspace_id,name' },
+  );
+  if (upsertError) return { ok: false, error: upsertError.message };
+
+  revalidatePath('/skills');
+  return { ok: true, name: parsed.name, replaced: existing !== null };
+}
+
+export async function removeUploadedSkill(name: string): Promise<ActionResult> {
+  const user = await getSessionUser();
+  if (!user) return { ok: false, error: 'Not authenticated' };
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { ok: false, error: 'No workspace selected' };
+  if (workspace.role !== 'admin') {
+    return { ok: false, error: 'Only admins can remove uploaded skills' };
+  }
+  if (!name.trim()) return { ok: false, error: 'name is required' };
+
+  const supabase = createSupabaseAdminClient();
+  const { error } = await supabase
+    .from('uploaded_skills')
+    .delete()
+    .eq('workspace_id', workspace.id)
+    .eq('name', name);
+  if (error) return { ok: false, error: error.message };
+  revalidatePath('/skills');
+  return { ok: true };
+}

--- a/packages/gui/src/app/skills/upload-actions.ts
+++ b/packages/gui/src/app/skills/upload-actions.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from 'next/cache';
 import { parseSkillMarkdown } from '@cezar/core';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import type { Database } from '@/lib/supabase/types';
 
 /**
  * Issue #262 (PR 3) — disk uploads as a skill source.
@@ -29,6 +31,48 @@ export interface UploadFilesSummary {
   added: number;
   replaced: number;
   failed: UploadFailure[];
+}
+
+/**
+ * Revalidate every surface that consumes uploaded skills:
+ *   - `/skills` (list)
+ *   - `/skills/[name]` (detail page — stale across tabs after re-upload)
+ *   - `/workflows` layout (covers the dynamic `/workflows/[id]` editor whose
+ *     `listAvailableSkills` picker now folds uploaded skills in)
+ */
+function revalidateUploadSurfaces(name?: string) {
+  revalidatePath('/skills');
+  if (name) revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  revalidatePath('/workflows', 'layout');
+}
+
+/**
+ * Upsert an `enabled=true` row in `workspace_skill_states` so the freshly
+ * uploaded skill shows up in the workflow picker and the dispatch catalog
+ * immediately — without this the runtime would default-off for any workspace
+ * that's already been seeded (the common case), and the admin would have to
+ * toggle the new skill on at `/skills` before it does anything.
+ */
+async function enableUploadedSkillState(
+  supabase: SupabaseClient<Database>,
+  workspaceId: string,
+  skillName: string,
+  userId: string,
+) {
+  // Upsert with `ignoreDuplicates: false` so we re-enable a previously-disabled
+  // state row when the admin replaces the file. `created_by` is only set on
+  // first insert (the unique constraint takes the existing value otherwise).
+  await supabase.from('workspace_skill_states').upsert(
+    {
+      workspace_id: workspaceId,
+      skill_name: skillName,
+      enabled: true,
+      pinned_source: 'disk',
+      created_by: userId,
+      updated_by: userId,
+    },
+    { onConflict: 'workspace_id,skill_name' },
+  );
 }
 
 /**
@@ -61,6 +105,12 @@ export async function uploadSkillsFromFiles(
     .select('name')
     .eq('workspace_id', workspace.id);
   const existingNames = new Set((existingRows ?? []).map((r) => r.name));
+
+  // Track names already upserted in THIS batch so a second file with the same
+  // resolved name doesn't silently clobber the first (and we surface a
+  // 'duplicate within batch' failure on the second file).
+  const batchNames = new Set<string>();
+  const upsertedNames: string[] = [];
 
   for (const file of files) {
     const filename = file.name || 'untitled.md';
@@ -96,6 +146,21 @@ export async function uploadSkillsFromFiles(
       summary.failed.push({ filename, error: 'body is empty' });
       continue;
     }
+    // After-parse byte-size check: frontmatter is stripped but the body still
+    // needs to fit. `Buffer.byteLength` measures real UTF-8 bytes — `.length`
+    // would let multi-byte glyphs (emoji, CJK) blow past the cap.
+    if (Buffer.byteLength(parsed.body, 'utf8') > MAX_BODY_BYTES) {
+      summary.failed.push({ filename, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` });
+      continue;
+    }
+    if (batchNames.has(parsed.name)) {
+      summary.failed.push({
+        filename,
+        error: `duplicate of "${parsed.name}" already in this batch — only the first file was uploaded`,
+      });
+      continue;
+    }
+    batchNames.add(parsed.name);
 
     const wasExisting = existingNames.has(parsed.name);
     const { error: upsertError } = await supabase.from('uploaded_skills').upsert(
@@ -114,6 +179,8 @@ export async function uploadSkillsFromFiles(
       summary.failed.push({ filename, error: upsertError.message });
       continue;
     }
+    await enableUploadedSkillState(supabase, workspace.id, parsed.name, user.id);
+    upsertedNames.push(parsed.name);
     if (wasExisting) summary.replaced += 1;
     else {
       summary.added += 1;
@@ -121,7 +188,10 @@ export async function uploadSkillsFromFiles(
     }
   }
 
-  revalidatePath('/skills');
+  revalidateUploadSurfaces();
+  for (const name of upsertedNames) {
+    revalidatePath(`/skills/${encodeURIComponent(name)}`);
+  }
   return { ok: true, ...summary };
 }
 
@@ -148,7 +218,9 @@ export async function uploadSkillFromText(
   }
 
   if (!input.body || !input.body.trim()) return { ok: false, error: 'body is empty' };
-  if (input.body.length > MAX_BODY_BYTES) {
+  // Use UTF-8 byte length — `.length` counts code units, so a body packed with
+  // 4-byte glyphs could be 4× the intended size before tripping the cap.
+  if (Buffer.byteLength(input.body, 'utf8') > MAX_BODY_BYTES) {
     return { ok: false, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` };
   }
 
@@ -163,6 +235,9 @@ export async function uploadSkillFromText(
     return { ok: false, error: 'name must be alphanumeric + `-`/`_` (max 63 chars)' };
   }
   if (!parsed.body.trim()) return { ok: false, error: 'body is empty' };
+  if (Buffer.byteLength(parsed.body, 'utf8') > MAX_BODY_BYTES) {
+    return { ok: false, error: `body exceeds ${MAX_BODY_BYTES / 1024}KB limit` };
+  }
 
   const supabase = createSupabaseAdminClient();
   const { data: existing } = await supabase
@@ -185,8 +260,9 @@ export async function uploadSkillFromText(
     { onConflict: 'workspace_id,name' },
   );
   if (upsertError) return { ok: false, error: upsertError.message };
+  await enableUploadedSkillState(supabase, workspace.id, parsed.name, user.id);
 
-  revalidatePath('/skills');
+  revalidateUploadSurfaces(parsed.name);
   return { ok: true, name: parsed.name, replaced: existing !== null };
 }
 
@@ -207,6 +283,6 @@ export async function removeUploadedSkill(name: string): Promise<ActionResult> {
     .eq('workspace_id', workspace.id)
     .eq('name', name);
   if (error) return { ok: false, error: error.message };
-  revalidatePath('/skills');
+  revalidateUploadSurfaces(name);
   return { ok: true };
 }

--- a/packages/gui/src/app/skills/upload-modal.tsx
+++ b/packages/gui/src/app/skills/upload-modal.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+import { cn } from '@/components/ui/cn';
+import {
+  uploadSkillsFromFiles,
+  uploadSkillFromText,
+  type UploadFailure,
+  type UploadFilesSummary,
+} from './upload-actions';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type TabKey = 'files' | 'text';
+
+interface FileSummary {
+  added: number;
+  replaced: number;
+  failed: UploadFailure[];
+}
+
+/**
+ * Issue #262 (PR 3) — multi-purpose upload modal. Files tab handles
+ * drag-and-drop + click-to-browse for `.md`; Paste tab takes raw markdown
+ * with an optional name field for skills without frontmatter.
+ */
+export function UploadModal({ open, onClose }: Props) {
+  const [tab, setTab] = useState<TabKey>('files');
+  const [files, setFiles] = useState<File[]>([]);
+  const [dragOver, setDragOver] = useState(false);
+  const [name, setName] = useState('');
+  const [body, setBody] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [filesResult, setFilesResult] = useState<FileSummary | null>(null);
+  const [textResult, setTextResult] = useState<{ name: string; replaced: boolean } | null>(null);
+  const [submitting, startSubmit] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (!open) return null;
+
+  function reset() {
+    setFiles([]);
+    setName('');
+    setBody('');
+    setError(null);
+    setFilesResult(null);
+    setTextResult(null);
+  }
+
+  function closeAndReset() {
+    reset();
+    onClose();
+  }
+
+  function pickFiles(list: FileList | null | undefined) {
+    if (!list) return;
+    const incoming = Array.from(list).filter((f) => f.name.toLowerCase().endsWith('.md'));
+    if (incoming.length === 0) {
+      setError('only .md files are accepted');
+      return;
+    }
+    setError(null);
+    setFiles((prev) => [...prev, ...incoming]);
+  }
+
+  function handleSubmitFiles(e: React.FormEvent) {
+    e.preventDefault();
+    if (files.length === 0) {
+      setError('add at least one file');
+      return;
+    }
+    setError(null);
+    setFilesResult(null);
+    const fd = new FormData();
+    for (const f of files) fd.append('files', f);
+    startSubmit(async () => {
+      const res = await uploadSkillsFromFiles(fd);
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      setFilesResult({ added: res.added, replaced: res.replaced, failed: res.failed });
+      setFiles([]);
+    });
+  }
+
+  function handleSubmitText(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setTextResult(null);
+    startSubmit(async () => {
+      const res = await uploadSkillFromText({ name: name || undefined, body });
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      setTextResult({ name: res.name, replaced: res.replaced });
+      setName('');
+      setBody('');
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Upload skills"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeAndReset();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg border border-outline-variant bg-surface-container p-5 shadow-xl">
+        <header className="mb-4">
+          <h2 className="text-base font-semibold text-on-surface">Upload skills from disk</h2>
+          <p className="mt-1 text-xs text-on-surface-variant">
+            Drop one or more <code className="font-mono">.md</code> files with YAML frontmatter — or
+            paste raw markdown.
+          </p>
+        </header>
+
+        <div className="mb-4 inline-flex items-center rounded-md border border-outline-variant bg-surface-container-low p-0.5 text-sm">
+          {(
+            [
+              { id: 'files', label: 'Files' },
+              { id: 'text', label: 'Paste markdown' },
+            ] as const
+          ).map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => {
+                setTab(t.id);
+                setError(null);
+              }}
+              className={cn(
+                'inline-flex h-7 items-center rounded-[5px] px-3 font-medium transition-colors',
+                tab === t.id
+                  ? 'bg-surface text-on-surface shadow-sm'
+                  : 'text-on-surface-variant hover:text-on-surface',
+              )}
+              aria-pressed={tab === t.id}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="mb-3 rounded-md border border-error/30 bg-error-container/30 px-3 py-2 text-xs text-error">
+            {error}
+          </div>
+        )}
+
+        {tab === 'files' ? (
+          <form onSubmit={handleSubmitFiles} className="space-y-3">
+            <div
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={(e) => {
+                e.preventDefault();
+                setDragOver(false);
+                pickFiles(e.dataTransfer.files);
+              }}
+              onClick={() => inputRef.current?.click()}
+              className={cn(
+                'cursor-pointer rounded-md border border-dashed px-4 py-8 text-center text-sm transition-colors',
+                dragOver
+                  ? 'border-primary bg-primary-container/30 text-primary'
+                  : 'border-outline-variant text-on-surface-variant hover:border-primary hover:bg-surface-container/60',
+              )}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  inputRef.current?.click();
+                }
+              }}
+            >
+              Drop <code className="font-mono">.md</code> files here, or click to browse.
+              <input
+                ref={inputRef}
+                type="file"
+                accept=".md,text/markdown"
+                multiple
+                hidden
+                onChange={(e) => {
+                  pickFiles(e.target.files);
+                  if (inputRef.current) inputRef.current.value = '';
+                }}
+              />
+            </div>
+
+            {files.length > 0 && (
+              <ul className="max-h-40 overflow-auto rounded-md border border-outline-variant divide-y divide-outline-variant/50">
+                {files.map((file, idx) => (
+                  <li key={`${file.name}-${idx}`} className="flex items-center justify-between px-3 py-2 text-xs">
+                    <span className="truncate font-mono text-on-surface">{file.name}</span>
+                    <button
+                      type="button"
+                      onClick={() => setFiles((prev) => prev.filter((_, i) => i !== idx))}
+                      className="text-on-surface-variant hover:text-error"
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {filesResult && (
+              <ResultSummary summary={filesResult} />
+            )}
+
+            <footer className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeAndReset}
+                className="h-9 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface hover:border-primary"
+              >
+                {filesResult ? 'Close' : 'Cancel'}
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || files.length === 0}
+                className={cn(
+                  'h-9 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface',
+                  (submitting || files.length === 0) && 'opacity-60',
+                )}
+              >
+                {submitting ? 'Uploading…' : `Upload ${files.length || ''}`.trim()}
+              </button>
+            </footer>
+          </form>
+        ) : (
+          <form onSubmit={handleSubmitText} className="space-y-3">
+            <label className="block">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-on-surface-variant">
+                Name (optional if set in frontmatter)
+              </div>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-skill"
+                className="mt-1 h-9 w-full rounded-md border border-outline-variant bg-surface px-2 text-sm text-on-surface focus:border-primary focus:outline-none"
+              />
+            </label>
+            <label className="block">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-on-surface-variant">
+                Markdown
+              </div>
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                placeholder={'---\nname: my-skill\ndescription: …\ncezar-stages: [bug-detector]\n---\n\n# …'}
+                className="mt-1 h-48 w-full rounded-md border border-outline-variant bg-surface p-2 font-mono text-xs text-on-surface focus:border-primary focus:outline-none"
+              />
+            </label>
+
+            {textResult && (
+              <div className="rounded-md border border-primary/30 bg-primary-container/20 px-3 py-2 text-xs text-primary">
+                {textResult.replaced ? 'Replaced' : 'Added'}{' '}
+                <span className="font-mono">{textResult.name}</span>.
+              </div>
+            )}
+
+            <footer className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeAndReset}
+                className="h-9 rounded-md border border-outline-variant bg-surface px-3 text-sm text-on-surface hover:border-primary"
+              >
+                {textResult ? 'Close' : 'Cancel'}
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !body.trim()}
+                className={cn(
+                  'h-9 rounded-md bg-primary px-3 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface',
+                  (submitting || !body.trim()) && 'opacity-60',
+                )}
+              >
+                {submitting ? 'Uploading…' : 'Upload'}
+              </button>
+            </footer>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ResultSummary({ summary }: { summary: FileSummary }) {
+  return (
+    <div className="rounded-md border border-primary/30 bg-primary-container/20 px-3 py-2 text-xs text-primary">
+      <div>
+        Added: <span className="font-mono">{summary.added}</span> · Replaced:{' '}
+        <span className="font-mono">{summary.replaced}</span> · Failed:{' '}
+        <span className="font-mono">{summary.failed.length}</span>
+      </div>
+      {summary.failed.length > 0 && (
+        <ul className="mt-2 space-y-0.5 text-amber-300/90">
+          {summary.failed.map((f, i) => (
+            <li key={i}>
+              <span className="font-mono">{f.filename}</span> — {f.error}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/gui/src/app/skills/uploaded-skills-section.tsx
+++ b/packages/gui/src/app/skills/uploaded-skills-section.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useTransition, useState } from 'react';
+import Link from 'next/link';
+import { removeUploadedSkill } from './upload-actions';
+
+export interface UploadedSkillRow {
+  name: string;
+  description: string | null;
+  uploadedAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  uploaded: UploadedSkillRow[];
+  readOnly: boolean;
+  onOpenUpload: () => void;
+}
+
+/**
+ * Issue #262 (PR 3) — list of skills the workspace has uploaded from disk.
+ * Sits below the External sources panel on /skills. Mirrors that panel's
+ * "list + actions" pattern (`external-sources-section.tsx`).
+ */
+export function UploadedSkillsSection({ uploaded, readOnly, onOpenUpload }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [busyName, setBusyName] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function handleRemove(name: string) {
+    if (!confirm(`Remove the uploaded skill "${name}"?`)) return;
+    setError(null);
+    setBusyName(name);
+    startTransition(async () => {
+      const res = await removeUploadedSkill(name);
+      setBusyName(null);
+      if (!res.ok) setError(res.error);
+    });
+  }
+
+  return (
+    <section className="mb-6 rounded-lg border border-outline-variant bg-surface-container-low p-4">
+      <header className="mb-3 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-on-surface">Uploaded skills</h2>
+          <p className="mt-0.5 text-xs text-on-surface-variant">
+            Skills added by drag-and-drop or pasted markdown. Bodies live in the database — no
+            on-disk clone needed.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenUpload}
+          disabled={readOnly}
+          className="inline-flex h-8 items-center rounded-md border border-outline-variant bg-surface-container px-2 text-xs font-medium text-on-surface transition-colors hover:border-primary disabled:opacity-50"
+        >
+          Upload
+        </button>
+      </header>
+
+      {error && (
+        <div className="mb-3 rounded-md border border-error/30 bg-error-container/30 px-3 py-2 text-xs text-error">
+          {error}
+        </div>
+      )}
+
+      {uploaded.length === 0 ? (
+        <div className="rounded-md border border-dashed border-outline-variant px-3 py-6 text-center text-xs text-on-surface-variant">
+          No uploaded skills yet. Use{' '}
+          <span className="font-mono text-on-surface">Add skill source → Upload from disk</span> or
+          the Upload button above.
+        </div>
+      ) : (
+        <ul className="divide-y divide-outline-variant/50 rounded-md border border-outline-variant">
+          {uploaded.map((u) => (
+            <li key={u.name} className="flex flex-wrap items-center gap-3 px-3 py-2 text-sm">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2 text-on-surface">
+                  <Link
+                    href={`/skills/${encodeURIComponent(u.name)}`}
+                    className="font-medium hover:text-primary"
+                  >
+                    {u.name}
+                  </Link>
+                </div>
+                {u.description && (
+                  <div className="mt-0.5 truncate text-[11px] text-on-surface-variant">
+                    {u.description}
+                  </div>
+                )}
+                <div className="mt-0.5 text-[11px] text-on-surface-variant">
+                  uploaded {formatTimestamp(u.uploadedAt)}
+                  {u.updatedAt !== u.uploadedAt && ` · edited ${formatTimestamp(u.updatedAt)}`}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemove(u.name)}
+                disabled={readOnly || busyName === u.name}
+                className="inline-flex h-7 items-center rounded-md border border-error/40 bg-surface-container px-2 text-[11px] font-medium text-error transition-colors hover:bg-error-container/40 disabled:opacity-50"
+              >
+                {busyName === u.name ? 'Removing…' : 'Remove'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -430,11 +430,12 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return [];
   const supabase = createSupabaseAdminClient();
-  const [{ data }, activation, externalRows, uploadedRows] = await Promise.all([
+  const [{ data }, activation, externalRows, uploadedRows, skillsShRows] = await Promise.all([
     supabase.from('repo_skills').select('skills').eq('workspace_id', workspace.id),
     getSkillActivationContext(workspace.id, supabase),
     listExternalRepoSkills(workspace.id, supabase),
     listUploadedSkillSummaries(workspace.id, supabase),
+    listSkillsShSkillSummaries(workspace.id, supabase),
   ]);
   // Don't early-return on `!data` — repo_skills failures are independent of
   // external sources. Falling back to `[]` keeps the external loop below
@@ -474,6 +475,10 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
     pushIfActive(up.name, up.description, 'disk');
   }
 
+  for (const sh of skillsShRows) {
+    pushIfActive(sh.name, sh.description, 'skills-sh');
+  }
+
   return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 
@@ -493,6 +498,22 @@ async function listUploadedSkillSummaries(
 ): Promise<ExternalSkillSummary[]> {
   const { data } = await supabase
     .from('uploaded_skills')
+    .select('name, description')
+    .eq('workspace_id', workspaceId)
+    .returns<UploadedSkillSummaryRow[]>();
+  if (!data) return [];
+  return data.map((row) => ({
+    name: row.name,
+    description: row.description?.split('\n')[0].trim().slice(0, 240) ?? '',
+  }));
+}
+
+async function listSkillsShSkillSummaries(
+  workspaceId: string,
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+): Promise<ExternalSkillSummary[]> {
+  const { data } = await supabase
+    .from('skills_sh_skills')
     .select('name, description')
     .eq('workspace_id', workspaceId)
     .returns<UploadedSkillSummaryRow[]>();

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -435,7 +435,11 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
     getSkillActivationContext(workspace.id, supabase),
     listExternalRepoSkills(workspace.id, supabase),
   ]);
-  if (!data) return [];
+  // Don't early-return on `!data` — repo_skills failures are independent of
+  // external sources. Falling back to `[]` keeps the external loop below
+  // reachable so the picker degrades gracefully (workflows pointing at
+  // external-only skills still see them during a transient repo_skills blip).
+  const repoSkillRows = data ?? [];
   const { states, seeded: workspaceSeeded } = activation;
   const byName = new Map<string, SkillSummary>();
 
@@ -448,7 +452,7 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
     byName.set(name, { name, description });
   }
 
-  for (const row of data) {
+  for (const row of repoSkillRows) {
     const arr = (row.skills as Array<Record<string, unknown>> | null) ?? [];
     for (const s of arr) {
       if (!s || typeof s.name !== 'string' || !s.name.trim()) continue;

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -430,10 +430,11 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return [];
   const supabase = createSupabaseAdminClient();
-  const [{ data }, activation, externalRows] = await Promise.all([
+  const [{ data }, activation, externalRows, uploadedRows] = await Promise.all([
     supabase.from('repo_skills').select('skills').eq('workspace_id', workspace.id),
     getSkillActivationContext(workspace.id, supabase),
     listExternalRepoSkills(workspace.id, supabase),
+    listUploadedSkillSummaries(workspace.id, supabase),
   ]);
   // Don't early-return on `!data` — repo_skills failures are independent of
   // external sources. Falling back to `[]` keeps the external loop below
@@ -469,12 +470,37 @@ export async function listAvailableSkills(): Promise<SkillSummary[]> {
     pushIfActive(ext.name, ext.description, 'external-repo');
   }
 
+  for (const up of uploadedRows) {
+    pushIfActive(up.name, up.description, 'disk');
+  }
+
   return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 interface ExternalSkillSummary {
   name: string;
   description: string;
+}
+
+interface UploadedSkillSummaryRow {
+  name: string;
+  description: string | null;
+}
+
+async function listUploadedSkillSummaries(
+  workspaceId: string,
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+): Promise<ExternalSkillSummary[]> {
+  const { data } = await supabase
+    .from('uploaded_skills')
+    .select('name, description')
+    .eq('workspace_id', workspaceId)
+    .returns<UploadedSkillSummaryRow[]>();
+  if (!data) return [];
+  return data.map((row) => ({
+    name: row.name,
+    description: row.description?.split('\n')[0].trim().slice(0, 240) ?? '',
+  }));
 }
 
 async function listExternalRepoSkills(

--- a/packages/gui/src/app/workflows/actions.ts
+++ b/packages/gui/src/app/workflows/actions.ts
@@ -421,41 +421,86 @@ export async function runFlowOnIssue(params: {
  * `workspace_skill_states`) are returned. A workspace that hasn't been seeded
  * yet falls back to "every skill in the cached catalog is active" so an
  * unmigrated workspace doesn't suddenly see an empty picker.
+ *
+ * PR 2: external repo sources contribute too — their cached `skills` jsonb is
+ * folded in via `external_repo_skills` (joined on the workspace's
+ * `skill_sources` rows). The dedup-by-name policy from PR 1 still applies.
  */
 export async function listAvailableSkills(): Promise<SkillSummary[]> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return [];
   const supabase = createSupabaseAdminClient();
-  const [{ data }, activation] = await Promise.all([
+  const [{ data }, activation, externalRows] = await Promise.all([
     supabase.from('repo_skills').select('skills').eq('workspace_id', workspace.id),
     getSkillActivationContext(workspace.id, supabase),
+    listExternalRepoSkills(workspace.id, supabase),
   ]);
   if (!data) return [];
   const { states, seeded: workspaceSeeded } = activation;
   const byName = new Map<string, SkillSummary>();
+
+  function pushIfActive(name: string, description: string, source: string) {
+    if (byName.has(name)) return;
+    // Use the canonical predicate so the picker can't drift from
+    // `filterActiveSkills` (the runtime). The cache may hold a legacy
+    // `'repo'` value, so bridge it through `normalizeSkillSource` first.
+    if (!isSkillActive(states.get(name), normalizeSkillSource(source), workspaceSeeded)) return;
+    byName.set(name, { name, description });
+  }
+
   for (const row of data) {
     const arr = (row.skills as Array<Record<string, unknown>> | null) ?? [];
     for (const s of arr) {
       if (!s || typeof s.name !== 'string' || !s.name.trim()) continue;
-      // Use the canonical predicate so the picker can't drift from
-      // `filterActiveSkills` (the runtime). The cache may hold a legacy
-      // `'repo'` value, so bridge it through `normalizeSkillSource` first.
-      const active = isSkillActive(
-        states.get(s.name),
-        normalizeSkillSource(s.source),
-        workspaceSeeded,
-      );
-      if (!active) continue;
       const description =
         typeof s.description === 'string'
           ? s.description.split('\n')[0].trim().slice(0, 240)
           : '';
-      // First write wins (repo_skills is one row per repo; for multi-repo
-      // workspaces, skills across repos with the same name are de-duped here).
-      if (!byName.has(s.name)) byName.set(s.name, { name: s.name, description });
+      const source = typeof s.source === 'string' ? s.source : 'built-in';
+      pushIfActive(s.name, description, source);
     }
   }
+
+  for (const ext of externalRows) {
+    pushIfActive(ext.name, ext.description, 'external-repo');
+  }
+
   return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface ExternalSkillSummary {
+  name: string;
+  description: string;
+}
+
+async function listExternalRepoSkills(
+  workspaceId: string,
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+): Promise<ExternalSkillSummary[]> {
+  const { data: sourceRows } = await supabase
+    .from('skill_sources')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('kind', 'external-repo');
+  if (!sourceRows || sourceRows.length === 0) return [];
+  const { data: cacheRows } = await supabase
+    .from('external_repo_skills')
+    .select('skills')
+    .in('source_id', sourceRows.map((r) => r.id));
+  if (!cacheRows) return [];
+  const out: ExternalSkillSummary[] = [];
+  for (const row of cacheRows) {
+    const arr = (row.skills as Array<Record<string, unknown>> | null) ?? [];
+    for (const s of arr) {
+      if (!s || typeof s.name !== 'string' || !s.name.trim()) continue;
+      const description =
+        typeof s.description === 'string'
+          ? s.description.split('\n')[0].trim().slice(0, 240)
+          : '';
+      out.push({ name: s.name, description });
+    }
+  }
+  return out;
 }
 
 // ─── Prompt preview ─────────────────────────────────────────────────────────

--- a/packages/gui/src/lib/external-repo-clone.ts
+++ b/packages/gui/src/lib/external-repo-clone.ts
@@ -8,6 +8,28 @@ import { homedir } from 'node:os';
 const exec = promisify(execFile);
 
 /**
+ * Build env vars that inject `http.extraHeader: Authorization: Bearer <token>`
+ * into one git invocation via `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_<n>` /
+ * `GIT_CONFIG_VALUE_<n>`. The token stays out of argv (no leakage in `ps` or
+ * execFile error messages) AND out of `.git/config` on disk — the clone uses
+ * the clean public URL and the header is only present for the duration of the
+ * child process.
+ */
+function gitTokenEnv(token: string): Record<string, string> {
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.extraHeader',
+    GIT_CONFIG_VALUE_0: `Authorization: Bearer ${token}`,
+  };
+}
+
+/** Redact a token from a stringified git error so it can't surface in `last_sync_error`. */
+export function redactTokenFromMessage(message: string, token: string | null): string {
+  if (!token) return message;
+  return message.split(token).join('***');
+}
+
+/**
  * Issue #262 (PR 2) — external skill sources clone management.
  *
  * Workspace repos already live under `~/.cezar/repos/<owner>-<repo>/` (see
@@ -40,14 +62,20 @@ export async function acquireExternalRepoLock(sourceId: string): Promise<() => v
   const next = new Promise<void>((resolve) => {
     release = resolve;
   });
-  externalLocks.set(sourceId, prev.then(() => next, () => next));
+  // Store the chained promise (`prev.then(...)`) — NOT `next` — and compare
+  // against the same reference on cleanup. The original code compared against
+  // `next`, which is a different object identity than the value stored in the
+  // Map (the .then() always returns a new Promise), so the delete branch was
+  // unreachable and the Map grew without bound on long-lived workers.
+  const chained = prev.then(() => next, () => next);
+  externalLocks.set(sourceId, chained);
   await prev.catch(() => {});
   let released = false;
   return () => {
     if (released) return;
     released = true;
     release();
-    if (externalLocks.get(sourceId) === next) externalLocks.delete(sourceId);
+    if (externalLocks.get(sourceId) === chained) externalLocks.delete(sourceId);
   };
 }
 
@@ -87,19 +115,27 @@ export async function ensureExternalRepoClone(
   await mkdir(EXTERNAL_REPOS_DIR, { recursive: true });
 
   const repoDir = join(EXTERNAL_REPOS_DIR, sourceId);
-  const cloneUrl = githubToken
-    ? `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`
-    : `https://github.com/${owner}/${repo}.git`;
+  // Always use the clean public URL — auth flows via env-injected
+  // `http.extraHeader`, so the token never lands in argv (visible in `ps` and
+  // execFile error messages) nor in `.git/config` on disk.
+  const cloneUrl = `https://github.com/${owner}/${repo}.git`;
+  const tokenEnv = githubToken
+    ? { ...process.env, ...gitTokenEnv(githubToken) }
+    : process.env;
 
   if (existsSync(join(repoDir, '.git'))) {
+    // Heal any pre-existing clone that may have a token-bearing URL persisted
+    // from before the env-extraHeader switch.
     await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir });
-    await exec('git', ['fetch', 'origin'], { cwd: repoDir });
+    await exec('git', ['fetch', 'origin'], { cwd: repoDir, env: tokenEnv });
     await exec('git', ['checkout', branch], { cwd: repoDir }).catch(() =>
       exec('git', ['checkout', '-b', branch, `origin/${branch}`], { cwd: repoDir }),
     );
     await exec('git', ['reset', '--hard', `origin/${branch}`], { cwd: repoDir });
   } else {
-    await exec('git', ['clone', '--depth', '50', '--branch', branch, cloneUrl, repoDir]);
+    await exec('git', ['clone', '--depth', '50', '--branch', branch, cloneUrl, repoDir], {
+      env: tokenEnv,
+    });
   }
 
   return repoDir;

--- a/packages/gui/src/lib/external-repo-clone.ts
+++ b/packages/gui/src/lib/external-repo-clone.ts
@@ -1,0 +1,120 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const exec = promisify(execFile);
+
+/**
+ * Issue #262 (PR 2) — external skill sources clone management.
+ *
+ * Workspace repos already live under `~/.cezar/repos/<owner>-<repo>/` (see
+ * `lib/repo-clone.ts`). External skill repos go to a *separate* tree under
+ * `~/.cezar/external-skills/<source_id>/`. Two reasons for the separate
+ * namespace:
+ *
+ *   1. Lock domains stay disjoint. `withRepoLock` keys on owner/repo; an
+ *      external repo that happens to share owner/repo with the workspace
+ *      would otherwise serialize on the same key as the workspace's autofix
+ *      runs.
+ *   2. Different branches of the same repo can be added as separate sources
+ *      without colliding on the working-tree dir.
+ *
+ * Source id is a UUID so collisions are impossible.
+ */
+
+const EXTERNAL_REPOS_DIR = join(homedir(), '.cezar', 'external-skills');
+
+const externalLocks = new Map<string, Promise<void>>();
+
+/**
+ * Acquires the per-source working-tree lock and returns a release function.
+ * Prefer {@link withExternalRepoLock} unless the locked region spans control
+ * flow a callback can't wrap.
+ */
+export async function acquireExternalRepoLock(sourceId: string): Promise<() => void> {
+  const prev = externalLocks.get(sourceId) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  externalLocks.set(sourceId, prev.then(() => next, () => next));
+  await prev.catch(() => {});
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    release();
+    if (externalLocks.get(sourceId) === next) externalLocks.delete(sourceId);
+  };
+}
+
+/** Runs `fn` while holding the per-source lock. */
+export async function withExternalRepoLock<T>(
+  sourceId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireExternalRepoLock(sourceId);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+export interface ExternalRepoConfig {
+  owner: string;
+  repo: string;
+  branch: string;
+}
+
+/**
+ * Ensures a shallow clone of the external repo exists at
+ * `~/.cezar/external-skills/<sourceId>/`, fetching the configured branch.
+ * Token is optional — public repos work without one. When provided, it's
+ * wired into the HTTPS URL via the `x-access-token` GitHub auth convention.
+ *
+ * MUST be called inside {@link withExternalRepoLock} so a concurrent sync of
+ * the same source doesn't race on the checkout.
+ */
+export async function ensureExternalRepoClone(
+  sourceId: string,
+  { owner, repo, branch }: ExternalRepoConfig,
+  githubToken: string | null,
+): Promise<string> {
+  await mkdir(EXTERNAL_REPOS_DIR, { recursive: true });
+
+  const repoDir = join(EXTERNAL_REPOS_DIR, sourceId);
+  const cloneUrl = githubToken
+    ? `https://x-access-token:${githubToken}@github.com/${owner}/${repo}.git`
+    : `https://github.com/${owner}/${repo}.git`;
+
+  if (existsSync(join(repoDir, '.git'))) {
+    await exec('git', ['remote', 'set-url', 'origin', cloneUrl], { cwd: repoDir });
+    await exec('git', ['fetch', 'origin'], { cwd: repoDir });
+    await exec('git', ['checkout', branch], { cwd: repoDir }).catch(() =>
+      exec('git', ['checkout', '-b', branch, `origin/${branch}`], { cwd: repoDir }),
+    );
+    await exec('git', ['reset', '--hard', `origin/${branch}`], { cwd: repoDir });
+  } else {
+    await exec('git', ['clone', '--depth', '50', '--branch', branch, cloneUrl, repoDir]);
+  }
+
+  return repoDir;
+}
+
+/**
+ * Returns the HEAD commit sha of the cloned external repo (or null on
+ * failure). Cheap — runs `git rev-parse HEAD` against the on-disk worktree.
+ */
+export async function readExternalRepoHead(sourceId: string): Promise<string | null> {
+  const repoDir = join(EXTERNAL_REPOS_DIR, sourceId);
+  try {
+    const { stdout } = await exec('git', ['rev-parse', 'HEAD'], { cwd: repoDir });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/gui/src/lib/skill-state.ts
+++ b/packages/gui/src/lib/skill-state.ts
@@ -124,12 +124,12 @@ export async function setSkillEnabled(
 }
 
 /**
- * Sources the workspace implicitly consents to: shipped built-ins and skills
- * the user authored inside their own repo. Sources requiring explicit opt-in
- * (external-repo, disk, skills-sh) are intentionally excluded — those are
- * adversarial-by-default and stay off until a row says otherwise.
+ * Sources the workspace implicitly consents to: shipped built-ins, skills the
+ * user authored inside their own repo, and skills they uploaded directly
+ * (PR 3). Sources requiring explicit opt-in (external-repo, skills-sh) stay
+ * off until a row says otherwise — those are adversarial-by-default.
  */
-const DEFAULT_ON_SOURCES = new Set<SkillSource>(['built-in', 'workspace-repo']);
+const DEFAULT_ON_SOURCES = new Set<SkillSource>(['built-in', 'workspace-repo', 'disk']);
 
 /**
  * Canonical "default-on" rule for skills without an explicit state row: the

--- a/packages/gui/src/lib/skills-sh-api.ts
+++ b/packages/gui/src/lib/skills-sh-api.ts
@@ -15,9 +15,59 @@
  */
 
 const DEFAULT_API_BASE = 'https://skills.sh';
+const FETCH_TIMEOUT_MS = 15_000;
+/**
+ * Upper bound on the raw response payload we'll buffer from the registry.
+ * Keep modestly above the per-skill body cap (skills-sh-actions:MAX_BODY_BYTES)
+ * so headers/metadata fit while still bounding the OOM blast radius for a
+ * compromised or misconfigured upstream.
+ */
+const MAX_RESPONSE_BYTES = 1 * 1024 * 1024;
 
+/**
+ * Validate the API base at resolve-time so a misconfigured env (typo'd
+ * `http://`, internal/loopback hostnames pointing at cloud metadata, etc.)
+ * surfaces a clear error instead of silently downgrading TLS or exfiltrating
+ * the bearer token.
+ */
 function apiBase(): string {
-  return process.env.SKILLS_SH_API_BASE || DEFAULT_API_BASE;
+  const raw = process.env.SKILLS_SH_API_BASE || DEFAULT_API_BASE;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`SKILLS_SH_API_BASE is not a valid URL: ${raw}`);
+  }
+  if (url.protocol !== 'https:') {
+    throw new Error(`SKILLS_SH_API_BASE must use https:// (got ${url.protocol})`);
+  }
+  if (isPrivateHostname(url.hostname)) {
+    throw new Error(`SKILLS_SH_API_BASE points at a private/loopback address: ${url.hostname}`);
+  }
+  // Strip any trailing slash so the request URL stays predictable.
+  return raw.replace(/\/+$/, '');
+}
+
+/**
+ * Reject loopback (127/8, ::1, localhost), link-local (169.254/16) and
+ * RFC1918 private IPv4 (10/8, 172.16/12, 192.168/16) hostnames. Doesn't
+ * defend against DNS-rebinding — that needs explicit IP-pinning, out of
+ * scope for an admin-controlled env var.
+ */
+function isPrivateHostname(host: string): boolean {
+  if (!host) return true;
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const [a, b] = ipv4.slice(1).map(Number);
+    if (a === 127) return true;
+    if (a === 10) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+  }
+  return false;
 }
 
 export interface SkillsShSkill {
@@ -28,7 +78,7 @@ export interface SkillsShSkill {
   body: string;
   /** API snapshot fingerprint; we store it so Refresh can short-circuit. */
   contentHash: string | null;
-  /** Public skills.sh URL for the skill. */
+  /** Public skills.sh URL for the skill — `https:` only; non-https payloads are dropped. */
   installUrl: string | null;
 }
 
@@ -50,6 +100,20 @@ export class SkillsShNotConfiguredError extends Error {
   constructor() {
     super('SKILLS_SH_TOKEN is not set — skills.sh integration is disabled');
     this.name = 'SkillsShNotConfiguredError';
+  }
+}
+
+export class SkillsShTimeoutError extends Error {
+  constructor() {
+    super(`skills.sh request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+    this.name = 'SkillsShTimeoutError';
+  }
+}
+
+export class SkillsShPayloadTooLargeError extends Error {
+  constructor() {
+    super(`skills.sh response exceeded ${MAX_RESPONSE_BYTES / 1024}KB cap`);
+    this.name = 'SkillsShPayloadTooLargeError';
   }
 }
 
@@ -86,19 +150,46 @@ function parseFiles(raw: unknown): ApiFile[] {
     .filter((f): f is ApiFile => f !== null);
 }
 
+/**
+ * Only persist `installUrl` when it is a plain HTTPS URL. The value is later
+ * rendered as an `<a href>`, so any `javascript:` / `data:` scheme returned
+ * by a compromised or misconfigured registry would become a one-click XSS
+ * sink. We drop unsafe values rather than fail the whole fetch — the skill
+ * itself is fine, only the convenience link is missing.
+ */
+function sanitizeInstallUrl(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    const url = new URL(raw);
+    return url.protocol === 'https:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchSkillsShSkill(slug: string): Promise<SkillsShSkill> {
   const token = process.env.SKILLS_SH_TOKEN;
   if (!token) throw new SkillsShNotConfiguredError();
   if (!slug.trim()) throw new SkillsShNotFoundError(slug);
 
   const url = `${apiBase()}/api/v1/skills/${encodeSlug(slug)}`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/json',
-    },
-    cache: 'no-store',
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    // AbortSignal.timeout(...) abort surfaces as a TimeoutError-named DOMException.
+    if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+      throw new SkillsShTimeoutError();
+    }
+    throw err;
+  }
 
   if (res.status === 401 || res.status === 403) throw new SkillsShAuthError();
   if (res.status === 404) throw new SkillsShNotFoundError(slug);
@@ -107,7 +198,26 @@ export async function fetchSkillsShSkill(slug: string): Promise<SkillsShSkill> {
     throw new Error(`skills.sh fetch ${res.status}${tail ? `: ${tail.slice(0, 200)}` : ''}`);
   }
 
-  const data = (await res.json()) as ApiSkillResponse;
+  // Cheap pre-flight on Content-Length so a hostile multi-GB body doesn't
+  // make it past the network layer. We still rely on the JSON parser for the
+  // real size — chunked responses ship without Content-Length, so this catches
+  // the obvious case rather than every case.
+  const declared = res.headers.get('content-length');
+  if (declared && Number.parseInt(declared, 10) > MAX_RESPONSE_BYTES) {
+    throw new SkillsShPayloadTooLargeError();
+  }
+
+  const text = await res.text();
+  if (text.length > MAX_RESPONSE_BYTES) {
+    throw new SkillsShPayloadTooLargeError();
+  }
+  let data: ApiSkillResponse;
+  try {
+    data = JSON.parse(text) as ApiSkillResponse;
+  } catch {
+    throw new Error('skills.sh returned non-JSON body');
+  }
+
   const files = parseFiles(data.files);
   return {
     name:
@@ -117,7 +227,7 @@ export async function fetchSkillsShSkill(slug: string): Promise<SkillsShSkill> {
     description: typeof data.description === 'string' ? data.description : null,
     body: pickBody(files),
     contentHash: typeof data.contentHash === 'string' ? data.contentHash : null,
-    installUrl: typeof data.installUrl === 'string' ? data.installUrl : null,
+    installUrl: sanitizeInstallUrl(data.installUrl),
   };
 }
 
@@ -134,6 +244,12 @@ export function parseSkillsShIdentifier(input: string): string | null {
   // Allow letters, digits, dots, dashes, underscores; require at least 2 segments
   // (source/skill) and cap at 5 to stay close to the API's id format.
   if (!/^[\w.-]+(?:\/[\w.-]+){1,4}$/.test(candidate)) return null;
+  // Reject path-traversal segments — `[\w.-]+` would otherwise match `.` and
+  // `..`, and `encodeURIComponent` doesn't encode dots, so the literal `..`
+  // survives all the way to the outbound URL where fetch / upstream
+  // normalize it away and bypass the intended `{source}/{slug}` scoping.
+  const segments = candidate.split('/');
+  if (segments.some((s) => s === '' || s === '.' || s === '..')) return null;
   return candidate;
 }
 

--- a/packages/gui/src/lib/skills-sh-api.ts
+++ b/packages/gui/src/lib/skills-sh-api.ts
@@ -1,0 +1,147 @@
+/**
+ * Issue #262 (PR 4) — thin HTTP client for the skills.sh API.
+ *
+ * Docs: https://skills.sh/docs/api
+ *   GET /api/v1/skills/{source}/{slug} → { name, description, files[], contentHash, installUrl, … }
+ *
+ * Auth is required: `Authorization: Bearer <token>` (Vercel OIDC or a
+ * long-lived API key). Without `SKILLS_SH_TOKEN` set we throw early so the
+ * caller can surface a clear "configure SKILLS_SH_TOKEN" error instead of
+ * leaking a generic 401.
+ *
+ * Body lives in `files[].contents`. Skills.sh docs don't pin a canonical
+ * filename for the main markdown, so we prefer `SKILL.md` (a documented
+ * convention) and fall back to the first `*.md` entry.
+ */
+
+const DEFAULT_API_BASE = 'https://skills.sh';
+
+function apiBase(): string {
+  return process.env.SKILLS_SH_API_BASE || DEFAULT_API_BASE;
+}
+
+export interface SkillsShSkill {
+  /** API-supplied display name; may differ from the slug's last segment. */
+  name: string;
+  description: string | null;
+  /** Body of the chosen markdown file — empty string if no `.md` file shipped. */
+  body: string;
+  /** API snapshot fingerprint; we store it so Refresh can short-circuit. */
+  contentHash: string | null;
+  /** Public skills.sh URL for the skill. */
+  installUrl: string | null;
+}
+
+export class SkillsShAuthError extends Error {
+  constructor(message = 'skills.sh rejected the token (401/403)') {
+    super(message);
+    this.name = 'SkillsShAuthError';
+  }
+}
+
+export class SkillsShNotFoundError extends Error {
+  constructor(slug: string) {
+    super(`skills.sh skill not found: ${slug}`);
+    this.name = 'SkillsShNotFoundError';
+  }
+}
+
+export class SkillsShNotConfiguredError extends Error {
+  constructor() {
+    super('SKILLS_SH_TOKEN is not set — skills.sh integration is disabled');
+    this.name = 'SkillsShNotConfiguredError';
+  }
+}
+
+interface ApiFile {
+  path: string;
+  contents: string;
+}
+
+interface ApiSkillResponse {
+  name?: unknown;
+  description?: unknown;
+  contentHash?: unknown;
+  installUrl?: unknown;
+  files?: unknown;
+}
+
+function pickBody(files: ApiFile[]): string {
+  const skillFile =
+    files.find((f) => /(^|\/)skill\.md$/i.test(f.path)) ??
+    files.find((f) => f.path.toLowerCase().endsWith('.md')) ??
+    null;
+  return skillFile?.contents ?? '';
+}
+
+function parseFiles(raw: unknown): ApiFile[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry): ApiFile | null => {
+      if (!entry || typeof entry !== 'object') return null;
+      const obj = entry as Record<string, unknown>;
+      if (typeof obj.path !== 'string' || typeof obj.contents !== 'string') return null;
+      return { path: obj.path, contents: obj.contents };
+    })
+    .filter((f): f is ApiFile => f !== null);
+}
+
+export async function fetchSkillsShSkill(slug: string): Promise<SkillsShSkill> {
+  const token = process.env.SKILLS_SH_TOKEN;
+  if (!token) throw new SkillsShNotConfiguredError();
+  if (!slug.trim()) throw new SkillsShNotFoundError(slug);
+
+  const url = `${apiBase()}/api/v1/skills/${encodeSlug(slug)}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+  });
+
+  if (res.status === 401 || res.status === 403) throw new SkillsShAuthError();
+  if (res.status === 404) throw new SkillsShNotFoundError(slug);
+  if (!res.ok) {
+    const tail = await res.text().catch(() => '');
+    throw new Error(`skills.sh fetch ${res.status}${tail ? `: ${tail.slice(0, 200)}` : ''}`);
+  }
+
+  const data = (await res.json()) as ApiSkillResponse;
+  const files = parseFiles(data.files);
+  return {
+    name:
+      typeof data.name === 'string' && data.name.trim()
+        ? data.name.trim()
+        : slug.split('/').pop() ?? slug,
+    description: typeof data.description === 'string' ? data.description : null,
+    body: pickBody(files),
+    contentHash: typeof data.contentHash === 'string' ? data.contentHash : null,
+    installUrl: typeof data.installUrl === 'string' ? data.installUrl : null,
+  };
+}
+
+/**
+ * Accepts either the bare `'source/slug'` identifier or a full
+ * `https://skills.sh/<source>/<slug>` URL and returns the canonical
+ * `source/slug` form. Returns null on malformed input.
+ */
+export function parseSkillsShIdentifier(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const urlMatch = trimmed.match(/^https?:\/\/(?:www\.)?skills\.sh\/(.+?)\/?$/i);
+  const candidate = urlMatch ? urlMatch[1] : trimmed;
+  // Allow letters, digits, dots, dashes, underscores; require at least 2 segments
+  // (source/skill) and cap at 5 to stay close to the API's id format.
+  if (!/^[\w.-]+(?:\/[\w.-]+){1,4}$/.test(candidate)) return null;
+  return candidate;
+}
+
+/** URL-encodes each path segment without touching the `/` separators. */
+function encodeSlug(slug: string): string {
+  return slug.split('/').map(encodeURIComponent).join('/');
+}
+
+export function isSkillsShConfigured(): boolean {
+  return Boolean(process.env.SKILLS_SH_TOKEN);
+}

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -528,6 +528,33 @@ export interface Database {
         };
         Update: Partial<Database['public']['Tables']['external_repo_skills']['Insert']>;
       };
+      uploaded_skills: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          name: string;
+          body: string;
+          description: string | null;
+          /** Array of stage ids (`'verify-in-repo' | 'fix' | …`) — same shape as
+           *  the YAML `cezar-stages` frontmatter list. */
+          suggested_stages: Json;
+          uploaded_at: string;
+          updated_at: string;
+          uploaded_by: string | null;
+          updated_by: string | null;
+        };
+        Insert: Omit<Database['public']['Tables']['uploaded_skills']['Row'], 'id' | 'body' | 'description' | 'suggested_stages' | 'uploaded_at' | 'updated_at' | 'uploaded_by' | 'updated_by'> & {
+          id?: string;
+          body?: string;
+          description?: string | null;
+          suggested_stages?: Json;
+          uploaded_at?: string;
+          updated_at?: string;
+          uploaded_by?: string | null;
+          updated_by?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['uploaded_skills']['Insert']>;
+      };
       jobs: {
         Row: {
           id: string;

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -555,6 +555,38 @@ export interface Database {
         };
         Update: Partial<Database['public']['Tables']['uploaded_skills']['Insert']>;
       };
+      skills_sh_skills: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          /** API identifier — `{source}/{slug}` (e.g. `vercel-labs/skills/find-skills`). */
+          source_slug: string;
+          name: string;
+          body: string;
+          description: string | null;
+          suggested_stages: Json;
+          /** API snapshot fingerprint — Refresh compares against this. */
+          content_hash: string | null;
+          install_url: string | null;
+          imported_at: string;
+          last_synced_at: string;
+          last_sync_error: string | null;
+          imported_by: string | null;
+        };
+        Insert: Omit<Database['public']['Tables']['skills_sh_skills']['Row'], 'id' | 'body' | 'description' | 'suggested_stages' | 'content_hash' | 'install_url' | 'imported_at' | 'last_synced_at' | 'last_sync_error' | 'imported_by'> & {
+          id?: string;
+          body?: string;
+          description?: string | null;
+          suggested_stages?: Json;
+          content_hash?: string | null;
+          install_url?: string | null;
+          imported_at?: string;
+          last_synced_at?: string;
+          last_sync_error?: string | null;
+          imported_by?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['skills_sh_skills']['Insert']>;
+      };
       jobs: {
         Row: {
           id: string;

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -484,6 +484,50 @@ export interface Database {
         };
         Update: Partial<Database['public']['Tables']['workspace_skill_states']['Insert']>;
       };
+      skill_sources: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          /** PR 4 will widen this to `'external-repo' | 'skills-sh'`. */
+          kind: 'external-repo';
+          name: string;
+          /** For `kind='external-repo'`: `{ owner, repo, branch, folder }`. */
+          config: Json;
+          last_synced_at: string | null;
+          last_sync_error: string | null;
+          created_at: string;
+          updated_at: string;
+          created_by: string | null;
+          updated_by: string | null;
+        };
+        Insert: Omit<Database['public']['Tables']['skill_sources']['Row'], 'id' | 'config' | 'last_synced_at' | 'last_sync_error' | 'created_at' | 'updated_at' | 'created_by' | 'updated_by'> & {
+          id?: string;
+          config?: Json;
+          last_synced_at?: string | null;
+          last_sync_error?: string | null;
+          created_at?: string;
+          updated_at?: string;
+          created_by?: string | null;
+          updated_by?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['skill_sources']['Insert']>;
+      };
+      external_repo_skills: {
+        Row: {
+          source_id: string;
+          commit_sha: string | null;
+          /** Array of `{ name, description, suggestedStages, path, source, body }`
+           *  — body inline so the dispatcher works without a local clone. */
+          skills: Json;
+          fetched_at: string;
+        };
+        Insert: Omit<Database['public']['Tables']['external_repo_skills']['Row'], 'commit_sha' | 'skills' | 'fetched_at'> & {
+          commit_sha?: string | null;
+          skills?: Json;
+          fetched_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['external_repo_skills']['Insert']>;
+      };
       jobs: {
         Row: {
           id: string;

--- a/packages/gui/src/lib/workflow-config.ts
+++ b/packages/gui/src/lib/workflow-config.ts
@@ -119,9 +119,10 @@ export async function loadActiveSkillCatalog(
     return undefined;
   }
 
-  const [activation, externalSkills] = await Promise.all([
+  const [activation, externalSkills, uploadedSkills] = await Promise.all([
     getSkillActivationContext(workspaceId, supabase),
     loadExternalRepoSkills(workspaceId, supabase),
+    loadUploadedSkills(workspaceId, supabase),
   ]);
   if (activation.error) {
     // Surface the failure to the orchestrator so its `??` fallback to
@@ -130,10 +131,15 @@ export async function loadActiveSkillCatalog(
   }
 
   // SKILL_SOURCE_PRIORITY: built-in > workspace-repo > external-repo > disk > skills-sh.
-  // The repo-side catalog already covers the first two; external rows are
-  // appended only when their name isn't already taken.
+  // The repo-side catalog already covers the first two; external rows go
+  // before disk uploads. Each tier dedupes against the names already taken.
   const taken = new Set(catalog.map((s) => s.name));
   for (const s of externalSkills) {
+    if (taken.has(s.name)) continue;
+    taken.add(s.name);
+    catalog.push(s);
+  }
+  for (const s of uploadedSkills) {
     if (taken.has(s.name)) continue;
     taken.add(s.name);
     catalog.push(s);
@@ -148,6 +154,39 @@ interface CachedExternalSkill {
   suggestedStages?: unknown;
   path?: unknown;
   body?: unknown;
+}
+
+interface UploadedSkillDbRow {
+  name: string;
+  body: string;
+  description: string | null;
+  suggested_stages: unknown;
+}
+
+/**
+ * Hydrate `uploaded_skills` into `Skill` objects. Bodies live inline in this
+ * table — no on-disk clone is ever consulted for disk skills.
+ */
+async function loadUploadedSkills(
+  workspaceId: string,
+  supabase: SupabaseClient<Database>,
+): Promise<Skill[]> {
+  const { data, error } = await supabase
+    .from('uploaded_skills')
+    .select('name, body, description, suggested_stages')
+    .eq('workspace_id', workspaceId)
+    .returns<UploadedSkillDbRow[]>();
+  if (error || !data) return [];
+  return data.map<Skill>((row) => ({
+    name: row.name,
+    description: row.description ?? undefined,
+    body: row.body ?? '',
+    path: '',
+    suggestedStages: Array.isArray(row.suggested_stages)
+      ? (row.suggested_stages as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [],
+    source: 'disk',
+  }));
 }
 
 /**

--- a/packages/gui/src/lib/workflow-config.ts
+++ b/packages/gui/src/lib/workflow-config.ts
@@ -97,6 +97,10 @@ export async function loadWorkflowSettings(
  * orchestrator's `opts.skills ?? discoverSkillsSafe(...)` fallback fires and
  * the per-issue event stream sees a real failure log instead of a silent
  * zero-skill run.
+ *
+ * PR 2: also folds in cached external repo catalogs from `external_repo_skills`.
+ * External rows hydrate from the DB only (body inline), so dispatch never
+ * needs a clone of the external repo.
  */
 export async function loadActiveSkillCatalog(
   workspaceId: string,
@@ -115,11 +119,85 @@ export async function loadActiveSkillCatalog(
     return undefined;
   }
 
-  const activation = await getSkillActivationContext(workspaceId, supabase);
+  const [activation, externalSkills] = await Promise.all([
+    getSkillActivationContext(workspaceId, supabase),
+    loadExternalRepoSkills(workspaceId, supabase),
+  ]);
   if (activation.error) {
     // Surface the failure to the orchestrator so its `??` fallback to
     // `discoverSkillsSafe` fires (per-issue onEvent logging, no silent run).
     return undefined;
   }
+
+  // SKILL_SOURCE_PRIORITY: built-in > workspace-repo > external-repo > disk > skills-sh.
+  // The repo-side catalog already covers the first two; external rows are
+  // appended only when their name isn't already taken.
+  const taken = new Set(catalog.map((s) => s.name));
+  for (const s of externalSkills) {
+    if (taken.has(s.name)) continue;
+    taken.add(s.name);
+    catalog.push(s);
+  }
+
   return filterActiveSkills(catalog, activation.states, activation.seeded);
+}
+
+interface CachedExternalSkill {
+  name?: unknown;
+  description?: unknown;
+  suggestedStages?: unknown;
+  path?: unknown;
+  body?: unknown;
+}
+
+/**
+ * Hydrate the `external_repo_skills.skills` jsonb into proper `Skill` objects.
+ * Filters out any cached row whose source has since been removed (RLS-joined
+ * via the `skill_sources.workspace_id` predicate). Bodies live inline, so the
+ * engine doesn't need an on-disk clone of the external repo.
+ */
+async function loadExternalRepoSkills(
+  workspaceId: string,
+  supabase: SupabaseClient<Database>,
+): Promise<Skill[]> {
+  const { data: sourceRows } = await supabase
+    .from('skill_sources')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('kind', 'external-repo');
+  if (!sourceRows || sourceRows.length === 0) return [];
+
+  const sourceIds = sourceRows.map((r) => r.id);
+  const { data: cacheRows } = await supabase
+    .from('external_repo_skills')
+    .select('source_id, skills')
+    .in('source_id', sourceIds);
+  if (!cacheRows) return [];
+
+  const skills: Skill[] = [];
+  const seen = new Set<string>();
+  for (const row of cacheRows) {
+    if (!Array.isArray(row.skills)) continue;
+    for (const raw of row.skills as CachedExternalSkill[]) {
+      if (!raw || typeof raw !== 'object') continue;
+      const name = typeof raw.name === 'string' ? raw.name : null;
+      const body = typeof raw.body === 'string' ? raw.body : null;
+      if (!name || body === null) continue;
+      // Two sources in the same workspace can ship the same skill name; first
+      // hit wins. The /skills surface already disambiguates by source badge.
+      if (seen.has(name)) continue;
+      seen.add(name);
+      skills.push({
+        name,
+        description: typeof raw.description === 'string' ? raw.description : undefined,
+        body,
+        path: typeof raw.path === 'string' ? raw.path : '',
+        suggestedStages: Array.isArray(raw.suggestedStages)
+          ? (raw.suggestedStages as unknown[]).filter((x): x is string => typeof x === 'string')
+          : [],
+        source: 'external-repo',
+      });
+    }
+  }
+  return skills;
 }

--- a/packages/gui/src/lib/workflow-config.ts
+++ b/packages/gui/src/lib/workflow-config.ts
@@ -119,10 +119,11 @@ export async function loadActiveSkillCatalog(
     return undefined;
   }
 
-  const [activation, externalSkills, uploadedSkills] = await Promise.all([
+  const [activation, externalSkills, uploadedSkills, skillsShSkills] = await Promise.all([
     getSkillActivationContext(workspaceId, supabase),
     loadExternalRepoSkills(workspaceId, supabase),
     loadUploadedSkills(workspaceId, supabase),
+    loadSkillsShSkills(workspaceId, supabase),
   ]);
   if (activation.error) {
     // Surface the failure to the orchestrator so its `??` fallback to
@@ -131,8 +132,9 @@ export async function loadActiveSkillCatalog(
   }
 
   // SKILL_SOURCE_PRIORITY: built-in > workspace-repo > external-repo > disk > skills-sh.
-  // The repo-side catalog already covers the first two; external rows go
-  // before disk uploads. Each tier dedupes against the names already taken.
+  // The repo-side catalog already covers the first two; external rows go next,
+  // then disk uploads, then skills.sh imports last. Each tier dedupes against
+  // the names already taken.
   const taken = new Set(catalog.map((s) => s.name));
   for (const s of externalSkills) {
     if (taken.has(s.name)) continue;
@@ -140,6 +142,11 @@ export async function loadActiveSkillCatalog(
     catalog.push(s);
   }
   for (const s of uploadedSkills) {
+    if (taken.has(s.name)) continue;
+    taken.add(s.name);
+    catalog.push(s);
+  }
+  for (const s of skillsShSkills) {
     if (taken.has(s.name)) continue;
     taken.add(s.name);
     catalog.push(s);
@@ -161,6 +168,40 @@ interface UploadedSkillDbRow {
   body: string;
   description: string | null;
   suggested_stages: unknown;
+}
+
+interface SkillsShDbRow {
+  name: string;
+  body: string;
+  description: string | null;
+  suggested_stages: unknown;
+}
+
+/**
+ * Hydrate `skills_sh_skills` into `Skill` objects. Bodies live inline (the
+ * skills.sh API returns them with the metadata), so dispatch never has to
+ * call the registry at run time.
+ */
+async function loadSkillsShSkills(
+  workspaceId: string,
+  supabase: SupabaseClient<Database>,
+): Promise<Skill[]> {
+  const { data, error } = await supabase
+    .from('skills_sh_skills')
+    .select('name, body, description, suggested_stages')
+    .eq('workspace_id', workspaceId)
+    .returns<SkillsShDbRow[]>();
+  if (error || !data) return [];
+  return data.map<Skill>((row) => ({
+    name: row.name,
+    description: row.description ?? undefined,
+    body: row.body ?? '',
+    path: '',
+    suggestedStages: Array.isArray(row.suggested_stages)
+      ? (row.suggested_stages as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [],
+    source: 'skills-sh',
+  }));
 }
 
 /**

--- a/packages/gui/supabase/migrations/20260619104247_external_skill_sources.sql
+++ b/packages/gui/supabase/migrations/20260619104247_external_skill_sources.sql
@@ -1,0 +1,133 @@
+-- Issue #262 (PR 2) — external skill sources.
+--
+-- Lets a workspace pull skills from any GitHub repo (not just the one bound
+-- to the workspace). Two tables land in this migration:
+--
+--   * skill_sources — polymorphic registry of every non-built-in source the
+--     workspace knows about. PR 2 only supports kind='external-repo'; PR 4
+--     will extend the CHECK constraint with 'skills-sh'. The legacy "workspace
+--     repo" still lives under `repo_skills` (single, implicit source); this
+--     table is for *additional* sources.
+--
+--   * external_repo_skills — per-source cache of metadata + body inline.
+--     Unlike `repo_skills` (which only stores metadata because the dispatcher
+--     already has the workspace clone on disk), an external repo may be
+--     synced on machine A and dispatched on machine B, so we cache the body
+--     in the DB. Skill bodies are small markdown blobs (a few KB).
+
+create table skill_sources (
+  id              uuid primary key default gen_random_uuid(),
+  workspace_id    uuid not null references workspaces(id) on delete cascade,
+  -- PR 4 will widen this to also accept 'skills-sh'.
+  kind            text not null check (kind in ('external-repo')),
+  -- Human-friendly label (slug-ish). Surfaced in the /skills "Sources" panel
+  -- and in source badges next to each skill.
+  name            text not null,
+  -- Per-kind config blob. For 'external-repo' the shape is:
+  --   { owner: string, repo: string, branch: string, folder: string }
+  config          jsonb not null default '{}'::jsonb,
+  last_synced_at  timestamptz,
+  last_sync_error text,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  created_by      uuid references auth.users(id),
+  updated_by      uuid references auth.users(id),
+  unique (workspace_id, name)
+);
+
+create index skill_sources_workspace_idx on skill_sources(workspace_id);
+
+create table external_repo_skills (
+  source_id    uuid primary key references skill_sources(id) on delete cascade,
+  commit_sha   text,
+  -- Array of full Skill records (body inline so dispatch never needs a clone):
+  --   { name, description, suggestedStages, path, source: 'external-repo', body }
+  skills       jsonb not null default '[]'::jsonb,
+  fetched_at   timestamptz not null default now()
+);
+
+-- Keep updated_at fresh on every UPDATE of skill_sources.
+create or replace function skill_sources_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create trigger skill_sources_set_updated_at
+  before update on skill_sources
+  for each row execute function skill_sources_set_updated_at();
+
+alter table skill_sources       enable row level security;
+alter table external_repo_skills enable row level security;
+
+create policy "members read skill_sources"
+  on skill_sources for select
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skill_sources.workspace_id
+        and wm.user_id = auth.uid()
+    )
+  );
+
+create policy "admins write skill_sources"
+  on skill_sources for all
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skill_sources.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skill_sources.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  );
+
+-- external_repo_skills is keyed off a skill_sources row; mirror its access
+-- model by joining on workspace membership through the parent.
+create policy "members read external_repo_skills"
+  on external_repo_skills for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from skill_sources s
+      join workspace_members wm on wm.workspace_id = s.workspace_id
+      where s.id = external_repo_skills.source_id
+        and wm.user_id = auth.uid()
+    )
+  );
+
+create policy "admins write external_repo_skills"
+  on external_repo_skills for all
+  to authenticated
+  using (
+    exists (
+      select 1
+      from skill_sources s
+      join workspace_members wm on wm.workspace_id = s.workspace_id
+      where s.id = external_repo_skills.source_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from skill_sources s
+      join workspace_members wm on wm.workspace_id = s.workspace_id
+      where s.id = external_repo_skills.source_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  );

--- a/packages/gui/supabase/migrations/20260619104248_uploaded_skills.sql
+++ b/packages/gui/supabase/migrations/20260619104248_uploaded_skills.sql
@@ -1,0 +1,69 @@
+-- Issue #262 (PR 3) — disk uploads as a skill source.
+--
+-- Lets users add skills by dragging `.md` files into /skills (or pasting raw
+-- markdown). Bodies live inline in this table — no on-disk clone exists for
+-- uploaded skills, so dispatch reads bodies straight from the DB.
+--
+-- Re-uploading a skill with the same name replaces the row via the
+-- `(workspace_id, name)` unique constraint (the upload action runs an upsert).
+
+create table uploaded_skills (
+  id               uuid primary key default gen_random_uuid(),
+  workspace_id     uuid not null references workspaces(id) on delete cascade,
+  name             text not null,
+  body             text not null default '',
+  description      text,
+  suggested_stages jsonb not null default '[]'::jsonb,
+  uploaded_at      timestamptz not null default now(),
+  updated_at       timestamptz not null default now(),
+  uploaded_by      uuid references auth.users(id),
+  updated_by       uuid references auth.users(id),
+  unique (workspace_id, name)
+);
+
+create index uploaded_skills_workspace_idx on uploaded_skills(workspace_id);
+
+create or replace function uploaded_skills_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create trigger uploaded_skills_set_updated_at
+  before update on uploaded_skills
+  for each row execute function uploaded_skills_set_updated_at();
+
+alter table uploaded_skills enable row level security;
+
+create policy "members read uploaded_skills"
+  on uploaded_skills for select
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = uploaded_skills.workspace_id
+        and wm.user_id = auth.uid()
+    )
+  );
+
+create policy "admins write uploaded_skills"
+  on uploaded_skills for all
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = uploaded_skills.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = uploaded_skills.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  );

--- a/packages/gui/supabase/migrations/20260619104249_skills_sh.sql
+++ b/packages/gui/supabase/migrations/20260619104249_skills_sh.sql
@@ -1,0 +1,63 @@
+-- Issue #262 (PR 4) — skills.sh registry as a skill source.
+--
+-- Users install a skill from skills.sh by its '{source}/{slug}' identifier
+-- (e.g. 'vercel-labs/skills/find-skills'). The body comes back inline from
+-- the API, so dispatch doesn't need to call out at runtime — body, metadata,
+-- and the API's content_hash all live in this table.
+--
+-- `content_hash` is the API's snapshot fingerprint; Refresh compares it to
+-- decide whether the body actually changed. UI shows `install_url` as a
+-- "View on skills.sh" link.
+
+create table skills_sh_skills (
+  id               uuid primary key default gen_random_uuid(),
+  workspace_id     uuid not null references workspaces(id) on delete cascade,
+  source_slug      text not null,
+  name             text not null,
+  body             text not null default '',
+  description      text,
+  suggested_stages jsonb not null default '[]'::jsonb,
+  content_hash     text,
+  install_url      text,
+  imported_at      timestamptz not null default now(),
+  last_synced_at   timestamptz not null default now(),
+  last_sync_error  text,
+  imported_by      uuid references auth.users(id),
+  unique (workspace_id, source_slug),
+  unique (workspace_id, name)
+);
+
+create index skills_sh_skills_workspace_idx on skills_sh_skills(workspace_id);
+
+alter table skills_sh_skills enable row level security;
+
+create policy "members read skills_sh_skills"
+  on skills_sh_skills for select
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skills_sh_skills.workspace_id
+        and wm.user_id = auth.uid()
+    )
+  );
+
+create policy "admins write skills_sh_skills"
+  on skills_sh_skills for all
+  to authenticated
+  using (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skills_sh_skills.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  )
+  with check (
+    exists (
+      select 1 from workspace_members wm
+      where wm.workspace_id = skills_sh_skills.workspace_id
+        and wm.user_id = auth.uid()
+        and wm.role = 'admin'
+    )
+  );


### PR DESCRIPTION
**Stacked on top of #270 (PR 1), #271 (PR 2) and #272 (PR 3).** Diff includes all four PRs because GitHub can't target a cross-fork branch as the base; once the earlier PRs merge to main, this PR's diff will collapse to just PR 4.

## Summary

PR 4 of 5 for #262. Adds the fourth and final new source: the skills.sh registry. Users install a skill by its \`source/slug\` identifier or full skills.sh URL; the API returns body, description, content hash, and install URL in one call, all stored inline in the new \`skills_sh_skills\` table.

- New table \`0047\` — \`skills_sh_skills\`: body inline + \`content_hash\` (etag) + \`install_url\`; \`(workspace_id, source_slug)\` and \`(workspace_id, name)\` both unique.
- HTTP client \`lib/skills-sh-api.ts\` — Bearer auth using \`SKILLS_SH_TOKEN\` env var, dedicated error classes for missing-token / 401 / 404, body extraction from the API's \`files[]\` array (prefers \`SKILL.md\`, falls back to first \`.md\`).
- Server actions (\`skills-sh-actions.ts\`):
  - \`addSkillsShSkill\` — parse identifier, fetch from skills.sh, upsert with body inline (re-parses YAML frontmatter via \`parseSkillMarkdown\` from PR 3 so \`cezar-stages\` get picked up).
  - \`refreshSkillsShSkill\` — re-fetch by \`source_slug\`, short-circuit when \`content_hash\` matches, otherwise replace body + metadata.
  - \`removeSkillsShSkill\` — uninstall.
  - Detail-page wrappers in \`[name]/skills-sh-actions.ts\` resolve name→id and delegate.
- UI:
  - \`SkillsShModal\` — single input (identifier or URL), preview disabled when env var missing, success summary on install.
  - \`SkillsShSection\` — list with \`Refresh\` / \`Remove\` + \"View on skills.sh\" link.
  - \`Add skill source ▾ → skills.sh registry\` opens the modal; the dropdown is now fully populated (no more \"Coming soon\").
- Skill detail page — new \`source='skills-sh'\` variant:
  - Body is read-only; autosave is bypassed.
  - Sticky footer shows \"Refresh from skills.sh\" + \"Remove import\" instead of override / disk handshakes.
  - Header badge \`SKILLS.SH · SYNCED\`.
- Workflow surfaces (\`loadActiveSkillCatalog\` + \`listAvailableSkills\`): fold skills.sh imports deduped wg \`SKILL_SOURCE_PRIORITY\` (built-in > workspace-repo > external-repo > disk > skills-sh — skills.sh sits last, gets shadowed by anything above).
- \`.env.docker.example\` — documented optional \`SKILLS_SH_TOKEN\` + \`SKILLS_SH_API_BASE\` knobs.

## Roadmap

| PR | Status |
| --- | --- |
| #262 PR 1 | Open (#270) |
| #262 PR 2 | Open (#271) |
| #262 PR 3 | Open (#272) |
| **#262 PR 4 (this)** | Open |
| #262 PR 5 | Built-in skill audit — last one |

## Test plan

- [x] \`yarn typecheck\` — clean.
- [x] \`yarn build\` — clean (\`/skills\` 13.1 kB, \`/skills/[name]\` 7.34 kB).
- [ ] Apply migration \`0047\` against a Supabase clone; confirm RLS, both UNIQUE constraints, and cascade delete from \`workspaces\`.
- [ ] Without \`SKILLS_SH_TOKEN\`: \`/skills → Add skill source → skills.sh registry\` modal opens but the input + submit are disabled with a clear \"set SKILLS_SH_TOKEN\" banner. Install button on the section is also disabled. Refresh on existing imports still works only if a token is later configured.
- [ ] With a valid \`SKILLS_SH_TOKEN\`: paste an identifier (\`source/slug\`) → preview / install path succeeds; the import shows up in the section + main catalog with \`SKILLS.SH\` badge.
- [ ] Toggle Enable on the imported skill → it appears in the workflow picker.
- [ ] Detail page renders read-only body, Refresh from skills.sh, Remove import. Refresh when content_hash matches leaves body untouched; modify content_hash on the registry → Refresh updates body.
- [ ] 404 / 401 error paths surface the right messages.
- [ ] Trigger an autofix run binding a skills.sh skill → engine reads body from the table (no outbound call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)