### PR TITLE
feat: full-width Runs table view with live process telemetry (#348)

### DIFF
--- a/scripts/test-process-usage.mjs
+++ b/scripts/test-process-usage.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Unit check for the pure half of src/core/process-usage.ts (#348): ps-output
+// parsing + process-tree aggregation against canned `ps -axo pid=,ppid=,rss=,%cpu=`
+// output. Dependency-free; needs `npm run build` first (imports from dist/).
+//   node scripts/test-process-usage.mjs
+
+import assert from 'node:assert/strict';
+import { aggregateTreeUsage, parsePsOutput } from '../dist/core/process-usage.js';
+
+// Canned snapshot: two registered roots (100, 200) plus unrelated noise.
+// Root 100 owns a 3-level tree: 100 → 110 → 111, and 100 → 120.
+const PS_OUTPUT = `
+    1     0  1200   0.1
+  100     1 50000  10.0
+  110   100 20000   5.5
+  111   110  8000   0.0
+  120   100  4000   2.5
+  200     1 30000  50.0
+  210   200 10000  25.0
+  999     1 70000  99.0
+garbage line that ps should never emit
+  300   1
+`;
+
+const procs = parsePsOutput(PS_OUTPUT);
+assert.equal(procs.length, 8, 'parses 8 well-formed rows, skips malformed ones');
+assert.deepEqual(procs[1], { pid: 100, ppid: 1, rssKb: 50000, cpuPct: 10 });
+
+// Root 100: 4 processes across 3 levels; rss in KB × 1024 → bytes.
+const a = aggregateTreeUsage(procs, 100);
+assert.deepEqual(a, {
+  cpuPct: 18,
+  rssBytes: (50000 + 20000 + 8000 + 4000) * 1024,
+  procCount: 4,
+});
+
+// Root 200: 2 processes; the other tree's processes never leak in.
+const b = aggregateTreeUsage(procs, 200);
+assert.deepEqual(b, { cpuPct: 75, rssBytes: (30000 + 10000) * 1024, procCount: 2 });
+
+// A root missing from the snapshot (process exited) → null, not zeros.
+assert.equal(aggregateTreeUsage(procs, 12345), null);
+
+// A leaf works as a root of its own single-node tree.
+assert.deepEqual(aggregateTreeUsage(procs, 111), { cpuPct: 0, rssBytes: 8000 * 1024, procCount: 1 });
+
+console.log('process-usage: all assertions passed');

--- a/src/core/agent-runner.ts
+++ b/src/core/agent-runner.ts
@@ -107,6 +107,10 @@ export interface SessionOptions {
 export interface AgentSession {
   /** Resolves when the backend process exits — the session is fully over. */
   result: Promise<AgentRunResult>;
+  /** OS pid of the spawned backend process — the root of the run's process
+   *  tree (agents spawn Bash children under it). Absent when the spawn
+   *  failed before a pid existed. Feeds live resource telemetry (#348). */
+  readonly pid?: number;
   /** Write a user message into the live session. False when it is closed. */
   sendMessage(content: ContentBlock[]): boolean;
   /** Graceful close: end input, then a SIGTERM→SIGKILL watchdog. */

--- a/src/core/claude-cli-runner.ts
+++ b/src/core/claude-cli-runner.ts
@@ -256,6 +256,7 @@ export class ClaudeCliRunner implements AgentRunner {
       sendMessage,
       end,
       interrupt,
+      pid: child.pid,
       get open() {
         return stdinOpen;
       },

--- a/src/core/codex-app-server-runner.ts
+++ b/src/core/codex-app-server-runner.ts
@@ -201,6 +201,10 @@ class CodexSession implements AgentSession {
     return this.stdinOpen;
   }
 
+  get pid(): number | undefined {
+    return this.child.pid;
+  }
+
   sendMessage(content: ContentBlock[]): boolean {
     if (!this.stdinOpen) return false;
     if (this.autoEndTimer) {

--- a/src/core/opencode-server-runner.ts
+++ b/src/core/opencode-server-runner.ts
@@ -180,6 +180,10 @@ class OpencodeSession implements AgentSession {
     return this.serverOpen;
   }
 
+  get pid(): number | undefined {
+    return this.child.pid;
+  }
+
   sendMessage(content: ContentBlock[]): boolean {
     if (!this.serverOpen) return false;
     if (this.autoEndTimer) {

--- a/src/core/process-usage.ts
+++ b/src/core/process-usage.ts
@@ -1,0 +1,203 @@
+/**
+ * Live process telemetry for the Runs table (#348): while any run has a
+ * registered backend process, ONE `ps` snapshot every ~2 s is aggregated per
+ * run over the process's full descendant tree (the CLI plus every Bash child
+ * an agent spawned) into `{ cpuPct, rssBytes, procCount }`.
+ *
+ * Design constraints, in order:
+ *  - never affect a run — a missing/failing `ps` (Windows, exotic containers)
+ *    degrades silently to "no data";
+ *  - one shared sampler, not one per run — N parallel runs still cost a
+ *    single `ps` every tick, and the timer is unref()ed and stopped the
+ *    moment the registry empties, so an idle cockpit spawns nothing;
+ *  - parsing + tree aggregation are pure functions, testable against canned
+ *    `ps` output (scripts/test-process-usage.mjs).
+ */
+
+import { execFile } from 'node:child_process';
+
+/** One aggregated sample for a run's process tree. */
+export interface ProcessUsage {
+  /** Sum of `%cpu` across the tree — can exceed 100 on multi-core work. */
+  cpuPct: number;
+  /** Sum of resident set sizes, in bytes. */
+  rssBytes: number;
+  /** Number of live processes in the tree, the root included. */
+  procCount: number;
+}
+
+/** One parsed `ps` row (`pid ppid rss %cpu`; rss is in KB, ps's unit). */
+export interface ProcStat {
+  pid: number;
+  ppid: number;
+  rssKb: number;
+  cpuPct: number;
+}
+
+/**
+ * Parse `ps -axo pid=,ppid=,rss=,%cpu=` output (the `=` suffixes suppress
+ * headers on darwin and linux alike). Malformed lines are skipped — `ps`
+ * racing process exits can truncate rows.
+ */
+export function parsePsOutput(text: string): ProcStat[] {
+  const out: ProcStat[] = [];
+  for (const line of text.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 4) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    const rssKb = Number(parts[2]);
+    const cpuPct = Number(parts[3]);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    out.push({
+      pid,
+      ppid,
+      rssKb: Number.isFinite(rssKb) && rssKb > 0 ? rssKb : 0,
+      cpuPct: Number.isFinite(cpuPct) && cpuPct > 0 ? cpuPct : 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * Aggregate the full descendant tree rooted at `rootPid` from one `ps`
+ * snapshot. Null when the root is gone (process exited between register and
+ * sample) — callers treat that as "no data", not zero usage.
+ */
+export function aggregateTreeUsage(procs: ProcStat[], rootPid: number): ProcessUsage | null {
+  const byPid = new Map<number, ProcStat>();
+  const children = new Map<number, number[]>();
+  for (const p of procs) {
+    byPid.set(p.pid, p);
+    const siblings = children.get(p.ppid);
+    if (siblings) siblings.push(p.pid);
+    else children.set(p.ppid, [p.pid]);
+  }
+  if (!byPid.has(rootPid)) return null;
+
+  let cpuPct = 0;
+  let rssKb = 0;
+  let procCount = 0;
+  const queue = [rootPid];
+  const seen = new Set<number>(); // pid-reuse in a torn snapshot can't loop us
+  while (queue.length > 0) {
+    const pid = queue.pop() as number;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    const p = byPid.get(pid);
+    if (!p) continue;
+    cpuPct += p.cpuPct;
+    rssKb += p.rssKb;
+    procCount += 1;
+    for (const child of children.get(pid) ?? []) queue.push(child);
+  }
+  return { cpuPct: Math.round(cpuPct * 10) / 10, rssBytes: rssKb * 1024, procCount };
+}
+
+// ---- registry + sampler -----------------------------------------------------
+
+export const SAMPLE_INTERVAL_MS = 2_000;
+
+interface Entry {
+  pid: number;
+  last?: ProcessUsage;
+  peakRssBytes: number;
+  peakProcCount: number;
+}
+
+type UsageListener = (usage: Record<string, ProcessUsage>) => void;
+
+const entries = new Map<string, Entry>();
+const listeners = new Set<UsageListener>();
+let timer: NodeJS.Timeout | null = null;
+let sampling = false;
+
+/** Start tracking a run's process tree. A re-register (a run's next agent
+ *  step) replaces the pid but keeps nothing else — peaks are per session and
+ *  the engine maxes them into the run record on unregister. */
+export function registerRunProcess(runId: string, pid: number): void {
+  entries.set(runId, { pid, peakRssBytes: 0, peakProcCount: 0 });
+  if (!timer && process.platform !== 'win32') {
+    timer = setInterval(() => void sample(), SAMPLE_INTERVAL_MS);
+    timer.unref?.();
+    void sample(); // first data point right away, not 2 s late
+  }
+}
+
+/** Stop tracking; returns the session's peaks (undefined when no sample ever
+ *  landed — `ps` unavailable, or the process died before the first tick). */
+export function unregisterRunProcess(
+  runId: string,
+): { peakRssBytes: number; peakProcCount: number } | undefined {
+  const entry = entries.get(runId);
+  entries.delete(runId);
+  if (entries.size === 0 && timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  if (!entry || entry.peakProcCount === 0) return undefined;
+  return { peakRssBytes: entry.peakRssBytes, peakProcCount: entry.peakProcCount };
+}
+
+/** Latest sample for one run, if any. */
+export function currentUsage(runId: string): ProcessUsage | undefined {
+  return entries.get(runId)?.last;
+}
+
+/** Latest samples for every registered run that has data. */
+export function allUsage(): Record<string, ProcessUsage> {
+  const out: Record<string, ProcessUsage> = {};
+  for (const [runId, entry] of entries) {
+    if (entry.last) out[runId] = entry.last;
+  }
+  return out;
+}
+
+/** Subscribe to fresh samples (fires ~every 2 s while runs are registered);
+ *  returns the unsubscribe. The SSE endpoint relays these to the GUI. */
+export function onUsage(listener: UsageListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+async function sample(): Promise<void> {
+  if (sampling || entries.size === 0) return;
+  sampling = true;
+  try {
+    const text = await runPs();
+    if (text === null) return; // ps unavailable — degrade to no data
+    const procs = parsePsOutput(text);
+    for (const entry of entries.values()) {
+      const usage = aggregateTreeUsage(procs, entry.pid);
+      entry.last = usage ?? undefined;
+      if (usage) {
+        entry.peakRssBytes = Math.max(entry.peakRssBytes, usage.rssBytes);
+        entry.peakProcCount = Math.max(entry.peakProcCount, usage.procCount);
+      }
+    }
+    if (listeners.size > 0) {
+      const snapshot = allUsage();
+      for (const listener of listeners) {
+        try {
+          listener(snapshot);
+        } catch {
+          // a broken SSE stream must not kill the sampler
+        }
+      }
+    }
+  } finally {
+    sampling = false;
+  }
+}
+
+/** One system-wide snapshot; null on any failure (no ps, weird exit). */
+function runPs(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      'ps',
+      ['-axo', 'pid=,ppid=,rss=,%cpu='],
+      { maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout) => resolve(err ? null : stdout),
+    );
+  });
+}

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -57,6 +57,11 @@ const runRecordSchema = z.object({
   groupId: z.string().optional(),
   /** Variant letter within the group — 'A' | 'B' | 'C' (kept as a string). */
   variant: z.string().optional(),
+  /** Peak resident memory (bytes) / process count observed across the run's
+   *  agent process trees (#348) — written when a session's telemetry ends.
+   *  Optional: old runs.json files and `ps`-less platforms have neither. */
+  peakRssBytes: z.number().optional(),
+  peakProcCount: z.number().optional(),
   archived: z.boolean().default(false),
   archivedAt: z.string().optional(),
   currentStepId: z.string().optional(),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { z } from 'zod';
 import { detectEnvironment } from '../core/backend-detect.js';
 import type { ContentBlock } from '../core/agent-runner.js';
+import { currentUsage, onUsage } from '../core/process-usage.js';
 import { WORKFLOWS_DIR, loadWorkflows } from '../workflows/load.js';
 import {
   QUICK_TASK_WORKFLOW,
@@ -111,6 +112,9 @@ const uiStateSchema = z
     lastTask: z
       .object({ source: z.enum(['workflow', 'skill']), ref: z.string().min(1).max(200) })
       .optional(),
+    // Runs area presentation (#348): the sidebar-list + detail pane, or the
+    // full-width table ("task manager") view.
+    runsView: z.enum(['list', 'table']).optional(),
   })
   .passthrough();
 
@@ -326,7 +330,16 @@ export function createApp(deps: ServerDeps): Hono {
   });
 
   // ---- runs ----------------------------------------------------------------
-  app.get('/api/runs', (c) => c.json(store.listRuns()));
+
+  // Additive `usage` field (#348): the latest CPU/RSS/proc-count sample of the
+  // run's live process tree — absent for finished runs and when `ps` yields
+  // nothing. The stored record itself is never touched.
+  const withUsage = (run: RunRecord): RunRecord & { usage?: ReturnType<typeof currentUsage> } => {
+    const usage = currentUsage(run.id);
+    return usage ? { ...run, usage } : run;
+  };
+
+  app.get('/api/runs', (c) => c.json(store.listRuns().map(withUsage)));
 
   // Registered before the `/:id/...` routes so "archive-finished" never
   // matches as a run id.
@@ -459,7 +472,7 @@ export function createApp(deps: ServerDeps): Hono {
 
   app.get('/api/runs/:id', (c) => {
     const run = store.getRun(c.req.param('id'));
-    return run ? c.json(run) : c.json({ error: 'not found' }, 404);
+    return run ? c.json(withUsage(run)) : c.json({ error: 'not found' }, 404);
   });
 
   app.post('/api/runs/:id/cancel', (c) => {
@@ -720,12 +733,20 @@ export function createApp(deps: ServerDeps): Hono {
         await stream.writeSSE({ event: 'todos', data: JSON.stringify(items) });
       };
       const offTodos = onTodosChanged(() => void sendTodos());
+      // Live resource telemetry (#348): the sampler ticks ~every 2 s only
+      // while some run has a registered process; each tick is relayed as one
+      // `usage` message (runId → {cpuPct, rssBytes, procCount}). Never
+      // persisted — the NDJSON transcripts stay usage-free.
+      const offUsage = onUsage(
+        (usage) => void stream.writeSSE({ event: 'usage', data: JSON.stringify(usage) }),
+      );
       store.on('run', onRun);
       store.on('deleted', onDeleted);
       stream.onAbort(() => {
         store.off('run', onRun);
         store.off('deleted', onDeleted);
         offTodos();
+        offUsage();
       });
       while (!stream.aborted) {
         await stream.writeSSE({ event: 'ping', data: '' });

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -3,6 +3,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { type AgentSession } from '../core/claude-cli-runner.js';
+import { registerRunProcess, unregisterRunProcess } from '../core/process-usage.js';
 import { createRunner } from '../core/runner-factory.js';
 import type { RunnerId } from '../core/agent-runner.js';
 import {
@@ -513,6 +514,7 @@ export class RunManager {
     state.session = session;
     state.currentStepId = stepId;
     state.interrupt = () => session.interrupt();
+    if (session.pid !== undefined) registerRunProcess(runId, session.pid);
 
     const finishedAt = () => new Date().toISOString();
     try {
@@ -540,6 +542,7 @@ export class RunManager {
       });
       this.store.appendEvent(runId, { type: 'lifecycle', message: `continue failed — ${message}` });
     } finally {
+      this.recordUsagePeaks(runId);
       this.clearIdleTimer(state);
       this.clearAutosaveTimer(state);
       if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd);
@@ -867,6 +870,7 @@ export class RunManager {
     state.session = session;
     state.currentStepId = step.id;
     state.interrupt = () => session.interrupt();
+    if (session.pid !== undefined) registerRunProcess(runId, session.pid);
 
     try {
       const result = await session.result;
@@ -875,11 +879,28 @@ export class RunManager {
     } catch (err) {
       return err instanceof Error ? err.message : String(err);
     } finally {
+      this.recordUsagePeaks(runId);
       this.clearIdleTimer(state);
       state.session = undefined;
       state.currentStepId = undefined;
       state.interrupt = () => undefined;
     }
+  }
+
+  /**
+   * End-of-session telemetry (#348): stop sampling the run's process tree and
+   * fold the session's peaks into the run record. `max` with existing values —
+   * a run can hold several sessions (multiple agent steps, Continue) and the
+   * record keeps the highest water mark across all of them.
+   */
+  private recordUsagePeaks(runId: string): void {
+    const peaks = unregisterRunProcess(runId);
+    if (!peaks) return;
+    const run = this.store.getRun(runId);
+    this.store.updateRun(runId, {
+      peakRssBytes: Math.max(run?.peakRssBytes ?? 0, peaks.peakRssBytes),
+      peakProcCount: Math.max(run?.peakProcCount ?? 0, peaks.peakProcCount),
+    });
   }
 
   /**

--- a/web/app.js
+++ b/web/app.js
@@ -24,6 +24,8 @@ const state = {
   pendingImages: [],      // [{mediaType, data, preview}] queued for the next message
   taskImages: [],         // screenshots pasted into the new-task form
   listView: 'active',     // 'active' | 'archived'
+  runsView: 'list',       // 'list' (sidebar + detail) | 'table' — #348, persisted in ui-state
+  usage: {},              // runId -> {cpuPct, rssBytes, procCount} — live telemetry (#348)
   todos: [],              // global inbox entries (spec 007)
   plan: null,             // {task, steps, rationale, fallback} — proposed chain (spec 008)
   planDragIdx: null,      // index of the plan step being dragged
@@ -95,6 +97,22 @@ function fmtTokens(n) {
 function fmtCost(usd) {
   if (!usd) return '';
   return `$${usd >= 10 ? usd.toFixed(0) : usd.toFixed(2)}`;
+}
+
+/* Humanized RSS for the table view (#348) — ps gives KB, we store bytes. */
+function fmtBytes(n) {
+  if (!n) return '';
+  if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(1)} GB`;
+  if (n >= 1024 ** 2) return `${Math.round(n / 1024 ** 2)} MB`;
+  return `${Math.round(n / 1024)} kB`;
+}
+
+/* "42s" / "3m" / "1.2h" — how long a finished run took. */
+function fmtDuration(ms) {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  return `${(s / 3600).toFixed(1)}h`;
 }
 
 /* Queue position among queued runs (FIFO = createdAt order) — spec 006. */
@@ -410,10 +428,15 @@ async function init() {
   state.taskRef = pick.ref;
   setWorkflowOptions(workflowsRes.workflows);
   for (const run of runs) state.runs.set(run.id, run);
+  mergeUsage(runs);
+  // Runs presentation (#348): restore the persisted list/table choice before
+  // anything renders or auto-selects.
+  state.runsView = uiState.runsView === 'table' ? 'table' : 'list';
   renderRunList();
+  applyRunsView();
   connectGlobal();
   const deepLinked = await handleDeepLink();
-  if (!deepLinked) {
+  if (!deepLinked && state.runsView !== 'table') {
     const latest = sortedRuns()[0];
     if (latest) selectRun(latest.id);
   }
@@ -792,6 +815,7 @@ async function resyncRuns() {
     const fresh = new Set(runs.map((r) => r.id));
     for (const id of [...state.runs.keys()]) if (!fresh.has(id)) state.runs.delete(id);
     for (const run of runs) state.runs.set(run.id, run);
+    mergeUsage(runs);
     renderRunList();
     const sel = state.selectedId ? state.runs.get(state.selectedId) : null;
     if (sel) {
@@ -803,6 +827,13 @@ async function resyncRuns() {
   } catch {
     // offline — the next reconnect/visibility flip retries
   }
+}
+
+/* GET /api/runs carries an additive per-run `usage` sample (#348) — rebuild
+   the live map from it so a resync also clears entries for finished runs. */
+function mergeUsage(runs) {
+  state.usage = {};
+  for (const run of runs) if (run.usage) state.usage[run.id] = run.usage;
 }
 
 function connectGlobal() {
@@ -837,6 +868,13 @@ function connectGlobal() {
     state.todos = JSON.parse(e.data);
     renderInboxBadge();
     if (!$('#view-inbox').hidden) renderInbox();
+  });
+  // Live resource telemetry (#348): a fresh runId → {cpuPct, rssBytes,
+  // procCount} map ~every 2 s while any run is executing. Table rows re-render
+  // from it; absent messages (older server, idle cockpit) simply mean no data.
+  es.addEventListener('usage', (e) => {
+    state.usage = JSON.parse(e.data);
+    if (state.runsView === 'table') renderRunsTable();
   });
 }
 
@@ -1141,8 +1179,22 @@ function bindUi() {
       await fetch('/api/runs/archive-finished', { method: 'POST' });
       return; // SSE run updates re-render the list
     }
+    if (btn.dataset.list === 'toggle-view') {
+      // List/table switch (#348) — the table lives in the Runs main view.
+      showRunsView();
+      setRunsView(state.runsView === 'table' ? 'list' : 'table');
+      return;
+    }
     state.listView = btn.dataset.list;
     renderRunList();
+  });
+
+  // Table rows select the run like a sidebar click (#348) — links keep
+  // navigating (the PR column).
+  $('#runs-table').addEventListener('click', (e) => {
+    if (e.target.closest('a')) return;
+    const row = e.target.closest('tr[data-id]');
+    if (row) selectRun(row.dataset.id);
   });
 
   $('#detail').addEventListener('click', async (e) => {
@@ -1696,7 +1748,12 @@ function renderRunList() {
     <button data-list="archived" class="${state.listView === 'archived' ? 'active' : ''}">
       Archived${archivedCount ? ` ${archivedCount}` : ''}
     </button>
-    ${state.listView === 'active' && finishedCount ? `<button data-list="archive-finished" title="Archive all finished runs"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1.5px;margin-right:4px"><path d="M4 5h16v4H4zM6 9v10h12V9M9 13h6"/></svg>${finishedCount}</button>` : ''}`;
+    ${state.listView === 'active' && finishedCount ? `<button data-list="archive-finished" title="Archive all finished runs"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1.5px;margin-right:4px"><path d="M4 5h16v4H4zM6 9v10h12V9M9 13h6"/></svg>${finishedCount}</button>` : ''}
+    <button data-list="toggle-view" class="view-toggle ${state.runsView === 'table' ? 'active' : ''}" title="${state.runsView === 'table' ? 'Back to the run detail view' : 'Table view — every run with live CPU / memory'}">
+      ${state.runsView === 'table'
+        ? '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 5h7v14H4zM14 5h6M14 9h6M14 13h6M14 17h6"/></svg>'
+        : '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 5h16v14H4zM4 10h16M9 10v9"/></svg>'}
+    </button>`;
 
   // Variant groups (spec 010): runs sharing a groupId collapse into one
   // group tile at the position of their best-ranked member; click expands.
@@ -1731,6 +1788,10 @@ function renderRunList() {
     `<div class="dim" style="padding:14px 12px;font-size:12px">${
       state.listView === 'archived' ? 'Nothing archived yet.' : 'No runs yet — describe a task above.'
     }</div>`;
+
+  // The table mirrors the sidebar (#348): every path that re-renders the list
+  // (SSE run updates, tab switches, deletions) refreshes it in one place.
+  if (state.runsView === 'table') renderRunsTable();
 }
 
 function runItemHtml(r, variantRow = false) {
@@ -1762,11 +1823,113 @@ function groupTileHtml(groupId, members) {
       ${expanded ? members.map((m) => runItemHtml(m, true)).join('') : ''}`;
 }
 
+// ---- runs table view (#348) --------------------------------------------------
+
+/* The "task manager" presentation: every run as one row in the central pane,
+   with live CPU / memory / process-count columns fed by the `usage` SSE
+   stream while a run executes, and the persisted peaks (dimmed) after it
+   finished. Same filter (Active/Archived) and status-first sort as the
+   sidebar; a row click drops back into the detail pane. */
+
+/* Statuses whose usage sample is current — a session is registered while
+   running AND while parked at `waiting` (the CLI process stays alive). */
+const USAGE_LIVE_STATUSES = new Set(['running', 'waiting']);
+
+/* Show/hide the table vs the detail pane and persist the choice (#348). */
+function setRunsView(mode, persist = true) {
+  const changed = state.runsView !== mode;
+  state.runsView = mode;
+  applyRunsView();
+  if (changed) {
+    renderRunList(); // the toggle button in #list-tabs reflects the mode
+    if (persist) {
+      void fetch('/api/ui-state', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ runsView: mode }),
+      }).catch(() => {});
+    }
+  }
+}
+
+function applyRunsView() {
+  const table = state.runsView === 'table';
+  $('#detail').hidden = table;
+  $('#runs-table').hidden = !table;
+  if (table) renderRunsTable();
+}
+
+/* The column reads better as the actual skill for ad-hoc runs: '(planned)'
+   chains and one-skill runs carry their meaning in the first agent step. */
+function workflowLabel(run) {
+  if (run.workflow === '(planned)' || run.workflow === '(inbox)') {
+    const agent = (run.steps ?? []).find((s) => s.kind === 'agent');
+    if (agent?.name) return agent.name;
+  }
+  return run.workflow;
+}
+
+function renderRunsTable() {
+  const box = $('#runs-table');
+  if (!box || state.runsView !== 'table') return;
+  const runs = sortedRuns();
+  box.innerHTML = `
+    <div class="rt-head">
+      <h1>Runs</h1>
+      <span class="dim">${runs.length} ${state.listView === 'archived' ? 'archived' : 'active'}</span>
+    </div>
+    <div class="rt-scroll">${
+      runs.length
+        ? `<table>
+        <thead><tr>
+          <th>Status</th><th>Task</th><th>Skill / workflow</th><th>PR</th>
+          <th class="num">Tokens</th><th class="num">Cost</th>
+          <th class="num">CPU</th><th class="num">Mem</th><th class="num">Procs</th>
+          <th class="num">Started</th>
+        </tr></thead>
+        <tbody>${runs.map(runRowHtml).join('')}</tbody>
+      </table>`
+        : `<div class="empty dim">${
+            state.listView === 'archived' ? 'Nothing archived yet.' : 'No runs yet — describe a task in the sidebar.'
+          }</div>`
+    }</div>`;
+}
+
+function runRowHtml(r) {
+  const live = USAGE_LIVE_STATUSES.has(r.status) ? state.usage[r.id] : null;
+  const cpu = live ? `${live.cpuPct.toFixed(0)}%` : '';
+  const mem = live ? fmtBytes(live.rssBytes) : fmtBytes(r.peakRssBytes);
+  const procs = live ? String(live.procCount) : r.peakProcCount ? String(r.peakProcCount) : '';
+  // No live sample → the mem/procs cells show the run's persisted peaks, dimmed.
+  const peak = !live && Boolean(r.peakRssBytes || r.peakProcCount);
+  const started = r.startedAt ?? r.createdAt;
+  const dur =
+    r.finishedAt && r.startedAt
+      ? fmtDuration(new Date(r.finishedAt).getTime() - new Date(r.startedAt).getTime())
+      : '';
+  return `
+    <tr data-id="${esc(r.id)}" class="${r.id === state.selectedId ? 'selected' : ''}">
+      <td>${statusPill(r)}</td>
+      <td class="rt-title" title="${esc(r.task)}">${esc(r.title)}</td>
+      <td class="rt-flow" title="${esc(r.workflow)}">${esc(workflowLabel(r))}</td>
+      <td>${prLink(r)}</td>
+      <td class="num mono">${esc(fmtTokens(r.tokensUsed))}</td>
+      <td class="num mono">${esc(fmtCost(r.costUsd))}</td>
+      <td class="num mono">${esc(cpu)}</td>
+      <td class="num mono${peak ? ' rt-peak' : ''}"${peak ? ' title="peak — run finished"' : ''}>${esc(mem)}</td>
+      <td class="num mono${peak ? ' rt-peak' : ''}"${peak ? ' title="peak — run finished"' : ''}>${esc(procs)}</td>
+      <td class="num mono rt-time">${esc(timeAgo(started))}${dur ? ` <span class="rt-dur">· ${esc(dur)}</span>` : ''}</td>
+    </tr>`;
+}
+
 // ---- run detail ------------------------------------------------------------
 
 function selectRun(id) {
   const run = state.runs.get(id);
   if (!run) return;
+  // Selecting a run always lands on its detail pane — a table-mode row click
+  // (or sidebar click) switches back to the list presentation (#348).
+  if (state.runsView === 'table') setRunsView('list');
   state.selectedId = id;
   state.selectedGroupId = null;
   state.lastSeq = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -90,6 +90,8 @@
       <section id="detail">
         <div class="empty">Select a run — or start one.</div>
       </section>
+      <!-- full-width "task manager" table (#348) — swaps in for #detail -->
+      <section id="runs-table" hidden></section>
     </section>
 
     <section id="view-workflows" class="view" hidden></section>

--- a/web/style.css
+++ b/web/style.css
@@ -1805,6 +1805,53 @@ a.bm:hover { border-color: var(--accent-line); color: var(--accent); text-decora
 .wb-note { display: flex; align-items: flex-start; gap: 7px; margin-top: 10px; font-size: 11px; color: var(--text3); line-height: 1.5; }
 .wb-note svg { flex: none; margin-top: 1px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; }
 
+/* ---- runs table view (#348) — the "task manager" central pane ---- */
+
+#runs-table { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+/* explicit display beats the UA [hidden] rule — pin both panes' hidden state */
+#runs-table[hidden], #detail[hidden] { display: none; }
+#runs-table .rt-head { display: flex; align-items: baseline; gap: 10px; padding: 20px 24px 10px; }
+#runs-table .rt-head h1 { margin: 0; font-family: var(--serif); font-size: 21px; font-weight: 500; }
+#runs-table .rt-head .dim { font-size: 12px; }
+#runs-table .rt-scroll { flex: 1; min-height: 0; overflow: auto; padding: 0 24px 24px; }
+#runs-table .empty { padding: 40px 0; font-size: 13px; }
+#runs-table table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+#runs-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg);
+  text-align: left;
+  padding: 8px 10px 6px;
+  border-bottom: 1px solid var(--line2);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text3);
+  white-space: nowrap;
+}
+#runs-table td {
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  vertical-align: middle;
+}
+#runs-table th.num, #runs-table td.num { text-align: right; }
+#runs-table td.mono { font-family: var(--mono); font-size: 11.5px; }
+#runs-table tbody tr { cursor: pointer; }
+#runs-table tbody tr:hover td { background: color-mix(in oklab, var(--text) 4%, transparent); }
+#runs-table tbody tr.selected td { background: var(--panel2); }
+#runs-table td.rt-title { max-width: 340px; overflow: hidden; text-overflow: ellipsis; }
+#runs-table td.rt-flow { max-width: 150px; overflow: hidden; text-overflow: ellipsis; color: var(--text2); }
+#runs-table td.rt-peak { color: var(--text3); }
+#runs-table td.rt-time { color: var(--text2); }
+#runs-table .rt-dur { color: var(--text3); }
+
+/* list/table switch — sits at the right edge of the sidebar's list tabs */
+#list-tabs .view-toggle { margin-left: auto; display: inline-flex; align-items: center; }
+#list-tabs .view-toggle svg { display: block; }
+
 /* narrow screens: sidebar shrinks, splits stack */
 @media (max-width: 900px) {
   #sidebar { width: 258px; min-width: 258px; }


### PR DESCRIPTION
Adds the full-width **Runs table view** ("task manager" style) alongside the existing sidebar-list + detail pane, with live per-run resource telemetry.

> **Stacked on `fix/feedback-round-0.1.1`** — merge that PR first, or this one's base will collapse to `main` automatically once it lands. Only the last commit (`5bbaab6`) is unique to this branch.

## What's new
- **Process telemetry** (`src/core/process-usage.ts`, new): one shared `ps -axo pid=,ppid=,rss=,%cpu=` snapshot every ~2 s, aggregated per run over the CLI's full descendant tree (incl. the Bash children an agent spawns) into `{ cpuPct, rssBytes, procCount }`. Pure, tested `parsePsOutput` / `aggregateTreeUsage`. Timer `unref()`ed and stopped when no run is registered; Windows / `ps` failure degrades silently to no data.
- **PID exposure**: `AgentSession.pid` set by all three backends (claude/codex/opencode); the engine registers it after `startSession` and folds peak RSS/proc-count into the run record on settle.
- **API/SSE** (additive): `usage` field on `GET /api/runs` and `/api/runs/:id`; periodic `usage` message on the `/api/events` SSE stream (not persisted to NDJSON). New optional `peakRssBytes`/`peakProcCount` on the run record — old `runs.json` still parses.
- **GUI**: list/table toggle in the Runs header (persisted in ui-state); full-width table with status pill, task, skill/workflow, PR link, tokens, cost, CPU %, memory, procs, started/duration. Live runs show current usage; finished runs show dimmed peaks. Status-first sort and Active/Archived filter match the sidebar. Row click returns to the detail pane. Everything escaped via `esc()`.

## Testing
`node scripts/test-process-usage.mjs` (3-level tree, two roots, malformed-line + missing-root cases) passes; `npm run typecheck` + `build` + `node --check web/app.js` clean. E2E with `CEZ_DRY_RUN=1` + `mock:slow`: `usage` appears on the running task, SSE emits `usage` frames, peaks land on the record after the session closes and survive in `runs.json`. Browser smoke: table renders with all columns, live vs dimmed-peak cells, toggle both ways, row click returns to detail, no console errors.

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
