### PR TITLE
fix(runner): accept current Claude/Codex CLI version formats; add link:bins

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,8 +31,8 @@ node packages/cli/dist/index.js sync
 node packages/cli/dist/index.js run bug-detector --apply
 ```
 
-`npm link packages/cli` (or `yarn workspace cezar link`) installs the `cezar`
-binary globally.
+`yarn link:bins` installs the `cezar` and `cezar-runner` binaries globally
+(via `npm link`); `yarn unlink:bins` removes them.
 
 <!-- SCREENSHOT: Terminal screenshot of the `cezar` interactive hub — the
      setup-wizard greeting, then the main menu of analysis actions

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -25,8 +25,8 @@ yarn workspace @cezar/runner build
 ```
 
 This produces the `cezar-runner` binary (`packages/runner/dist/cli.js`). Run it
-via `yarn workspace @cezar/runner exec cezar-runner …`, or `npm link` /
-`yarn link` the package, or just call `node packages/runner/dist/cli.js …`.
+via `node packages/runner/dist/cli.js …`, or put it on your PATH globally with
+`yarn link:bins` (from the repo root; `yarn unlink:bins` removes it).
 
 ## 2. Register the runner in the web app
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "dev": "yarn workspace cezar dev",
+    "link:bins": "(cd packages/cli && npm link) && (cd packages/runner && npm link)",
+    "unlink:bins": "npm rm -g cezar @cezar/runner",
     "db:start": "docker compose -f infra/supabase/docker-compose.yml up -d",
     "db:stop": "docker compose -f infra/supabase/docker-compose.yml down",
     "db:reset": "docker compose -f infra/supabase/docker-compose.yml down -v && docker compose -f infra/supabase/docker-compose.yml up -d",

--- a/packages/runner/src/backend-detect.ts
+++ b/packages/runner/src/backend-detect.ts
@@ -29,7 +29,8 @@ export async function detectBackends(): Promise<BackendCheck[]> {
       backend: 'claude-cli',
       binary: 'claude',
       loginCmd: 'claude login',
-      versionRegex: /^(?:claude(?:\s+code)?\s+version\s+\d+\.\d+|\d+\.\d+\.\d+\s*\(claude\s+code\))/i,
+      versionRegex:
+        /^(?:claude(?:\s+code)?\s+version\s+\d+\.\d+|\d+\.\d+\.\d+\s*\(claude\s+code\))/i,
     },
     // The Codex CLI prints e.g. `codex-cli 0.132.0` (or `codex 0.4.2` on older releases).
     {

--- a/packages/runner/src/backend-detect.ts
+++ b/packages/runner/src/backend-detect.ts
@@ -23,19 +23,20 @@ export async function detectBackends(): Promise<BackendCheck[]> {
     loginCmd: string;
     versionRegex: RegExp;
   }> = [
-    // The Anthropic Claude CLI prints e.g. `claude version 1.0.13` (or `claude code version …`).
+    // The Anthropic Claude CLI prints e.g. `2.1.201 (Claude Code)` (≥2.x) or
+    // `claude version 1.0.13` / `claude code version …` (older releases).
     {
       backend: 'claude-cli',
       binary: 'claude',
       loginCmd: 'claude login',
-      versionRegex: /^claude(\s+code)?\s+version\s+\d+\.\d+/i,
+      versionRegex: /^(?:claude(?:\s+code)?\s+version\s+\d+\.\d+|\d+\.\d+\.\d+\s*\(claude\s+code\))/i,
     },
-    // The Codex CLI prints e.g. `codex 0.4.2`.
+    // The Codex CLI prints e.g. `codex-cli 0.132.0` (or `codex 0.4.2` on older releases).
     {
       backend: 'codex-cli',
       binary: 'codex',
       loginCmd: 'codex login',
-      versionRegex: /^codex\s+\d+\.\d+/i,
+      versionRegex: /^codex(?:-cli)?\s+\d+\.\d+/i,
     },
   ];
   return Promise.all(


### PR DESCRIPTION
## Summary
- Fix `detectBackends()` version regexes: current CLI releases print `2.1.201 (Claude Code)` and `codex-cli 0.132.0`, which the old patterns rejected, so both backends were reported as not installed. Both new and legacy formats are now accepted.
- Add root `link:bins` / `unlink:bins` scripts to globally link/unlink the `cezar` and `cezar-runner` binaries via `npm link`.
- Update `docs/INSTALL.md` and `docs/runner-setup.md` to point at the new scripts.

## Test plan
- `yarn workspace @cezar/runner run build` passes.
- Manually verified the new regexes against current `claude --version` / `codex --version` output formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)