### PR TITLE
fix(gui/workflows): use right-0 instead of left-0 for dropdown positioning

### DIFF
--- a/packages/gui/src/app/workflows/flow-card.tsx
+++ b/packages/gui/src/app/workflows/flow-card.tsx
@@ -650,7 +650,7 @@ function ArgsTemplateInput({
         className="w-full rounded-md border border-border bg-bg-subtle px-3 py-2 font-mono text-base text-fg focus:border-accent/50 focus:outline-none lg:text-xs"
       />
       {showAutocomplete && (
-        <div className="absolute left-0 top-full z-20 mt-1 w-full max-w-[calc(100vw-2rem)] rounded-md border border-border bg-bg-elevated shadow-lg">
+        <div className="absolute right-0 top-full z-20 mt-1 w-full max-w-[calc(100vw-2rem)] rounded-md border border-border bg-bg-elevated shadow-lg">
           {TEMPLATE_VARS.map((v, i) => (
             <button
               key={v.name}

--- a/packages/gui/src/app/workflows/workflows-list.tsx
+++ b/packages/gui/src/app/workflows/workflows-list.tsx
@@ -242,7 +242,7 @@ function NewFlowMenu({ onPick, busy }: { onPick: (t: FlowTemplate) => void; busy
       </button>
 
       {open && !isMobile && (
-        <div className="absolute left-0 top-full z-popover mt-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-ambient">
+        <div className="absolute right-0 top-full z-popover mt-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-ambient">
           <div className="border-b border-border px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
             Start from a template
           </div>


### PR DESCRIPTION
## Summary

Fix dropdown menu overflow on narrower screens by changing absolute positioning from `left-0` to `right-0`. This prevents dropdowns from extending off-screen when trigger buttons are positioned towards the right side of the viewport.

## Changes

- **workflows-list.tsx** (line 245): NewFlowMenu dropdown — changed from `left-0` to `right-0`
- **flow-card.tsx** (line 653): ArgsTemplateInput autocomplete — changed from `left-0` to `right-0`

## Problem

When the trigger button is positioned on the right side of the screen (e.g., the "+ Flow" button in the workflows header), using `left-0` causes the dropdown to overflow off-screen because it aligns the dropdown's left edge to the button's left position. At ~1290px viewport width, dropdowns would require manual `margin-left: -200px` adjustment to remain visible.

## Solution

Using `right-0` aligns the dropdown's right edge to the button's right edge, which naturally prevents overflow and works correctly at all viewport widths, including the reported 1290px case.

## Test Plan

- [ ] Open `/workflows` tab and click the "+ Flow" button on various screen widths (~1290px, 1024px, 768px)
- [ ] Verify the dropdown menu stays within viewport bounds
- [ ] Open a workflow step and edit the "Args template" field
- [ ] Verify the autocomplete dropdown doesn't overflow when typing template variables

## Related Files

- `packages/gui/src/app/workflows/workflows-list.tsx`
- `packages/gui/src/app/workflows/flow-card.tsx`