### PR TITLE
feat(runs): display user-pasted screenshots in the run thread (#345)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -37,7 +37,8 @@ interface ActiveRun {
   currentStepId?: string;
   idleTimer?: NodeJS.Timeout;
   autosaveTimer?: NodeJS.Timeout;
-  /** Running counter for persisted agent screenshots (`screenshot-<n>.png`). */
+  /** Running counter for persisted images — agent screenshots
+   *  (`screenshot-<n>.png`) and user-pasted ones (`pasted-<n>.png`). */
   imageSeq?: number;
 }
 
@@ -215,11 +216,15 @@ export class RunManager {
       .map((b) => b.text)
       .join('\n');
     const imageCount = content.filter((b) => b.type === 'image').length;
+    // `images` is additive next to the legacy `imageCount` (kept for old
+    // transcripts and readers — BACKWARD_COMPATIBILITY.md surface #2).
+    const images = this.persistUserImages(runId, state, content);
     this.store.appendEvent(runId, {
       type: 'user-message',
       stepId: state.currentStepId,
       text,
       imageCount,
+      ...(images.length ? { images } : {}),
     });
 
     const delivered = state.session.sendMessage(content);
@@ -628,11 +633,20 @@ export class RunManager {
       userPrompt += `\n\nA verification command failed after the previous attempt. Fix the cause. Failing output:\n\n${checkFailure}`;
     }
     if (images?.length) {
-      emit({
-        type: 'note',
-        stepId: step.id,
-        message: `${images.length} screenshot${images.length > 1 ? 's' : ''} attached to the task`,
-      });
+      // Task screenshots render in the thread like agent ones, marked as the
+      // user's (spec: issue #345). Falls back to the old text note when none
+      // could be persisted, so the attachment is never silently invisible.
+      const saved = this.persistUserImages(runId, state, images);
+      for (const file of saved) {
+        emit({ type: 'image', stepId: step.id, origin: 'user', ...file });
+      }
+      if (!saved.length) {
+        emit({
+          type: 'note',
+          stepId: step.id,
+          message: `${images.length} screenshot${images.length > 1 ? 's' : ''} attached to the task`,
+        });
+      }
     }
 
     const sessionId = randomUUID();
@@ -758,6 +772,7 @@ export class RunManager {
     state: ActiveRun,
     mediaType: string,
     data: string,
+    prefix = 'screenshot',
   ): { name: string; url: string } | null {
     try {
       const ext =
@@ -767,7 +782,7 @@ export class RunManager {
         : /gif/.test(mediaType) ? 'gif'
         : 'img';
       state.imageSeq = (state.imageSeq ?? 0) + 1;
-      const name = `screenshot-${state.imageSeq}.${ext}`;
+      const name = `${prefix}-${state.imageSeq}.${ext}`;
       const dir = join(this.dataDir, 'runs', `${runId}-images`);
       mkdirSync(dir, { recursive: true });
       writeFileSync(join(dir, name), Buffer.from(data, 'base64'));
@@ -775,6 +790,24 @@ export class RunManager {
     } catch {
       return null;
     }
+  }
+
+  /** Persist the image blocks of a user message (pasted/attached screenshots)
+   *  as `pasted-<n>.<ext>` files so the thread can render them like agent
+   *  screenshots. Same guarantee as `persistImage`: only `{name, url}` ever
+   *  reaches the NDJSON log, never the base64 bytes. */
+  private persistUserImages(
+    runId: string,
+    state: ActiveRun,
+    blocks: ContentBlock[],
+  ): { name: string; url: string }[] {
+    const saved: { name: string; url: string }[] = [];
+    for (const block of blocks) {
+      if (block.type !== 'image') continue;
+      const file = this.persistImage(runId, state, block.source.media_type, block.source.data, 'pasted');
+      if (file) saved.push(file);
+    }
+    return saved;
   }
 
   private armIdleTimer(runId: string, state: ActiveRun): void {

--- a/test/user-images.test.ts
+++ b/test/user-images.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for issue #345 — user-pasted screenshots must be persisted
+ * like agent ones and referenced from the transcript, while the base64 bytes
+ * stay out of the NDJSON log (BACKWARD_COMPATIBILITY.md surface #1/#2).
+ *
+ * Run with: npm test  (node --import tsx --test test/)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { RunStore } from '../src/runs/store.js';
+import { RunManager } from '../src/workflows/run.js';
+import type { ContentBlock } from '../src/core/agent-runner.js';
+
+// 1x1 transparent PNG
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+function setup() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'cezar-test-'));
+  const store = RunStore.open(join(repoRoot, '.ai/cezar'));
+  const manager = new RunManager(store, repoRoot);
+  const run = store.createRun({
+    title: 'test',
+    workflow: 'task',
+    task: 'test task',
+    steps: [{ id: 'task', name: 'task', kind: 'agent' }],
+  });
+  // Inject a live session the way execute() would have — sendMessage refuses
+  // to run without one.
+  const state = {
+    cancelled: false,
+    interrupt: () => undefined,
+    cwd: repoRoot,
+    currentStepId: 'task',
+    session: { open: true, sendMessage: () => true, end: () => undefined },
+  };
+  (manager as unknown as { active: Map<string, unknown> }).active.set(run.id, state);
+  return { repoRoot, store, manager, run };
+}
+
+test('sendMessage persists pasted images and references them from the user-message event', () => {
+  const { repoRoot, store, manager, run } = setup();
+  try {
+    const content: ContentBlock[] = [
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_B64 } },
+      { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: PNG_B64 } },
+      { type: 'text', text: 'look at these' },
+    ];
+    assert.equal(manager.sendMessage(run.id, content), true);
+
+    const evt = store.readEvents(run.id).find((e) => e.type === 'user-message');
+    assert.ok(evt, 'user-message event appended');
+    assert.equal(evt.text, 'look at these');
+    assert.equal(evt.imageCount, 2, 'legacy imageCount field kept');
+    const images = evt.images as Array<{ name: string; url: string }>;
+    assert.equal(images.length, 2);
+    assert.deepEqual(images[0], {
+      name: 'pasted-1.png',
+      url: `/api/runs/${run.id}/images/pasted-1.png`,
+    });
+    assert.deepEqual(images[1], {
+      name: 'pasted-2.jpg',
+      url: `/api/runs/${run.id}/images/pasted-2.jpg`,
+    });
+
+    for (const img of images) {
+      const file = join(repoRoot, '.ai/cezar/runs', `${run.id}-images`, img.name);
+      assert.ok(existsSync(file), `${img.name} written to the run's images dir`);
+    }
+
+    const ndjson = readFileSync(join(repoRoot, '.ai/cezar/runs', `${run.id}.ndjson`), 'utf8');
+    assert.ok(!ndjson.includes(PNG_B64), 'base64 bytes never enter the NDJSON log');
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('sendMessage without images keeps the old event shape (no images field)', () => {
+  const { repoRoot, store, manager, run } = setup();
+  try {
+    assert.equal(manager.sendMessage(run.id, [{ type: 'text', text: 'just text' }]), true);
+    const evt = store.readEvents(run.id).find((e) => e.type === 'user-message');
+    assert.ok(evt);
+    assert.equal(evt.imageCount, 0);
+    assert.ok(!('images' in evt), 'no empty images field on text-only messages');
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/web/app.js
+++ b/web/app.js
@@ -2013,6 +2013,21 @@ function appendToStreak(inner, el) {
   }
 }
 
+/** Lightboxed image card — agent screenshots, and (spec: issue #345) the
+ *  user's own pasted/attached screenshots in `image` and `user-message`
+ *  events. Every interpolated value goes through esc(). */
+function imgCardHtml(url, name) {
+  return `
+        <div class="img-card" data-lightbox="${esc(url)}" data-name="${esc(name)}" title="Click to zoom">
+          <img src="${esc(url)}" alt="${esc(name)}" loading="lazy">
+          <div class="img-foot">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--text3)" stroke-width="1.8" stroke-linejoin="round"><path d="M4 5h16v14H4z"/><path d="M4 15l5-5 4 4 3-3 4 4"/><circle cx="9.5" cy="9.5" r="1.1"/></svg>
+            <span class="nm">${esc(name)}</span>
+            <span class="zm">click to zoom</span>
+          </div>
+        </div>`;
+}
+
 function appendLog(evt) {
   const inner = $('#log-inner');
   const log = $('#log');
@@ -2058,16 +2073,10 @@ function appendLog(evt) {
       break;
     }
     case 'image':
-      el.className = 'ev image-ev';
-      el.innerHTML = `
-        <div class="img-card" data-lightbox="${esc(evt.url)}" data-name="${esc(evt.name)}" title="Click to zoom">
-          <img src="${esc(evt.url)}" alt="${esc(evt.name)}" loading="lazy">
-          <div class="img-foot">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--text3)" stroke-width="1.8" stroke-linejoin="round"><path d="M4 5h16v14H4z"/><path d="M4 15l5-5 4 4 3-3 4 4"/><circle cx="9.5" cy="9.5" r="1.1"/></svg>
-            <span class="nm">${esc(evt.name)}</span>
-            <span class="zm">click to zoom</span>
-          </div>
-        </div>`;
+      // `origin: 'user'` marks a pasted/attached screenshot — same card,
+      // aligned/styled as the user's own content. Absent on old transcripts.
+      el.className = `ev image-ev${evt.origin === 'user' ? ' user-img' : ''}`;
+      el.innerHTML = imgCardHtml(evt.url, evt.name);
       break;
     case 'step-start':
       el.className = 'ev step';
@@ -2087,8 +2096,15 @@ function appendLog(evt) {
       break;
     case 'user-message': {
       el.className = 'ev user';
-      const imgs = evt.imageCount > 0 ? ` [${evt.imageCount} image${evt.imageCount > 1 ? 's' : ''}]` : '';
-      el.innerHTML = `<div class="bubble">${esc(`${evt.text ?? ''}${imgs}`)}</div>`;
+      // New transcripts carry `images: [{name, url}]`; old ones only
+      // `imageCount`, which keeps rendering as the text placeholder.
+      const files = Array.isArray(evt.images) ? evt.images.filter((f) => f && f.url && f.name) : [];
+      const imgs = !files.length && evt.imageCount > 0 ? ` [${evt.imageCount} image${evt.imageCount > 1 ? 's' : ''}]` : '';
+      const thumbs = files.length
+        ? `<div class="bubble-imgs">${files.map((f) => imgCardHtml(f.url, f.name)).join('')}</div>`
+        : '';
+      const text = `${evt.text ?? ''}${imgs}`;
+      el.innerHTML = `${thumbs}${text.trim() ? `<div class="bubble">${esc(text)}</div>` : ''}`;
       break;
     }
     case 'error':

--- a/web/style.css
+++ b/web/style.css
@@ -994,7 +994,10 @@ main { flex: 1; min-width: 0; display: flex; min-height: 0; background: var(--bg
   max-height: 260px;
 }
 
-.ev.user { display: flex; justify-content: flex-end; margin: 12px 0; }
+.ev.user { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; margin: 12px 0; }
+/* Pasted/attached screenshots inside a user message (issue #345) */
+.ev.user .bubble-imgs { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; max-width: 75%; }
+.ev.user .bubble-imgs .img-card { max-width: 260px; }
 .ev.user .bubble {
   max-width: 75%;
   padding: 10px 15px;
@@ -1007,6 +1010,10 @@ main { flex: 1; min-width: 0; display: flex; min-height: 0; background: var(--bg
 }
 
 .ev.image-ev { margin: 11px 0; }
+/* Task-start screenshot pasted by the user (`image` event, origin: 'user') —
+   right-aligned so it reads as "sent by me", like the user bubble. */
+.ev.image-ev.user-img { display: flex; justify-content: flex-end; }
+.ev.image-ev.user-img .img-card { max-width: 260px; }
 .img-card {
   display: inline-block;
   border: 1px solid var(--line2);


### PR DESCRIPTION
Fixes #345

## Problem
Screenshots pasted into the new-task form or a follow-up message reach the agent but never appear in the run thread — the transcript only shows the text line `· N screenshot(s) attached to the task` (task start) or `[N images]` inside the user bubble (follow-ups), while agent screenshots render as image cards.

## Root Cause
Only agent screenshots used the display pipeline (`persistImage` → `image` event `{name, url}` → `GET /api/runs/:id/images/:file` → lightboxed card). The two user-image paths bypassed it: `runAgentStep` emitted only a `note` event and `RunManager.sendMessage` persisted only an `imageCount` on the `user-message` event — the bytes were never written to disk, so there was nothing to render.

## What Changed
- `src/workflows/run.ts` — `persistImage` gained a name-prefix parameter; new `persistUserImages` helper stores user image blocks as `pasted-<n>.<ext>` under `.ai/cezar/runs/<id>-images/`. Task-start images emit one `image` event per saved file with `origin: 'user'` (the old text note remains as a fallback when persistence fails); follow-up images ride on the `user-message` event as `images: [{name, url}]` next to the legacy `imageCount`.
- `web/app.js` — shared `imgCardHtml` helper; `image` events with `origin: 'user'` render as a right-aligned user variant; `user-message` events with `images` render thumbnails in the bubble, falling back to the `[N images]` text for old transcripts. Every interpolated value goes through `esc()`.
- `web/style.css` — user-aligned image card and in-bubble thumbnail styles.
- No server route changes; base64 never enters the NDJSON log.

## Tests
- New `test/user-images.test.ts` (node:test via tsx, wired as `npm test`): follow-up images are persisted to disk, referenced as `{name, url}` from the `user-message` event, and no base64 lands in the NDJSON; text-only messages keep the old event shape.
- Full validation gate green: `npm run typecheck`, `npm run build`.

## Breaking Changes
None — new optional `images` field on `user-message` and optional `origin` field on `image` events (additive per `BACKWARD_COMPATIBILITY.md` surface #2); old transcripts render unchanged.

🤖 Generated by autofix.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
