### PR TITLE
feat(web): Runs nav opens the table view; Active/Archived tabs move to the table header

### DIFF
--- a/.ai/runs/2026-07-14-runs-nav-table-link.md
+++ b/.ai/runs/2026-07-14-runs-nav-table-link.md
@@ -1,0 +1,105 @@
+# Runs nav as table link + table-header Active/Archived tabs
+
+Date: 2026-07-14
+Owner: pkarw
+Branch: `feat/runs-nav-table-link`
+Source doc: `.ai/specs/` has no spec for #348; behavior extends PR #376 (runs table view).
+
+## Goal
+
+Make the sidebar **Runs** nav tab the entry point to the full-width runs table
+view, make selecting a specific run open its detail pane (with Runs still
+active), and give the table header its own Active/Archived filter tabs.
+
+## Scope
+
+- `web/app.js` — nav click behavior, removal of the `#list-tabs` grid-icon
+  toggle, table-header tabs render + click handling.
+- `web/index.html` — no structural change expected (tabs render into the
+  existing `#runs-table` container).
+- `web/style.css` — styles for the table-header tabs.
+
+## Non-goals
+
+- No changes to the server, API, SSE, telemetry, or run store.
+- No changes to the sidebar run list itself (it keeps its own Active/Archived
+  tabs — they filter the sidebar list and stay in sync via shared
+  `state.listView`).
+- No framework/build-tool introduction (per AGENTS.md).
+
+## Behavior contract
+
+1. Clicking the **Runs** nav button (`#tabs button[data-view="runs"]`) always
+   lands on the table view — including when Runs is already the active view
+   (it acts as "back to overview").
+2. Clicking a run — sidebar `.run-item` or table row — opens the detail pane
+   (`#detail`), Runs nav stays selected. (Existing `selectRun` already flips
+   `runsView` to `'list'`; unchanged.)
+3. Deep links to a run keep opening the detail pane.
+4. Programmatic `showRunsView()` callers (inbox goto/start, github checkout,
+   deep link) that immediately `selectRun(...)` still end on the detail pane —
+   the nav handler's `setRunsView('table')` runs synchronously before
+   `selectRun` flips back to `'list'`.
+5. The grid-icon `toggle-view` button in `#list-tabs` is removed (nav link
+   fully covers it).
+6. The table header (`.rt-head`) gets Active/Archived tabs bound to
+   `state.listView`, with counts, mirroring the sidebar tabs; changing the
+   filter in either place re-renders both.
+7. `runsView` persistence in ui-state stays as-is.
+
+## Risks
+
+- The repo has no GUI test framework (vanilla JS, no bundler — AGENTS.md);
+  verification is `npm run typecheck`, `npm run build`,
+  `node --check web/app.js`, plus a manual `CEZ_DRY_RUN=1` smoke pass.
+- `showRunsView()` triggers the nav handler via `.click()` only when the tab
+  is inactive; flows relying on it must still end on the right pane (covered
+  by contract item 4).
+
+## Implementation Plan
+
+### Phase 1: Runs nav opens the table
+
+- 1.1 `#tabs` click handler: on `data-view="runs"`, call `setRunsView('table')`
+  (and keep firing even when the tab is already active — currently the handler
+  runs on every click, keep that).
+- 1.2 Remove the `toggle-view` button from `renderRunList()` and its branch in
+  the `#list-tabs` click handler; drop the now-dead `.view-toggle` CSS.
+- 1.3 Verify programmatic flows (`showRunsView()` + `selectRun`) and the
+  deep-link path still land on the detail pane; adjust `showRunsView()` if
+  needed.
+
+### Phase 2: Table-header Active/Archived tabs
+
+- 2.1 Render Active/Archived tab buttons (with counts) in `renderRunsTable()`'s
+  `.rt-head`, selection driven by `state.listView`.
+- 2.2 Handle tab clicks in the `#runs-table` listener (before row selection):
+  set `state.listView`, re-render sidebar list and table.
+- 2.3 Style the tabs in `web/style.css` consistent with `#list-tabs`.
+
+### Phase 3: Validation
+
+- 3.1 Run `npm run typecheck`, `npm run build`, `node --check web/app.js`.
+- 3.2 Manual smoke pass with `CEZ_DRY_RUN=1` (nav click → table, row click →
+  detail, tab filter, back to table via Runs).
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Runs nav opens the table
+
+- [ ] 1.1 Runs nav click always shows the table view
+- [ ] 1.2 Remove the #list-tabs grid-icon toggle
+- [ ] 1.3 Verify programmatic showRunsView/selectRun flows land on detail
+
+### Phase 2: Table-header Active/Archived tabs
+
+- [ ] 2.1 Render Active/Archived tabs in the table header
+- [ ] 2.2 Handle table-header tab clicks and sync with sidebar
+- [ ] 2.3 Style the table-header tabs
+
+### Phase 3: Validation
+
+- [ ] 3.1 Full validation gate (typecheck, build, node --check)
+- [ ] 3.2 Manual CEZ_DRY_RUN smoke pass

