### PR TITLE
fix: 0.1.1 feedback round — queue slots, restart resume, update discovery, markdown, queued placeholder

### DIFF
--- a/alias-cezar/package.json
+++ b/alias-cezar/package.json
@@ -1,10 +1,10 @@
 {
   "name": "cezar-cli",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Alias for @pat-lewczuk/cezar — so `npx cezar-cli` just works. Local cockpit for running and tracking AI agent tasks in your repo.",
   "license": "MIT",
   "type": "module",
   "bin": { "cezar-cli": "bin.js", "cezar": "bin.js", "cez": "bin.js" },
-  "dependencies": { "@pat-lewczuk/cezar": "^0.1.1" },
+  "dependencies": { "@pat-lewczuk/cezar": "^0.1.3" },
   "publishConfig": { "access": "public" }
 }

--- a/scripts/mock-claude.mjs
+++ b/scripts/mock-claude.mjs
@@ -70,6 +70,44 @@ async function respond(userText, imageCount) {
   // completion marker (#347), so the auto-close path is testable dry.
   const doneMarker = userText.includes('mock:done') ? '\n\nCEZ:DONE' : '';
 
+  // `mock:slow` → hold the turn for ~25 s so queue states are observable.
+  if (userText.includes('mock:slow')) await sleep(25_000);
+
+  // `mock:md` → answer with a markdown-rich reply (#346 QA: tables, nested
+  // lists, emphasis, fences, quotes) instead of the scripted turn.
+  if (userText.includes('mock:md')) {
+    const md = [
+      '## Markdown fixture',
+      'This paragraph is soft-wrapped\nacross two source lines.',
+      '',
+      '| Column | Align | Result |',
+      '|:-------|:-----:|-------:|',
+      '| left `code` | *center* | **42** |',
+      '| ~~old~~ new | mid | $1.50 |',
+      '',
+      '- top item with *emphasis*',
+      '  - nested child with `code`',
+      '    - [x] deep done task',
+      '  - [ ] nested todo',
+      '- second top',
+      '',
+      '> quoted intro',
+      '> - quoted list item',
+      '',
+      '```ts',
+      'const answer: number = 42;',
+      '```',
+      'Literal guards: snake_case_name, 2*3 and <script>alert(1)</script>.',
+    ].join('\n');
+    emit({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: md }], usage: { input_tokens: 100, output_tokens: 200 } },
+    });
+    await sleep(100);
+    emit({ type: 'result', subtype: 'success', result: md, usage: { input_tokens: 100, output_tokens: 200 }, total_cost_usd: 0.001 });
+    return;
+  }
+
   // Spec 008: a planning call (marked `[cez-planner]` in the user prompt)
   // gets a canned chain plan. The `code-review` skill is deliberately made up:
   // the planner's sanitizer strips unknown skills, and the step survives on

--- a/scripts/mock-claude.mjs
+++ b/scripts/mock-claude.mjs
@@ -66,6 +66,9 @@ function writeHandoffAndTodo() {
 async function respond(userText, imageCount) {
   turn += 1;
   await sleep(250);
+  // `mock:done` anywhere in the message → the reply ends with the CEZ:DONE
+  // completion marker (#347), so the auto-close path is testable dry.
+  const doneMarker = userText.includes('mock:done') ? '\n\nCEZ:DONE' : '';
 
   // Spec 008: a planning call (marked `[cez-planner]` in the user prompt)
   // gets a canned chain plan. The `code-review` skill is deliberately made up:
@@ -167,7 +170,7 @@ async function respond(userText, imageCount) {
       type: 'assistant',
       message: {
         role: 'assistant',
-        content: [{ type: 'text', text: 'Done with the first pass — opened a draft PR: https://github.com/open-mercato/demo/pull/123. Anything to adjust? (dry-run mock)' }],
+        content: [{ type: 'text', text: `Done with the first pass — opened a draft PR: https://github.com/open-mercato/demo/pull/123. Anything to adjust? (dry-run mock)${doneMarker}` }],
         usage: { input_tokens: 300, output_tokens: 90 },
       },
     });
@@ -187,7 +190,7 @@ async function respond(userText, imageCount) {
     type: 'assistant',
     message: {
       role: 'assistant',
-      content: [{ type: 'text', text: `Follow-up #${turn - 1} received: "${userText.slice(0, 100)}".${imgNote} Applied (dry run).` }],
+      content: [{ type: 'text', text: `Follow-up #${turn - 1} received: "${userText.slice(0, 100)}".${imgNote} Applied (dry run).${doneMarker}` }],
       usage: { input_tokens: 200, output_tokens: 60 },
     },
   });

