### PR TITLE
fix(gui/workflows): use right-0 instead of left-0 for dropdown positioning

### DIFF
--- a/packages/gui/src/app/workflows/workflows-list.tsx
+++ b/packages/gui/src/app/workflows/workflows-list.tsx
@@ -242,7 +242,7 @@ function NewFlowMenu({ onPick, busy }: { onPick: (t: FlowTemplate) => void; busy
       </button>
 
       {open && !isMobile && (
-        <div className="absolute left-0 top-full z-popover mt-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-ambient">
+        <div className="absolute right-0 top-full z-popover mt-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-border bg-bg-elevated shadow-ambient">
           <div className="border-b border-border px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-fg-muted">
             Start from a template
           </div>


### PR DESCRIPTION
## Problem
The \`+ Flow\` button's dropdown menu overflows off the right edge of the screen because it's positioned with \`left-0\` while the button itself is on the right side.

## Solution
Change dropdown positioning from \`left-0\` to \`right-0\` to align it with the button on the right.

## Before (Menu cut off) ❌
<img width="523" height="524" alt="Screenshot_425" src="https://github.com/user-attachments/assets/ff97b5c3-d191-4b85-ae3c-3fa0601e9654" />


## After (Menu fully visible) ✅
<img width="581" height="466" alt="Screenshot_407" src="https://github.com/user-attachments/assets/29eb10af-c371-4d45-951b-4c2b260469d8" />


## Changes
- **File**: \`packages/gui/src/app/workflows/workflows-list.tsx\` (line 245)
- **Change**: \`absolute left-0\` → \`absolute right-0\`

## Notes
- \`ArgsTemplateInput\` dropdown (flow-card.tsx:653) correctly remains at \`left-0\` since the input is \`w-full\` and the dropdown matches its width.
- This is a minimal, focused fix that prevents dropdown overflow on the right edge while keeping the ArgsTemplateInput positioning correct.