### PR TITLE
feat: agentic setup

### DIFF
--- a/.ai/agentic.config.json
+++ b/.ai/agentic.config.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "baseBranch": "auto",
+  "tracker": "github",
+  "validation": {
+    "commands": ["npm run typecheck", "npm run build"]
+  },
+  "labels": {
+    "enabled": true,
+    "pipeline": ["review", "changes-requested", "qa", "qa-failed", "merge-queue", "blocked", "do-not-merge"],
+    "category": ["bug", "feature", "refactor", "security", "dependencies", "documentation"],
+    "meta": ["needs-qa", "skip-qa", "qa-approved", "qa-self-verified", "in-progress"],
+    "priority": ["priority-low", "priority-medium", "priority-high", "priority-extreme"],
+    "risk": ["risk-low", "risk-medium", "risk-high"]
+  },
+  "qaGate": true,
+  "paths": {
+    "runs": ".ai/runs",
+    "analysis": ".ai/analysis",
+    "specs": ".ai/specs",
+    "scripts": ".ai/scripts",
+    "qa": ".ai/qa"
+  },
+  "reviewChecklist": null
+}

--- a/.ai/trackers/github.md
+++ b/.ai/trackers/github.md
@@ -1,0 +1,376 @@
+# Tracker provider: GitHub
+
+This file is the GitHub implementation of the tracker operations contract (see `TEMPLATE.md` for the contract itself). Every skill in the collection performs issue/PR state management through **named tracker operations** — `**get-issue**`, `**comment-pr**`, and so on — and this file defines what each operation means for GitHub, using the `gh` CLI.
+
+How it is used at runtime: `om-setup-agent-pipeline` copies this file into the repository at `.ai/trackers/github.md`, and the config's `tracker` field selects it. When a skill says "tracker operation **get-pr**", execute the command documented under that operation heading in the repo's copy. The repo's copy is authoritative: teams extend or override any operation by editing it — add flags, swap a command, append repo-specific conventions — and every skill picks the change up on its next run. An operation not covered by an edit keeps its behavior from this file's text as copied.
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated. Verify with the **auth-check** operation before a batch run; fail fast when unauthenticated.
+- All operations accept an optional `{repo}` (`owner/name`); when omitted, `gh` infers it from the current checkout's git remote. Pass `--repo {owner}/{repo}` explicitly whenever a skill operates on a repository other than the current one.
+
+## Conventions
+
+- Issue and PR identifiers are numbers; in text they are written `#123`.
+- A PR is linked to the issue it resolves with `Fixes #{issueId}` (or `Closes #{issueId}`) in the PR body; GitHub then closes the issue on merge. To reference without auto-closing, use a plain issue link.
+- PRs open as **drafts** when a skill says so; a human (or **mark-pr-ready**) promotes them.
+- Claim/lock signals on an issue or PR are: assignee set to the automation user, the `in-progress` label, and a `🤖`-prefixed claim comment. All three are set on claim; the label is guarded (below).
+- Long, multi-line comment bodies are posted with `--body-file` (or a heredoc via process substitution) so formatting is preserved.
+- CI status truth comes from **get-pr-checks**; the set of *required* checks comes from **get-required-checks** (branch protection). When branch protection is not readable (404), treat every reported check as required.
+
+## Label guards
+
+Every label mutation goes through an existence guard so a missing label degrades to a logged skip instead of a failure, and `labels.enabled: false` in the config skips label operations entirely.
+
+```bash
+label_exists() {
+  gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "$1"
+}
+
+# PR labels
+apply_label() {
+  if [ "$LABELS_ENABLED" != "true" ]; then return 0; fi
+  if label_exists "$1"; then
+    gh pr edit "$2" --add-label "$1"
+  else
+    echo "Skipping label '$1' (not defined in this repo). Create it with: gh label create '$1'"
+  fi
+}
+
+# Issue labels
+apply_issue_label() {
+  if [ "$LABELS_ENABLED" != "true" ]; then return 0; fi
+  if label_exists "$1"; then
+    gh issue edit "$2" --add-label "$1"
+  else
+    echo "Skipping label '$1' (not defined in this repo). Create it with: gh label create '$1'"
+  fi
+}
+
+remove_issue_label() {
+  if [ "$LABELS_ENABLED" != "true" ]; then return 0; fi
+  if label_exists "$1"; then
+    gh issue edit "$2" --remove-label "$1"
+  fi
+}
+
+# Pipeline labels are mutually exclusive: setting one removes the others first.
+set_pipeline_label() {
+  if [ "$LABELS_ENABLED" != "true" ]; then return 0; fi
+  for label in $PIPELINE_LABELS; do
+    [ "$label" = "$2" ] && continue
+    gh pr edit "$1" --remove-label "$label" 2>/dev/null || true
+  done
+  apply_label "$2" "$1"
+}
+```
+
+When operating on a different repository than the current checkout, add `--repo "$REPO"` to each command inside the guards and check label existence against that repo (`gh label list --repo "$REPO"`).
+
+## Operations
+
+### Identity and repository
+
+#### auth-check
+Verify the CLI is authenticated. → exit status.
+```bash
+gh auth status
+```
+
+#### current-user
+→ the automation user's login.
+```bash
+CURRENT_USER=$(gh api user --jq '.login')
+```
+
+#### repo-info
+→ `owner/name` handle and default branch of the current repository.
+```bash
+gh repo view --json nameWithOwner,defaultBranchRef
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+```
+
+#### default-branch
+→ the repository's default branch name (used when the config's `baseBranch` is `"auto"`).
+```bash
+BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+[ -z "$BASE_BRANCH" ] && BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+[ -z "$BASE_BRANCH" ] && BASE_BRANCH="main"
+```
+
+### Issues
+
+#### get-issue
+`{issueId}`, field list → issue data. Request only the fields the calling skill names.
+```bash
+gh issue view {issueId} --repo {owner}/{repo} --json number,title,body,state,author,url,labels,assignees,comments
+```
+
+#### search-issues
+Query (text, `in:title,body`, state) → matching issues.
+```bash
+gh issue list --repo {owner}/{repo} --state open --search "<query> in:title,body" --json number,title,url
+```
+
+#### create-issue
+Title, body, assignee, labels → created issue URL.
+```bash
+gh issue create --repo {owner}/{repo} --title "<title>" --assignee <login> --label <labels> --body "<body>"
+```
+
+#### close-issue
+`{issueId}`, reason, closing comment.
+```bash
+gh issue close {issueId} --repo {owner}/{repo} --reason completed --comment "<comment>"
+```
+
+#### comment-issue
+`{issueId}`, body (use a heredoc/body-file for multi-line bodies).
+```bash
+gh issue comment {issueId} --repo {owner}/{repo} --body "<body>"
+```
+
+#### assign-issue / unassign-issue
+```bash
+gh issue edit {issueId} --repo {owner}/{repo} --add-assignee "<login>"
+gh issue edit {issueId} --repo {owner}/{repo} --remove-assignee "<login>"
+```
+
+#### label-issue / unlabel-issue
+Always through the guards: `apply_issue_label "<label>" {issueId}` / `remove_issue_label "<label>" {issueId}`.
+
+#### get-issue-comment
+Comment id → body, author, URL.
+```bash
+gh api repos/{owner}/{repo}/issues/comments/{commentId} --jq '{body,user:.user.login,url:.html_url}'
+```
+
+#### list-issue-comments
+`{issueId or prNumber}` → conversation comments (PR conversation comments are issue comments on GitHub).
+```bash
+gh api repos/{owner}/{repo}/issues/{number}/comments --jq '.[] | {id,user:.user.login,body}'
+```
+
+### Pull requests
+
+#### get-pr
+`{prNumber}`, field list → PR data. Request only the fields the calling skill names; the full field set skills use:
+```bash
+gh pr view {prNumber} --json number,title,url,body,state,author,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,mergeable,mergeStateStatus,reviewDecision,labels,latestReviews,reviews,commits,files,assignees,comments,mergedAt,mergeCommit,closingIssuesReferences
+```
+
+#### list-prs
+State/search filters, field list, limit → PRs.
+```bash
+gh pr list --state open --json number,title,url,author,labels,reviewDecision,mergeable,mergeStateStatus,headRefName,baseRefName,updatedAt,isDraft,assignees --limit 100
+gh pr list --state merged --search "merged:>=${SINCE_DATE}" --json number,title,url,body,author,mergedAt,mergeCommit,baseRefName,headRefName,closingIssuesReferences,labels --limit {limit}
+gh pr list --state closed --search "closed:>=${SINCE_DATE} is:unmerged" --json number,title,url,body,author,closedAt,baseRefName,headRefName,closingIssuesReferences,labels --limit {limit}
+```
+
+#### search-prs
+Free-text query (for example an issue reference) and state → matching PRs.
+```bash
+gh search prs --repo {owner}/{repo} "#{issueId}" --state open --json number,title,url,state
+```
+
+#### create-pr
+Base branch, draft flag, title, body → PR.
+```bash
+gh pr create --repo {owner}/{repo} --base "$BASE_BRANCH" --draft --title "<title>" --body "<body>"
+PR_URL=$(gh pr view --json url --jq .url)
+PR_NUMBER=$(gh pr view --json number --jq .number)
+```
+
+#### comment-pr
+`{prNumber}`, body. For long structured comments:
+```bash
+gh pr comment {prNumber} --body-file <path-or-process-substitution>
+```
+
+#### attach-image-evidence
+`{prNumber}`, a markdown comment body (without the images), a `{slug}` (e.g. `pr-{prNumber}`), and a list of local PNG paths → post one comment with the images embedded **inline**, and return the comment URL.
+
+GitHub does not accept image bytes through the comment API, so make the images referenceable first. For a **public** repo, upload them to a dedicated **slash-free** evidence branch (never the change's own branch) via the Contents API and reference `raw.githubusercontent.com` URLs — those render inline in comments:
+
+```bash
+OWNER_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+EVIDENCE_BRANCH="qa-evidence-{slug}"                 # slash-free: some raw URLs 404 on slashed refs
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+
+# create the evidence branch if missing (branched from the default branch head)
+gh api "repos/${OWNER_REPO}/git/refs/heads/${EVIDENCE_BRANCH}" >/dev/null 2>&1 || {
+  SHA=$(gh api "repos/${OWNER_REPO}/git/refs/heads/${DEFAULT_BRANCH}" --jq .object.sha)
+  gh api -X POST "repos/${OWNER_REPO}/git/refs" -f ref="refs/heads/${EVIDENCE_BRANCH}" -f sha="$SHA" >/dev/null
+}
+
+# upload each image. An image-sized base64 string blows the shell arg limit, so it
+# must never touch a command line — write it to a temp file and let `jq --rawfile`
+# read it into the JSON body, which `gh api --input -` sends over stdin. Pass the
+# existing blob sha to overwrite on re-runs.
+BODY_IMAGES=""
+for img in <image-paths>; do
+  path="{slug}/$(basename "$img")"
+  base64 < "$img" | tr -d '\n' > /tmp/ev-content.b64            # portable across GNU/BSD; no newlines
+  existing=$(gh api "repos/${OWNER_REPO}/contents/${path}?ref=${EVIDENCE_BRANCH}" --jq .sha 2>/dev/null || true)
+  jq -n --rawfile c /tmp/ev-content.b64 --arg m "qa evidence {slug}" --arg b "$EVIDENCE_BRANCH" --arg s "$existing" \
+     'if $s == "" then {message:$m,branch:$b,content:$c} else {message:$m,branch:$b,content:$c,sha:$s} end' \
+     | gh api -X PUT "repos/${OWNER_REPO}/contents/${path}" --input - >/dev/null
+  url="https://raw.githubusercontent.com/${OWNER_REPO}/${EVIDENCE_BRANCH}/${path}"
+  BODY_IMAGES="${BODY_IMAGES}\n![$(basename "$img")](${url})"
+done
+
+# assemble the comment (caller's body + the image markdown) and post it
+{ cat <body-file>; printf "%b" "$BODY_IMAGES"; } | gh pr comment {prNumber} --body-file -
+gh pr view {prNumber} --json url --jq .url
+```
+
+Fallbacks: for a **private** repo the raw URLs need auth and will not render — post the comment with the image links plus the local artifact paths and note that inline rendering is unavailable (a private-visibility limit), rather than failing. When even the evidence branch cannot be pushed (no write access), degrade to listing the artifact paths in the comment. Never store evidence on the change's own branch, and never force-push.
+
+#### assign-pr / unassign-pr
+```bash
+gh pr edit {prNumber} --add-assignee "<login>"
+gh pr edit {prNumber} --remove-assignee "<login>"
+```
+
+#### label-pr / unlabel-pr
+Always through the guards: `apply_label "<label>" {prNumber}` / `set_pipeline_label {prNumber} "<label>"` for the mutually exclusive pipeline group; direct removal:
+```bash
+gh pr edit {prNumber} --remove-label "<label>"
+```
+
+#### get-pr-diff
+`{prNumber}` → full diff, or the changed-file list with `--name-only`.
+```bash
+gh pr diff {prNumber}
+gh pr diff {prNumber} --name-only
+```
+
+#### get-pr-files
+`{prNumber}` → changed files with per-file status (added/modified/removed), paginated.
+```bash
+gh api "repos/{owner}/{repo}/pulls/{prNumber}/files" --paginate --jq '.[] | {path: .filename, status: .status}'
+```
+
+#### checkout-pr
+`{prNumber}` → the PR's head available locally (needed for cross-repository fork PRs where the head branch cannot be fetched from `origin`).
+```bash
+gh pr checkout {prNumber} --recurse-submodules=no
+```
+
+#### review-pr
+`{prNumber}`, verdict (approve / request changes), body.
+```bash
+gh pr review {prNumber} --approve --body "<body>"
+gh pr review {prNumber} --request-changes --body "<body>"
+```
+GitHub rejects self-approval (reviewing your own PR); surface that instead of working around it.
+
+#### merge-pr
+`{prNumber}`; squash is the default merge strategy. `--auto` merges when checks pass; `--delete-branch` only when asked.
+```bash
+gh pr merge {prNumber} --squash
+```
+
+#### mark-pr-ready
+Promote a draft PR.
+```bash
+gh pr ready {prNumber}
+```
+
+#### get-pr-checks
+`{prNumber}` → CI check runs with name, state, and link.
+```bash
+gh pr checks {prNumber} --json name,state,link
+```
+
+#### get-required-checks
+Base branch → the set of required status checks. A 404 means branch protection is not readable — treat all reported checks as required.
+```bash
+gh api repos/{owner}/{repo}/branches/{baseRefName}/protection/required_status_checks --jq '.contexts[]' 2>/dev/null
+```
+
+#### get-pr-comment / get-review-comment
+Conversation comment id (`issuecomment-<id>` links) vs inline review comment id (`discussion_r<id>` links) → body, author, URL.
+```bash
+gh api repos/{owner}/{repo}/issues/comments/{commentId} --jq '{body,user:.user.login,url:.html_url}'
+gh api repos/{owner}/{repo}/pulls/comments/{commentId} --jq '{body,user:.user.login,url:.html_url}'
+```
+
+### CI runs
+
+CI status for a *PR* comes from **get-pr-checks** / **get-required-checks** above. The operations here address CI runs directly — needed when working from a bare branch, or when a failure diagnosis needs the actual logs.
+
+#### list-runs
+Branch (or head SHA) → recent workflow runs with id, workflow name, status, and conclusion.
+```bash
+gh run list --branch {branch} --limit 20 --json databaseId,workflowName,name,status,conclusion,headSha,url,createdAt
+```
+
+#### get-run
+Run id → status, conclusion, and per-job breakdown.
+```bash
+gh run view {runId} --json status,conclusion,workflowName,headSha,url,jobs
+```
+
+#### get-run-failed-logs
+Run id → the log output of failed steps only. This is the primary diagnosis input for CI failures.
+```bash
+gh run view {runId} --log-failed
+```
+
+#### rerun-failed
+Run id → re-execute only the failed jobs of that run. Use to disambiguate flaky failures before changing any code.
+```bash
+gh run rerun {runId} --failed
+```
+
+#### watch-run
+Run id → block until the run completes, exiting non-zero on failure. Prefer this over sleep-polling; fall back to periodic **get-run** when watching is unavailable.
+```bash
+gh run watch {runId} --exit-status
+```
+
+### Labels
+
+#### list-labels
+→ all label names defined in the repo.
+```bash
+gh label list --limit 200 --json name --jq '.[].name'
+```
+
+#### create-label
+Name, color, description. Never delete, rename, or recolor existing labels.
+```bash
+gh label create <name> --color <hex> --description "<description>"
+```
+
+#### ensure-label-taxonomy
+Create every label from the config's taxonomy that does not exist yet (used by `om-setup-agent-pipeline`; skip ones that already exist per **list-labels**):
+```bash
+gh label create review            --color 0366d6 --description "Ready for code review"
+gh label create changes-requested --color b60205 --description "Reviewer requested changes"
+gh label create qa                --color fbca04 --description "Manual QA in progress"
+gh label create qa-failed         --color b60205 --description "Manual QA failed"
+gh label create merge-queue       --color 0e8a16 --description "Approved, ready to merge"
+gh label create blocked           --color b60205 --description "Blocked by a dependency"
+gh label create do-not-merge      --color b60205 --description "Hard merge block"
+gh label create bug               --color d73a4a --description "Bug fix"
+gh label create feature           --color a2eeef --description "New capability"
+gh label create refactor          --color cfd3d7 --description "No behavior change"
+gh label create security          --color b60205 --description "Security-relevant change"
+gh label create dependencies      --color 0366d6 --description "Dependency update"
+gh label create documentation     --color 0075ca --description "Docs only"
+gh label create needs-qa          --color fbca04 --description "Requires manual QA before merge"
+gh label create skip-qa           --color 0e8a16 --description "Low risk, QA not required"
+gh label create qa-approved       --color 0e8a16 --description "Manual QA passed"
+gh label create qa-self-verified  --color c5def5 --description "Self-QA exception used"
+gh label create in-progress       --color c5def5 --description "An automated skill is working on this"
+gh label create do-not-close      --color c5def5 --description "Humans only: never auto-close this issue"
+gh label create priority-low      --color e4e669 --description "Cosmetic or follow-up work"
+gh label create priority-medium   --color fbca04 --description "Ordinary bug or feature"
+gh label create priority-high     --color d93f0b --description "Release-blocking"
+gh label create priority-extreme  --color b60205 --description "Outage or security incident"
+gh label create risk-low          --color 0e8a16 --description "Isolated, low blast radius"
+gh label create risk-medium       --color fbca04 --description "Ordinary change with tests"
+gh label create risk-high         --color b60205 --description "Wide blast radius, review deeply"
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent instructions — cezar
+
+cezar is a local cockpit for running and tracking AI coding-agent tasks in a repository: a Node 20+ TypeScript CLI (`cezar` / `cez`, entry `src/index.ts`) that starts a Hono HTTP server serving a zero-build vanilla-JS web cockpit (`web/`) and drives agent backends (Claude CLI, Codex, OpenCode) through per-run worktrees. All state lives in `.ai/cezar/` inside the target repo as plain JSON/NDJSON/Markdown — no database, no accounts, no cloud.
+
+## Task routing
+
+| When the task involves… | Read first | Key rules |
+|---|---|---|
+| CLI entry, flags, startup | `src/index.ts`, `src/config.ts` | Node ≥ 20; bins are `cezar` and `cez` (both → `dist/index.js`). Zero-config philosophy: new options need a sensible default. |
+| HTTP API / server routes | `src/server/server.ts`, then `src/server/{git,pr,github,launch-key,open-in-terminal}.ts` | Hono app; every request body is validated with a zod schema at the top of `server.ts`. Follow the existing limits (e.g. images: `image/*`, ~5 MB decoded, max 4). Static cockpit files are served from `web/`. |
+| Web cockpit UI | `web/app.js`, `web/index.html`, `web/style.css` | Single-file vanilla JS, no framework, no build step, no dependencies. State lives in the top-level `state` object; DOM is built with template literals + the `esc()` helper (always escape interpolated values). Events stream over SSE and are rendered per-type in the big `switch (evt.type)` renderer. |
+| Agent runners / backends | `src/core/agent-runner.ts` (types), `src/core/{claude-cli-runner,codex-app-server-runner,opencode-server-runner}.ts`, `src/core/runner-factory.ts`, `src/core/backend-detect.ts` | Runners implement the `AgentSession` contract and emit typed `AgentEvent`s. New event types must be handled (or explicitly ignored) in `src/workflows/run.ts` and rendered in `web/app.js`. |
+| Workflow engine / run lifecycle | `src/workflows/run.ts` (RunManager), `src/workflows/{load,types}.ts` | Runs execute step-by-step; the last agent step is interactive (session stays open, `waiting` status, idle timeout). Transcript events are append-only NDJSON via `store.appendEvent` — image bytes never enter the NDJSON log (see `persistImage`). |
+| Run persistence / transcripts | `src/runs/store.ts` | State under `.ai/cezar/runs/`: `<id>.json` (run), `<id>.ndjson` (events), `<id>-images/` (persisted screenshots). Files must stay hand-fixable plain text. |
+| Worktrees, git, PRs | `src/git-worktree.ts`, `src/server/git.ts`, `src/server/pr.ts`, `src/server/github.ts` | Each run gets an isolated worktree under `.ai/cezar/worktrees/` on branch `cez/<id-prefix>`; degrade gracefully when not in a git repo. |
+| Skills / handoff / todos | `src/skills.ts`, `src/skills-remote.ts`, `src/handoff.ts`, `src/todos.ts` | Skills are discovered from `.ai/cezar/skills`, `.ai/skills`, and the team skills repo. Every agent step carries the handoff/todos contract (spec 007). |
+| Feature design docs | `.ai/specs/` (`000`–`012`, some in Polish) | Specs are numbered and status-tagged; check whether one already covers your change before designing. |
+| Testing without tokens | `scripts/mock-claude.mjs` | Mock Claude CLI runner reading/writing NDJSON on stdio; there is no automated test suite — validation is `npm run typecheck` + `npm run build`. |
+
+## Validation gate
+
+Run before any commit/PR, in order (from `.ai/agentic.config.json`):
+
+1. `npm run typecheck`
+2. `npm run build`
+
+## Process pointers
+
+- Ticket flow, labels, QA gate: `SDLC.md`
+- Review rules: `CODE_REVIEW.md`
+- Protected contract surfaces: `BACKWARD_COMPATIBILITY.md`
+- Pipeline config: `.ai/agentic.config.json` (tracker ops in `.ai/trackers/github.md`)

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -1,0 +1,47 @@
+# Backward compatibility — protected contract surfaces
+
+cezar ships as an npm CLI (`@pat-lewczuk/cezar`, bins `cezar`/`cez`) and persists user state in-place inside target repositories. These surfaces are contracts; changing one requires the listed handling.
+
+## 1. On-disk state under `.ai/cezar/` (highest sensitivity)
+
+Runs (`runs/<id>.json`), transcripts (`runs/<id>.ndjson`), images (`runs/<id>-images/`), handoff files (`runs/<id>.handoff.md`), todos (`todos.json`), skills, worktrees, launch-key. Users are told they can `cat` and hand-fix these files, and old runs must remain viewable after upgrades.
+
+- **Breaking:** renaming/removing fields readers depend on, changing NDJSON event semantics, relocating directories.
+- **Required path:** additive changes only where possible; readers (`src/runs/store.ts`, `web/app.js`) must tolerate missing new fields and unknown event types. A relocation or rename needs a lazy migration in the store plus a CHANGELOG note.
+
+## 2. NDJSON transcript event types
+
+Every `evt.type` (`user-message`, `image`, `note`, `lifecycle`, `tool-call`, `tool-result`, `step-start`, `step-end`, `check-output`, `error`, `token-usage`, `cost`, `turn-end`, `done`, …) is read back by the cockpit renderer for **old runs too**.
+
+- **Breaking:** removing a type, repurposing a field, making a previously optional field required at render time.
+- **Required path:** add new event types or optional fields; the renderer keeps handling the old shape indefinitely (cheap — one `switch` case).
+
+## 3. HTTP API (`/api/*` in `src/server/server.ts`)
+
+Consumed by the bundled cockpit and by user bookmarklets (spec 011), so it is not purely internal.
+
+- **Breaking:** removing/renaming routes or request/response fields, tightening validation on previously accepted input.
+- **Required path:** additive fields; keep old field names accepted for at least one release when renaming; note route removals in the CHANGELOG.
+
+## 4. CLI commands and flags (`src/index.ts`, bins `cezar`/`cez`)
+
+- **Breaking:** removing/renaming flags or changing defaults (port, data dir).
+- **Required path:** deprecation warning for one release before removal; keep `cez` and `cezar` equivalent.
+
+## 5. Workflow YAML format (`src/workflows/{load,types}.ts`)
+
+User-authored workflow files must keep loading.
+
+- **Breaking:** renaming step keys, changing step-kind semantics, new required fields.
+- **Required path:** new fields optional with defaults; loader accepts old spellings or fails with a message naming the exact migration.
+
+## 6. Skills discovery layout
+
+Locations (`.ai/cezar/skills`, `.ai/skills`, team skills repo) and the SKILL.md format are user-facing.
+
+- **Breaking:** dropping a discovery location or requiring new frontmatter.
+- **Required path:** add locations/fields additively; keep old locations scanned.
+
+## Not protected
+
+`src/` internal module structure, `web/` internals (shipped with the server, always version-matched), `scripts/mock-claude.mjs`, and anything under `dist/`.

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,28 @@
+# Code review rules — cezar
+
+Applies to every PR; `om-code-review` (and human reviewers) read this in addition to the built-in checklist.
+
+## Review priorities
+
+1. **Correctness of the run lifecycle.** The RunManager (`src/workflows/run.ts`) is the heart of the app: step transitions, `waiting`/idle-timer semantics, cancellation, and crash recovery must stay coherent. Any change there needs a walk-through of: fresh run, retry loop, cancel mid-turn, server restart with an active run.
+2. **Security of the local server.** The cockpit binds locally but executes agents with filesystem access. Check: zod validation on every new/changed request body (`src/server/server.ts`), path traversal guards on file-serving routes (the `basename`/join pattern used by `/api/runs/:id/images/:file`), and size/type limits on user-supplied data (images: `image/*`, ~5 MB decoded, max 4 per message).
+3. **XSS in the cockpit.** `web/app.js` builds DOM from template literals — every interpolated value must go through `esc()`. Event payloads (tool output, agent text, filenames) are attacker-influenced content.
+4. **Contract surfaces.** HTTP API shapes, NDJSON event types, and on-disk state formats are contracts — see `BACKWARD_COMPATIBILITY.md`. Old transcripts must still render after an event-schema change.
+5. **Graceful degradation.** cezar's philosophy: no hard failures for optional capabilities (no git repo → run in place; image persist fails → drop with placeholder). New features should follow the same best-effort pattern instead of throwing.
+
+## Repo-specific checks
+
+- New `AgentEvent` types are handled in all three layers: emitted by a runner (`src/core/*`), routed/persisted in `src/workflows/run.ts`, rendered (or deliberately ignored) in the `switch (evt.type)` in `web/app.js` — including the `default:` JSON fallback not leaking raw base64.
+- Image/binary data never enters the NDJSON event log — persist to `.ai/cezar/runs/<id>-images/` and reference by URL (see `persistImage`).
+- `web/` stays framework-free and build-free: no npm dependencies, no bundler, ES modules/vanilla only.
+- Runner parity: a feature added for the Claude backend states explicitly whether Codex/OpenCode backends support it or degrade.
+- State files under `.ai/cezar/` remain human-readable and hand-fixable.
+- TypeScript strictness: no `any` escapes in `src/`; zod schemas and TS types for the same payload stay in sync.
+
+## Severity guidance
+
+- **Blocker** — data loss in run state, XSS/path traversal, broken run lifecycle, validation gate red.
+- **Major** — contract break without a migration note, unhandled new event type, missing input validation.
+- **Minor** — degradation-pattern violations, naming/convention drift, missing spec cross-reference.
+
+Verdict: request changes on any Blocker/Major; Minors can land with follow-up issues.

--- a/SDLC.md
+++ b/SDLC.md
@@ -1,0 +1,94 @@
+# Software delivery process
+
+## Purpose
+
+This file documents how work flows from ticket to merged PR in this repository. The agent skills configured in `.ai/agentic.config.json` enforce the process; humans read it here. PRs target `main`; issues and PRs live in github, with every tracker operation the skills run defined in `.ai/trackers/github.md` (edit that file to extend or override tracker behavior).
+
+Work enters through two paths: a free-form task brief handed to an agent, or a filed ticket. Both converge on the same review loop, the same validation gate, and the same merge gates.
+
+## Roles
+
+- **Author** — the human or agent who writes the change. Owns the ticket from claim to a merge-ready PR.
+- **Reviewer** — reads the diff and approves or requests changes. May be a human or the `om-auto-review-pr` skill; the `om-code-review` checklist applies either way.
+- **QA reviewer** — manually exercises user-facing changes before they merge. Always referenced by role, never by name or handle: assignments change.
+- **Maintainer** — owns branch protection, the label taxonomy, the config, and this document; arbitrates when gates conflict.
+
+## Ticket lifecycle
+
+| Stage | What happens | Driven by | Done when |
+|---|---|---|---|
+| Intake | A ticket or task brief is filed in github with enough detail to act on. | Anyone | Ticket exists |
+| Triage | Confirm the issue is real, still unfixed on `main`, and not already claimed or covered by an open PR. Read-only; stops the chain cleanly when there is nothing to do. | `om-verify-in-repo` or a human | Confirmed actionable, or closed as no-action |
+| Claim | The author claims the ticket so concurrent agents back off. See the claim protocol below. | `om-fix` / `om-auto-create-pr`, or a human | Claim visible on the ticket |
+| Implement | Locate the minimal change surface (`om-root-cause`, read-only), then implement the change with regression tests and run the validation gate. Task briefs without a ticket go through `om-auto-create-pr`, which plans, implements phase by phase in an isolated worktree, and runs the same gate. | `om-root-cause` + `om-fix`, `om-auto-create-pr`, or a human author | Change complete, validation gate green |
+| PR | Commit, push, and open a PR against `main` with normalized labels. On a hand-worked branch, `om-check-and-commit` runs the gate, fixes obvious drift, and pushes when green. | `om-open-pr`, `om-auto-create-pr`, or `om-check-and-commit` | Open, labeled PR |
+| Review loop | The reviewer reads the diff against the `om-code-review` checklist and approves or requests changes. Requested changes are addressed (`om-auto-continue-pr` resumes agent PRs from the tracking plan) and the PR is re-reviewed until approved. | `om-auto-review-pr` (single PR), `om-review-prs` (sweep), or a human | Approving review submitted |
+| QA | A PR carrying `needs-qa` waits for manual QA. A QA reviewer tests it and records the outcome. See the QA gate below. | QA reviewer (manual) | `qa-approved` applied, or `qa-failed` routes it back |
+| Merge | `om-merge-buddy` reports, read-only, which PRs can merge now and which are close but blocked. `om-approve-merge-pr` re-checks every gate, approves, and squash-merges. | `om-merge-buddy` + `om-approve-merge-pr`, or a human | PR squash-merged into `main` |
+| Post-merge housekeeping | Close issues the merged PR fixes; comment on issues whose PRs were closed without merging; turn leftover asks or review comments into tracked follow-up issues. | `om-sync-merged-pr-issues`, `om-followup-issue-from-pr` | Tracker reconciled, follow-ups filed |
+
+## Label state machine
+
+Pipeline labels are mutually exclusive: a PR carries at most one, and it names where the PR sits in the flow.
+
+- A ready, non-draft PR carries `review`.
+- The reviewer moves it: request changes → `changes-requested`; after fixes it returns to `review`; approval → `merge-queue`.
+- `merge-queue` is routing, not proof of QA: a `needs-qa` PR legitimately sits there until QA signs off.
+- Only a QA reviewer sets the `qa` pipeline label. They move a queued `needs-qa` PR from `merge-queue` to `qa` while testing, then back to `merge-queue` with `qa-approved` on pass, or to `qa-failed` on failure. Automated skills request QA with `needs-qa`; they never set `qa`.
+- `blocked` and `do-not-merge` are set and cleared by humans and stop the flow wherever it is.
+
+| Group | Labels | Exclusivity | Meaning |
+|---|---|---|---|
+| Pipeline | `review`, `changes-requested`, `qa`, `qa-failed`, `merge-queue`, `blocked`, `do-not-merge` | one at a time | Workflow state |
+| Category | `bug`, `feature`, `refactor`, `security`, `dependencies`, `documentation` | additive | Kind of change |
+| Meta | `needs-qa`, `skip-qa`, `qa-approved`, `qa-self-verified`, `in-progress` | additive | Process signals |
+| Priority | `priority-low`, `priority-medium`, `priority-high`, `priority-extreme` | one at a time; unset = medium | Urgency of the work |
+| Risk | `risk-low`, `risk-medium`, `risk-high` | one at a time; unset = medium | Blast radius of the change |
+
+Priority is how urgent the work is; risk is how dangerous the change is to ship. A one-line fix for an outage can be `priority-extreme` and `risk-low`; a large auth refactor that can wait can be `priority-low` and `risk-high`. A PR inherits both from its source issue unless the scope clearly changed. When an automated skill adds or changes a pipeline or meta label, it leaves a short comment explaining why.
+
+When no priority label is set, infer one:
+
+- `priority-extreme` — production outage, data loss, or an active security incident.
+- `priority-high` — security hardening or a release-blocking regression.
+- `priority-medium` — ordinary bug fixes and net-new features (also the default reading of unset).
+- `priority-low` — cosmetic, docs-only, dependency bumps, follow-up cleanup.
+
+When no risk label is set, infer one:
+
+- `risk-high` — auth, sessions, data scoping, money, schema migrations, shared contract surfaces, or broad cross-cutting edits.
+- `risk-medium` — an ordinary single-area change that ships with tests (also the default reading of unset).
+- `risk-low` — docs-only, test-only, typo, or isolated cosmetic changes.
+
+When signals conflict, pick the higher label and say why in the label comment. A `risk-high` PR strengthens the case for `needs-qa` and deeper review even when it would otherwise look routine.
+
+One label lives outside this taxonomy: `do-not-close`, applied by humans to issues that housekeeping skills must never auto-close. Skills only ever read it.
+
+## The QA gate
+
+The one hard rule of this process: **a PR carrying `needs-qa` must not merge until it also carries `qa-approved`, even when every other check is green.** `om-merge-buddy` classifies such a PR as blocked; `om-approve-merge-pr` refuses to merge it.
+
+- Apply `needs-qa` to UI changes, new features, and other user-facing behavior that needs manual exercise.
+- `skip-qa` is the explicit opt-out for docs-only, dependency-only, CI-only, test-only, and similarly low-risk non-user-facing changes. Never combine it with `needs-qa`.
+- `qa-failed`, `do-not-merge`, and `blocked` are hard blocks regardless of every other signal. An active `qa` pipeline label means a tester is on the PR right now — never merge under an active tester.
+- The gate is satisfied when a QA reviewer tests the PR and applies `qa-approved`.
+- **Self-QA exception**: when no QA reviewer has capacity in time, any engineer may sign off instead — but only by (1) checking the PR out and running it locally, (2) exercising the affected flow, and (3) attaching evidence to the PR: a screenshot of it working, or a written account of what was exercised and the observed result. Then apply both `qa-approved` (so the gate passes) and `qa-self-verified` (so the exception is auditable). No evidence, no `qa-approved`.
+
+## The claim protocol
+
+Before mutating an issue or PR, an agent claims it with all three signals: it assigns itself, adds the `in-progress` label, and posts a claim comment saying what it is doing. Any agent that finds an existing claim backs off instead of colliding. A PR carrying `in-progress` is also skipped by the merge tooling.
+
+The claim is released when the work finishes — on success and on failure alike. A stale `in-progress` with no recent activity may be cleared by the maintainer.
+
+## Validation gate
+
+Every PR passes the full validation gate before review sign-off, in this order:
+
+- `npm run typecheck`
+- `npm run build`
+
+Any non-zero exit fails the gate and blocks the PR. The implementing skills run the gate before opening a PR, and `om-check-and-commit` runs it before pushing a hand-worked branch. The command list lives in `.ai/agentic.config.json`; when it changes, update it there and in this section together.
+
+## Amending this process
+
+This document and `.ai/agentic.config.json` describe the same process: change them together, and re-run the `om-setup-agent-pipeline` skill when the toolchain or label taxonomy changes. Per-skill deviations — extra review rules, a different PR body template, an added gate step — belong in a repo-local skill of the same name at `.ai/skills/<skill-name>/SKILL.md`, which takes precedence over the installed skill (and can `@`-import or reference it to extend rather than replace it); local rules win, but a repo-local skill cannot grant what the installed skill's safety rules forbid.


### PR DESCRIPTION
## Goal

when starting new task with screenshot pasted or attachment pasted it should be displayed in the thread

## Progress log

- 2026-07-13T09:43:27.997Z — step "task" complete — status=done
- 2026-07-13T09:41:36.546Z — turn complete — status=waiting
- 2026-07-13T11:41:22+02:00 — created issue open-mercato/cezar#347: finished tasks stuck in waiting/'needs you' + queue slot saturation; proposed CEZ:DONE / CEZ:NEEDS-INPUT marker in HANDOFF_INSTRUCTIONS + slot release for waiting runs
- 2026-07-13T09:38:18.414Z — turn complete — status=waiting
- 2026-07-13T11:38:08+02:00 — created issue open-mercato/cezar#346: better markdown rendering in conversation history (renderMarkdown gaps: tables, em/del, nested lists, paragraph joining)
- 2026-07-13T09:35:14.325Z — turn complete — status=waiting
- 2026-07-13T11:34:58+02:00 — pipeline setup: wrote .ai/agentic.config.json + .ai/trackers/github.md + SDLC/AGENTS/CODE_REVIEW/BACKWARD_COMPATIBILITY docs (uncommitted, primary checkout); all taxonomy labels already existed
- 2026-07-13T11:34:58+02:00 — duplicate search (4 queries + open PRs): none found; spec 002 partially covers (delivery, not display)
- 2026-07-13T11:34:58+02:00 — created issue open-mercato/cezar#345 with file/line-level implementation plan (run.ts persistImage reuse + app.js renderer)

---

🤖 made with cezar