### PR TITLE
fix: unbreak compose runner default URL and surface real accept errors

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -106,3 +106,8 @@ CEZAR_RUNNER_TOKEN=replace-me
 # Defaults to http://gui:3000 over the compose network — fine unless the
 # runner is on a different host.
 # CEZAR_RUNNER_URL=http://gui:3000
+# The runner refuses to send its token over plain http unless this is 1.
+# compose.yaml defaults it to 1 because the default URL above is http on the
+# private compose network. Set to 0 if CEZAR_RUNNER_URL is an external
+# https:// endpoint.
+# CEZAR_RUNNER_ALLOW_INSECURE=1

--- a/compose.yaml
+++ b/compose.yaml
@@ -115,6 +115,11 @@ services:
     environment:
       CEZAR_RUNNER_URL: ${CEZAR_RUNNER_URL:-http://gui:3000}
       CEZAR_RUNNER_TOKEN: ${CEZAR_RUNNER_TOKEN}
+      # The default URL is plain http over the private compose network, which
+      # the runner's TLS guard would otherwise refuse (it protects the bearer
+      # token from leaving the host in plaintext). Set to 0 if you point
+      # CEZAR_RUNNER_URL at an external https:// endpoint.
+      CEZAR_RUNNER_ALLOW_INSECURE: ${CEZAR_RUNNER_ALLOW_INSECURE:-1}
     command:
       - 'start'
       - '--kind'

--- a/packages/gui/src/app/inbox/decision-actions.ts
+++ b/packages/gui/src/app/inbox/decision-actions.ts
@@ -93,11 +93,16 @@ async function buildEffectContext(
 // ─────────────────────────────────────────────────────────────────────
 export async function acceptDecision(id: string): Promise<DecisionResult> {
   const result = await acceptDecisionsImpl([id]);
-  if (!result.ok) return result;
+  if (result.ok) return { ok: true, results: result.results };
+  // A per-row failure leaves the impl's top-level `error` unset — lift the
+  // row's message so the single-accept toast shows the real cause instead
+  // of "unknown".
   const first = result.results?.[0];
-  return first?.ok
-    ? { ok: true, results: result.results }
-    : { ok: false, error: first?.error ?? 'accept failed', results: result.results };
+  return {
+    ok: false,
+    error: result.error ?? first?.error ?? 'accept failed',
+    results: result.results,
+  };
 }
 
 export async function acceptDecisions(ids: string[]): Promise<DecisionResult> {


### PR DESCRIPTION
## Summary

Two production fixes observed on a live compose deployment:

### 1. Runner crash-loop on the shipped compose defaults
`compose.yaml` defaults the runner to `CEZAR_RUNNER_URL=http://gui:3000` (the private compose network), but the runner's TLS guard in `runner-client.ts` refuses to send the bearer token over plain `http` unless the host is loopback or `CEZAR_RUNNER_ALLOW_INSECURE=1` — and compose never forwarded that variable. Result: the runner dies in the `RunnerClient` constructor and `restart: unless-stopped` loops it forever.

Fix: pass `CEZAR_RUNNER_ALLOW_INSECURE` through to the runner service, defaulting to `1` because the default URL is http on the private compose network — exactly the topology the escape hatch exists for. Operators pointing `CEZAR_RUNNER_URL` at an external endpoint should use https and set it to `0`. Documented in `.env.docker.example`.

### 2. "Accept failed: unknown" hides the real error
`acceptDecision` returned the impl result early on failure, skipping the code that lifts `results[0].error` to the top-level `error` field (that branch was unreachable for failures). The inbox toast renders `result.error ?? 'unknown'`, so every single-accept failure read **Accept failed: unknown** while the true cause only landed in `pending_decisions.apply_error`.

Fix: lift the per-row error into the top-level `error` on failure.

## Test plan
- `yarn build` (all workspaces, topological) ✓
- `yarn workspace @cezar/gui run typecheck` ✓
- Deploy: `docker compose up` with default env no longer crash-loops the runner; a failing accept now shows the underlying message in the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)