--- a/scripts/test-process-usage.mjs
+++ b/scripts/test-process-usage.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Unit check for the pure half of src/core/process-usage.ts (#348): ps-output
+// parsing + process-tree aggregation against canned `ps -axo pid=,ppid=,rss=,%cpu=`
+// output. Dependency-free; needs `npm run build` first (imports from dist/).
+//   node scripts/test-process-usage.mjs
+
+import assert from 'node:assert/strict';
+import { aggregateTreeUsage, parsePsOutput } from '../dist/core/process-usage.js';
+
+// Canned snapshot: two registered roots (100, 200) plus unrelated noise.
+// Root 100 owns a 3-level tree: 100 → 110 → 111, and 100 → 120.
+const PS_OUTPUT = `
+    1     0  1200   0.1
+  100     1 50000  10.0
+  110   100 20000   5.5
+  111   110  8000   0.0
+  120   100  4000   2.5
+  200     1 30000  50.0
+  210   200 10000  25.0
+  999     1 70000  99.0
+garbage line that ps should never emit
+  300   1
+`;
+
+const procs = parsePsOutput(PS_OUTPUT);
+assert.equal(procs.length, 8, 'parses 8 well-formed rows, skips malformed ones');
+assert.deepEqual(procs[1], { pid: 100, ppid: 1, rssKb: 50000, cpuPct: 10 });
+
+// Root 100: 4 processes across 3 levels; rss in KB × 1024 → bytes.
+const a = aggregateTreeUsage(procs, 100);
+assert.deepEqual(a, {
+  cpuPct: 18,
+  rssBytes: (50000 + 20000 + 8000 + 4000) * 1024,
+  procCount: 4,
+});
+
+// Root 200: 2 processes; the other tree's processes never leak in.
+const b = aggregateTreeUsage(procs, 200);
+assert.deepEqual(b, { cpuPct: 75, rssBytes: (30000 + 10000) * 1024, procCount: 2 });
+
+// A root missing from the snapshot (process exited) → null, not zeros.
+assert.equal(aggregateTreeUsage(procs, 12345), null);
+
+// A leaf works as a root of its own single-node tree.
+assert.deepEqual(aggregateTreeUsage(procs, 111), { cpuPct: 0, rssBytes: 8000 * 1024, procCount: 1 });
+
+console.log('process-usage: all assertions passed');

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -107,6 +107,10 @@ export interface SessionOptions {
 export interface AgentSession {
   /** Resolves when the backend process exits — the session is fully over. */
   result: Promise<AgentRunResult>;
+  /** OS pid of the spawned backend process — the root of the run's process
+   *  tree (agents spawn Bash children under it). Absent when the spawn
+   *  failed before a pid existed. Feeds live resource telemetry (#348). */
+  readonly pid?: number;
   /** Write a user message into the live session. False when it is closed. */
   sendMessage(content: ContentBlock[]): boolean;
   /** Graceful close: end input, then a SIGTERM→SIGKILL watchdog. */

--- a/src/core/claude-cli-runner.ts
+++ b/src/core/claude-cli-runner.ts
@@ -256,6 +256,7 @@ export class ClaudeCliRunner implements AgentRunner {
       sendMessage,
       end,
       interrupt,
+      pid: child.pid,
       get open() {
         return stdinOpen;
       },

--- a/src/core/codex-app-server-runner.ts
+++ b/src/core/codex-app-server-runner.ts
@@ -201,6 +201,10 @@ class CodexSession implements AgentSession {
     return this.stdinOpen;
   }
 
+  get pid(): number | undefined {
+    return this.child.pid;
+  }
+
   sendMessage(content: ContentBlock[]): boolean {
     if (!this.stdinOpen) return false;
     if (this.autoEndTimer) {

--- a/src/core/opencode-server-runner.ts
+++ b/src/core/opencode-server-runner.ts
@@ -180,6 +180,10 @@ class OpencodeSession implements AgentSession {
     return this.serverOpen;
   }
 
+  get pid(): number | undefined {
+    return this.child.pid;
+  }
+
   sendMessage(content: ContentBlock[]): boolean {
     if (!this.serverOpen) return false;
     if (this.autoEndTimer) {

--- a/src/core/process-usage.ts
+++ b/src/core/process-usage.ts
@@ -1,0 +1,203 @@
+/**
+ * Live process telemetry for the Runs table (#348): while any run has a
+ * registered backend process, ONE `ps` snapshot every ~2 s is aggregated per
+ * run over the process's full descendant tree (the CLI plus every Bash child
+ * an agent spawned) into `{ cpuPct, rssBytes, procCount }`.
+ *
+ * Design constraints, in order:
+ *  - never affect a run — a missing/failing `ps` (Windows, exotic containers)
+ *    degrades silently to "no data";
+ *  - one shared sampler, not one per run — N parallel runs still cost a
+ *    single `ps` every tick, and the timer is unref()ed and stopped the
+ *    moment the registry empties, so an idle cockpit spawns nothing;
+ *  - parsing + tree aggregation are pure functions, testable against canned
+ *    `ps` output (scripts/test-process-usage.mjs).
+ */
+
+import { execFile } from 'node:child_process';
+
+/** One aggregated sample for a run's process tree. */
+export interface ProcessUsage {
+  /** Sum of `%cpu` across the tree — can exceed 100 on multi-core work. */
+  cpuPct: number;
+  /** Sum of resident set sizes, in bytes. */
+  rssBytes: number;
+  /** Number of live processes in the tree, the root included. */
+  procCount: number;
+}
+
+/** One parsed `ps` row (`pid ppid rss %cpu`; rss is in KB, ps's unit). */
+export interface ProcStat {
+  pid: number;
+  ppid: number;
+  rssKb: number;
+  cpuPct: number;
+}
+
+/**
+ * Parse `ps -axo pid=,ppid=,rss=,%cpu=` output (the `=` suffixes suppress
+ * headers on darwin and linux alike). Malformed lines are skipped — `ps`
+ * racing process exits can truncate rows.
+ */
+export function parsePsOutput(text: string): ProcStat[] {
+  const out: ProcStat[] = [];
+  for (const line of text.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 4) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    const rssKb = Number(parts[2]);
+    const cpuPct = Number(parts[3]);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    out.push({
+      pid,
+      ppid,
+      rssKb: Number.isFinite(rssKb) && rssKb > 0 ? rssKb : 0,
+      cpuPct: Number.isFinite(cpuPct) && cpuPct > 0 ? cpuPct : 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * Aggregate the full descendant tree rooted at `rootPid` from one `ps`
+ * snapshot. Null when the root is gone (process exited between register and
+ * sample) — callers treat that as "no data", not zero usage.
+ */
+export function aggregateTreeUsage(procs: ProcStat[], rootPid: number): ProcessUsage | null {
+  const byPid = new Map<number, ProcStat>();
+  const children = new Map<number, number[]>();
+  for (const p of procs) {
+    byPid.set(p.pid, p);
+    const siblings = children.get(p.ppid);
+    if (siblings) siblings.push(p.pid);
+    else children.set(p.ppid, [p.pid]);
+  }
+  if (!byPid.has(rootPid)) return null;
+
+  let cpuPct = 0;
+  let rssKb = 0;
+  let procCount = 0;
+  const queue = [rootPid];
+  const seen = new Set<number>(); // pid-reuse in a torn snapshot can't loop us
+  while (queue.length > 0) {
+    const pid = queue.pop() as number;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    const p = byPid.get(pid);
+    if (!p) continue;
+    cpuPct += p.cpuPct;
+    rssKb += p.rssKb;
+    procCount += 1;
+    for (const child of children.get(pid) ?? []) queue.push(child);
+  }
+  return { cpuPct: Math.round(cpuPct * 10) / 10, rssBytes: rssKb * 1024, procCount };
+}
+
+// ---- registry + sampler -----------------------------------------------------
+
+export const SAMPLE_INTERVAL_MS = 2_000;
+
+interface Entry {
+  pid: number;
+  last?: ProcessUsage;
+  peakRssBytes: number;
+  peakProcCount: number;
+}
+
+type UsageListener = (usage: Record<string, ProcessUsage>) => void;
+
+const entries = new Map<string, Entry>();
+const listeners = new Set<UsageListener>();
+let timer: NodeJS.Timeout | null = null;
+let sampling = false;
+
+/** Start tracking a run's process tree. A re-register (a run's next agent
+ *  step) replaces the pid but keeps nothing else — peaks are per session and
+ *  the engine maxes them into the run record on unregister. */
+export function registerRunProcess(runId: string, pid: number): void {
+  entries.set(runId, { pid, peakRssBytes: 0, peakProcCount: 0 });
+  if (!timer && process.platform !== 'win32') {
+    timer = setInterval(() => void sample(), SAMPLE_INTERVAL_MS);
+    timer.unref?.();
+    void sample(); // first data point right away, not 2 s late
+  }
+}
+
+/** Stop tracking; returns the session's peaks (undefined when no sample ever
+ *  landed — `ps` unavailable, or the process died before the first tick). */
+export function unregisterRunProcess(
+  runId: string,
+): { peakRssBytes: number; peakProcCount: number } | undefined {
+  const entry = entries.get(runId);
+  entries.delete(runId);
+  if (entries.size === 0 && timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  if (!entry || entry.peakProcCount === 0) return undefined;
+  return { peakRssBytes: entry.peakRssBytes, peakProcCount: entry.peakProcCount };
+}
+
+/** Latest sample for one run, if any. */
+export function currentUsage(runId: string): ProcessUsage | undefined {
+  return entries.get(runId)?.last;
+}
+
+/** Latest samples for every registered run that has data. */
+export function allUsage(): Record<string, ProcessUsage> {
+  const out: Record<string, ProcessUsage> = {};
+  for (const [runId, entry] of entries) {
+    if (entry.last) out[runId] = entry.last;
+  }
+  return out;
+}
+
+/** Subscribe to fresh samples (fires ~every 2 s while runs are registered);
+ *  returns the unsubscribe. The SSE endpoint relays these to the GUI. */
+export function onUsage(listener: UsageListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+async function sample(): Promise<void> {
+  if (sampling || entries.size === 0) return;
+  sampling = true;
+  try {
+    const text = await runPs();
+    if (text === null) return; // ps unavailable — degrade to no data
+    const procs = parsePsOutput(text);
+    for (const entry of entries.values()) {
+      const usage = aggregateTreeUsage(procs, entry.pid);
+      entry.last = usage ?? undefined;
+      if (usage) {
+        entry.peakRssBytes = Math.max(entry.peakRssBytes, usage.rssBytes);
+        entry.peakProcCount = Math.max(entry.peakProcCount, usage.procCount);
+      }
+    }
+    if (listeners.size > 0) {
+      const snapshot = allUsage();
+      for (const listener of listeners) {
+        try {
+          listener(snapshot);
+        } catch {
+          // a broken SSE stream must not kill the sampler
+        }
+      }
+    }
+  } finally {
+    sampling = false;
+  }
+}
+
+/** One system-wide snapshot; null on any failure (no ps, weird exit). */
+function runPs(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      'ps',
+      ['-axo', 'pid=,ppid=,rss=,%cpu='],
+      { maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout) => resolve(err ? null : stdout),
+    );
+  });
+}

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -123,6 +123,8 @@ CEZ_HANDOFF_FILE (env) is the absolute path to this task's rolling handoff file.
 2. After every meaningful milestone (passing tests, a commit, a PR, a scope decision), append one terse timestamped line under "## Progress log", newest at the top.
 3. Before finishing or pausing, update "## Resume notes" with what's done, what's next and any blockers. Leave it empty only when the task is truly complete.
 
+Task completion marker: when the task's goal is fully achieved and you have no question for the user, end your final message with a line containing exactly CEZ:DONE — cez then closes the session and marks the task finished. If you are waiting on the user (a question, a decision, missing input), just end your message normally; the session stays open for their reply. Never emit CEZ:DONE while anything is unfinished or unverified.
+
 CEZ_TODOS_FILE (env) is the absolute path to the user's follow-up inbox — a JSON array. When you finish the task and a concrete follow-up remains for the user or a next agent, read the file (treat a missing file as []), append ONE object and write the whole array back:
 { "ts": "<ISO 8601>", "taskId": "<value of CEZ_TASK_ID>", "summary": "<one sentence: what was done / what's next>", "action": "<imperative user action, optional>", "prUrl": "<optional>", "suggestedSkill": "<optional skill name for the follow-up>", "suggestedArgs": "<optional>", "suggestedPrompt": "<optional freeform prompt for the follow-up task>" }
 Never modify or remove existing entries — append only.`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,9 @@ async function main(): Promise<void> {
 // ---- serve -----------------------------------------------------------------
 
 async function serveCommand(repoRoot: string, preferredPort: number, openBrowser: boolean): Promise<void> {
-  const store = openStore(repoRoot);
+  // keepLive + recover() (#367): runs that were queued/running/waiting when
+  // the previous process exited are re-queued or resumed instead of failed.
+  const store = openStore(repoRoot, { keepLive: true });
   const manager = new RunManager(store, repoRoot);
   const version = readOwnVersion();
 
@@ -92,6 +94,12 @@ async function serveCommand(repoRoot: string, preferredPort: number, openBrowser
       console.log(`  cleaned ${orphans.length} orphaned worktree(s): ${orphans.map((id) => id.slice(0, 8)).join(', ')}`);
     }
   }
+
+  const recovered = store
+    .listRuns()
+    .filter((r) => ['queued', 'waiting', 'running'].includes(r.status)).length;
+  await manager.recover();
+  if (recovered > 0) console.log(`  recovered ${recovered} run(s) from the previous session`);
 
   const port = await pickPort(preferredPort);
   startServer({ repoRoot, store, manager, version }, port);
@@ -277,9 +285,9 @@ description: House rules the agent should follow in this repo.
 
 // ---- helpers -----------------------------------------------------------------
 
-function openStore(repoRoot: string): RunStore {
+function openStore(repoRoot: string, opts?: { keepLive?: boolean }): RunStore {
   const dataDir = join(repoRoot, '.ai/cezar');
-  const store = RunStore.open(dataDir);
+  const store = RunStore.open(dataDir, opts);
   ensureDataGitignore(repoRoot);
   return store;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { RunStore } from './runs/store.js';
 import { RunManager } from './workflows/run.js';
 import { loadWorkflows } from './workflows/load.js';
 import { startServer } from './server/server.js';
+import { checkForUpdate } from './update-check.js';
 
 const HELP = `cezar — local cockpit for AI agent tasks in your repo
 
@@ -101,8 +102,18 @@ async function serveCommand(repoRoot: string, preferredPort: number, openBrowser
   await manager.recover();
   if (recovered > 0) console.log(`  recovered ${recovered} run(s) from the previous session`);
 
+  // Update discovery (#368) — fire-and-forget; the banner prints whenever the
+  // registry answers and /api/health picks it up for the GUI chip.
+  const pkgName = readOwnName();
+  const update: { latest?: string } = {};
+  void checkForUpdate(pkgName, version).then((latest) => {
+    if (!latest) return;
+    update.latest = latest;
+    console.log(`\n  ⬆ cezar ${latest} is available (running ${version}) — restart with: npx ${pkgName}@latest\n`);
+  });
+
   const port = await pickPort(preferredPort);
-  startServer({ repoRoot, store, manager, version }, port);
+  startServer({ repoRoot, store, manager, version, update }, port);
   const url = `http://localhost:${port}`;
 
   console.log(`\n  cezar v${version} — ${repoRoot}`);
@@ -307,6 +318,17 @@ function ensureDataGitignore(repoRoot: string): void {
     }
   } catch {
     // non-fatal
+  }
+}
+
+/** Own package name — for the npm-registry update check (#368). */
+function readOwnName(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')) as { name?: string };
+    return pkg.name ?? '@pat-lewczuk/cezar';
+  } catch {
+    return '@pat-lewczuk/cezar';
   }
 }
 

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -62,6 +62,11 @@ const runRecordSchema = z.object({
   currentStepId: z.string().optional(),
   error: z.string().optional(),
   steps: z.array(stepStateSchema),
+  /** Full workflow definition, persisted so a `queued` run can be re-enqueued
+   *  after a restart (#367) — including ad-hoc "(planned)" chains that exist
+   *  nowhere else. Kept loose here to avoid an upward import; the run manager
+   *  validates the shape before reviving it. */
+  workflowDef: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type StepState = z.infer<typeof stepStateSchema>;
@@ -96,7 +101,13 @@ export class RunStore extends EventEmitter {
     this.setMaxListeners(100);
   }
 
-  static open(dataDir: string): RunStore {
+  /**
+   * `keepLive` (#367): leave `queued`/`running`/`waiting` statuses untouched
+   * so the caller can recover them (RunManager.recover re-queues queued runs,
+   * resumes interrupted ones). Without it — one-shot CLI paths that never
+   * recover — live-looking runs are marked failed so no ghost stays behind.
+   */
+  static open(dataDir: string, opts?: { keepLive?: boolean }): RunStore {
     mkdirSync(join(dataDir, 'runs'), { recursive: true });
     const store = new RunStore(dataDir);
     const indexPath = join(dataDir, 'runs.json');
@@ -112,9 +123,10 @@ export class RunStore extends EventEmitter {
             // (worktree + branch + record) with no live process, so the diff
             // panel, Send back (resume) and Draft PR all still work.
             if (
-              run.status === 'running' ||
-              run.status === 'queued' ||
-              run.status === 'waiting'
+              !opts?.keepLive &&
+              (run.status === 'running' ||
+                run.status === 'queued' ||
+                run.status === 'waiting')
             ) {
               run.status = 'failed';
               run.error = 'interrupted — cezar process exited during the run';

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -57,6 +57,11 @@ const runRecordSchema = z.object({
   groupId: z.string().optional(),
   /** Variant letter within the group — 'A' | 'B' | 'C' (kept as a string). */
   variant: z.string().optional(),
+  /** Peak resident memory (bytes) / process count observed across the run's
+   *  agent process trees (#348) — written when a session's telemetry ends.
+   *  Optional: old runs.json files and `ps`-less platforms have neither. */
+  peakRssBytes: z.number().optional(),
+  peakProcCount: z.number().optional(),
   archived: z.boolean().default(false),
   archivedAt: z.string().optional(),
   currentStepId: z.string().optional(),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
 import { detectEnvironment } from '../core/backend-detect.js';
 import type { ContentBlock } from '../core/agent-runner.js';
+import { currentUsage, onUsage } from '../core/process-usage.js';
 import { WORKFLOWS_DIR, loadWorkflows } from '../workflows/load.js';
 import {
   QUICK_TASK_WORKFLOW,
@@ -111,6 +112,9 @@ const uiStateSchema = z
     lastTask: z
       .object({ source: z.enum(['workflow', 'skill']), ref: z.string().min(1).max(200) })
       .optional(),
+    // Runs area presentation (#348): the sidebar-list + detail pane, or the
+    // full-width table ("task manager") view.
+    runsView: z.enum(['list', 'table']).optional(),
   })
   .passthrough();
 
@@ -326,7 +330,16 @@ export function createApp(deps: ServerDeps): Hono {
   });
 
   // ---- runs ----------------------------------------------------------------
-  app.get('/api/runs', (c) => c.json(store.listRuns()));
+
+  // Additive `usage` field (#348): the latest CPU/RSS/proc-count sample of the
+  // run's live process tree — absent for finished runs and when `ps` yields
+  // nothing. The stored record itself is never touched.
+  const withUsage = (run: RunRecord): RunRecord & { usage?: ReturnType<typeof currentUsage> } => {
+    const usage = currentUsage(run.id);
+    return usage ? { ...run, usage } : run;
+  };
+
+  app.get('/api/runs', (c) => c.json(store.listRuns().map(withUsage)));
 
   // Registered before the `/:id/...` routes so "archive-finished" never
   // matches as a run id.
@@ -459,7 +472,7 @@ export function createApp(deps: ServerDeps): Hono {
 
   app.get('/api/runs/:id', (c) => {
     const run = store.getRun(c.req.param('id'));
-    return run ? c.json(run) : c.json({ error: 'not found' }, 404);
+    return run ? c.json(withUsage(run)) : c.json({ error: 'not found' }, 404);
   });
 
   app.post('/api/runs/:id/cancel', (c) => {
@@ -720,12 +733,20 @@ export function createApp(deps: ServerDeps): Hono {
         await stream.writeSSE({ event: 'todos', data: JSON.stringify(items) });
       };
       const offTodos = onTodosChanged(() => void sendTodos());
+      // Live resource telemetry (#348): the sampler ticks ~every 2 s only
+      // while some run has a registered process; each tick is relayed as one
+      // `usage` message (runId → {cpuPct, rssBytes, procCount}). Never
+      // persisted — the NDJSON transcripts stay usage-free.
+      const offUsage = onUsage(
+        (usage) => void stream.writeSSE({ event: 'usage', data: JSON.stringify(usage) }),
+      );
       store.on('run', onRun);
       store.on('deleted', onDeleted);
       stream.onAbort(() => {
         store.off('run', onRun);
         store.off('deleted', onDeleted);
         offTodos();
+        offUsage();
       });
       while (!stream.aborted) {
         await stream.writeSSE({ event: 'ping', data: '' });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -40,6 +40,9 @@ export interface ServerDeps {
   store: RunStore;
   manager: RunManager;
   version: string;
+  /** Mutable holder for the async npm-registry update check (#368) —
+   *  `latest` appears once the registry answers with a newer version. */
+  update?: { latest?: string };
 }
 
 // A run starts from a named workflow OR an inline chain of steps (spec 008 —
@@ -130,7 +133,7 @@ const messageSchema = z
   });
 
 export function createApp(deps: ServerDeps): Hono {
-  const { repoRoot, store, manager, version } = deps;
+  const { repoRoot, store, manager, version, update } = deps;
   const dataDir = join(repoRoot, '.ai/cezar');
   startTodosWatch(dataDir); // inbox live updates (spec 007)
   const launchKey = ensureLaunchKey(dataDir); // bookmarklet auto-start secret (spec 011)
@@ -172,7 +175,14 @@ export function createApp(deps: ServerDeps): Hono {
       getRepoInfo(repoRoot),
       loadConfig(repoRoot),
     ]);
-    return c.json({ version, repoRoot, repo, checks, defaultRunner: config.defaultRunner });
+    return c.json({
+      version,
+      latestVersion: update?.latest,
+      repoRoot,
+      repo,
+      checks,
+      defaultRunner: config.defaultRunner,
+    });
   });
 
   // The bookmarklet generator bakes this key into the `javascript:` URLs —

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,0 +1,41 @@
+/**
+ * Update discovery (#368): a best-effort, fire-and-forget check against the
+ * npm registry so the cockpit can tell the user a newer cezar exists — the
+ * root cause behind most "bug already fixed" reports is `npx` happily reusing
+ * a stale cached version forever. Silent on any failure: offline, slow
+ * registry or a weird payload must never affect startup.
+ */
+
+const REGISTRY_TIMEOUT_MS = 3_000;
+
+/** Newest published version when it's newer than `current`, else null. */
+export async function checkForUpdate(pkgName: string, current: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkgName)}/latest`, {
+      signal: AbortSignal.timeout(REGISTRY_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: unknown };
+    const latest = typeof data.version === 'string' ? data.version : null;
+    return latest && isNewerVersion(latest, current) ? latest : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Plain numeric semver compare (`1.2.10` > `1.2.9`); pre-release tags and
+ *  anything unparseable compare as 0 — good enough for release-only publishes. */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const parse = (v: string) =>
+    v
+      .split('.')
+      .slice(0, 3)
+      .map((part) => Number.parseInt(part, 10) || 0);
+  const a = parse(candidate);
+  const b = parse(current);
+  for (let i = 0; i < 3; i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff > 0;
+  }
+  return false;
+}

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -18,6 +18,7 @@ import { materializeSkillDir } from '../skills-remote.js';
 import { loadConfig } from '../config.js';
 import { autosaveCommit, createWorktree, resolveBaseRef, worktreeDiff } from '../git-worktree.js';
 import { getRepoInfo } from '../server/git.js';
+import { loadWorkflows } from './load.js';
 import type { RunRecord, RunStore } from '../runs/store.js';
 import { DEFAULT_ALLOWED_TOOLS, stepKind, type WorkflowDef, type WorkflowStepDef } from './types.js';
 
@@ -135,6 +136,9 @@ export class RunManager {
       variant: group?.variant,
       steps: workflow.steps.map((s) => ({ id: s.id, name: s.name ?? s.id, kind: stepKind(s) })),
     });
+    // Persist the full definition so a queued run survives a restart (#367) —
+    // ad-hoc "(planned)" chains exist nowhere else to re-resolve from.
+    this.store.updateRun(run.id, { workflowDef: workflow as unknown as Record<string, unknown> });
     this.pendingJobs.set(run.id, { workflow, input });
     this.queue.push(run.id);
     void this.pump();
@@ -201,6 +205,96 @@ export class RunManager {
     } finally {
       this.pumping = false;
     }
+  }
+
+  /**
+   * Startup recovery (#367) — re-adopt runs that were live when the previous
+   * cezar process exited (requires the store opened with `keepLive`):
+   *  - `queued`  → back into the queue (FIFO by createdAt), from the persisted
+   *    workflowDef (or the catalog by name for older records);
+   *  - `waiting` → the turn was over and the ball was in the user's court —
+   *    settle exactly like a closed session (review/done, Continue still works);
+   *  - `running` → mark interrupted, then immediately resume the last agent
+   *    session via the Continue path, pointing the agent at its handoff file.
+   * Call once, before the server starts taking requests.
+   */
+  async recover(): Promise<void> {
+    const live = this.store
+      .listRuns()
+      .filter((r) => ['queued', 'waiting', 'running'].includes(r.status))
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    for (const run of live) {
+      if (run.status === 'queued') {
+        const workflow = await this.reviveWorkflow(run);
+        if (workflow) {
+          this.pendingJobs.set(run.id, {
+            workflow,
+            input: { task: run.task, model: run.model, runner: run.runner },
+          });
+          this.queue.push(run.id);
+          this.store.appendEvent(run.id, { type: 'lifecycle', message: 'cezar restarted — task re-queued' });
+        } else {
+          this.store.updateRun(run.id, {
+            status: 'failed',
+            error: 'interrupted — workflow definition not recoverable after a restart',
+            finishedAt: new Date().toISOString(),
+          });
+          this.store.appendEvent(run.id, {
+            type: 'lifecycle',
+            message: 'cezar restarted — workflow definition not recoverable, task failed',
+          });
+        }
+        continue;
+      }
+      if (run.status === 'waiting') {
+        for (const step of run.steps) {
+          if (step.status === 'waiting' || step.status === 'running') {
+            this.store.updateStep(run.id, step.id, { status: 'done', finishedAt: new Date().toISOString() });
+          }
+        }
+        this.store.appendEvent(run.id, {
+          type: 'lifecycle',
+          message: 'cezar restarted — the open session was settled',
+        });
+        await this.settleSuccess(run.id);
+        continue;
+      }
+      // `running`: the process died mid-turn. Mark it interrupted (the state
+      // continueRun expects), then pick the work back up from the last session.
+      const finishedAt = new Date().toISOString();
+      for (const step of run.steps) {
+        if (step.status === 'running' || step.status === 'waiting') {
+          this.store.updateStep(run.id, step.id, { status: 'failed', finishedAt });
+        }
+      }
+      this.store.updateRun(run.id, {
+        status: 'failed',
+        error: 'interrupted — cezar process exited during the run',
+        finishedAt,
+        currentStepId: undefined,
+      });
+      const resumed = this.continueRun(
+        run.id,
+        'The cezar process restarted while you were working on this task. Read the handoff file (CEZ_HANDOFF_FILE) to recover context, then continue the task from where you left off.',
+      );
+      this.store.appendEvent(run.id, {
+        type: 'lifecycle',
+        message: resumed.ok
+          ? 'cezar restarted — resuming the interrupted task from its last session'
+          : `cezar restarted — could not resume the interrupted task (${resumed.error ?? 'unknown'})`,
+      });
+    }
+    void this.pump();
+  }
+
+  /** The persisted definition when it looks sane, else the catalog by name. */
+  private async reviveWorkflow(run: RunRecord): Promise<WorkflowDef | null> {
+    const def = run.workflowDef;
+    if (def && Array.isArray((def as { steps?: unknown }).steps)) {
+      return def as unknown as WorkflowDef;
+    }
+    const { workflows } = await loadWorkflows(this.repoRoot);
+    return workflows.find((w) => w.name === run.workflow) ?? null;
   }
 
   /** Remove a run from the live registries — keeps `waiting ⊆ active`. */

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -3,6 +3,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type AgentSession } from '../core/claude-cli-runner.js';
+import { registerRunProcess, unregisterRunProcess } from '../core/process-usage.js';
 import { createRunner } from '../core/runner-factory.js';
 import type { RunnerId } from '../core/agent-runner.js';
 import {
@@ -513,6 +514,7 @@ export class RunManager {
     state.session = session;
     state.currentStepId = stepId;
     state.interrupt = () => session.interrupt();
+    if (session.pid !== undefined) registerRunProcess(runId, session.pid);
 
     const finishedAt = () => new Date().toISOString();
     try {
@@ -540,6 +542,7 @@ export class RunManager {
       });
       this.store.appendEvent(runId, { type: 'lifecycle', message: `continue failed — ${message}` });
     } finally {
+      this.recordUsagePeaks(runId);
       this.clearIdleTimer(state);
       this.clearAutosaveTimer(state);
       if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd);
@@ -867,6 +870,7 @@ export class RunManager {
     state.session = session;
     state.currentStepId = step.id;
     state.interrupt = () => session.interrupt();
+    if (session.pid !== undefined) registerRunProcess(runId, session.pid);
 
     try {
       const result = await session.result;
@@ -875,11 +879,28 @@ export class RunManager {
     } catch (err) {
       return err instanceof Error ? err.message : String(err);
     } finally {
+      this.recordUsagePeaks(runId);
       this.clearIdleTimer(state);
       state.session = undefined;
       state.currentStepId = undefined;
       state.interrupt = () => undefined;
     }
+  }
+
+  /**
+   * End-of-session telemetry (#348): stop sampling the run's process tree and
+   * fold the session's peaks into the run record. `max` with existing values —
+   * a run can hold several sessions (multiple agent steps, Continue) and the
+   * record keeps the highest water mark across all of them.
+   */
+  private recordUsagePeaks(runId: string): void {
+    const peaks = unregisterRunProcess(runId);
+    if (!peaks) return;
+    const run = this.store.getRun(runId);
+    this.store.updateRun(runId, {
+      peakRssBytes: Math.max(run?.peakRssBytes ?? 0, peaks.peakRssBytes),
+      peakProcCount: Math.max(run?.peakProcCount ?? 0, peaks.peakProcCount),
+    });
   }
 
   /**

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -24,6 +24,20 @@ import { DEFAULT_ALLOWED_TOOLS, stepKind, type WorkflowDef, type WorkflowStepDef
 const CHECK_OUTPUT_CAP = 20_000;
 /** An interactive session that hears nothing from the user closes itself. */
 export const IDLE_TIMEOUT_MS = 15 * 60_000;
+/**
+ * Task-completion marker from the agent contract (HANDOFF_INSTRUCTIONS): a
+ * turn whose text ends with `CEZ:DONE` means "goal achieved, nothing to ask" —
+ * the session is closed right away instead of parking at `waiting` (#347).
+ * Detection runs on the accumulated turn text so delta-streaming backends
+ * (codex, opencode) can't split the marker across text events.
+ */
+const DONE_MARKER_RE = /CEZ:DONE\s*$/;
+/** Strip a trailing marker from one text event so transcripts stay free of
+ *  protocol noise. Delta backends may split the marker across events — then
+ *  it stays visible; detection above is unaffected. */
+function stripDoneMarker(text: string): string {
+  return text.replace(/\s*CEZ:DONE\s*$/, '');
+}
 /** Periodic "cezar autosave" commit in the task worktree (spec 006). */
 export const AUTOSAVE_INTERVAL_MS = 90_000;
 
@@ -77,6 +91,12 @@ export class RunManager {
   // registering in `active`, so parallel-slot counting is never racy.
   private readonly queue: string[] = [];
   private readonly starting = new Set<string>();
+  // Runs parked at `waiting` (open session, ball in the user's court). They
+  // don't consume a `maxParallel` slot (#347) — an idle claude process costs
+  // memory but no tokens, queued work progressing matters more, and the idle
+  // timeout already bounds how long a session can sit open. Invariant:
+  // `waiting ⊆ active` — always cleared together via dropActive().
+  private readonly waiting = new Set<string>();
   private readonly pendingJobs = new Map<string, { workflow: WorkflowDef; input: StartRunInput }>();
   private pumping = false;
 
@@ -150,7 +170,11 @@ export class RunManager {
     try {
       const repo = await getRepoInfo(this.repoRoot);
       const maxParallel = repo ? (await loadConfig(this.repoRoot)).maxParallel : 1;
-      while (this.queue.length > 0 && this.active.size + this.starting.size < maxParallel) {
+      // `waiting` runs don't hold a slot (#347). A message into a waiting run
+      // resumes it even when that momentarily exceeds maxParallel — resumed
+      // conversations must never be blocked by the queue.
+      const busy = () => this.active.size + this.starting.size - this.waiting.size;
+      while (this.queue.length > 0 && busy() < maxParallel) {
         const runId = this.queue.shift();
         if (!runId) break;
         const job = this.pendingJobs.get(runId);
@@ -170,13 +194,19 @@ export class RunManager {
             this.clearAutosaveTimer(state);
           }
           this.starting.delete(runId);
-          this.active.delete(runId);
+          this.dropActive(runId);
           void this.pump();
         });
       }
     } finally {
       this.pumping = false;
     }
+  }
+
+  /** Remove a run from the live registries — keeps `waiting ⊆ active`. */
+  private dropActive(runId: string): void {
+    this.waiting.delete(runId);
+    this.active.delete(runId);
   }
 
   cancel(runId: string): boolean {
@@ -225,6 +255,7 @@ export class RunManager {
     const delivered = state.session.sendMessage(content);
     if (delivered) {
       this.clearIdleTimer(state);
+      this.waiting.delete(runId); // resumed — the run counts against slots again
       this.store.updateRun(runId, { status: 'running' });
       if (state.currentStepId) {
         this.store.updateStep(runId, state.currentStepId, { status: 'running' });
@@ -283,7 +314,7 @@ export class RunManager {
           error: `continue crashed: ${message}`,
           finishedAt: new Date().toISOString(),
         });
-        this.active.delete(runId);
+        this.dropActive(runId);
         void this.pump();
       },
     );
@@ -324,10 +355,17 @@ export class RunManager {
     this.store.appendEvent(runId, { type: 'user-message', stepId, text: prompt, imageCount: 0 });
 
     let stepCost = 0;
+    let turnText = '';
     const onEvent = (event: AgentEvent) => {
       if (event.type === 'image') {
         const saved = this.persistImage(runId, state, event.mediaType, event.data);
         if (saved) this.store.appendEvent(runId, { type: 'image', stepId, ...saved });
+        return;
+      }
+      if (event.type === 'text') {
+        turnText += event.text;
+        const text = stripDoneMarker(event.text);
+        if (text) this.store.appendEvent(runId, { type: 'text', text, stepId });
         return;
       }
       this.store.appendEvent(runId, { ...event, stepId });
@@ -342,13 +380,24 @@ export class RunManager {
         this.store.updateStep(runId, stepId, { costUsd: stepCost });
       }
       if (event.type === 'turn-end') {
-        const waiting = !state.cancelled && state.session?.open;
-        if (waiting) {
+        const sessionOpen = !state.cancelled && state.session?.open;
+        const done = sessionOpen && DONE_MARKER_RE.test(turnText.trimEnd());
+        turnText = '';
+        if (done) {
+          // Goal achieved (agent contract, #347) — same as in runAgentStep.
+          this.store.appendEvent(runId, { type: 'lifecycle', message: 'goal achieved — session closed' });
+          appendHandoffHeartbeat(this.dataDir, runId, 'turn complete — goal achieved, session closed');
+          state.session?.end();
+          return;
+        }
+        if (sessionOpen) {
           this.store.updateRun(runId, { status: 'waiting' });
           this.store.updateStep(runId, stepId, { status: 'waiting' });
+          this.waiting.add(runId);
           this.armIdleTimer(runId, state);
+          void this.pump();
         }
-        appendHandoffHeartbeat(this.dataDir, runId, `turn complete — status=${waiting ? 'waiting' : 'running'}`);
+        appendHandoffHeartbeat(this.dataDir, runId, `turn complete — status=${sessionOpen ? 'waiting' : 'running'}`);
       }
     };
 
@@ -400,7 +449,7 @@ export class RunManager {
       this.clearIdleTimer(state);
       this.clearAutosaveTimer(state);
       if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd);
-      this.active.delete(runId);
+      this.dropActive(runId);
       void this.pump();
     }
   }
@@ -578,7 +627,7 @@ export class RunManager {
       await this.settleSuccess(runId);
     }
     this.clearIdleTimer(state);
-    this.active.delete(runId);
+    this.dropActive(runId);
     void this.pump();
   }
 
@@ -641,10 +690,17 @@ export class RunManager {
     const stepRecord = this.store.getRun(runId)?.steps.find((s) => s.id === step.id);
     const startTokens = stepRecord?.tokensUsed ?? 0;
     let stepCost = stepRecord?.costUsd ?? 0;
+    let turnText = '';
     const onEvent = (event: AgentEvent) => {
       if (event.type === 'image') {
         const saved = this.persistImage(runId, state, event.mediaType, event.data);
         if (saved) emit({ type: 'image', stepId: step.id, ...saved });
+        return;
+      }
+      if (event.type === 'text') {
+        turnText += event.text;
+        const text = stripDoneMarker(event.text);
+        if (text) emit({ type: 'text', text, stepId: step.id });
         return;
       }
       emit({ ...event, stepId: step.id });
@@ -660,12 +716,25 @@ export class RunManager {
         this.store.updateStep(runId, step.id, { costUsd: stepCost });
       }
       if (event.type === 'turn-end') {
-        const waiting = interactive && !state.cancelled && state.session?.open;
+        const sessionOpen = !state.cancelled && state.session?.open;
+        const done = interactive && sessionOpen && DONE_MARKER_RE.test(turnText.trimEnd());
+        turnText = '';
+        if (done) {
+          // Goal achieved (agent contract, #347): close the session instead
+          // of parking at `waiting` — the run completes and frees its slot.
+          emit({ type: 'lifecycle', message: 'goal achieved — session closed' });
+          appendHandoffHeartbeat(this.dataDir, runId, 'turn complete — goal achieved, session closed');
+          state.session?.end();
+          return;
+        }
+        const waiting = interactive && sessionOpen;
         if (waiting) {
           // Turn over, session open: the ball is in the user's court.
           this.store.updateRun(runId, { status: 'waiting' });
           this.store.updateStep(runId, step.id, { status: 'waiting' });
+          this.waiting.add(runId);
           this.armIdleTimer(runId, state);
+          void this.pump(); // the freed slot can start a queued run right away
         }
         // Cez's own heartbeat — the handoff stays current even when the
         // agent forgets to write (spec 007).

--- a/web/app.js
+++ b/web/app.js
@@ -579,19 +579,47 @@ function closePillMenus() {
   }
 }
 
+// `git@github.com:org/repo.git` / `https://github.com/org/repo.git` → the
+// repo's web URL; null for anything that isn't an http-browsable remote.
+function remoteWebUrl(remote) {
+  if (!remote) return null;
+  const ssh = remote.match(/^(?:ssh:\/\/)?git@([^:/]+)[:/](.+?)(?:\.git)?\/?$/);
+  if (ssh) return `https://${ssh[1]}/${ssh[2]}`;
+  if (/^https?:\/\//.test(remote)) return remote.replace(/\.git$/, '');
+  return null;
+}
+
 function renderChrome(health) {
   const repoChip = $('#repo-chip');
   repoChip.hidden = false;
-  repoChip.textContent = health.repo
+  const repoLabel = health.repo
     ? `${health.repo.root.split('/').pop()} / ${health.repo.branch}`
     : 'no git — tasks run in place';
-  repoChip.title = health.repo ? `${health.repo.root} · ${health.repo.branch}` : 'not a git repo — tasks run in place, one at a time';
-  $('#env-chips').innerHTML = health.checks
-    .map(
-      (c) =>
-        `<span class="env-chip ${c.available ? 'ok' : 'bad'}" title="${esc(c.hint ?? c.version ?? '')}"><span class="led"></span>${esc(c.name)}</span>`,
-    )
-    .join('');
+  // The chip links to the repo on its forge when the origin remote is
+  // browsable (#366); otherwise it stays plain text.
+  const webUrl = remoteWebUrl(health.repo?.remote);
+  repoChip.innerHTML = webUrl
+    ? `<a href="${esc(webUrl)}" target="_blank" rel="noopener">${esc(repoLabel)}</a>`
+    : esc(repoLabel);
+  repoChip.title = health.repo
+    ? `${health.repo.root} · ${health.repo.branch}${webUrl ? `\n${webUrl}` : ''}`
+    : 'not a git repo — tasks run in place, one at a time';
+  // Version chip first — amber when the npm registry knows a newer release
+  // (#368) — then the backend/tool checks.
+  const upd = health.latestVersion;
+  const versionChip = `<span class="env-chip ${upd ? 'upd' : 'ok'}" title="${esc(
+    upd
+      ? `cezar ${upd} is available (running ${health.version}) — restart with: npx @pat-lewczuk/cezar@latest`
+      : `cezar ${health.version}`,
+  )}"><span class="led"></span>v${esc(health.version)}${upd ? ` ⬆ ${esc(upd)}` : ''}</span>`;
+  $('#env-chips').innerHTML =
+    versionChip +
+    health.checks
+      .map(
+        (c) =>
+          `<span class="env-chip ${c.available ? 'ok' : 'bad'}" title="${esc(c.hint ?? c.version ?? '')}"><span class="led"></span>${esc(c.name)}</span>`,
+      )
+      .join('');
 
   // Which agent backends are installed → which runners the pill offers.
   const available = RUNNERS.map((r) => r.id).filter((id) =>

--- a/web/app.js
+++ b/web/app.js
@@ -185,100 +185,199 @@ function renderDiff(text) {
   return out.join('');
 }
 
-/* Tiny markdown renderer for the handoff notes — headings, bold, inline code,
-   fenced code, lists, links, hr. Escape-first, line-based, ZERO libs. Not a
-   full parser; handoff files are simple and anything unrecognized falls
-   through as a plain paragraph. */
+/* Markdown renderer (#346) for transcripts, handoff notes and GitHub bodies:
+   headings h1–h6, soft-wrap-joined paragraphs, em/strong/del, inline and
+   fenced code (with a language-* class hook), nested ul/ol with task
+   checkboxes, GFM pipe tables with alignment, blockquotes holding block
+   content, hr, links and autolinks. Two hard invariants: escape-first (the
+   input is attacker-influenced — esc() runs before any tag is inserted, raw
+   HTML never passes through) and ZERO libs (web/ is framework- and
+   build-free). Not a full CommonMark parser; unrecognized text falls through
+   as a plain paragraph. */
 function renderMarkdown(src) {
-  const lines = String(src ?? '').replace(/\r\n?/g, '\n').split('\n');
+  return mdBlocks(String(src ?? '').replace(/\r\n?/g, '\n').split('\n'));
+}
+
+const MD_LIST_ITEM = /^(\s*)(?:([-*+])|(\d+)[.)])\s+(.*)$/;
+const MD_TABLE_SEP = /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/;
+
+function mdBlocks(lines) {
   const out = [];
-  let list = null; // 'ul' | 'ol'
-  let code = null; // collected fenced-code lines
-  let quote = false; // inside a > blockquote
-  const closeList = () => {
-    if (list) {
-      out.push(`</${list}>`);
-      list = null;
+  const para = [];
+  const flushPara = () => {
+    if (para.length) {
+      out.push(`<p>${mdInline(para.join(' '))}</p>`);
+      para.length = 0;
     }
   };
-  const closeQuote = () => {
-    if (quote) {
-      out.push('</blockquote>');
-      quote = false;
-    }
-  };
-  const inline = (s) => {
-    let h = esc(s);
-    h = h.replace(/`([^`]+)`/g, '<code>$1</code>');
-    h = h.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-    h = h.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
-    h = h.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, '$1<a href="$2" target="_blank" rel="noopener">$2</a>');
-    return h;
-  };
-  for (const line of lines) {
-    if (code) {
-      if (/^```/.test(line)) {
-        out.push(`<pre><code>${esc(code.join('\n'))}</code></pre>`);
-        code = null;
-      } else {
-        code.push(line);
-      }
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const fence = /^\s*```\s*(\S*)/.exec(line);
+    if (fence) {
+      flushPara();
+      const buf = [];
+      i++;
+      while (i < lines.length && !/^\s*```\s*$/.test(lines[i])) buf.push(lines[i++]);
+      i++; // closing fence (or EOF — an unclosed fence still renders)
+      const lang = /^[\w+-]+$/.test(fence[1]) ? fence[1] : '';
+      out.push(`<pre><code${lang ? ` class="language-${lang}"` : ''}>${esc(buf.join('\n'))}</code></pre>`);
       continue;
     }
-    if (/^```/.test(line)) {
-      closeList();
-      closeQuote();
-      code = [];
+    if (/^\s*>/.test(line)) {
+      // Blockquote — recurse so quoted lists/fences/tables parse too.
+      flushPara();
+      const buf = [];
+      while (i < lines.length && /^\s*>/.test(lines[i])) buf.push(lines[i++].replace(/^\s*>\s?/, ''));
+      out.push(`<blockquote>${mdBlocks(buf)}</blockquote>`);
       continue;
     }
-    const bq = /^>\s?(.*)$/.exec(line);
-    if (bq) {
-      if (!quote) {
-        closeList();
-        out.push('<blockquote>');
-        quote = true;
-      }
-      if (bq[1].trim()) out.push(`<p>${inline(bq[1])}</p>`);
-      continue;
-    }
-    closeQuote();
-    const heading = /^(#{1,4})\s+(.*)$/.exec(line);
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
     if (heading) {
-      closeList();
+      flushPara();
       const level = heading[1].length;
-      out.push(`<h${level}>${inline(heading[2])}</h${level}>`);
+      out.push(`<h${level}>${mdInline(heading[2])}</h${level}>`);
+      i++;
       continue;
     }
-    if (/^\s*(---+|\*\*\*+)\s*$/.test(line)) {
-      closeList();
+    if (/^\s*(---+|\*\*\*+|___+)\s*$/.test(line)) {
+      flushPara();
       out.push('<hr>');
+      i++;
       continue;
     }
-    const ul = /^\s*[-*]\s+(.*)$/.exec(line);
-    const ol = /^\s*\d+[.)]\s+(.*)$/.exec(line);
-    if (ul || ol) {
-      const kind = ul ? 'ul' : 'ol';
-      if (list !== kind) {
-        closeList();
-        out.push(`<${kind}>`);
-        list = kind;
-      }
-      const content = (ul ?? ol)[1];
-      const task = /^\[( |x|X)\]\s+(.*)$/.exec(content);
-      out.push(
-        task
-          ? `<li class="task"><span class="cb">${task[1].trim() ? '☑' : '☐'}</span>${inline(task[2])}</li>`
-          : `<li>${inline(content)}</li>`,
-      );
+    if (MD_LIST_ITEM.test(line)) {
+      flushPara();
+      i = mdList(lines, i, out);
       continue;
     }
-    closeList();
-    if (line.trim()) out.push(`<p>${inline(line)}</p>`);
+    if (
+      line.includes('|') &&
+      i + 1 < lines.length &&
+      lines[i + 1].includes('|') &&
+      MD_TABLE_SEP.test(lines[i + 1])
+    ) {
+      flushPara();
+      i = mdTable(lines, i, out);
+      continue;
+    }
+    if (!line.trim()) {
+      flushPara();
+      i++;
+      continue;
+    }
+    para.push(line.trim()); // soft-wrapped prose joins into one <p>
+    i++;
   }
-  if (code) out.push(`<pre><code>${esc(code.join('\n'))}</code></pre>`); // unclosed fence
-  closeList();
-  closeQuote();
+  flushPara();
   return out.join('\n');
+}
+
+/* Consecutive list items → nested <ul>/<ol> via an indent stack (2-space
+   steps, tabs count as 2). Each list's last <li> stays open until the next
+   item decides whether it nests, ends, or is a sibling. */
+function mdList(lines, i, out) {
+  const buf = [];
+  const stack = []; // { kind: 'ul' | 'ol', indent }
+  while (i < lines.length) {
+    const m = MD_LIST_ITEM.exec(lines[i]);
+    if (!m) break;
+    const indent = m[1].replace(/\t/g, '  ').length;
+    const kind = m[2] !== undefined ? 'ul' : 'ol';
+    const openTag = kind === 'ol' && Number(m[3]) > 1 ? `<ol start="${Number(m[3])}">` : `<${kind}>`;
+    if (!stack.length || indent > stack[stack.length - 1].indent + 1) {
+      stack.push({ kind, indent });
+      buf.push(openTag); // nests inside the still-open parent <li>
+    } else {
+      while (stack.length > 1 && indent < stack[stack.length - 1].indent - 1) {
+        buf.push('</li>', `</${stack.pop().kind}>`);
+      }
+      buf.push('</li>');
+      if (stack[stack.length - 1].kind !== kind) {
+        buf.push(`</${stack.pop().kind}>`);
+        stack.push({ kind, indent });
+        buf.push(openTag);
+      }
+    }
+    const task = /^\[( |x|X)\]\s+(.*)$/.exec(m[4]);
+    buf.push(
+      task
+        ? `<li class="task"><span class="cb">${task[1].trim() ? '☑' : '☐'}</span>${mdInline(task[2])}`
+        : `<li>${mdInline(m[4])}`,
+    );
+    i++;
+  }
+  while (stack.length) buf.push('</li>', `</${stack.pop().kind}>`);
+  out.push(buf.join(''));
+  return i;
+}
+
+/* GFM pipe table: header row + |---| separator, then body rows. Cell
+   alignment from the separator (:--- / :---: / ---:) lands as an inline
+   text-align — the value is renderer-generated, never user input. */
+function mdTable(lines, i, out) {
+  const splitRow = (row) => {
+    let r = row.trim();
+    if (r.startsWith('|')) r = r.slice(1);
+    if (r.endsWith('|')) r = r.slice(0, -1);
+    return r.split('|').map((c) => c.trim());
+  };
+  const header = splitRow(lines[i]);
+  const aligns = splitRow(lines[i + 1]).map((c) =>
+    /^:-+:$/.test(c) ? 'center' : /^-+:$/.test(c) ? 'right' : /^:-+$/.test(c) ? 'left' : null,
+  );
+  const cell = (tag, text, col) =>
+    `<${tag}${aligns[col] ? ` style="text-align:${aligns[col]}"` : ''}>${mdInline(text)}</${tag}>`;
+  const rows = [];
+  i += 2;
+  while (i < lines.length && lines[i].trim() && lines[i].includes('|')) {
+    rows.push(splitRow(lines[i]));
+    i++;
+  }
+  out.push(
+    `<table><thead><tr>${header.map((h, c) => cell('th', h, c)).join('')}</tr></thead>` +
+      (rows.length
+        ? `<tbody>${rows
+            .map((r) => `<tr>${header.map((_, c) => cell('td', r[c] ?? '', c)).join('')}</tr>`)
+            .join('')}</tbody>`
+        : '') +
+      '</table>',
+  );
+  return i;
+}
+
+/* Inline pass. Escape first, then stash code spans / links / autolinks as
+   opaque tokens so the emphasis regexes can't touch their insides (URLs are
+   full of underscores), run emphasis, and restore the tokens. */
+function mdInline(s) {
+  const tokens = [];
+  const stash = (html) => `\x00${tokens.push(html) - 1}\x00`;
+  let h = esc(s);
+  h = h.replace(/\\([\\`*_~[\]()#+\-.!>|])/g, (_, ch) => stash(ch)); // backslash escapes stay literal
+  h = h.replace(/`([^`]+)`/g, (_, code) => stash(`<code>${code}</code>`));
+  h = h.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, (_, text, url) =>
+    stash(`<a href="${url}" target="_blank" rel="noopener">${mdEmphasis(text)}</a>`),
+  );
+  h = h.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, (_, pre, url) =>
+    `${pre}${stash(`<a href="${url}" target="_blank" rel="noopener">${url}</a>`)}`,
+  );
+  h = mdEmphasis(h);
+  // Tokens can reference earlier tokens (a link holding a code span) —
+  // resolve until none remain; references only ever point backwards.
+  while (/\x00\d+\x00/.test(h)) h = h.replace(/\x00(\d+)\x00/g, (_, n) => tokens[n] ?? '');
+  return h;
+}
+
+/* Emphasis on already-escaped text. Single * and _ require word boundaries
+   so `snake_case` and `2*3` stay literal. */
+function mdEmphasis(h) {
+  h = h.replace(/\*\*\*([^*]+)\*\*\*/g, '<strong><em>$1</em></strong>');
+  h = h.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  h = h.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+  h = h.replace(/(^|[^\w*])\*([^*\s](?:[^*]*[^*\s])?)\*(?![\w*])/g, '$1<em>$2</em>');
+  h = h.replace(/(^|[^\w_])_([^_\s](?:[^_]*[^_\s])?)_(?![\w_])/g, '$1<em>$2</em>');
+  h = h.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+  return h;
 }
 
 // ---- boot ------------------------------------------------------------------
@@ -717,7 +816,13 @@ function connectGlobal() {
     const run = JSON.parse(e.data);
     state.runs.set(run.id, run);
     renderRunList();
-    if (run.id === state.selectedId) updateDetail(run);
+    if (run.id === state.selectedId) {
+      updateDetail(run);
+    } else if (state.selectedId) {
+      // Another run moved — the selected queued run's position may have too.
+      const sel = state.runs.get(state.selectedId);
+      if (sel?.status === 'queued') renderQueuedState(sel);
+    }
   });
   es.addEventListener('run-deleted', (e) => {
     const { id } = JSON.parse(e.data);
@@ -1819,6 +1924,36 @@ function updateDetail(run) {
       : 'Session closed — Continue to reopen.';
     $('#waiting-note').hidden = run.status !== 'waiting';
   }
+
+  renderQueuedState(run);
+}
+
+/* Queued placeholder (#351): a queued run has emitted no transcript events,
+   so the central log pane would be blank — show a prominent animated state
+   with the live queue position instead. Removed by the first real event
+   (appendLog) or as soon as the status moves on. */
+function renderQueuedState(run) {
+  const inner = $('#log-inner');
+  if (!inner) return;
+  const existing = inner.querySelector('.queued-state');
+  const hasEvents = [...inner.children].some((el) => el !== existing);
+  if (run.status !== 'queued' || hasEvents) {
+    existing?.remove();
+    return;
+  }
+  const pos = queuePosition(run);
+  const html = `
+    <div class="q-dots"><span></span><span></span><span></span></div>
+    <div class="q-head">Waiting for a free agent slot${pos ? ` — #${esc(String(pos))} in queue` : ''}</div>
+    <div class="q-sub">${esc(run.workflow)} · starts automatically when a slot frees up</div>`;
+  if (existing) {
+    existing.innerHTML = html;
+  } else {
+    const el = document.createElement('div');
+    el.className = 'queued-state';
+    el.innerHTML = html;
+    inner.appendChild(el);
+  }
 }
 
 /* Review gate panel (spec 009): the full diff on top, then a notes field with
@@ -2045,6 +2180,7 @@ function appendLog(evt) {
   const inner = $('#log-inner');
   const log = $('#log');
   if (!inner || !log) return;
+  inner.querySelector('.queued-state')?.remove(); // first real event replaces the placeholder (#351)
   const el = document.createElement('div');
 
   switch (evt.type) {

--- a/web/app.js
+++ b/web/app.js
@@ -24,6 +24,8 @@ const state = {
   pendingImages: [],      // [{mediaType, data, preview}] queued for the next message
   taskImages: [],         // screenshots pasted into the new-task form
   listView: 'active',     // 'active' | 'archived'
+  runsView: 'list',       // 'list' (sidebar + detail) | 'table' — #348, persisted in ui-state
+  usage: {},              // runId -> {cpuPct, rssBytes, procCount} — live telemetry (#348)
   todos: [],              // global inbox entries (spec 007)
   plan: null,             // {task, steps, rationale, fallback} — proposed chain (spec 008)
   planDragIdx: null,      // index of the plan step being dragged
@@ -95,6 +97,22 @@ function fmtTokens(n) {
 function fmtCost(usd) {
   if (!usd) return '';
   return `$${usd >= 10 ? usd.toFixed(0) : usd.toFixed(2)}`;
+}
+
+/* Humanized RSS for the table view (#348) — ps gives KB, we store bytes. */
+function fmtBytes(n) {
+  if (!n) return '';
+  if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(1)} GB`;
+  if (n >= 1024 ** 2) return `${Math.round(n / 1024 ** 2)} MB`;
+  return `${Math.round(n / 1024)} kB`;
+}
+
+/* "42s" / "3m" / "1.2h" — how long a finished run took. */
+function fmtDuration(ms) {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  return `${(s / 3600).toFixed(1)}h`;
 }
 
 /* Queue position among queued runs (FIFO = createdAt order) — spec 006. */
@@ -410,10 +428,15 @@ async function init() {
   state.taskRef = pick.ref;
   setWorkflowOptions(workflowsRes.workflows);
   for (const run of runs) state.runs.set(run.id, run);
+  mergeUsage(runs);
+  // Runs presentation (#348): restore the persisted list/table choice before
+  // anything renders or auto-selects.
+  state.runsView = uiState.runsView === 'table' ? 'table' : 'list';
   renderRunList();
+  applyRunsView();
   connectGlobal();
   const deepLinked = await handleDeepLink();
-  if (!deepLinked) {
+  if (!deepLinked && state.runsView !== 'table') {
     const latest = sortedRuns()[0];
     if (latest) selectRun(latest.id);
   }
@@ -792,6 +815,7 @@ async function resyncRuns() {
     const fresh = new Set(runs.map((r) => r.id));
     for (const id of [...state.runs.keys()]) if (!fresh.has(id)) state.runs.delete(id);
     for (const run of runs) state.runs.set(run.id, run);
+    mergeUsage(runs);
     renderRunList();
     const sel = state.selectedId ? state.runs.get(state.selectedId) : null;
     if (sel) {
@@ -803,6 +827,13 @@ async function resyncRuns() {
   } catch {
     // offline — the next reconnect/visibility flip retries
   }
+}
+
+/* GET /api/runs carries an additive per-run `usage` sample (#348) — rebuild
+   the live map from it so a resync also clears entries for finished runs. */
+function mergeUsage(runs) {
+  state.usage = {};
+  for (const run of runs) if (run.usage) state.usage[run.id] = run.usage;
 }
 
 function connectGlobal() {
@@ -837,6 +868,13 @@ function connectGlobal() {
     state.todos = JSON.parse(e.data);
     renderInboxBadge();
     if (!$('#view-inbox').hidden) renderInbox();
+  });
+  // Live resource telemetry (#348): a fresh runId → {cpuPct, rssBytes,
+  // procCount} map ~every 2 s while any run is executing. Table rows re-render
+  // from it; absent messages (older server, idle cockpit) simply mean no data.
+  es.addEventListener('usage', (e) => {
+    state.usage = JSON.parse(e.data);
+    if (state.runsView === 'table') renderRunsTable();
   });
 }
 
@@ -1141,8 +1179,22 @@ function bindUi() {
       await fetch('/api/runs/archive-finished', { method: 'POST' });
       return; // SSE run updates re-render the list
     }
+    if (btn.dataset.list === 'toggle-view') {
+      // List/table switch (#348) — the table lives in the Runs main view.
+      showRunsView();
+      setRunsView(state.runsView === 'table' ? 'list' : 'table');
+      return;
+    }
     state.listView = btn.dataset.list;
     renderRunList();
+  });
+
+  // Table rows select the run like a sidebar click (#348) — links keep
+  // navigating (the PR column).
+  $('#runs-table').addEventListener('click', (e) => {
+    if (e.target.closest('a')) return;
+    const row = e.target.closest('tr[data-id]');
+    if (row) selectRun(row.dataset.id);
   });
 
   $('#detail').addEventListener('click', async (e) => {
@@ -1696,7 +1748,12 @@ function renderRunList() {
     <button data-list="archived" class="${state.listView === 'archived' ? 'active' : ''}">
       Archived${archivedCount ? ` ${archivedCount}` : ''}
     </button>
-    ${state.listView === 'active' && finishedCount ? `<button data-list="archive-finished" title="Archive all finished runs"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1.5px;margin-right:4px"><path d="M4 5h16v4H4zM6 9v10h12V9M9 13h6"/></svg>${finishedCount}</button>` : ''}`;
+    ${state.listView === 'active' && finishedCount ? `<button data-list="archive-finished" title="Archive all finished runs"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1.5px;margin-right:4px"><path d="M4 5h16v4H4zM6 9v10h12V9M9 13h6"/></svg>${finishedCount}</button>` : ''}
+    <button data-list="toggle-view" class="view-toggle ${state.runsView === 'table' ? 'active' : ''}" title="${state.runsView === 'table' ? 'Back to the run detail view' : 'Table view — every run with live CPU / memory'}">
+      ${state.runsView === 'table'
+        ? '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 5h7v14H4zM14 5h6M14 9h6M14 13h6M14 17h6"/></svg>'
+        : '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 5h16v14H4zM4 10h16M9 10v9"/></svg>'}
+    </button>`;
 
   // Variant groups (spec 010): runs sharing a groupId collapse into one
   // group tile at the position of their best-ranked member; click expands.
@@ -1731,6 +1788,10 @@ function renderRunList() {
     `<div class="dim" style="padding:14px 12px;font-size:12px">${
       state.listView === 'archived' ? 'Nothing archived yet.' : 'No runs yet — describe a task above.'
     }</div>`;
+
+  // The table mirrors the sidebar (#348): every path that re-renders the list
+  // (SSE run updates, tab switches, deletions) refreshes it in one place.
+  if (state.runsView === 'table') renderRunsTable();
 }
 
 function runItemHtml(r, variantRow = false) {
@@ -1762,11 +1823,113 @@ function groupTileHtml(groupId, members) {
       ${expanded ? members.map((m) => runItemHtml(m, true)).join('') : ''}`;
 }
 
+// ---- runs table view (#348) --------------------------------------------------
+
+/* The "task manager" presentation: every run as one row in the central pane,
+   with live CPU / memory / process-count columns fed by the `usage` SSE
+   stream while a run executes, and the persisted peaks (dimmed) after it
+   finished. Same filter (Active/Archived) and status-first sort as the
+   sidebar; a row click drops back into the detail pane. */
+
+/* Statuses whose usage sample is current — a session is registered while
+   running AND while parked at `waiting` (the CLI process stays alive). */
+const USAGE_LIVE_STATUSES = new Set(['running', 'waiting']);
+
+/* Show/hide the table vs the detail pane and persist the choice (#348). */
+function setRunsView(mode, persist = true) {
+  const changed = state.runsView !== mode;
+  state.runsView = mode;
+  applyRunsView();
+  if (changed) {
+    renderRunList(); // the toggle button in #list-tabs reflects the mode
+    if (persist) {
+      void fetch('/api/ui-state', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ runsView: mode }),
+      }).catch(() => {});
+    }
+  }
+}
+
+function applyRunsView() {
+  const table = state.runsView === 'table';
+  $('#detail').hidden = table;
+  $('#runs-table').hidden = !table;
+  if (table) renderRunsTable();
+}
+
+/* The column reads better as the actual skill for ad-hoc runs: '(planned)'
+   chains and one-skill runs carry their meaning in the first agent step. */
+function workflowLabel(run) {
+  if (run.workflow === '(planned)' || run.workflow === '(inbox)') {
+    const agent = (run.steps ?? []).find((s) => s.kind === 'agent');
+    if (agent?.name) return agent.name;
+  }
+  return run.workflow;
+}
+
+function renderRunsTable() {
+  const box = $('#runs-table');
+  if (!box || state.runsView !== 'table') return;
+  const runs = sortedRuns();
+  box.innerHTML = `
+    <div class="rt-head">
+      <h1>Runs</h1>
+      <span class="dim">${runs.length} ${state.listView === 'archived' ? 'archived' : 'active'}</span>
+    </div>
+    <div class="rt-scroll">${
+      runs.length
+        ? `<table>
+        <thead><tr>
+          <th>Status</th><th>Task</th><th>Skill / workflow</th><th>PR</th>
+          <th class="num">Tokens</th><th class="num">Cost</th>
+          <th class="num">CPU</th><th class="num">Mem</th><th class="num">Procs</th>
+          <th class="num">Started</th>
+        </tr></thead>
+        <tbody>${runs.map(runRowHtml).join('')}</tbody>
+      </table>`
+        : `<div class="empty dim">${
+            state.listView === 'archived' ? 'Nothing archived yet.' : 'No runs yet — describe a task in the sidebar.'
+          }</div>`
+    }</div>`;
+}
+
+function runRowHtml(r) {
+  const live = USAGE_LIVE_STATUSES.has(r.status) ? state.usage[r.id] : null;
+  const cpu = live ? `${live.cpuPct.toFixed(0)}%` : '';
+  const mem = live ? fmtBytes(live.rssBytes) : fmtBytes(r.peakRssBytes);
+  const procs = live ? String(live.procCount) : r.peakProcCount ? String(r.peakProcCount) : '';
+  // No live sample → the mem/procs cells show the run's persisted peaks, dimmed.
+  const peak = !live && Boolean(r.peakRssBytes || r.peakProcCount);
+  const started = r.startedAt ?? r.createdAt;
+  const dur =
+    r.finishedAt && r.startedAt
+      ? fmtDuration(new Date(r.finishedAt).getTime() - new Date(r.startedAt).getTime())
+      : '';
+  return `
+    <tr data-id="${esc(r.id)}" class="${r.id === state.selectedId ? 'selected' : ''}">
+      <td>${statusPill(r)}</td>
+      <td class="rt-title" title="${esc(r.task)}">${esc(r.title)}</td>
+      <td class="rt-flow" title="${esc(r.workflow)}">${esc(workflowLabel(r))}</td>
+      <td>${prLink(r)}</td>
+      <td class="num mono">${esc(fmtTokens(r.tokensUsed))}</td>
+      <td class="num mono">${esc(fmtCost(r.costUsd))}</td>
+      <td class="num mono">${esc(cpu)}</td>
+      <td class="num mono${peak ? ' rt-peak' : ''}"${peak ? ' title="peak — run finished"' : ''}>${esc(mem)}</td>
+      <td class="num mono${peak ? ' rt-peak' : ''}"${peak ? ' title="peak — run finished"' : ''}>${esc(procs)}</td>
+      <td class="num mono rt-time">${esc(timeAgo(started))}${dur ? ` <span class="rt-dur">· ${esc(dur)}</span>` : ''}</td>
+    </tr>`;
+}
+
 // ---- run detail ------------------------------------------------------------
 
 function selectRun(id) {
   const run = state.runs.get(id);
   if (!run) return;
+  // Selecting a run always lands on its detail pane — a table-mode row click
+  // (or sidebar click) switches back to the list presentation (#348).
+  if (state.runsView === 'table') setRunsView('list');
   state.selectedId = id;
   state.selectedGroupId = null;
   state.lastSeq = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -90,6 +90,8 @@
       <section id="detail">
         <div class="empty">Select a run — or start one.</div>
       </section>
+      <!-- full-width "task manager" table (#348) — swaps in for #detail -->
+      <section id="runs-table" hidden></section>
     </section>
 
     <section id="view-workflows" class="view" hidden></section>

--- a/web/style.css
+++ b/web/style.css
@@ -1805,6 +1805,53 @@ a.bm:hover { border-color: var(--accent-line); color: var(--accent); text-decora
 .wb-note { display: flex; align-items: flex-start; gap: 7px; margin-top: 10px; font-size: 11px; color: var(--text3); line-height: 1.5; }
 .wb-note svg { flex: none; margin-top: 1px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; }
 
+/* ---- runs table view (#348) — the "task manager" central pane ---- */
+
+#runs-table { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+/* explicit display beats the UA [hidden] rule — pin both panes' hidden state */
+#runs-table[hidden], #detail[hidden] { display: none; }
+#runs-table .rt-head { display: flex; align-items: baseline; gap: 10px; padding: 20px 24px 10px; }
+#runs-table .rt-head h1 { margin: 0; font-family: var(--serif); font-size: 21px; font-weight: 500; }
+#runs-table .rt-head .dim { font-size: 12px; }
+#runs-table .rt-scroll { flex: 1; min-height: 0; overflow: auto; padding: 0 24px 24px; }
+#runs-table .empty { padding: 40px 0; font-size: 13px; }
+#runs-table table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+#runs-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg);
+  text-align: left;
+  padding: 8px 10px 6px;
+  border-bottom: 1px solid var(--line2);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text3);
+  white-space: nowrap;
+}
+#runs-table td {
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  vertical-align: middle;
+}
+#runs-table th.num, #runs-table td.num { text-align: right; }
+#runs-table td.mono { font-family: var(--mono); font-size: 11.5px; }
+#runs-table tbody tr { cursor: pointer; }
+#runs-table tbody tr:hover td { background: color-mix(in oklab, var(--text) 4%, transparent); }
+#runs-table tbody tr.selected td { background: var(--panel2); }
+#runs-table td.rt-title { max-width: 340px; overflow: hidden; text-overflow: ellipsis; }
+#runs-table td.rt-flow { max-width: 150px; overflow: hidden; text-overflow: ellipsis; color: var(--text2); }
+#runs-table td.rt-peak { color: var(--text3); }
+#runs-table td.rt-time { color: var(--text2); }
+#runs-table .rt-dur { color: var(--text3); }
+
+/* list/table switch — sits at the right edge of the sidebar's list tabs */
+#list-tabs .view-toggle { margin-left: auto; display: inline-flex; align-items: center; }
+#list-tabs .view-toggle svg { display: block; }
+
 /* narrow screens: sidebar shrinks, splits stack */
 @media (max-width: 900px) {
   #sidebar { width: 258px; min-width: 258px; }

--- a/web/style.css
+++ b/web/style.css
@@ -254,6 +254,9 @@ summary::-webkit-details-marker { display: none; }
   white-space: nowrap;
   max-width: 130px;
 }
+/* the chip links to the repo on its forge when origin is browsable (#366) */
+#repo-chip a { color: inherit; text-decoration: none; }
+#repo-chip a:hover { color: var(--text); text-decoration: underline; }
 
 /* new task composer */
 #new-task-wrap { padding: 0 14px 14px; }
@@ -692,6 +695,9 @@ summary::-webkit-details-marker { display: none; }
 }
 .env-chip .led { width: 5px; height: 5px; border-radius: 50%; background: var(--green); flex: none; }
 .env-chip.bad .led { background: var(--red); }
+/* update available (#368): amber pulse until the user restarts on @latest */
+.env-chip.upd { color: var(--amber); }
+.env-chip.upd .led { background: var(--amber); animation: cz-pulse 1.5s ease-in-out infinite; }
 #theme-toggle {
   margin-left: auto;
   align-self: flex-end;

--- a/web/style.css
+++ b/web/style.css
@@ -742,6 +742,34 @@ main { flex: 1; min-width: 0; display: flex; min-height: 0; background: var(--bg
 #detail { flex: 1; min-width: 0; display: flex; flex-direction: column; min-height: 0; }
 #detail .empty { margin: auto; color: var(--text3); font-size: 13.5px; }
 
+/* queued placeholder in the log pane (#351) */
+.queued-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 64px 20px;
+  text-align: center;
+  color: var(--text3);
+}
+.queued-state .q-dots { display: flex; gap: 7px; }
+.queued-state .q-dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: cz-qbounce 1.25s ease-in-out infinite;
+}
+.queued-state .q-dots span:nth-child(2) { animation-delay: 0.15s; }
+.queued-state .q-dots span:nth-child(3) { animation-delay: 0.3s; }
+.queued-state .q-head { font-size: 14px; font-weight: 600; color: var(--text2); }
+.queued-state .q-sub { font-size: 12px; }
+@keyframes cz-qbounce {
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
 .detail-head { flex: none; padding: 26px 40px 0; max-width: 860px; width: 100%; margin: 0 auto; }
 .detail-head .meta-line {
   display: flex;
@@ -836,6 +864,20 @@ main { flex: 1; min-width: 0; display: flex; min-height: 0; background: var(--bg
 .md pre code { background: transparent; padding: 0; word-break: normal; font-size: 11.5px; line-height: 1.6; }
 .md hr { border: none; border-top: 1px solid var(--line); margin: 14px 0; }
 .md strong { font-weight: 600; }
+.md del { color: var(--text3); }
+.md h5, .md h6 { font-family: var(--serif); font-weight: 600; font-size: 12.5px; margin: 14px 0 4px; }
+.md ul ul, .md ul ol, .md ol ul, .md ol ol { margin: 2px 0; }
+/* GFM tables (#346) — wide ones scroll inside the transcript, never the page */
+.md table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 12.5px;
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.md th, .md td { border: 1px solid var(--line); padding: 4px 9px; text-align: left; }
+.md th { font-weight: 600; background: color-mix(in oklab, var(--text3) 7%, transparent); }
 .md blockquote {
   margin: 8px 0;
   padding: 3px 14px;


### PR DESCRIPTION
Fixes the actionable part of Piotr's 0.1.1 feedback round. Five issues turned out to be already fixed in 0.1.2/0.1.3 (he tested a stale npx-cached 0.1.1) and were closed with evidence; their residue is tracked in #374. This branch fixes the rest.

## Engine
- **#347 — waiting runs held queue slots.** New `CEZ:DONE` task-completion marker in the agent contract: a turn ending with it closes the session immediately (run settles to `review`/`done`) instead of parking at `waiting`. Detection runs on the accumulated turn text so codex/opencode deltas can't split the marker; it's stripped from the transcript. Independently, `waiting` runs no longer count against `maxParallel` — queued work starts the moment a run turns to the user.
- **#367 — no resume after restart.** `queued` runs are re-enqueued (the full workflow definition is now persisted on the record, so ad-hoc `(planned)` chains survive too), interrupted `running` runs auto-resume via the Continue path pointing at the handoff file, and `waiting` runs settle like a closed session. One-shot CLI paths keep failing live-looking runs so no ghost survives.

## GUI
- **#368 — update discovery.** Best-effort npm-registry check (3 s timeout, silent on failure) → console banner + amber pulsing `v0.1.3 ⬆ x.y.z` chip; `/api/health` gains `latestVersion`. Directly addresses the stale-npx root cause behind #342.
- **#366** — the repo/branch chip in the top bar links to the repo on its forge (ssh + https remotes both convert).
- **#346 — markdown renderer** reworked into a two-phase block+inline renderer: GFM tables with alignment, `*em*`/`__strong__`/`~~del~~` (word-boundary rules keep `snake_case`/`2*3` literal), nested lists with task checkboxes, paragraph joining, code-fence `language-*` hook, blockquotes with block content. Escape-first (XSS) and zero-dependency invariants kept.
- **#351** — queued runs show an animated placeholder with live queue position in the central pane; clears on the first event.

## Testing
`npm run typecheck` + `npm run build` clean; `node --check web/app.js` clean. Verified end-to-end with `CEZ_DRY_RUN=1` (new mock modes `mock:done` / `mock:md` / `mock:slow`): auto-close frees the slot, restart re-runs the queue, update chip renders, markdown fixture renders with `<script>` escaped, queued placeholder shows and clears. Markdown renderer additionally checked against a 12-case fixture in Node.

Closes #347, #367, #368, #366, #346, #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
