### PR TITLE
feat(runner): join-token registration + per-user runner ownership and job routing

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -108,8 +108,9 @@ CEZAR_RUNNER_JOIN_TOKEN=replace-me
 # Runner name — (workspace, owner, name) identifies the runner; re-registering
 # the same name re-keys it instead of creating a duplicate.
 # CEZAR_RUNNER_NAME=compose-runner
-# Legacy pre-issued runner token (pre-join-token deployments only). Leave
-# empty when using CEZAR_RUNNER_JOIN_TOKEN.
+# DEPRECATED — will be removed in v0.3.0. Legacy pre-issued runner token
+# (pre-join-token deployments only); migrate to CEZAR_RUNNER_JOIN_TOKEN and
+# leave this empty.
 # CEZAR_RUNNER_TOKEN=
 # Defaults to http://gui:3000 over the compose network — fine unless the
 # runner is on a different host.

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -100,9 +100,17 @@ CEZAR_USE_WORKFLOW_ENGINE=true
 # CEZAR_INPROCESS_CRON_BASE_URL=
 
 # ─── Self-hosted runner ───────────────────────────────────────────────────────
-# Issue this token in the GUI: Settings → Runners → Register a runner.
-# Shown once; treat it like a password.
-CEZAR_RUNNER_TOKEN=replace-me
+# Mint a join token in the GUI: Settings → Runners → Mint join token (shown
+# once; treat it like a password). The runner registers itself on first boot
+# and persists its credential in the runner-home volume; the runner belongs
+# to whoever minted the token, and jobs they request route to their runners.
+CEZAR_RUNNER_JOIN_TOKEN=replace-me
+# Runner name — (workspace, owner, name) identifies the runner; re-registering
+# the same name re-keys it instead of creating a duplicate.
+# CEZAR_RUNNER_NAME=compose-runner
+# Legacy pre-issued runner token (pre-join-token deployments only). Leave
+# empty when using CEZAR_RUNNER_JOIN_TOKEN.
+# CEZAR_RUNNER_TOKEN=
 # Defaults to http://gui:3000 over the compose network — fine unless the
 # runner is on a different host.
 # CEZAR_RUNNER_URL=http://gui:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,5 +187,5 @@ confirmation; `--dry-run` previews.
 - `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` / `GITHUB_APP_WEBHOOK_SECRET` — the GitHub App (webhooks + install tokens); without the secret the webhook receiver returns 503
 - `CEZAR_USE_WORKFLOW_ENGINE` — local CLI only: `true` opts the legacy `AutofixOrchestrator` path into delegating to `runWorkflow` (or set `workflow.useEngine: true` in `.issuemanagerrc.json`). The SaaS dispatch path always uses the engine.
 - `CRON_SECRET` — bearer check shared by `/api/cron/dispatch`, `/api/cron/triage-sweep`, `/api/cron/issue-sync`
-- `CEZAR_RUNNER_URL` / `CEZAR_RUNNER_TOKEN` — the self-hosted runner
+- `CEZAR_RUNNER_URL` / `CEZAR_RUNNER_JOIN_TOKEN` — the self-hosted runner (join token minted in Settings → Runners; the runner registers itself). `CEZAR_RUNNER_TOKEN` (pre-issued per-runner token) is **deprecated — removed in v0.3.0**.
 - Supabase vars + `NEXT_PUBLIC_APP_URL` (GUI) — see `docs/SELF-HOSTING.md` and `.env.docker.example` for the full list and the `CEZAR_DISPATCH_*` / `CEZAR_TRIAGE_SWEEP_*` tuning vars

