### PR TITLE
chore(migrations): switch to UTC-timestamp naming convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,32 @@ jobs:
       - name: Install
         run: yarn install --immutable
 
-      - name: Migration numbering sanity
-        # Four legacy 0029_* migrations predate this check and are allowlisted;
-        # any new duplicate number fails the build.
+      - name: Migration naming sanity
+        # New migrations must use a UTC timestamp prefix (YYYYMMDDHHMMSS_) so two
+        # branches never collide on a number — see docs/DEVELOPMENT.md. The legacy
+        # zero-padded 00xx_ files (<= 0044, four of them sharing 0029) predate the
+        # convention and are grandfathered. This step fails on (a) any new prefix
+        # that is neither a 14-digit timestamp nor a grandfathered legacy number,
+        # and (b) any two migrations sharing a numeric prefix (0029 allowlisted).
         run: |
-          dups=$(ls packages/gui/supabase/migrations/*.sql | sed -E 's/.*\/([0-9]+)_.*/\1/' | sort | uniq -d | grep -v '^0029$' || true)
+          prefixes=$(ls packages/gui/supabase/migrations/*.sql | sed -E 's/.*\/([0-9]+)_.*/\1/')
+
+          # (a) format: 14-digit timestamp, or legacy 4-digit number <= 0044
+          for p in $prefixes; do
+            if echo "$p" | grep -qE '^[0-9]{14}$'; then
+              continue
+            fi
+            if echo "$p" | grep -qE '^[0-9]{4}$' && [ "$((10#$p))" -le 44 ]; then
+              continue
+            fi
+            echo "Bad migration prefix '$p' — new migrations must be a UTC timestamp (run: date -u +%Y%m%d%H%M%S)."
+            exit 1
+          done
+
+          # (b) duplicate prefixes (legacy 0029 set allowlisted)
+          dups=$(echo "$prefixes" | sort | uniq -d | grep -v '^0029$' || true)
           if [ -n "$dups" ]; then
-            echo "Duplicate migration numbers: $dups"
+            echo "Duplicate migration prefixes: $dups"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,11 @@ queue is `jobs` → `workflow_runs` → `agent_runs` → `agent_run_events` plus
 `/api/cron/triage-sweep` is the missed-webhook poll fallback; `/api/cron/issue-sync` is
 the GitHub → `issues`-table reconcile; `/api/runner/*` is the long-poll API for
 self-hosted runners. Shared `workflow_runs` / `agent_runs` / `agent_run_events` writes
-go through `lib/persist-workflow-run.ts`.
+go through `lib/persist-workflow-run.ts`. New Supabase migrations
+(`packages/gui/supabase/migrations/`) use a UTC timestamp prefix —
+`YYYYMMDDHHMMSS_desc.sql` (`date -u +%Y%m%d%H%M%S`) — not a sequential number, so
+branches never collide; legacy `00xx_` files (≤ `0044`) are grandfathered. CI's
+"Migration naming sanity" step enforces this. See `docs/DEVELOPMENT.md`.
 
 **Webhook receiver** (`packages/gui/src/app/api/github/webhook/`): GitHub App deliveries —
 `issues.opened`/`reopened`/`edited` enqueue a deduped `triage` job; `check_run.completed`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -152,3 +152,29 @@ Workspace-scoped Action (no code change):
    with a Zod schema for its input and an `execute(args, ctx)` impl.
 2. Register it in `EFFECT_REGISTRY`. The runner and the Anthropic-tools
    generator pick it up automatically — no other plumbing.
+
+---
+
+## Adding a Supabase migration
+
+Migrations live in [`packages/gui/supabase/migrations/`](../packages/gui/supabase/migrations/)
+and are applied in lexicographic filename order by
+[`infra/supabase/migrate.sh`](../infra/supabase/migrate.sh) (tracked once each
+in `public._cezar_migrations`).
+
+**Naming convention — use a UTC timestamp prefix, not a sequential number:**
+
+```
+YYYYMMDDHHMMSS_short_description.sql      e.g. 20260618143000_add_foo_index.sql
+```
+
+Generate the prefix with `date -u +%Y%m%d%H%M%S`. Timestamps sort correctly
+(every `2026…` file runs after every legacy `00xx_` file) and never collide
+across branches — the old zero-padded `0001`–`0044` scheme produced merge
+conflicts whenever two PRs grabbed the same number (see the four legacy
+`0029_*` files). Existing numbered migrations are left as-is; only **new**
+migrations use the timestamp form.
+
+CI's "Migration numbering sanity" step fails the build on any two migrations
+that share a numeric prefix (the legacy `0029` set is allowlisted), so a
+duplicate prefix is caught before merge.


### PR DESCRIPTION
## Why

Sequential zero-padded migration numbers (`0001`…`0044`) collide whenever two PRs grab the same number on separate branches. This is already visible in `packages/gui/supabase/migrations/` — there are **four** colliding `0029_*` files. The numbered scheme guarantees a merge conflict every time two branches both add a migration.

## What

- **New convention:** migrations use a UTC timestamp prefix — `YYYYMMDDHHMMSS_short_description.sql`, generated with `date -u +%Y%m%d%H%M%S`. Branches never collide. Timestamps sort lexicographically *after* every legacy `00xx_` file, so apply-order and the `_cezar_migrations` (filename-keyed) tracking table are unaffected.
- **No files renamed** — the timestamp scheme applies only to new migrations; existing `0001`–`0044` files are grandfathered.
- **CI enforcement** (`.github/workflows/ci.yml`): the migration step now requires every prefix to be either a 14-digit timestamp or a grandfathered legacy number (`≤ 0044`), and still fails on any two migrations sharing a numeric prefix (the legacy `0029` set is allowlisted). A new `0045_`-style number now fails CI, steering everyone to timestamps.
- **Docs:** added an "Adding a Supabase migration" section to `docs/DEVELOPMENT.md` and a pointer in `CLAUDE.md`.

## Verification

CI logic tested locally under bash (the GitHub Actions shell):
- ✅ all 44 current migrations accepted
- ✅ a new `0045_` number is rejected
- ✅ a 14-digit timestamp prefix is accepted
- ✅ duplicate-prefix detection retained (`0029` allowlisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)