### PR TITLE
ci: add Dependabot + CodeQL (#269)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  # JavaScript/TypeScript deps — single Yarn 4 workspace at the repo root.
+  # One root yarn.lock covers every package (workspace ranges resolve here),
+  # so a single "/" entry updates the whole monorepo.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Batch all minor + patch bumps into one PR to cut review noise; majors
+      # still open individually so breaking changes get a dedicated review.
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the workflows in .github/workflows/.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly scan (Mondays 06:17 UTC) to catch advisories in unchanged code.
+    - cron: "17 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL analyzes JavaScript and TypeScript together under one language.
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # JS/TS is interpreted — no compilation step is required.
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds automated dependency updates and code scanning to the repo.

### `.github/dependabot.yml` (version 2)
- **npm** ecosystem at `/` — single entry covers the whole Yarn 4 monorepo (one root `yarn.lock`, workspace ranges resolve there), weekly schedule, `open-pull-requests-limit: 10`. A `npm-minor-patch` group batches all minor + patch bumps into one PR to cut review noise; majors still open individually for dedicated review.
- **github-actions** ecosystem at `/` — weekly, `open-pull-requests-limit: 5`, grouped minor/patch bumps.

### `.github/workflows/codeql.yml`
- `github/codeql-action/init@v3` + `analyze@v3`, language `javascript-typescript` (CodeQL scans JS/TS together), `build-mode: none` (interpreted — no compile step).
- Triggers: `pull_request` + `push` on `main`, and a weekly `schedule` (Mon 06:17 UTC).
- Least-privilege `permissions`: `security-events: write`, `actions: read`, `contents: read`.

## Verification
- YAML validated with `yaml.safe_load` for both files.
- `actionlint` 1.7.12 passes on `codeql.yml` (and existing `ci.yml` still passes).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)