--- a/compose.yaml
+++ b/compose.yaml
@@ -114,7 +114,13 @@ services:
       - gui
     environment:
       CEZAR_RUNNER_URL: ${CEZAR_RUNNER_URL:-http://gui:3000}
-      CEZAR_RUNNER_TOKEN: ${CEZAR_RUNNER_TOKEN}
+      # Join token minted in Settings → Runners. The runner registers itself
+      # on first boot (name defaults to `compose-runner`) and persists the
+      # resulting credential in the runner-home volume.
+      CEZAR_RUNNER_JOIN_TOKEN: ${CEZAR_RUNNER_JOIN_TOKEN:-}
+      CEZAR_RUNNER_NAME: ${CEZAR_RUNNER_NAME:-compose-runner}
+      # Legacy pre-issued runner token; leave empty when using the join token.
+      CEZAR_RUNNER_TOKEN: ${CEZAR_RUNNER_TOKEN:-}
       # The default URL is plain http over the private compose network, which
       # the runner's TLS guard would otherwise refuse (it protects the bearer
       # token from leaving the host in plaintext). Set to 0 if you point
@@ -129,8 +135,9 @@ services:
       - '--concurrency'
       - '1'
     volumes:
-      # Persists `~/.claude` and `~/.codex` so the one-time interactive
-      # login survives container restarts and rebuilds.
+      # Persists `~/.claude` and `~/.codex` (CLI logins) plus
+      # `~/.cezar-runner/credentials.json` (the registered runner credential)
+      # across container restarts and rebuilds.
       - runner-home:/home/node
     networks:
       - cezar

--- a/compose.yaml
+++ b/compose.yaml
@@ -119,7 +119,8 @@ services:
       # resulting credential in the runner-home volume.
       CEZAR_RUNNER_JOIN_TOKEN: ${CEZAR_RUNNER_JOIN_TOKEN:-}
       CEZAR_RUNNER_NAME: ${CEZAR_RUNNER_NAME:-compose-runner}
-      # Legacy pre-issued runner token; leave empty when using the join token.
+      # DEPRECATED — removed in v0.3.0. Legacy pre-issued runner token;
+      # migrate to CEZAR_RUNNER_JOIN_TOKEN and leave this empty.
       CEZAR_RUNNER_TOKEN: ${CEZAR_RUNNER_TOKEN:-}
       # The default URL is plain http over the private compose network, which
       # the runner's TLS guard would otherwise refuse (it protects the bearer

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -104,7 +104,8 @@ The full template with every supported variable is in
 | `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` | GitHub App auth (short-lived install tokens) |
 | `GITHUB_APP_WEBHOOK_SECRET` | Webhook signature verification (until set, the receiver returns 503) |
 | `CRON_SECRET` | Bearer check shared by `/api/cron/*` routes |
-| `CEZAR_RUNNER_URL` / `CEZAR_RUNNER_TOKEN` | `@cezar/runner` connection defaults |
+| `CEZAR_RUNNER_URL` / `CEZAR_RUNNER_JOIN_TOKEN` | `@cezar/runner` connection defaults (join token minted in Settings → Runners) |
+| `CEZAR_RUNNER_TOKEN` | **Deprecated — removed in v0.3.0.** Pre-issued runner token; migrate to `CEZAR_RUNNER_JOIN_TOKEN` |
 | Supabase + `NEXT_PUBLIC_APP_URL` | GUI |
 
 The CLI auto-loads `.env` from the project root; env vars override config-file

--- a/docs/dokploy-setup.md
+++ b/docs/dokploy-setup.md
@@ -142,8 +142,11 @@ GITHUB_APP_WEBHOOK_SECRET=replace-me
 # Engine
 CEZAR_USE_WORKFLOW_ENGINE=true
 
-# Runner token (placeholder — replaced after step 9)
-CEZAR_RUNNER_TOKEN=placeholder
+# Runner join token (placeholder — replaced after step 9)
+CEZAR_RUNNER_JOIN_TOKEN=placeholder
+# DEPRECATED — removed in v0.3.0; pre-issued runner token, superseded by
+# CEZAR_RUNNER_JOIN_TOKEN. Leave unset.
+# CEZAR_RUNNER_TOKEN=
 ```
 
 The full reference (optional tuning vars: `CEZAR_DISPATCH_BATCH`,
@@ -201,11 +204,12 @@ GitHub OAuth, and confirm the cockpit loads.
 
 ## 9 · Register the runner and finish the auth dance
 
-1. In the GUI, **Settings → Runners → Register a runner**. Give it a name
-   (e.g. `dokploy-runner`). Copy the **token** that's shown — it's only
-   displayed once.
-2. Back in Dokploy → **Environment** → set `CEZAR_RUNNER_TOKEN` to that
-   token. Save.
+1. In the GUI, **Settings → Runners → Mint join token**. Copy the **join
+   token** that's shown — it's only displayed once. (The runner registers
+   itself with it and belongs to you; jobs you trigger route to your
+   runners.)
+2. Back in Dokploy → **Environment** → set `CEZAR_RUNNER_JOIN_TOKEN` to that
+   token. Save. (`CEZAR_RUNNER_TOKEN` is deprecated — removed in v0.3.0.)
 3. Dokploy will offer to redeploy — accept (or use **Redeploy** manually).
    Only the `runner` container needs the new value, but a stack redeploy is
    the simplest path.
@@ -309,7 +313,7 @@ If you scale and want only one replica to drive `sync`, set
 | Browser shows Dokploy's default page, not Cezar | Domain not yet routed | Check **Domains** tab, container port `3000`, service `gui`. Wait for Let's Encrypt. |
 | `502 Bad Gateway` from Traefik | GUI container crashed | `docker logs <gui>`. Usually a missing/wrong Supabase env var. |
 | GUI loads but login redirects to localhost | Supabase auth URL config | Re-check Site URL + Redirect URLs in Supabase (step 3.4). |
-| Runner stuck on `auth lookup failed` | Token still placeholder | Repeat step 9; redeploy after setting `CEZAR_RUNNER_TOKEN`. |
+| Runner stuck on `unknown or revoked join token` | Token still placeholder | Repeat step 9; redeploy after setting `CEZAR_RUNNER_JOIN_TOKEN`. |
 | `claude login` errors with "command not found" | Wrong container | Confirm you're `exec`-ing into the **runner** container, not `gui`. |
 | Webhook deliveries show `503` | `GITHUB_APP_WEBHOOK_SECRET` unset | Set it, redeploy. Until then `triage-sweep` polls as a fallback. |
 | Jobs stay queued forever | Dispatcher not running, or no runner for the required backend | Check `/api/cron/dispatch` logs (in-process scheduler tail). For CLI backends, confirm a runner is registered + online. |

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -28,18 +28,27 @@ This produces the `cezar-runner` binary (`packages/runner/dist/cli.js`). Run it
 via `yarn workspace @cezar/runner exec cezar-runner …`, or `npm link` /
 `yarn link` the package, or just call `node packages/runner/dist/cli.js …`.
 
-## 2. Register the runner in the web app
+## 2. Mint a join token in the web app
+
+Runners register **themselves** — you never create a runner row by hand.
 
 1. In the Cezar web app, go to **Settings → Runners**.
-2. Click **Register a runner**, give it a name (e.g. `ci-box-1`), and pick the
-   backends it will serve (`claude-cli`, `codex-cli`, and/or — unusually —
-   `anthropic-api`).
-3. Copy the **token** shown on the next screen. **It is shown once and never
-   again** — only a SHA-256 hash of it is stored. If you lose it, revoke the
-   runner and register a new one.
+2. Click **Mint join token** (any workspace member can; give it a label like
+   `laptop` or `ci-box` if you'll mint several).
+3. Copy the **join token**. **It is shown once and never again** — only a
+   SHA-256 hash is stored. Unlike the old per-runner token it is *reusable*:
+   the same join token can register any number of runners across devices,
+   until you revoke it.
+
+A runner registered with your join token **belongs to you**: jobs you trigger
+in the GUI route to *your* runners; jobs another user triggers route to
+*theirs*. System-initiated jobs (webhooks, sweeps) can run on any runner in
+the workspace. Runners are identified by *(workspace, owner, name)* — starting
+a runner again with the same name re-keys the existing registration instead of
+creating a duplicate.
 
 The page also shows a ready-to-paste `cezar-runner start …` command with the
-token and backends filled in.
+join token filled in.
 
 ## 3. Check the CLIs on the runner host
 
@@ -57,17 +66,32 @@ be billed** — those credentials live on this host only; Cezar never sees them.
 ```bash
 cezar-runner start \
   --url https://<your-cezar-host> \
-  --token <token-from-step-2> \
-  --backends claude-cli,codex-cli
+  --join-token <join-token-from-step-2>
 ```
 
 Or via environment variables instead of flags:
 
 ```bash
 export CEZAR_RUNNER_URL=https://<your-cezar-host>
-export CEZAR_RUNNER_TOKEN=<token-from-step-2>
-cezar-runner start --backends claude-cli,codex-cli
+export CEZAR_RUNNER_JOIN_TOKEN=<join-token-from-step-2>
+cezar-runner start
 ```
+
+On first start the daemon registers itself (name defaults to the hostname —
+override with `--name` / `CEZAR_RUNNER_NAME`; backends are auto-detected from
+the CLIs on `PATH` — override with `--backends`), then persists the resulting
+per-runner credential in `~/.cezar-runner/credentials.json` (`0600`; override
+the directory with `CEZAR_RUNNER_STATE_DIR`). Later starts reuse the persisted
+credential, and if the SaaS ever rejects it (you revoked the runner, or the
+database was reset) the daemon automatically re-registers with the join token.
+
+A runner registered before the join-token flow keeps working: pass its
+pre-issued token via `--token` / `CEZAR_RUNNER_TOKEN` and registration is
+skipped entirely.
+
+In the Docker compose stack, set `CEZAR_RUNNER_JOIN_TOKEN` in `.env` — the
+`runner` service self-registers as `compose-runner` on first boot and keeps
+its credential in the `runner-home` volume.
 
 The daemon polls the SaaS for jobs matching its advertised backends, claims one,
 clones the repo into a worktree, runs the agent there (sandboxed to the worktree

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -87,7 +87,10 @@ database was reset) the daemon automatically re-registers with the join token.
 
 A runner registered before the join-token flow keeps working: pass its
 pre-issued token via `--token` / `CEZAR_RUNNER_TOKEN` and registration is
-skipped entirely.
+skipped entirely. **Deprecated — `--token` / `CEZAR_RUNNER_TOKEN` will be
+removed in v0.3.0**; re-register through a join token before upgrading (this
+also gives the runner an owner, without which it only receives
+system-initiated jobs).
 
 In the Docker compose stack, set `CEZAR_RUNNER_JOIN_TOKEN` in `.env` — the
 `runner` service self-registers as `compose-runner` on first boot and keeps

--- a/packages/core/src/agents/runner-register.model.ts
+++ b/packages/core/src/agents/runner-register.model.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+/**
+ * Wire contract for `POST /api/runner/register` — the join-token runner
+ * registration flow. The daemon presents a workspace member's join token
+ * (minted in Settings → Runners) as `Authorization: Bearer <join-token>`
+ * with this body; the SaaS creates (or re-keys) the `runners` row owned by
+ * the token's creator and returns the per-runner bearer token the daemon
+ * persists and uses for every subsequent claim/heartbeat/finalize call.
+ *
+ * Lives in `@cezar/core` because both sides validate it at the boundary:
+ * the GUI route parses the request, the runner parses the response.
+ */
+export const RunnerRegisterRequestSchema = z.object({
+  /** Runner display name; (workspace, owner, name) identifies the runner. */
+  name: z.string().min(1).max(80),
+  kind: z.enum(['cloud', 'self-hosted']).default('self-hosted'),
+  backends: z.array(z.enum(['anthropic-api', 'claude-cli', 'codex-cli'])).min(1),
+});
+export type RunnerRegisterRequest = z.infer<typeof RunnerRegisterRequestSchema>;
+
+export const RunnerRegisterResponseSchema = z.object({
+  runnerId: z.string().uuid(),
+  /** The per-runner bearer token — travels only in this one response. */
+  token: z.string().min(1),
+  workspaceId: z.string().uuid(),
+  /** GitHub login of the runner's owner (the join token's creator). */
+  ownerLogin: z.string(),
+  /** True when an existing (workspace, owner, name) row was re-keyed
+   *  instead of a new row created — the old runner token is now invalid. */
+  reRegistered: z.boolean(),
+});
+export type RunnerRegisterResponse = z.infer<typeof RunnerRegisterResponseSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,12 @@ export {
   DEFAULT_AGENT_BACKEND,
   type CreateAgentRunnerOptions,
 } from './agents/runner-factory.js';
+export {
+  RunnerRegisterRequestSchema,
+  RunnerRegisterResponseSchema,
+  type RunnerRegisterRequest,
+  type RunnerRegisterResponse,
+} from './agents/runner-register.model.js';
 
 // Autofix internals (orchestrator + agent session). The CLI still owns the
 // terminal-facing AutofixRunner + verbose toggle.

--- a/packages/gui/src/app/actions/[name]/run-now-action.ts
+++ b/packages/gui/src/app/actions/[name]/run-now-action.ts
@@ -101,6 +101,7 @@ export async function enqueueActionRun(actionId: string, number: number): Promis
     // the cron dispatcher executes. Stamping the backend keeps self-hosted CLI
     // runners — which only know the workflow kinds — from claiming it.
     required_backend: 'anthropic-api',
+    requested_by: user.id,
     payload: { trigger: 'manual', actionId, runId, target: actionRow.target },
   });
   if (jobErr) {

--- a/packages/gui/src/app/api/runner/register/route.ts
+++ b/packages/gui/src/app/api/runner/register/route.ts
@@ -1,0 +1,129 @@
+import { randomBytes } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { RunnerRegisterRequestSchema, type RunnerRegisterResponse } from '@cezar/core';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { hashRunnerToken, invalidateRunnerAuth } from '../_auth';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/**
+ * POST /api/runner/register — join-token runner registration, the only way
+ * a runner row comes into existence (migration 20260706075137).
+ *
+ * `Authorization: Bearer <join-token>` where the join token was minted by a
+ * workspace member in Settings → Runners. Body: `RunnerRegisterRequest`.
+ * The resulting runner is owned by the token's creator — job routing then
+ * sends that user's requested jobs to their runners only.
+ *
+ * Registration is idempotent per (workspace, owner, name): re-registering
+ * re-keys the existing row (the previous runner token stops working) instead
+ * of piling up duplicates, so a recreated container converges on one row.
+ *
+ * The join token can only create/re-key runner rows — it can never claim
+ * jobs (which carry GitHub tokens); only the returned per-runner bearer can.
+ */
+export async function POST(req: Request) {
+  const header = req.headers.get('authorization') ?? '';
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) return NextResponse.json({ error: 'missing join token' }, { status: 401 });
+
+  const admin = createSupabaseAdminClient();
+  const { data: joinToken, error: jtErr } = await admin
+    .from('runner_join_tokens')
+    .select('id, workspace_id, created_by, created_by_login, revoked_at')
+    .eq('token_hash', hashRunnerToken(match[1]))
+    .maybeSingle();
+  if (jtErr) return NextResponse.json({ error: 'auth lookup failed' }, { status: 500 });
+  if (!joinToken || joinToken.revoked_at) {
+    return NextResponse.json({ error: 'unknown or revoked join token' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+  const parsed = RunnerRegisterRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: `invalid register request: ${parsed.error.message}` },
+      { status: 400 },
+    );
+  }
+  const { name, kind, backends } = parsed.data;
+
+  const token = randomBytes(32).toString('hex');
+  const tokenHash = hashRunnerToken(token);
+
+  // Re-key the existing (workspace, owner, name) row if there is one; the
+  // partial unique index runners_workspace_owner_name_uniq guarantees at
+  // most one. Grab the old hash first so its cached auth entry dies with it.
+  const { data: existing, error: exErr } = await admin
+    .from('runners')
+    .select('id, token_hash')
+    .eq('workspace_id', joinToken.workspace_id)
+    .eq('owner_user_id', joinToken.created_by)
+    .eq('name', name)
+    .maybeSingle();
+  if (exErr) return NextResponse.json({ error: exErr.message }, { status: 500 });
+
+  let runnerId: string;
+  if (existing) {
+    const { error } = await admin
+      .from('runners')
+      .update({
+        kind,
+        backends,
+        token_hash: tokenHash,
+        owner_login: joinToken.created_by_login,
+        join_token_id: joinToken.id,
+        status: 'offline',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', existing.id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (existing.token_hash) invalidateRunnerAuth(existing.token_hash);
+    runnerId = existing.id;
+  } else {
+    const { data: inserted, error } = await admin
+      .from('runners')
+      .insert({
+        workspace_id: joinToken.workspace_id,
+        name,
+        kind,
+        backends,
+        models: [],
+        token_hash: tokenHash,
+        status: 'offline',
+        owner_user_id: joinToken.created_by,
+        owner_login: joinToken.created_by_login,
+        join_token_id: joinToken.id,
+      })
+      .select('id')
+      .single();
+    if (error?.code === '23505') {
+      // Two daemons raced the same (workspace, owner, name) — one row won the
+      // unique index. This register's token was never returned to anyone, so
+      // just tell the caller to retry (it will hit the re-key branch).
+      return NextResponse.json(
+        { error: 'registration raced a duplicate — retry' },
+        { status: 409 },
+      );
+    }
+    if (error || !inserted) {
+      return NextResponse.json({ error: error?.message ?? 'insert failed' }, { status: 500 });
+    }
+    runnerId = inserted.id;
+  }
+
+  const response: RunnerRegisterResponse = {
+    runnerId,
+    token,
+    workspaceId: joinToken.workspace_id,
+    ownerLogin: joinToken.created_by_login,
+    reRegistered: Boolean(existing),
+  };
+  return NextResponse.json(response);
+}

--- a/packages/gui/src/app/cockpit/actions.ts
+++ b/packages/gui/src/app/cockpit/actions.ts
@@ -16,6 +16,7 @@ export interface ActionResult {
 interface Ctx {
   supabase: ReturnType<typeof createSupabaseAdminClient>;
   workspaceId: string;
+  userId: string;
   actorLabel: string;
 }
 
@@ -33,6 +34,7 @@ async function guard(): Promise<Ctx | { error: string }> {
   return {
     supabase: createSupabaseAdminClient(),
     workspaceId: workspace.id,
+    userId: user.id,
     actorLabel: user.name || user.email || user.id,
   };
 }
@@ -218,6 +220,7 @@ export async function retryRun(runId: string): Promise<ActionResult> {
     pr_number: run.pr_number,
     status: 'queued',
     max_attempts: 1,
+    requested_by: ctx.userId,
     payload: { retryOf: runId },
   });
   if (error) return { error: error.message };
@@ -291,6 +294,7 @@ export async function enqueueWorkflowRun(params: {
       status: 'queued',
       priority: 10,
       max_attempts: 1,
+      requested_by: user.id,
       payload: {},
     })
     .select('id')

--- a/packages/gui/src/app/issues/autofix-actions.ts
+++ b/packages/gui/src/app/issues/autofix-actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
 
 /**
@@ -14,6 +15,8 @@ import { getActiveWorkspace } from '@/lib/workspace';
  * see it appear via Realtime.
  */
 export async function startAutofix(issueNumber: number): Promise<void> {
+  const user = await getSessionUser();
+  if (!user) throw new Error('not authenticated');
   const workspace = await getActiveWorkspace();
   if (!workspace) throw new Error('no active workspace');
 
@@ -38,6 +41,7 @@ export async function startAutofix(issueNumber: number): Promise<void> {
       priority: 10,
       status: 'queued',
       max_attempts: 1,
+      requested_by: user.id,
       payload: { trigger: 'manual' },
     });
     if (error) throw new Error(`enqueue failed: ${error.message}`);

--- a/packages/gui/src/app/settings/labels-actions.ts
+++ b/packages/gui/src/app/settings/labels-actions.ts
@@ -62,6 +62,7 @@ export async function startLabelAnalysis(): Promise<StartLabelAnalysisResult> {
     // guard (0023) is the hard enforcement; this stamp documents intent and
     // makes a misrouted job easy to spot.
     required_backend: 'anthropic-api',
+    requested_by: user.id,
     payload: { analysisId: analysis.id },
   });
   if (jErr) {

--- a/packages/gui/src/app/settings/runners/page.tsx
+++ b/packages/gui/src/app/settings/runners/page.tsx
@@ -1,9 +1,15 @@
 import Link from 'next/link';
+import { getSessionUser } from '@/lib/auth';
 import { getActiveWorkspace } from '@/lib/workspace';
-import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient, createSupabaseServerClient } from '@/lib/supabase/server';
 import type { RunnerKind, RunnerStatus } from '@/lib/supabase/types';
 import { PageContainer } from '@/components/ui/page-container';
-import { RunnersSection, type RunnerRowView, type RunnerDisplayStatus } from './runners-section';
+import {
+  RunnersSection,
+  type RunnerRowView,
+  type RunnerDisplayStatus,
+  type JoinTokenView,
+} from './runners-section';
 
 interface RunnerDbRow {
   id: string;
@@ -14,6 +20,17 @@ interface RunnerDbRow {
   status: RunnerStatus;
   last_heartbeat_at: string | null;
   created_at: string;
+  owner_user_id: string | null;
+  owner_login: string | null;
+}
+
+interface JoinTokenDbRow {
+  id: string;
+  created_by: string;
+  created_by_login: string;
+  label: string;
+  created_at: string;
+  revoked_at: string | null;
 }
 
 const ONLINE_WINDOW_MS = 2 * 60_000;
@@ -30,7 +47,7 @@ function displayStatus(lastHeartbeatAt: string | null): RunnerDisplayStatus {
   return 'offline';
 }
 
-function toView(r: RunnerDbRow): RunnerRowView {
+function toView(r: RunnerDbRow, currentUserId: string | null): RunnerRowView {
   return {
     id: r.id,
     name: r.name,
@@ -40,6 +57,8 @@ function toView(r: RunnerDbRow): RunnerRowView {
     lastHeartbeatAt: r.last_heartbeat_at,
     createdAt: r.created_at,
     managed: r.workspace_id == null,
+    ownerLogin: r.owner_login,
+    mine: r.owner_user_id != null && r.owner_user_id === currentUserId,
   };
 }
 
@@ -61,20 +80,34 @@ export default async function RunnersPage() {
     );
   }
 
-  const supabase = createSupabaseAdminClient();
-  const [{ data: ownRows }, { data: managedRows }] = await Promise.all([
-    supabase
+  const user = await getSessionUser();
+  const admin = createSupabaseAdminClient();
+  // Join tokens go through the user-scoped client: RLS shows members their
+  // own tokens and admins every token in the workspace.
+  const userClient = await createSupabaseServerClient();
+  const [{ data: ownRows }, { data: managedRows }, { data: tokenRows }] = await Promise.all([
+    admin
       .from('runners')
-      .select('id, workspace_id, name, kind, backends, status, last_heartbeat_at, created_at')
+      .select(
+        'id, workspace_id, name, kind, backends, status, last_heartbeat_at, created_at, owner_user_id, owner_login',
+      )
       .eq('workspace_id', workspace.id)
       .order('created_at', { ascending: true })
       .returns<RunnerDbRow[]>(),
-    supabase
+    admin
       .from('runners')
-      .select('id, workspace_id, name, kind, backends, status, last_heartbeat_at, created_at')
+      .select(
+        'id, workspace_id, name, kind, backends, status, last_heartbeat_at, created_at, owner_user_id, owner_login',
+      )
       .is('workspace_id', null)
       .order('created_at', { ascending: true })
       .returns<RunnerDbRow[]>(),
+    userClient
+      .from('runner_join_tokens')
+      .select('id, created_by, created_by_login, label, created_at, revoked_at')
+      .eq('workspace_id', workspace.id)
+      .order('created_at', { ascending: false })
+      .returns<JoinTokenDbRow[]>(),
   ]);
 
   const isAdmin = workspace.role === 'admin';
@@ -82,6 +115,15 @@ export default async function RunnersPage() {
     process.env.NEXT_PUBLIC_APP_URL ||
     (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '') ||
     '';
+
+  const joinTokens: JoinTokenView[] = (tokenRows ?? []).map((t) => ({
+    id: t.id,
+    label: t.label,
+    createdByLogin: t.created_by_login,
+    createdAt: t.created_at,
+    revokedAt: t.revoked_at,
+    mine: user != null && t.created_by === user.id,
+  }));
 
   return (
     <PageContainer max="max-w-[1080px]">
@@ -108,7 +150,10 @@ export default async function RunnersPage() {
           <code className="rounded bg-surface-container px-1 py-px font-mono text-[12px] text-on-surface">
             codex-cli
           </code>{' '}
-          jobs on your own infra under your own CLI login. The managed cloud handles{' '}
+          jobs on your own infra under your own CLI login. Runners register themselves with a{' '}
+          <strong className="font-medium text-on-surface">join token</strong> you mint below; a
+          runner belongs to whoever minted its token, and jobs you request run on your runners. The
+          managed cloud handles{' '}
           <code className="rounded bg-surface-container px-1 py-px font-mono text-[12px] text-on-surface">
             anthropic-api
           </code>{' '}
@@ -117,17 +162,13 @@ export default async function RunnersPage() {
             docs/runner-setup.md
           </code>{' '}
           for the full setup.
-          {!isAdmin && (
-            <span className="ml-1 text-outline">
-              — read-only, admin required to register or revoke.
-            </span>
-          )}
         </p>
       </header>
 
       <RunnersSection
-        ownRunners={(ownRows ?? []).map(toView)}
-        managedRunners={(managedRows ?? []).map(toView)}
+        ownRunners={(ownRows ?? []).map((r) => toView(r, user?.id ?? null))}
+        managedRunners={(managedRows ?? []).map((r) => toView(r, user?.id ?? null))}
+        joinTokens={joinTokens}
         isAdmin={isAdmin}
         appUrl={appUrl}
       />

--- a/packages/gui/src/app/settings/runners/runners-actions.ts
+++ b/packages/gui/src/app/settings/runners/runners-actions.ts
@@ -6,73 +6,104 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getActiveWorkspace } from '@/lib/workspace';
 import { hashRunnerToken, invalidateRunnerAuth } from '@/app/api/runner/_auth';
 
-/** Backends a *self-hosted* runner may advertise. */
-const VALID_BACKENDS = ['claude-cli', 'codex-cli', 'anthropic-api'] as const;
-type SelfHostedBackend = (typeof VALID_BACKENDS)[number];
-
 export interface RunnerActionState {
   ok?: boolean;
   error?: string;
-  /** The raw bearer token — travels only in this one response, never stored/logged. */
+}
+
+export interface JoinTokenActionState {
+  ok?: boolean;
+  error?: string;
+  /** The raw join token — travels only in this one response, never stored/logged. */
   token?: string;
-  runnerId?: string;
-  /** The backends the new runner was registered with (for the paste-ready command). */
-  backends?: string[];
+  joinTokenId?: string;
 }
 
 /**
- * Register a new self-hosted runner. Generates a high-entropy bearer token,
- * stores only its SHA-256 hash (the exact hash `api/runner/_auth.ts` checks),
- * and returns the raw token once so the operator can copy it. Admin-only.
+ * Mint a join token — the ONLY way to register a runner. Any workspace
+ * member mints tokens for themselves; runners registered through a token are
+ * owned by its creator, and job routing sends that user's requested jobs to
+ * their runners only. The token is reusable across devices until revoked;
+ * only its SHA-256 hash is stored (the exact hash `/api/runner/register`
+ * looks up).
  */
-export async function registerRunner(
-  _prev: RunnerActionState,
+export async function mintJoinToken(
+  _prev: JoinTokenActionState,
   formData: FormData,
-): Promise<RunnerActionState> {
+): Promise<JoinTokenActionState> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return { error: 'No workspace selected' };
-  if (workspace.role !== 'admin') return { error: 'Only admins can register runners' };
 
-  const name = (formData.get('name') as string | null)?.trim() ?? '';
-  if (!name) return { error: 'Runner name is required' };
-  if (name.length > 80) return { error: 'Runner name is too long (max 80 chars)' };
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
 
-  // `backends` arrives as repeated form fields (checkboxes).
-  const backends = formData
-    .getAll('backends')
-    .map((b) => String(b).trim())
-    .filter((b): b is SelfHostedBackend => (VALID_BACKENDS as readonly string[]).includes(b));
-  if (backends.length === 0) return { error: 'Pick at least one backend' };
+  const label = (formData.get('label') as string | null)?.trim() ?? '';
+  if (label.length > 80) return { error: 'Label is too long (max 80 chars)' };
+
+  // The GitHub login (users sign in via GitHub OAuth) — denormalized onto the
+  // token so the runners list can show "owner" without an auth-admin lookup.
+  const login =
+    (typeof user.user_metadata?.user_name === 'string' && user.user_metadata.user_name) ||
+    user.email ||
+    '';
 
   const token = randomBytes(32).toString('hex');
-  const supabase = await createSupabaseServerClient();
   const { data, error } = await supabase
-    .from('runners')
+    .from('runner_join_tokens')
     .insert({
       workspace_id: workspace.id,
-      name,
-      kind: 'self-hosted',
-      backends,
-      models: [],
+      created_by: user.id,
+      created_by_login: login,
+      label,
       token_hash: hashRunnerToken(token),
-      status: 'offline',
     })
     .select('id')
     .single();
   if (error) return { error: error.message };
 
   revalidatePath('/settings/runners');
-  return { ok: true, token, runnerId: data.id as string, backends };
+  return { ok: true, token, joinTokenId: data.id as string };
 }
 
-/** Revoke (delete) a workspace-scoped runner. Admin-only. */
+/**
+ * Revoke a join token: it can no longer register runners. Runners already
+ * registered through it keep working (revoke those individually below).
+ * RLS limits this to the token's creator or a workspace admin.
+ */
+export async function revokeJoinToken(
+  _prev: JoinTokenActionState,
+  formData: FormData,
+): Promise<JoinTokenActionState> {
+  const workspace = await getActiveWorkspace();
+  if (!workspace) return { error: 'No workspace selected' };
+
+  const id = (formData.get('joinTokenId') as string | null)?.trim() ?? '';
+  if (!id) return { error: 'Missing join token id' };
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase
+    .from('runner_join_tokens')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('workspace_id', workspace.id);
+  if (error) return { error: error.message };
+
+  revalidatePath('/settings/runners');
+  return { ok: true };
+}
+
+/** Revoke (delete) a workspace-scoped runner. Admins revoke any; owners
+ *  revoke their own (RLS enforces both — runners_admin_write from 0008 plus
+ *  runners_owner_delete from the join-token migration). */
 export async function revokeRunner(
   _prev: RunnerActionState,
   formData: FormData,
 ): Promise<RunnerActionState> {
   const workspace = await getActiveWorkspace();
   if (!workspace) return { error: 'No workspace selected' };
-  if (workspace.role !== 'admin') return { error: 'Only admins can revoke runners' };
 
   const id = (formData.get('runnerId') as string | null)?.trim() ?? '';
   if (!id) return { error: 'Missing runner id' };

--- a/packages/gui/src/app/settings/runners/runners-section.tsx
+++ b/packages/gui/src/app/settings/runners/runners-section.tsx
@@ -4,7 +4,13 @@ import { useActionState, useEffect, useState } from 'react';
 import { cn } from '@/components/ui/cn';
 import { StatusDotIcon } from '@/components/icons';
 import { timeAgo } from '@/lib/time-ago';
-import { registerRunner, revokeRunner, type RunnerActionState } from './runners-actions';
+import {
+  mintJoinToken,
+  revokeJoinToken,
+  revokeRunner,
+  type JoinTokenActionState,
+  type RunnerActionState,
+} from './runners-actions';
 
 export type RunnerDisplayStatus = 'online' | 'stale' | 'offline';
 
@@ -17,27 +23,29 @@ export interface RunnerRowView {
   lastHeartbeatAt: string | null;
   createdAt: string;
   managed: boolean;
+  /** GitHub login of the runner's owner; null on legacy pre-join-token rows. */
+  ownerLogin: string | null;
+  /** True when the current user owns this runner (may revoke it). */
+  mine: boolean;
+}
+
+export interface JoinTokenView {
+  id: string;
+  label: string;
+  createdByLogin: string;
+  createdAt: string;
+  revokedAt: string | null;
+  /** True when the current user minted this token (may revoke it). */
+  mine: boolean;
 }
 
 interface RunnersSectionProps {
   ownRunners: RunnerRowView[];
   managedRunners: RunnerRowView[];
+  joinTokens: JoinTokenView[];
   isAdmin: boolean;
   appUrl: string;
 }
-
-// Backends a self-hosted runner can serve. `anthropic-api` is the managed-cloud
-// one — a self-hosted runner *may* register for it (it just needs an API key
-// in its env) but it's the unusual case, so it's offered as secondary.
-const BACKEND_OPTIONS: { value: string; label: string; secondary?: boolean }[] = [
-  { value: 'claude-cli', label: 'claude-cli — Claude Code subscription' },
-  { value: 'codex-cli', label: 'codex-cli — OpenAI Codex subscription' },
-  {
-    value: 'anthropic-api',
-    label: 'anthropic-api — uses ANTHROPIC_API_KEY (usually the managed cloud)',
-    secondary: true,
-  },
-];
 
 const STATUS_TONE: Record<RunnerDisplayStatus, 'enabled' | 'warning' | 'queued'> = {
   online: 'enabled',
@@ -54,11 +62,12 @@ const STATUS_LABEL_CLASS: Record<RunnerDisplayStatus, string> = {
 export function RunnersSection({
   ownRunners,
   managedRunners,
+  joinTokens,
   isAdmin,
   appUrl,
 }: RunnersSectionProps) {
-  const [state, formAction, pending] = useActionState<RunnerActionState, FormData>(
-    registerRunner,
+  const [state, formAction, pending] = useActionState<JoinTokenActionState, FormData>(
+    mintJoinToken,
     {},
   );
 
@@ -66,14 +75,10 @@ export function RunnersSection({
   // useActionState keeps its own result around (and can replay it on a
   // back/forward navigation), so we never render `state.token` directly — we
   // surface a copy that we clear on a timeout or an explicit dismiss.
-  const [revealedToken, setRevealedToken] = useState<{ token: string; backends: string[] } | null>(
-    null,
-  );
+  const [revealedToken, setRevealedToken] = useState<string | null>(null);
   useEffect(() => {
-    if (state.token && state.runnerId) {
-      setRevealedToken({ token: state.token, backends: state.backends ?? [] });
-    }
-  }, [state.token, state.runnerId, state.backends]);
+    if (state.token && state.joinTokenId) setRevealedToken(state.token);
+  }, [state.token, state.joinTokenId]);
 
   return (
     <div className="space-y-6">
@@ -83,17 +88,11 @@ export function RunnersSection({
         subtitle={`${ownRunners.length} self-hosted runner${ownRunners.length === 1 ? '' : 's'}`}
       >
         {ownRunners.length === 0 ? (
-          <EmptyState
-            body={
-              isAdmin
-                ? 'No self-hosted runners yet. Register one below.'
-                : 'No self-hosted runners yet. Ask an admin to register one.'
-            }
-          />
+          <EmptyState body="No self-hosted runners yet. Mint a join token below and start a runner with it — it registers itself." />
         ) : (
           <ul className="divide-y divide-outline-variant/60">
             {ownRunners.map((r) => (
-              <RunnerRow key={r.id} runner={r} canRevoke={isAdmin} />
+              <RunnerRow key={r.id} runner={r} canRevoke={isAdmin || r.mine} />
             ))}
           </ul>
         )}
@@ -115,78 +114,60 @@ export function RunnersSection({
         )}
       </Card>
 
-      {/* Register a runner */}
-      {isAdmin && (
-        <Card title="Register a runner">
+      {/* Join tokens — the only way to register a runner */}
+      <Card
+        title="Join tokens"
+        subtitle="A runner registers itself with a join token and belongs to whoever minted it. Tokens are reusable across devices until revoked."
+      >
+        <div className="space-y-4">
           {revealedToken ? (
             <TokenReveal
-              token={revealedToken.token}
-              backends={revealedToken.backends}
+              token={revealedToken}
               appUrl={appUrl}
               onDismiss={() => setRevealedToken(null)}
             />
           ) : (
-            <form action={formAction} className="space-y-4">
+            <form action={formAction} className="flex flex-col gap-3 sm:flex-row sm:items-end">
               {state.error && (
-                <div className="rounded-md border border-error/40 bg-error/10 px-3 py-2 text-sm text-error">
+                <div className="rounded-md border border-error/40 bg-error/10 px-3 py-2 text-sm text-error sm:order-last">
                   {state.error}
                 </div>
               )}
-              <div>
+              <div className="flex-1 sm:max-w-md">
                 <label
-                  htmlFor="runner-name"
+                  htmlFor="join-token-label"
                   className="mb-1 block text-xs font-medium text-on-surface-variant"
                 >
-                  Name
+                  Label <span className="text-outline">(optional — e.g. “laptop”, “ci-box”)</span>
                 </label>
                 <input
-                  id="runner-name"
-                  name="name"
+                  id="join-token-label"
+                  name="label"
                   type="text"
-                  required
                   maxLength={80}
-                  placeholder="e.g. ci-box-1"
-                  className="h-9 w-full sm:max-w-md rounded-md border border-outline-variant bg-surface px-3 text-base lg:text-sm text-on-surface placeholder:text-outline focus:border-primary focus:outline-none"
+                  placeholder="What is this token for?"
+                  className="h-9 w-full rounded-md border border-outline-variant bg-surface px-3 text-base lg:text-sm text-on-surface placeholder:text-outline focus:border-primary focus:outline-none"
                 />
               </div>
-              <div>
-                <span className="mb-1 block text-xs font-medium text-on-surface-variant">
-                  Backends
-                </span>
-                <div className="space-y-2">
-                  {BACKEND_OPTIONS.map((b) => (
-                    <label
-                      key={b.value}
-                      className={cn(
-                        'flex items-center gap-3 rounded-md border border-outline-variant bg-surface px-3 py-2 text-sm',
-                        b.secondary && 'opacity-80',
-                      )}
-                    >
-                      <input
-                        type="checkbox"
-                        name="backends"
-                        value={b.value}
-                        defaultChecked={!b.secondary && b.value === 'claude-cli'}
-                        className="h-4 w-4 accent-primary"
-                      />
-                      <span className="text-on-surface">{b.label}</span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-              <div className="flex justify-end pt-1">
-                <button
-                  type="submit"
-                  disabled={pending}
-                  className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {pending ? 'Registering…' : 'Register runner'}
-                </button>
-              </div>
+              <button
+                type="submit"
+                disabled={pending}
+                className="inline-flex h-9 shrink-0 items-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-on transition-colors hover:bg-primary-container hover:text-on-surface disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {pending ? 'Minting…' : 'Mint join token'}
+              </button>
             </form>
           )}
-        </Card>
-      )}
+
+          {joinTokens.length > 0 && (
+            <ul className="divide-y divide-outline-variant/60">
+              {joinTokens.map((t) => (
+                <JoinTokenRow key={t.id} token={t} canRevoke={isAdmin || t.mine} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </Card>
     </div>
   );
 }
@@ -243,6 +224,11 @@ function RunnerRow({ runner, canRevoke }: { runner: RunnerRowView; canRevoke: bo
             {runner.managed && <span className="font-mono text-[11px] text-outline">managed</span>}
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            {!runner.managed && (
+              <span className="font-mono text-[10.5px] text-on-surface-variant">
+                {runner.ownerLogin ? `@${runner.ownerLogin}` : 'unowned (legacy)'}
+              </span>
+            )}
             {(runner.managed ? ['anthropic-api'] : runner.backends).map((b) => (
               <span
                 key={b}
@@ -261,6 +247,33 @@ function RunnerRow({ runner, canRevoke }: { runner: RunnerRowView; canRevoke: bo
         </div>
         {canRevoke && !runner.managed && <RevokeButton runnerId={runner.id} name={runner.name} />}
       </div>
+    </li>
+  );
+}
+
+function JoinTokenRow({ token, canRevoke }: { token: JoinTokenView; canRevoke: boolean }) {
+  const revoked = token.revokedAt != null;
+  return (
+    <li className="flex items-center gap-4 py-3 first:pt-0 last:pb-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-sm">
+          <span className={cn('truncate text-on-surface', revoked && 'line-through opacity-60')}>
+            {token.label || 'untitled token'}
+          </span>
+          {revoked && (
+            <span className="font-display text-[10.5px] font-semibold uppercase tracking-wider text-on-surface-variant">
+              revoked
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 font-mono text-[10.5px] text-on-surface-variant">
+          @{token.createdByLogin}
+        </div>
+      </div>
+      <div className="shrink-0 text-right text-[11px] text-outline">
+        minted {timeAgo(token.createdAt)}
+      </div>
+      {canRevoke && !revoked && <RevokeJoinTokenButton joinTokenId={token.id} />}
     </li>
   );
 }
@@ -289,24 +302,52 @@ function RevokeButton({ runnerId, name }: { runnerId: string; name: string }) {
   );
 }
 
+function RevokeJoinTokenButton({ joinTokenId }: { joinTokenId: string }) {
+  const [state, action, pending] = useActionState<JoinTokenActionState, FormData>(
+    revokeJoinToken,
+    {},
+  );
+  return (
+    <form
+      action={action}
+      onSubmit={(e) => {
+        if (
+          !confirm(
+            'Revoke this join token? It can no longer register runners; already-registered runners keep working.',
+          )
+        )
+          e.preventDefault();
+      }}
+      className="shrink-0"
+    >
+      <input type="hidden" name="joinTokenId" value={joinTokenId} />
+      <button
+        type="submit"
+        disabled={pending}
+        className="inline-flex h-7 items-center rounded-md border border-outline-variant bg-surface px-2.5 text-xs text-on-surface-variant transition-colors hover:border-error/40 hover:text-error disabled:cursor-not-allowed disabled:opacity-50"
+        title={state.error ?? undefined}
+      >
+        {pending ? 'Revoking…' : 'Revoke'}
+      </button>
+    </form>
+  );
+}
+
 // Seconds the one-shot token stays in memory before it auto-clears. Keeps the
 // raw credential out of the DOM/React state for longer than necessary.
 const TOKEN_AUTO_CLEAR_MS = 60_000;
 
 function TokenReveal({
   token,
-  backends,
   appUrl,
   onDismiss,
 }: {
   token: string;
-  backends: string[];
   appUrl: string;
   onDismiss: () => void;
 }) {
   const url = appUrl || '<your-cezar-url>';
-  const csv = (backends.length > 0 ? backends : ['claude-cli']).join(',');
-  const command = `cezar-runner start --url ${url} --token ${token} --backends ${csv}`;
+  const command = `cezar-runner start --url ${url} --join-token ${token}`;
   const [revealed, setRevealed] = useState(false);
 
   // Auto-clear the token from memory after a short window so it doesn't sit in
@@ -319,11 +360,13 @@ function TokenReveal({
   return (
     <div className="space-y-3 rounded-md border border-primary/40 bg-primary/10 p-4">
       <p className="text-sm text-on-surface">
-        Runner registered.{' '}
-        <strong className="text-primary">Copy the token now — it won&apos;t be shown again.</strong>
+        Join token minted.{' '}
+        <strong className="text-primary">Copy it now — it won&apos;t be shown again.</strong> Start
+        a runner with it (backends are auto-detected from the CLIs on that host); in Docker, set{' '}
+        <code className="font-mono text-[12px]">CEZAR_RUNNER_JOIN_TOKEN</code> instead.
       </p>
       <CopyBox
-        label="Token"
+        label="Join token"
         value={token}
         secret
         revealed={revealed}

--- a/packages/gui/src/app/workspaces/actions.ts
+++ b/packages/gui/src/app/workspaces/actions.ts
@@ -130,6 +130,7 @@ export async function startLabelAnalysisForWorkspace(
     status: 'queued',
     // Cron-dispatched + Anthropic API only. See migration 0023.
     required_backend: 'anthropic-api',
+    requested_by: user.id,
     payload: { analysisId: analysis.id },
   });
   if (jErr) {

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -760,6 +760,11 @@ export interface Database {
           /** Phase 4 (migration 0026) soft-affinity window. After this instant
            *  the preference is ignored and any matching runner may claim. */
           preferred_until: string | null;
+          /** Owner routing (migration 20260706075137) — the user who asked
+           *  for this work; NULL for system-initiated jobs (webhooks, sweeps,
+           *  schedulers). Non-NULL restricts runner claims to runners owned
+           *  by this user. */
+          requested_by: string | null;
           attempts: number;
           max_attempts: number;
           scheduled_at: string;
@@ -786,6 +791,7 @@ export interface Database {
           | 'claim_expires_at'
           | 'preferred_runner_id'
           | 'preferred_until'
+          | 'requested_by'
         > & {
           id?: string;
           repo?: string | null;
@@ -798,6 +804,7 @@ export interface Database {
           claim_expires_at?: string | null;
           preferred_runner_id?: string | null;
           preferred_until?: string | null;
+          requested_by?: string | null;
           attempts?: number;
           max_attempts?: number;
           scheduled_at?: string;
@@ -995,6 +1002,14 @@ export interface Database {
            *  time-series here. Shape: `RunnerUtilization`. NULL on older
            *  daemons that don't report. */
           utilization: RunnerUtilization | null;
+          /** Join-token registration (migration 20260706075137) — the user
+           *  who owns this runner (the join token's creator). NULL only on
+           *  legacy rows registered before the join-token flow. */
+          owner_user_id: string | null;
+          /** GitHub login of the owner, denormalized at registration. */
+          owner_login: string | null;
+          /** The join token this runner registered through. */
+          join_token_id: string | null;
         };
         Insert: Omit<
           Database['public']['Tables']['runners']['Row'],
@@ -1010,6 +1025,9 @@ export interface Database {
           | 'github_installation_id'
           | 'github_inherit_host'
           | 'utilization'
+          | 'owner_user_id'
+          | 'owner_login'
+          | 'join_token_id'
         > & {
           id?: string;
           workspace_id?: string | null;
@@ -1023,9 +1041,36 @@ export interface Database {
           github_installation_id?: number | null;
           github_inherit_host?: boolean;
           utilization?: RunnerUtilization | null;
+          owner_user_id?: string | null;
+          owner_login?: string | null;
+          join_token_id?: string | null;
         };
         Update: Partial<Database['public']['Tables']['runners']['Insert']>;
         Relationships: [];
+      };
+      runner_join_tokens: {
+        Row: {
+          id: string;
+          workspace_id: string;
+          created_by: string;
+          /** GitHub login of the creator, denormalized at mint time. */
+          created_by_login: string;
+          label: string;
+          token_hash: string;
+          created_at: string;
+          revoked_at: string | null;
+        };
+        Insert: Omit<
+          Database['public']['Tables']['runner_join_tokens']['Row'],
+          'id' | 'created_by_login' | 'label' | 'created_at' | 'revoked_at'
+        > & {
+          id?: string;
+          created_by_login?: string;
+          label?: string;
+          created_at?: string;
+          revoked_at?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['runner_join_tokens']['Insert']>;
       };
       pending_decisions: {
         Row: {

--- a/packages/gui/src/lib/supabase/types.ts
+++ b/packages/gui/src/lib/supabase/types.ts
@@ -1071,6 +1071,7 @@ export interface Database {
           revoked_at?: string | null;
         };
         Update: Partial<Database['public']['Tables']['runner_join_tokens']['Insert']>;
+        Relationships: [];
       };
       pending_decisions: {
         Row: {
@@ -1210,7 +1211,12 @@ export interface Database {
         Returns: Database['public']['Tables']['jobs']['Row'][];
       };
       claim_next_job_for_runner: {
-        Args: { p_runner_id: string; p_backends: string[]; p_limit?: number };
+        Args: {
+          p_runner_id: string;
+          p_backends: string[];
+          p_limit?: number;
+          p_lease_seconds?: number;
+        };
         Returns: Database['public']['Tables']['jobs']['Row'][];
       };
       enqueue_autofix_if_not_open: {

--- a/packages/gui/supabase/migrations/20260706075137_runner_join_tokens.sql
+++ b/packages/gui/supabase/migrations/20260706075137_runner_join_tokens.sql
@@ -1,0 +1,160 @@
+-- 20260706075137_runner_join_tokens.sql
+-- Join-token runner registration + owner-based job routing.
+--
+-- (A) `runner_join_tokens` — from now on the ONLY way to register a runner.
+--     A workspace member mints a join token in Settings → Runners; the
+--     runner daemon presents it to POST /api/runner/register, which creates
+--     (or re-keys) the `runners` row and returns the per-runner bearer
+--     token. The join token is stored hashed (SHA-256, same scheme as
+--     `runners.token_hash`) and is reusable until revoked — one token can
+--     register any number of runners across devices.
+--
+-- (B) Ownership + routing. `runners.owner_user_id` records whose runner it
+--     is (the join token's creator); `jobs.requested_by` records which user
+--     asked for the work (NULL for system-initiated jobs: webhooks, sweeps,
+--     schedulers). The claim RPC routes:
+--       * user-requested jobs  → only runners owned by that user;
+--       * system jobs          → any runner in the workspace (including
+--                                legacy unowned rows).
+--     It also closes a pre-existing gap: the claim RPC had no workspace
+--     filter at all, so a workspace-scoped runner could claim another
+--     workspace's jobs whose backend matched.
+
+-- ─── runner_join_tokens ─────────────────────────────────────────────────
+create table runner_join_tokens (
+  id                uuid primary key default gen_random_uuid(),
+  workspace_id      uuid not null references workspaces(id) on delete cascade,
+  created_by        uuid not null references auth.users(id) on delete cascade,
+  -- GitHub login of the creator, denormalized at mint time so the runners
+  -- list can show "owner" without an auth-admin lookup.
+  created_by_login  text not null default '',
+  label             text not null default '',
+  token_hash        text not null unique,
+  created_at        timestamptz not null default now(),
+  revoked_at        timestamptz
+);
+
+create index runner_join_tokens_workspace_idx on runner_join_tokens(workspace_id);
+
+alter table runner_join_tokens enable row level security;
+
+-- Members mint tokens for themselves; they see (and may revoke) their own,
+-- admins see and revoke any in the workspace. The register endpoint reads
+-- via the service-role key (bypasses RLS).
+create policy "rjt_select" on runner_join_tokens
+  for select using (
+    is_workspace_member(workspace_id)
+    and (created_by = auth.uid() or is_workspace_admin(workspace_id))
+  );
+create policy "rjt_insert" on runner_join_tokens
+  for insert with check (is_workspace_member(workspace_id) and created_by = auth.uid());
+create policy "rjt_update" on runner_join_tokens
+  for update using (
+    is_workspace_member(workspace_id)
+    and (created_by = auth.uid() or is_workspace_admin(workspace_id))
+  );
+create policy "rjt_delete" on runner_join_tokens
+  for delete using (
+    is_workspace_member(workspace_id)
+    and (created_by = auth.uid() or is_workspace_admin(workspace_id))
+  );
+
+-- ─── runners: ownership ─────────────────────────────────────────────────
+alter table runners
+  add column if not exists owner_user_id uuid references auth.users(id) on delete set null,
+  add column if not exists owner_login   text,
+  add column if not exists join_token_id uuid references runner_join_tokens(id) on delete set null;
+
+-- A runner is identified by (workspace, owner, name): re-registering from
+-- the same device re-keys the existing row instead of piling up duplicates.
+-- Legacy rows (owner NULL) are exempt so the migration can't fail on
+-- pre-existing name collisions.
+create unique index if not exists runners_workspace_owner_name_uniq
+  on runners (workspace_id, owner_user_id, name)
+  where owner_user_id is not null;
+
+-- Owners manage their own runners (revoke from Settings → Runners) even when
+-- they aren't workspace admins; 0008's runners_admin_write stays for admins.
+create policy "runners_owner_delete" on runners
+  for delete using (owner_user_id = auth.uid() and is_workspace_member(workspace_id));
+
+-- ─── jobs: requester ────────────────────────────────────────────────────
+alter table jobs
+  add column if not exists requested_by uuid references auth.users(id) on delete set null;
+
+-- Hot-path helper: the claim scan now filters on requested_by too. Partial
+-- on queued rows, same shape as jobs_preferred_runner_idx (0026/0034).
+create index if not exists jobs_requested_by_queued_idx
+  on jobs (requested_by)
+  where requested_by is not null and status = 'queued';
+
+-- ─── claim_next_job_for_runner — supersedes the 0033 body ───────────────
+-- Adds workspace scoping + owner routing on top of lease (0025) and soft
+-- affinity (0026). Owner routing is strict: a job with `requested_by` set is
+-- claimable only by runners whose `owner_user_id` matches; unowned runners
+-- (legacy rows, managed cloud) serve only system jobs. `claim_next_job`
+-- (the cron/in-process path) is deliberately unchanged — the managed
+-- anthropic-api path is not per-user.
+create or replace function claim_next_job_for_runner(
+  p_runner_id uuid,
+  p_backends  text[],
+  p_limit     int default 1,
+  p_lease_seconds int default 60
+)
+returns setof jobs
+language plpgsql
+as $$
+declare
+  v_now       timestamptz := now();
+  v_workspace uuid;
+  v_owner     uuid;
+begin
+  select workspace_id, owner_user_id
+    into v_workspace, v_owner
+    from runners
+   where id = p_runner_id;
+
+  return query
+  update jobs
+     set status            = 'claimed',
+         claimed_by_runner = p_runner_id,
+         claim_expires_at  = v_now + make_interval(secs => p_lease_seconds),
+         attempts          = attempts + 1,
+         updated_at        = v_now
+   where id in (
+     select j.id
+       from jobs j
+      where j.status = 'queued'
+        and j.scheduled_at <= v_now
+        and j.kind <> 'label-analysis'
+        and (j.required_backend is null or j.required_backend = any(p_backends))
+        -- workspace scoping: a workspace-bound runner serves only its own
+        -- workspace; managed runners (workspace_id NULL) serve any.
+        and (v_workspace is null or j.workspace_id = v_workspace)
+        -- owner routing: user-requested jobs go only to that user's runners.
+        -- NULL v_owner never equals a non-NULL requested_by, so unowned
+        -- runners fall through to system jobs only.
+        and (j.requested_by is null or j.requested_by = v_owner)
+        and (
+          -- this runner is the preferred one (affinity match)
+          j.preferred_runner_id = p_runner_id
+          -- or no preference set
+          or j.preferred_runner_id is null
+          -- or the soft-affinity window has expired (fallback)
+          or j.preferred_until is null
+          or j.preferred_until <= v_now
+        )
+      order by
+        -- prioritize affinity matches over fallback matches
+        case when j.preferred_runner_id = p_runner_id then 0 else 1 end,
+        j.priority desc,
+        j.scheduled_at asc
+      limit p_limit
+      for update skip locked
+   )
+  returning *;
+end;
+$$;
+
+grant execute on function claim_next_job_for_runner(uuid, text[], int, int)
+  to anon, authenticated, service_role;

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@cezar/core": "workspace:*"
+    "@cezar/core": "workspace:*",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/runner/src/README.md
+++ b/packages/runner/src/README.md
@@ -36,10 +36,11 @@ The `cezar-runner` bin is installed when the package is built/linked.
   `<tool> login` to run. The `anthropic-api` backend needs `ANTHROPIC_API_KEY`
   in the environment instead.
 - **`git`** on PATH (the runner clones repos to `~/.cezar/runner-repos`).
-- A **runner token**, created on the Settings → Runners page (shown once,
-  stored hashed server-side — treat like a password). *(That UI lands in Phase
-  4b; until then a runner row + `token_hash` can be inserted directly into the
-  `runners` table — the token is `sha256(<raw>)` hex.)*
+- A **join token**, minted on the Settings → Runners page (shown once,
+  stored hashed server-side — treat like a password). The daemon registers
+  itself with it on first start and persists the resulting per-runner
+  credential in `~/.cezar-runner/credentials.json`. The runner belongs to
+  the user who minted the token; jobs they request route to their runners.
 
 The runner never sees a Supabase credential; the SaaS mints a short-lived GitHub
 App token per job and ships it (plus the merged workspace config and the issue
@@ -49,5 +50,8 @@ store snapshot) in the claim response.
 
 | Var | Purpose |
 |---|---|
-| `CEZAR_RUNNER_URL` / `CEZAR_RUNNER_TOKEN` | defaults for `--url` / `--token` |
+| `CEZAR_RUNNER_URL` / `CEZAR_RUNNER_JOIN_TOKEN` | defaults for `--url` / `--join-token` |
+| `CEZAR_RUNNER_NAME` | runner name (default: hostname); (workspace, owner, name) identifies the runner |
+| `CEZAR_RUNNER_STATE_DIR` | where the registered credential persists (default `~/.cezar-runner`) |
+| `CEZAR_RUNNER_TOKEN` | **deprecated — removed in v0.3.0**; pre-issued token, skips registration |
 | `ANTHROPIC_API_KEY` | required for the `anthropic-api` backend |

--- a/packages/runner/src/cli.ts
+++ b/packages/runner/src/cli.ts
@@ -30,9 +30,9 @@ Usage:
                                  identifies the runner; re-registering the
                                  same name re-keys it (default: hostname;
                                  or CEZAR_RUNNER_NAME)
-      --token <runner-token>     pre-issued runner token (or
-                                 CEZAR_RUNNER_TOKEN) — skips registration,
-                                 for already-registered legacy runners
+      --token <runner-token>     DEPRECATED, removed in v0.3.0: pre-issued
+                                 runner token (or CEZAR_RUNNER_TOKEN) — skips
+                                 registration; migrate to --join-token
       --backends <csv>           backends to advertise (default: anthropic-api
                                  for --kind cloud; auto-detected for
                                  self-hosted)
@@ -144,6 +144,11 @@ async function main(): Promise<void> {
     // 2. else the credential persisted by a previous registration,
     // 3. else register with the join token and persist the result.
     let token = explicitToken;
+    if (explicitToken) {
+      console.warn(
+        '[cezar-runner] --token / CEZAR_RUNNER_TOKEN is deprecated and will be removed in v0.3.0 — mint a join token in Settings → Runners and use --join-token / CEZAR_RUNNER_JOIN_TOKEN.',
+      );
+    }
     const stateDir = defaultStateDir();
     if (!token) {
       const saved = await readCredentials(stateDir, url);

--- a/packages/runner/src/cli.ts
+++ b/packages/runner/src/cli.ts
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 import { parseArgs } from 'node:util';
+import os from 'node:os';
 import { detectBackends } from './backend-detect.js';
+import {
+  clearCredentials,
+  defaultStateDir,
+  readCredentials,
+  registerWithJoinToken,
+  writeCredentials,
+} from './register.js';
 import { RunnerDaemon, type RunnerDaemonConfig } from './runner-daemon.js';
 
 const USAGE = `cezar-runner — Cezar agent runner (managed cloud / self-hosted)
@@ -10,7 +18,21 @@ Usage:
       Check that the \`claude\` / \`codex\` CLIs are on PATH and report which
       backends this host can serve. Advises which \`<tool> login\` to run.
 
-  cezar-runner start --url <saas-base-url> --token <runner-token> [options]
+  cezar-runner start --url <saas-base-url> --join-token <join-token> [options]
+      Registers this host with the join token (mint one in Settings →
+      Runners) on first start, persists the resulting runner credential
+      under ~/.cezar-runner/ and reuses it afterwards. The runner belongs
+      to the user who minted the join token; jobs they request route to
+      their runners.
+
+      --join-token <t>           join token (or CEZAR_RUNNER_JOIN_TOKEN)
+      --name <name>              runner name — (workspace, owner, name)
+                                 identifies the runner; re-registering the
+                                 same name re-keys it (default: hostname;
+                                 or CEZAR_RUNNER_NAME)
+      --token <runner-token>     pre-issued runner token (or
+                                 CEZAR_RUNNER_TOKEN) — skips registration,
+                                 for already-registered legacy runners
       --backends <csv>           backends to advertise (default: anthropic-api
                                  for --kind cloud; auto-detected for
                                  self-hosted)
@@ -30,8 +52,9 @@ Usage:
   cezar-runner help
       Show this help.
 
-The runner token comes from Settings → Runners (shown once). It is stored
-hashed on the server; treat it like a password.`;
+Mint a join token in Settings → Runners. Tokens are stored hashed on the
+server; treat them like passwords. The registered credential persists in
+~/.cezar-runner/ (override with CEZAR_RUNNER_STATE_DIR).`;
 
 async function main(): Promise<void> {
   const sub = process.argv[2];
@@ -60,7 +83,7 @@ async function main(): Promise<void> {
       return;
     }
     console.log(
-      '\nAt least one backend is available. Start the runner with `cezar-runner start --url ... --token ...`.',
+      '\nAt least one backend is available. Start the runner with `cezar-runner start --url ... --join-token ...`.',
     );
     return;
   }
@@ -71,6 +94,8 @@ async function main(): Promise<void> {
       options: {
         url: { type: 'string' },
         token: { type: 'string' },
+        'join-token': { type: 'string' },
+        name: { type: 'string' },
         backends: { type: 'string' },
         kind: { type: 'string' },
         concurrency: { type: 'string' },
@@ -79,11 +104,14 @@ async function main(): Promise<void> {
         'github-installation-id': { type: 'string' },
       },
     });
-    const url = values.url ?? process.env.CEZAR_RUNNER_URL;
-    const token = values.token ?? process.env.CEZAR_RUNNER_TOKEN;
-    if (!url || !token) {
+    // `||` (not `??`) throughout: compose passes unset vars as empty strings.
+    const url = values.url || process.env.CEZAR_RUNNER_URL;
+    const explicitToken = values.token || process.env.CEZAR_RUNNER_TOKEN;
+    const joinToken = values['join-token'] || process.env.CEZAR_RUNNER_JOIN_TOKEN;
+    if (!url || (!explicitToken && !joinToken)) {
       console.error(
-        'cezar-runner start: --url and --token are required (or set CEZAR_RUNNER_URL / CEZAR_RUNNER_TOKEN).',
+        'cezar-runner start: --url plus either --join-token or --token is required ' +
+          '(or set CEZAR_RUNNER_URL / CEZAR_RUNNER_JOIN_TOKEN / CEZAR_RUNNER_TOKEN).',
       );
       process.exitCode = 1;
       return;
@@ -108,6 +136,30 @@ async function main(): Promise<void> {
         process.exitCode = 1;
         return;
       }
+    }
+
+    // ── Credential resolution ──
+    // 1. an explicit --token / CEZAR_RUNNER_TOKEN wins (legacy pre-issued
+    //    runners; nothing is persisted),
+    // 2. else the credential persisted by a previous registration,
+    // 3. else register with the join token and persist the result.
+    let token = explicitToken;
+    const stateDir = defaultStateDir();
+    if (!token) {
+      const saved = await readCredentials(stateDir, url);
+      if (saved) {
+        token = saved.token;
+        console.log(`[cezar-runner] using persisted credentials (runner ${saved.runnerId})`);
+      }
+    }
+    if (!token && joinToken) {
+      token = await registerAndPersist({ url, joinToken, kind, backends, stateDir, values });
+    }
+    if (!token) {
+      // Unreachable given the arg check above, but keeps the types honest.
+      console.error('cezar-runner start: no usable credential.');
+      process.exitCode = 1;
+      return;
     }
 
     // ── Per-runner GitHub identity (Phase 4) ──
@@ -140,23 +192,73 @@ async function main(): Promise<void> {
       );
     }
 
-    const daemon = new RunnerDaemon({
-      url,
-      token,
-      backends,
-      kind,
-      concurrency: values.concurrency ? Number(values.concurrency) : undefined,
-      pollIntervalSec: values['poll-interval'] ? Number(values['poll-interval']) : undefined,
-      githubInheritHost: inheritHostGithub,
-      githubInstallationId,
-    });
-    await daemon.start();
+    const startDaemon = async (t: string) => {
+      const daemon = new RunnerDaemon({
+        url,
+        token: t,
+        backends,
+        kind,
+        concurrency: values.concurrency ? Number(values.concurrency) : undefined,
+        pollIntervalSec: values['poll-interval'] ? Number(values['poll-interval']) : undefined,
+        githubInheritHost: inheritHostGithub,
+        githubInstallationId,
+        // A persisted credential can go stale (runner revoked in Settings →
+        // Runners, DB reset). With a join token at hand we can recover: wipe
+        // the stale credential, re-register, and hand the daemon the fresh
+        // token to restart with. Without one, exit loudly (previous behavior).
+        onAuthError:
+          !explicitToken && joinToken
+            ? async () => {
+                console.warn(
+                  '[cezar-runner] runner token rejected — re-registering with the join token',
+                );
+                await clearCredentials(stateDir);
+                return registerAndPersist({ url, joinToken, kind, backends, stateDir, values });
+              }
+            : undefined,
+      });
+      return daemon.start();
+    };
+    await startDaemon(token);
     return;
   }
 
   console.error(`cezar-runner: unknown command '${sub}'\n`);
   console.log(USAGE);
   process.exitCode = 1;
+}
+
+/** Registers via the join token, persists the credential, returns the runner token. */
+async function registerAndPersist(opts: {
+  url: string;
+  joinToken: string;
+  kind: RunnerDaemonConfig['kind'];
+  backends: string[];
+  stateDir: string;
+  values: { name?: string };
+}): Promise<string> {
+  const name = opts.values.name || process.env.CEZAR_RUNNER_NAME || os.hostname();
+  const res = await registerWithJoinToken({
+    url: opts.url,
+    joinToken: opts.joinToken,
+    request: {
+      name,
+      kind: opts.kind,
+      backends: opts.backends as ('anthropic-api' | 'claude-cli' | 'codex-cli')[],
+    },
+  });
+  await writeCredentials(opts.stateDir, {
+    url: opts.url,
+    runnerId: res.runnerId,
+    token: res.token,
+    registeredAt: new Date().toISOString(),
+  });
+  console.log(
+    `[cezar-runner] registered as "${name}" (owner @${res.ownerLogin})${
+      res.reRegistered ? ' — re-keyed the existing runner of that name' : ''
+    }`,
+  );
+  return res.token;
 }
 
 main().catch((err) => {

--- a/packages/runner/src/register.ts
+++ b/packages/runner/src/register.ts
@@ -1,0 +1,153 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import os from 'node:os';
+import { z } from 'zod';
+import {
+  RunnerRegisterResponseSchema,
+  type RunnerRegisterRequest,
+  type RunnerRegisterResponse,
+} from '@cezar/core';
+import { assertSecureRunnerUrl } from './runner-client.js';
+
+// ─── persisted credentials ──────────────────────────────────────────────
+// The per-runner bearer token returned by /api/runner/register, persisted so
+// a restarted daemon (or recreated container with the home volume mounted)
+// reuses its identity instead of re-registering every boot.
+
+const CredentialsSchema = z.object({
+  /** SaaS base URL these credentials were registered against. */
+  url: z.string(),
+  runnerId: z.string(),
+  token: z.string(),
+  registeredAt: z.string(),
+});
+export type RunnerCredentials = z.infer<typeof CredentialsSchema>;
+
+const CREDENTIALS_FILE = 'credentials.json';
+
+export function defaultStateDir(): string {
+  return process.env.CEZAR_RUNNER_STATE_DIR || join(os.homedir(), '.cezar-runner');
+}
+
+/**
+ * Reads persisted credentials. Returns null when absent, unparseable, or
+ * registered against a different SaaS URL (a stale volume pointed at a new
+ * deployment must re-register, not present a foreign token).
+ */
+export async function readCredentials(
+  stateDir: string,
+  url: string,
+): Promise<RunnerCredentials | null> {
+  let raw: string;
+  try {
+    raw = await readFile(join(stateDir, CREDENTIALS_FILE), 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed: RunnerCredentials;
+  try {
+    parsed = CredentialsSchema.parse(JSON.parse(raw));
+  } catch {
+    console.warn(`[cezar-runner] ignoring malformed ${join(stateDir, CREDENTIALS_FILE)}`);
+    return null;
+  }
+  if (normalizeUrl(parsed.url) !== normalizeUrl(url)) {
+    console.warn(
+      `[cezar-runner] persisted credentials are for ${parsed.url}, not ${url} — re-registering`,
+    );
+    return null;
+  }
+  return parsed;
+}
+
+export async function writeCredentials(stateDir: string, creds: RunnerCredentials): Promise<void> {
+  await mkdir(stateDir, { recursive: true, mode: 0o700 });
+  await writeFile(join(stateDir, CREDENTIALS_FILE), `${JSON.stringify(creds, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+export async function clearCredentials(stateDir: string): Promise<void> {
+  await rm(join(stateDir, CREDENTIALS_FILE), { force: true });
+}
+
+function normalizeUrl(u: string): string {
+  return u.replace(/\/+$/, '');
+}
+
+// ─── registration ───────────────────────────────────────────────────────
+
+// Backoff for transient failures (SaaS still booting behind `depends_on`,
+// 5xx, a lost registration race). Grows 2s → 4s → … capped at 30s; retries
+// until the SaaS answers so a compose stack converges without a crash-loop.
+const BACKOFF_START_MS = 2000;
+const BACKOFF_CAP_MS = 30_000;
+
+/**
+ * Registers this daemon with the SaaS via a join token (minted in Settings →
+ * Runners). Returns the per-runner bearer token; the caller persists it.
+ *
+ * Retries transient failures forever (the compose `runner` service typically
+ * races the `gui` service at boot) and fails hard on auth/validation errors —
+ * a revoked join token can never converge, so exiting loudly beats spinning.
+ */
+export async function registerWithJoinToken(opts: {
+  url: string;
+  joinToken: string;
+  request: RunnerRegisterRequest;
+}): Promise<RunnerRegisterResponse> {
+  assertSecureRunnerUrl(opts.url);
+  const endpoint = `${normalizeUrl(opts.url)}/api/runner/register`;
+  let delay = BACKOFF_START_MS;
+
+  for (;;) {
+    let res: Response;
+    try {
+      res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${opts.joinToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(opts.request),
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (err) {
+      console.warn(
+        `[cezar-runner] register: SaaS unreachable (${err instanceof Error ? err.message : err}) — retrying in ${Math.round(delay / 1000)}s`,
+      );
+      await sleep(delay);
+      delay = Math.min(delay * 2, BACKOFF_CAP_MS);
+      continue;
+    }
+
+    if (res.status === 401) {
+      throw new Error(
+        'cezar-runner: join token rejected (unknown or revoked). Mint a new one in Settings → Runners.',
+      );
+    }
+    if (res.status === 400) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`cezar-runner: register request invalid: ${body}`);
+    }
+    if (!res.ok) {
+      // 409 (lost a duplicate-name race) and 5xx are both retryable.
+      console.warn(
+        `[cezar-runner] register: HTTP ${res.status} — retrying in ${Math.round(delay / 1000)}s`,
+      );
+      await sleep(delay);
+      delay = Math.min(delay * 2, BACKOFF_CAP_MS);
+      continue;
+    }
+
+    const parsed = RunnerRegisterResponseSchema.safeParse(await res.json());
+    if (!parsed.success) {
+      throw new Error(`cezar-runner: register response malformed: ${parsed.error.message}`);
+    }
+    return parsed.data;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/runner/src/runner-client.ts
+++ b/packages/runner/src/runner-client.ts
@@ -184,6 +184,35 @@ export interface HeartbeatReply {
 
 const MAX_RETRIES = 4;
 
+/**
+ * Refuse to send a long-lived credential (runner bearer token OR join token)
+ * over a non-TLS transport. A prod typo (`http://…`) or a local-dev URL
+ * pasted into a deployment would otherwise leak the credential in plaintext
+ * on every call. Localhost stays painless; opt out with
+ * CEZAR_RUNNER_ALLOW_INSECURE=1 for non-localhost dev setups (e.g. the
+ * private compose network). Shared by RunnerClient and the register flow.
+ */
+export function assertSecureRunnerUrl(baseUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(`cezar-runner: invalid --url / CEZAR_RUNNER_URL: '${baseUrl}'`);
+  }
+  const isLoopback =
+    parsed.hostname === 'localhost' ||
+    parsed.hostname === '127.0.0.1' ||
+    parsed.hostname === '[::1]' ||
+    parsed.hostname === '::1';
+  const allowInsecure = process.env.CEZAR_RUNNER_ALLOW_INSECURE === '1';
+  if (parsed.protocol !== 'https:' && !isLoopback && !allowInsecure) {
+    throw new Error(
+      `cezar-runner: refusing to send the runner token over ${parsed.protocol} ` +
+        `(${parsed.host}). Use an https:// URL, or set CEZAR_RUNNER_ALLOW_INSECURE=1 for local dev.`,
+    );
+  }
+}
+
 /** Thin bearer-authed HTTP client for the SaaS runner API. Retries 5xx/network
  * with exponential backoff; throws hard on 401 (bad/revoked token). */
 export class RunnerClient {
@@ -191,29 +220,7 @@ export class RunnerClient {
     private readonly baseUrl: string,
     private readonly token: string,
   ) {
-    // Refuse to send the long-lived runner bearer token over a non-TLS
-    // transport. A prod typo (`http://…`) or a local-dev URL pasted into a
-    // deployment would otherwise leak the credential in plaintext on every
-    // claim/heartbeat/finalize call. Localhost stays painless; opt out with
-    // CEZAR_RUNNER_ALLOW_INSECURE=1 for non-localhost dev setups.
-    let parsed: URL;
-    try {
-      parsed = new URL(baseUrl);
-    } catch {
-      throw new Error(`cezar-runner: invalid --url / CEZAR_RUNNER_URL: '${baseUrl}'`);
-    }
-    const isLoopback =
-      parsed.hostname === 'localhost' ||
-      parsed.hostname === '127.0.0.1' ||
-      parsed.hostname === '[::1]' ||
-      parsed.hostname === '::1';
-    const allowInsecure = process.env.CEZAR_RUNNER_ALLOW_INSECURE === '1';
-    if (parsed.protocol !== 'https:' && !isLoopback && !allowInsecure) {
-      throw new Error(
-        `cezar-runner: refusing to send the runner token over ${parsed.protocol} ` +
-          `(${parsed.host}). Use an https:// URL, or set CEZAR_RUNNER_ALLOW_INSECURE=1 for local dev.`,
-      );
-    }
+    assertSecureRunnerUrl(baseUrl);
     this.baseUrl = baseUrl.replace(/\/+$/, '');
   }
 

--- a/packages/runner/src/runner-daemon.ts
+++ b/packages/runner/src/runner-daemon.ts
@@ -39,6 +39,12 @@ export interface RunnerDaemonConfig {
   /** Phase 4 (migration 0026) — advertise a per-runner GitHub App install id.
    *  Mutually exclusive with `githubInheritHost` (the latter wins server-side). */
   githubInstallationId?: number | null;
+  /** Join-token recovery: called when the SaaS rejects our runner token
+   *  (401 — revoked in Settings → Runners, or a reset DB). Returns a fresh
+   *  runner token (the CLI re-registers with its join token); the daemon
+   *  swaps its client and keeps going. Absent → 401 shuts the daemon down
+   *  (legacy pre-issued-token behavior). */
+  onAuthError?: () => Promise<string>;
 }
 
 interface InFlight {
@@ -64,7 +70,8 @@ interface InFlight {
  * pause/cancel probes read between steps.
  */
 export class RunnerDaemon {
-  private readonly client: RunnerClient;
+  /** Swapped for a re-authenticated client after a join-token re-register. */
+  private client: RunnerClient;
   private readonly concurrency: number;
   private readonly pollMs: number;
   private readonly inFlight = new Map<string, InFlight>();
@@ -177,8 +184,9 @@ export class RunnerDaemon {
         } catch (err) {
           console.error('[runner] claim tick failed:', err instanceof Error ? err.message : err);
           if (err instanceof Error && err.message.includes('(401)')) {
-            await this.shutdown('auth-error');
-            return;
+            const recovered = await this.handleAuthError();
+            if (!recovered) return;
+            continue;
           }
           // Back off briefly on unexpected errors so we don't hot-spin if the
           // SaaS is returning 5xx.
@@ -381,8 +389,43 @@ export class RunnerDaemon {
       }
     } catch (err) {
       console.error('[runner] heartbeat failed:', err instanceof Error ? err.message : err);
-      if (err instanceof Error && err.message.includes('(401)')) await this.shutdown('auth-error');
+      if (err instanceof Error && err.message.includes('(401)')) {
+        await this.handleAuthError();
+      }
     }
+  }
+
+  /** In-flight re-auth attempt, shared so a heartbeat 401 and a claim 401
+   *  landing together trigger one re-registration, not two. */
+  private reauth: Promise<boolean> | null = null;
+
+  /**
+   * 401 from the SaaS: our runner token is dead. With an `onAuthError` hook
+   * (join-token mode) we re-register and swap the client — resolves true and
+   * the caller carries on. Without one, or when re-registration itself fails
+   * hard (join token revoked too), we shut down — resolves false.
+   */
+  private async handleAuthError(): Promise<boolean> {
+    if (this.stopping) return false;
+    if (!this.cfg.onAuthError) {
+      await this.shutdown('auth-error');
+      return false;
+    }
+    this.reauth ??= (async () => {
+      try {
+        const fresh = await this.cfg.onAuthError!();
+        this.client = new RunnerClient(this.cfg.url, fresh);
+        console.log('[runner] re-registered — resuming with a fresh runner token');
+        return true;
+      } catch (err) {
+        console.error('[runner] re-registration failed:', err instanceof Error ? err.message : err);
+        await this.shutdown('auth-error');
+        return false;
+      } finally {
+        this.reauth = null;
+      }
+    })();
+    return this.reauth;
   }
 
   private async shutdown(why: string): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,6 +194,7 @@ __metadata:
     "@cezar/core": "workspace:*"
     "@types/node": "npm:^20.0.0"
     typescript: "npm:^5.4.0"
+    zod: "npm:^3.23.0"
   bin:
     cezar-runner: ./dist/cli.js
   languageName: unknown


### PR DESCRIPTION
## Summary

Makes the join token the **only** way to register a runner, gives every runner an **owner** (the GitHub-authenticated user who minted the token), and routes jobs by requester: jobs you trigger run on *your* runners, another user's jobs run on *theirs*.

### Registration (join tokens)
- New `runner_join_tokens` table + **POST /api/runner/register** (migration `20260706075137`). Any workspace member mints a reusable join token in Settings → Runners; the daemon presents it and receives its per-runner bearer token. The old admin-side "Register a runner" flow is removed.
- Registration is idempotent per **(workspace, owner, name)** — re-registering the same name re-keys the existing row (old token invalidated, auth cache dropped) instead of piling up duplicates. A lost insert race returns 409 and the daemon retries.
- A join token can only create/re-key runner rows — it can never claim jobs (which carry GitHub tokens).
- The daemon persists the credential in `~/.cezar-runner/credentials.json` (0600, `CEZAR_RUNNER_STATE_DIR` to override), retries registration with backoff while the GUI is still booting (fixes the compose `depends_on` crash-loop class of failures), and **re-registers automatically on 401** when it still holds a join token. Legacy pre-issued tokens keep working via `--token` / `CEZAR_RUNNER_TOKEN`.
- Compose: set `CEZAR_RUNNER_JOIN_TOKEN` in `.env` and the runner self-registers as `compose-runner` on first boot — no restart dance. Also forwards `CEZAR_RUNNER_NAME` and `CEZAR_RUNNER_ALLOW_INSECURE` (default 1, the default URL is http on the private compose network).

### Ownership + routing
- `runners.owner_user_id` / `owner_login` (denormalized GitHub login) record the owner; the runners list shows `@owner` per runner and owners can revoke their own runners (new RLS policy) — admins can revoke any.
- `jobs.requested_by` is stamped by every user-initiated enqueue server action (cockpit enqueue/retry, issues Fix button, run-now action, label analysis). Webhook/sweep/system jobs stay NULL.
- `claim_next_job_for_runner` (superseding the 0033 body) routes: user-requested jobs → only that user's runners; system jobs → any workspace runner. It also adds the previously **missing workspace scoping** — before this, a workspace-bound runner could claim another workspace's jobs whose backend matched. The cron path (`claim_next_job`) is unchanged; the managed anthropic-api path is not per-user.
- Wire contract `RunnerRegisterRequest/Response` lives in `@cezar/core` and is Zod-validated on both ends.

### Notes for review
- Strictness choice: an **unowned** legacy runner row only serves system jobs after this migration; re-register it through a join token to receive user-requested jobs. Called out in `docs/runner-setup.md`.
- `cezar-runner start` now needs `--url` plus either `--join-token` or `--token`; `--name` defaults to the hostname (compose default: `compose-runner`).

## Test plan
- `yarn build` / `yarn typecheck` / `yarn lint` / `yarn test` / `yarn format:check` — all green (CI also applies migrations against real Postgres).
- Manual: mint a join token → `cezar-runner start --url … --join-token …` registers, persists credentials, appears online owned by the minter; restart reuses the credential; revoking the runner and restarting re-registers; jobs triggered by the owner are claimed, jobs triggered by another user are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)