--- a/.ai/runs/2026-07-14-runs-nav-table-link.md
+++ b/.ai/runs/2026-07-14-runs-nav-table-link.md
@@ -95,11 +95,11 @@ active), and give the table header its own Active/Archived filter tabs.
 
 ### Phase 2: Table-header Active/Archived tabs
 
-- [ ] 2.1 Render Active/Archived tabs in the table header
-- [ ] 2.2 Handle table-header tab clicks and sync with sidebar
-- [ ] 2.3 Style the table-header tabs
+- [x] 2.1 Render Active/Archived tabs in the table header — 938057d
+- [x] 2.2 Handle table-header tab clicks and sync with sidebar — 938057d
+- [x] 2.3 Style the table-header tabs — 938057d
 
 ### Phase 3: Validation
 
-- [ ] 3.1 Full validation gate (typecheck, build, node --check)
-- [ ] 3.2 Manual CEZ_DRY_RUN smoke pass
+- [x] 3.1 Full validation gate (typecheck, build, node --check) — green
+- [x] 3.2 Manual CEZ_DRY_RUN smoke pass — server boots, serves new app.js (3× data-rt-list, 0× toggle-view)

--- a/.ai/runs/2026-07-14-runs-nav-table-link.md
+++ b/.ai/runs/2026-07-14-runs-nav-table-link.md
@@ -89,9 +89,9 @@ active), and give the table header its own Active/Archived filter tabs.
 
 ### Phase 1: Runs nav opens the table
 
-- [ ] 1.1 Runs nav click always shows the table view
-- [ ] 1.2 Remove the #list-tabs grid-icon toggle
-- [ ] 1.3 Verify programmatic showRunsView/selectRun flows land on detail
+- [x] 1.1 Runs nav click always shows the table view — 10baaa3
+- [x] 1.2 Remove the #list-tabs grid-icon toggle — 10baaa3
+- [x] 1.3 Verify programmatic showRunsView/selectRun flows land on detail — 10baaa3
 
 ### Phase 2: Table-header Active/Archived tabs
 

--- a/.ai/runs/2026-07-14-runs-nav-table-link.md
+++ b/.ai/runs/2026-07-14-runs-nav-table-link.md
@@ -85,6 +85,8 @@ active), and give the table header its own Active/Archived filter tabs.
 
 ## Progress
 
+PR: #392
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Runs nav opens the table

