### PR TITLE
ci: apply all Supabase migrations against real Postgres (#268)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,58 @@ jobs:
 
       - name: Test
         run: yarn test
+
+  # Apply every Supabase migration, in lexicographic filename order, against a
+  # real Postgres — the same order Supabase applies them. This catches SQL that
+  # only fails on a clean database (bad ordering, dropped-then-referenced
+  # objects, typos) which `next build` / unit tests never exercise.
+  apply-migrations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: cezar_migrations
+        ports:
+          - 5432:5432
+        # Wait until Postgres accepts connections before the job's steps run.
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply bootstrap + migrations + smoke asserts
+        # A plain postgres:15 is NOT Supabase: it has no `auth` schema and none
+        # of the `anon` / `authenticated` / `service_role` API roles that the
+        # migrations' FKs, RLS policies, and GRANTs depend on. ci-bootstrap.sql
+        # is a minimal CI-only stand-in for those (it lives outside
+        # migrations/ so the numbering-sanity check and this apply loop ignore
+        # it). The four legacy 0029_* files share a numeric prefix on purpose
+        # (see "Migration naming sanity" above) — we do NOT renumber them and
+        # rely solely on lexicographic filename sort for a deterministic order.
+        env:
+          PGPASSWORD: postgres
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: postgres
+          PGDATABASE: cezar_migrations
+        run: |
+          set -euo pipefail
+          cd packages/gui/supabase
+
+          psql -v ON_ERROR_STOP=1 -q -f ci-bootstrap.sql
+
+          for f in $(ls migrations/*.sql | sort); do
+            echo "--- applying ${f}"
+            psql -v ON_ERROR_STOP=1 -q -f "${f}"
+          done
+
+          echo "--- running smoke assertions"
+          psql -v ON_ERROR_STOP=1 -q -f ci-smoke-asserts.sql
+
+          echo "All migrations applied cleanly."

--- a/packages/gui/supabase/ci-bootstrap.sql
+++ b/packages/gui/supabase/ci-bootstrap.sql
@@ -1,0 +1,74 @@
+-- CI-only bootstrap for applying the Supabase migrations against a *plain*
+-- postgres:15 image (see .github/workflows/ci.yml → apply-migrations).
+--
+-- A real Supabase database ships an `auth` schema (the GoTrue auth server)
+-- with an `auth.users` table and the `auth.uid()` / `auth.role()` helper
+-- functions. A vanilla Postgres container has none of that, so the very first
+-- migration (0001_init.sql) fails immediately: it declares foreign keys to
+-- `auth.users(id)` and RLS policies that call `auth.uid()`.
+--
+-- This file is a *minimal stand-in* — just enough surface area for the
+-- migrations to apply cleanly. It is NOT a faithful reproduction of Supabase
+-- auth and must never ship to a real database. It lives OUTSIDE the
+-- migrations/ directory on purpose so the migration numbering-sanity check
+-- and the lexicographic apply loop never pick it up.
+--
+-- Two kinds of Supabase-isms appear across all migrations:
+--   * The `auth` schema
+--     (`grep -rn 'auth\.' packages/gui/supabase/migrations/`):
+--       - `auth.users(id)` — FK target; only the `id` column is referenced.
+--       - `auth.uid()`     — used inside RLS policy expressions. Policies are
+--                            registered (not evaluated) at apply time, so a
+--                            stub returning NULL is sufficient for migrations.
+--   * The Supabase API roles `anon` / `authenticated` / `service_role`, which
+--     migrations target with `GRANT ... TO`. They are created by Supabase, not
+--     by these migrations, so a plain Postgres lacks them and the GRANTs fail.
+
+create extension if not exists "pgcrypto";
+
+-- Supabase predefines these NOLOGIN roles; recreate them so the GRANT
+-- statements in the migrations resolve. Postgres has no
+-- `CREATE ROLE IF NOT EXISTS`, hence the guarded DO block.
+do $$
+declare
+  r text;
+begin
+  foreach r in array array['anon', 'authenticated', 'service_role'] loop
+    if not exists (select 1 from pg_roles where rolname = r) then
+      execute format('create role %I nologin', r);
+    end if;
+  end loop;
+end $$;
+
+create schema if not exists auth;
+
+-- Stub of Supabase's auth.users. Migrations only reference the `id` column
+-- (as a FK target); `email` is added defensively in case future migrations
+-- reference it. This is intentionally not the full GoTrue schema.
+create table if not exists auth.users (
+  id    uuid primary key default gen_random_uuid(),
+  email text
+);
+
+-- auth.uid() returns the current user's id from the request JWT in real
+-- Supabase. At migration-apply time no request context exists and policy
+-- bodies are not evaluated, so a NULL-returning stub is enough.
+create or replace function auth.uid()
+  returns uuid
+  language sql
+  stable
+as $$ select null::uuid $$;
+
+-- auth.role() / auth.jwt() are not referenced by any current migration, but
+-- are cheap to stub and guard against the next migration that uses them.
+create or replace function auth.role()
+  returns text
+  language sql
+  stable
+as $$ select null::text $$;
+
+create or replace function auth.jwt()
+  returns jsonb
+  language sql
+  stable
+as $$ select null::jsonb $$;

--- a/packages/gui/supabase/ci-smoke-asserts.sql
+++ b/packages/gui/supabase/ci-smoke-asserts.sql
@@ -1,0 +1,50 @@
+-- CI-only post-apply smoke assertions (see .github/workflows/ci.yml →
+-- apply-migrations). Runs after ci-bootstrap.sql + every migration has been
+-- applied. Each block raises an exception (failing the psql run under
+-- ON_ERROR_STOP) when the post-migration schema is not what we expect.
+--
+-- This is a lightweight sanity net, not a full schema test: it pins a couple
+-- of invariants that have actually broken before — the `actions` table shape
+-- (Actions v2) and the removal of the legacy seed_default_actions() function
+-- consolidated away in 0044.
+
+-- 1. The `actions` table exists with its core Actions v2 columns.
+do $$
+declare
+  expected text[] := array[
+    'workspace_id', 'name', 'kind', 'system_prompt',
+    'skill_refs', 'target', 'triggers', 'effects', 'enabled'
+  ];
+  missing text;
+begin
+  if to_regclass('public.actions') is null then
+    raise exception 'expected table public.actions to exist after migrations';
+  end if;
+
+  select string_agg(col, ', ') into missing
+  from unnest(expected) as col
+  where not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'actions'
+      and column_name = col
+  );
+
+  if missing is not null then
+    raise exception 'public.actions is missing expected column(s): %', missing;
+  end if;
+end $$;
+
+-- 2. seed_default_actions(uuid) must be gone — 0044 drops it.
+do $$
+declare
+  n integer;
+begin
+  select count(*) into n
+  from pg_proc
+  where proname = 'seed_default_actions';
+
+  if n <> 0 then
+    raise exception 'seed_default_actions still exists (% definition(s)); 0044 should have dropped it', n;
+  end if;
+end $$;


### PR DESCRIPTION
## What

Adds an `apply-migrations` CI job that applies **every** Supabase migration, in lexicographic filename order, against a real `postgres:15` service container. This catches SQL that only breaks on a clean database — bad ordering, dropped-then-referenced objects, typos — which `next build` and the unit tests never exercise.

Closes #268

## How

### `packages/gui/supabase/ci-bootstrap.sql` (auth-schema stand-in)
A plain Postgres is **not** Supabase: it has no `auth` schema and none of the `anon` / `authenticated` / `service_role` API roles that the migrations' FKs, RLS policies, and `GRANT`s depend on. `0001_init.sql` fails on the first FK to `auth.users(id)` otherwise.

The bootstrap is a minimal CI-only stand-in:
- `create schema auth` + stub `auth.users` (only the `id` column is referenced as an FK target; `email` added defensively)
- NULL-returning stubs for `auth.uid()` / `auth.role()` / `auth.jwt()` (policy bodies are registered, not evaluated, at apply time)
- the three Supabase `NOLOGIN` roles via a guarded `DO` block (Postgres has no `CREATE ROLE IF NOT EXISTS`)

It lives **outside** `migrations/` on purpose so the "Migration naming sanity" check and the apply loop never pick it up.

### The four legacy `0029_*` files
Not renumbered. The apply loop relies purely on lexicographic filename sort for a deterministic order — the same way Supabase applies them — and the numbering check already allowlists the shared `0029` prefix.

### `packages/gui/supabase/ci-smoke-asserts.sql`
Post-apply sanity net (each block `RAISE EXCEPTION` under `ON_ERROR_STOP`):
1. the `actions` table exists with its core Actions v2 columns
2. `seed_default_actions(uuid)` is gone (dropped in `0044`)

## Verification

Verified locally against a `postgres:15` Docker container before writing the YAML: bootstrap + all 53 migrations + smoke asserts apply cleanly with `ON_ERROR_STOP=1` (only harmless `IF EXISTS`/`already exists` NOTICEs). The negative path was also checked — creating `seed_default_actions` makes the smoke assert fail with exit 3. The workflow file passes `actionlint` (via the `rhysd/actionlint` Docker image; only an `info`-level SC2012 that the existing numbering-check step already triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)