--- a/web/app.js
+++ b/web/app.js
@@ -892,6 +892,9 @@ function bindUi() {
     for (const view of document.querySelectorAll('.view')) view.hidden = true;
     const view = $(`#view-${btn.dataset.view}`);
     view.hidden = false;
+    // Runs is a link to the table overview (#348): every click lands on the
+    // full-width table — selecting a run is what drops into the detail pane.
+    if (btn.dataset.view === 'runs') setRunsView('table');
     if (btn.dataset.view === 'repo') loadRepo();
     if (btn.dataset.view === 'skills') loadSkills();
     if (btn.dataset.view === 'inbox') renderInbox();
@@ -1178,12 +1181,6 @@ function bindUi() {
     if (btn.dataset.list === 'archive-finished') {
       await fetch('/api/runs/archive-finished', { method: 'POST' });
       return; // SSE run updates re-render the list
-    }
-    if (btn.dataset.list === 'toggle-view') {
-      // List/table switch (#348) — the table lives in the Runs main view.
-      showRunsView();
-      setRunsView(state.runsView === 'table' ? 'list' : 'table');
-      return;
     }
     state.listView = btn.dataset.list;
     renderRunList();
@@ -1748,12 +1745,7 @@ function renderRunList() {
     <button data-list="archived" class="${state.listView === 'archived' ? 'active' : ''}">
       Archived${archivedCount ? ` ${archivedCount}` : ''}
     </button>
-    ${state.listView === 'active' && finishedCount ? `<button data-list="archive-finished" title="Archive all finished runs"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1.5px;margin-right:4px"><path d="M4 5h16v4H4zM6 9v10h12V9M9 13h6"/></svg>${finishedCount}</button>` : ''}
-    <button data-list="toggle-view" class="view-toggle ${state.runsView === 'table' ? 'active' : ''}" title="${state.runsView === 'table' ? 'Back to the run detail view' : 'Table view — every run with live CPU / memory'}">
-      ${state.runsView === 'table'
-        ? '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 5h7v14H4zM14 5h6M14 9h6M14 13h6M14 17h6"/></svg>'
-        : '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 5h16v14H4zM4 10h16M9 10v9"/></svg>'}
-    </button>`;
+    ${state.listView === 'active' && finishedCount ? `<button data-list="archive-finished" title="Archive all finished runs"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1.5px;margin-right:4px"><path d="M4 5h16v4H4zM6 9v10h12V9M9 13h6"/></svg>${finishedCount}</button>` : ''}`;
 
   // Variant groups (spec 010): runs sharing a groupId collapse into one
   // group tile at the position of their best-ranked member; click expands.
@@ -1841,7 +1833,6 @@ function setRunsView(mode, persist = true) {
   state.runsView = mode;
   applyRunsView();
   if (changed) {
-    renderRunList(); // the toggle button in #list-tabs reflects the mode
     if (persist) {
       void fetch('/api/ui-state', {
         method: 'PUT',

--- a/web/app.js
+++ b/web/app.js
@@ -1189,6 +1189,12 @@ function bindUi() {
   // Table rows select the run like a sidebar click (#348) — links keep
   // navigating (the PR column).
   $('#runs-table').addEventListener('click', (e) => {
+    const tab = e.target.closest('button[data-rt-list]');
+    if (tab) {
+      state.listView = tab.dataset.rtList;
+      renderRunList(); // cascades into renderRunsTable() while in table mode
+      return;
+    }
     if (e.target.closest('a')) return;
     const row = e.target.closest('tr[data-id]');
     if (row) selectRun(row.dataset.id);
@@ -1864,10 +1870,23 @@ function renderRunsTable() {
   const box = $('#runs-table');
   if (!box || state.runsView !== 'table') return;
   const runs = sortedRuns();
+  // Filter tabs live on the table header (#348): Runs nav links straight to
+  // the table, so the Active/Archived selection belongs here. Same
+  // state.listView as the sidebar tabs — changing either re-renders both.
+  const all = [...state.runs.values()];
+  const archivedCount = all.filter((r) => r.archived).length;
+  const activeCount = all.length - archivedCount;
   box.innerHTML = `
     <div class="rt-head">
       <h1>Runs</h1>
-      <span class="dim">${runs.length} ${state.listView === 'archived' ? 'archived' : 'active'}</span>
+      <div class="rt-tabs">
+        <button data-rt-list="active" class="${state.listView === 'active' ? 'active' : ''}">
+          Active${activeCount ? ` ${activeCount}` : ''}
+        </button>
+        <button data-rt-list="archived" class="${state.listView === 'archived' ? 'active' : ''}">
+          Archived${archivedCount ? ` ${archivedCount}` : ''}
+        </button>
+      </div>
     </div>
     <div class="rt-scroll">${
       runs.length

--- a/web/style.css
+++ b/web/style.css
@@ -1812,7 +1812,21 @@ a.bm:hover { border-color: var(--accent-line); color: var(--accent); text-decora
 #runs-table[hidden], #detail[hidden] { display: none; }
 #runs-table .rt-head { display: flex; align-items: baseline; gap: 10px; padding: 20px 24px 10px; }
 #runs-table .rt-head h1 { margin: 0; font-family: var(--serif); font-size: 21px; font-weight: 500; }
-#runs-table .rt-head .dim { font-size: 12px; }
+#runs-table .rt-tabs { display: flex; gap: 4px; }
+#runs-table .rt-tabs button {
+  background: none;
+  border: none;
+  color: var(--text3);
+  padding: 3px 8px;
+  border-radius: 99px;
+  cursor: pointer;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+#runs-table .rt-tabs button:hover { color: var(--text2); }
+#runs-table .rt-tabs button.active { color: var(--text); background: var(--panel2); }
 #runs-table .rt-scroll { flex: 1; min-height: 0; overflow: auto; padding: 0 24px 24px; }
 #runs-table .empty { padding: 40px 0; font-size: 13px; }
 #runs-table table { width: 100%; border-collapse: collapse; font-size: 12.5px; }

--- a/web/style.css
+++ b/web/style.css
@@ -1848,10 +1848,6 @@ a.bm:hover { border-color: var(--accent-line); color: var(--accent); text-decora
 #runs-table td.rt-time { color: var(--text2); }
 #runs-table .rt-dur { color: var(--text3); }
 
-/* list/table switch — sits at the right edge of the sidebar's list tabs */
-#list-tabs .view-toggle { margin-left: auto; display: inline-flex; align-items: center; }
-#list-tabs .view-toggle svg { display: block; }
-
 /* narrow screens: sidebar shrinks, splits stack */
 @media (max-width: 900px) {
   #sidebar { width: 258px; min-width: 258px; }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-14-runs-nav-table-link.md
Status: complete

## Goal
- Make the sidebar **Runs** nav tab open the full-width runs table view directly, keep run selection landing on the detail pane, and move the Active/Archived filter selection onto tabs in the table header.

## What Changed
- **Runs nav is a link to the table (#348 follow-up)**: clicking the Runs tab in `#tabs` always lands on the full-width table overview — including when Runs is already active, so it doubles as "back to overview". Selecting a run (sidebar item or table row) still drops into the detail pane with Runs staying selected.
- **Removed the grid-icon list/table toggle** from `#list-tabs` (button, handler branch, and its CSS) — the nav link fully covers it. The `setRunsView` re-render tied to that button is gone too.
- **Active/Archived tabs in the table header**: `renderRunsTable()` now renders filter tabs (with counts) in `.rt-head`, bound to the same `state.listView` as the sidebar tabs; changing either re-renders both. Styled to match the sidebar pills.
- Programmatic flows (`showRunsView()` + `selectRun` from inbox/deep-link paths) still end on the detail pane — the nav handler switches to table synchronously before `selectRun` flips back.

## Tests
- No GUI test framework exists in this repo (vanilla JS, no bundler — per AGENTS.md); verification was `npm run typecheck`, `npm run build`, `node --check web/app.js` (all green).
- `CEZ_DRY_RUN=1` boot smoke: server healthy, served `app.js` contains the new `data-rt-list` tabs and zero references to the removed toggle.

## Breaking Changes
- None. `/api/*` untouched; ui-state `runsView` keeps the same `'list' | 'table'` values. Cockpit UI markup is an explicitly non-protected surface (BACKWARD_COMPATIBILITY.md).

## Progress
See the Progress section in the tracking plan.
