### PR TITLE
docs: refresh agent-pipeline process docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ skills-lock.json
 .ai/tmp/
 .ai/qa/artifacts_*/
 .ai/qa/test-env.json
+
+# local symlink into .agents/skills
+.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,36 @@
-# Agent instructions for cezar
+# AGENTS.md — working in this repository
 
-cezar is a local cockpit for running and tracking AI coding-agent tasks in a repository: a Node 20+ / TypeScript CLI (`cezar` / `cez`) that starts a Hono HTTP server and serves a vanilla-JS browser cockpit from `web/`. Tasks run through pluggable agent backends (Claude CLI, Codex app-server, OpenCode server), each in its own git worktree. All state is plain JSON / NDJSON / Markdown under `.ai/cezar/` — no database, no cloud, no accounts.
+cezar is a **parallel coding-agents orchestrator**: a local cockpit (CLI + browser GUI) for running and tracking AI coding-agent tasks in a repo. You type a task, pick a workflow and a backend — Claude Code, Codex or OpenCode, or a mix per step — and watch it work live: steps, tool calls, tokens, diffs. Each task runs in its own git worktree, ends at a review gate (never auto-merges), and can be pushed as a draft PR through `gh`. Everything is local: no accounts, no database, no cloud — state is plain JSON, NDJSON and Markdown under `.ai/cezar/`. The stack is deliberately small: strict TypeScript (ESM, Node 20+), Hono + SSE for the server, Zod at every boundary, YAML for workflows, and dependency-free vanilla JS for the GUI. Every module is meant to be read in one sitting.
 
 ## Task routing
 
 | When the task involves… | Read first | Key rules |
 |---|---|---|
-| CLI entrypoint, flags, commands | `src/index.ts`, `src/config.ts` | Keep `--help` output in `src/index.ts` in sync with any flag change. Node 20+, ESM (`"type": "module"`). |
-| Agent backends / run execution | `src/core/agent-runner.ts`, `src/core/runner-factory.ts`, `src/core/backend-detect.ts`, then the backend runner (`claude-cli-runner.ts`, `codex-app-server-runner.ts`, `opencode-server-runner.ts`) | New backends go through the runner factory + backend detection; keep the shared `agent-runner` contract. Streamed events are NDJSON (`src/core/ndjson.ts`); token/cost accounting in `src/core/usage.ts`. |
-| HTTP API | `src/server/server.ts` | Routes are `/api/*` on Hono. Validate request bodies with `zod` (already a dependency). The bundled `web/app.js` is the only consumer — update it in the same PR as any route change. |
-| Cockpit UI | `web/index.html`, `web/app.js`, `web/style.css` | Vanilla JS, no framework, no build step — `web/` ships as-is in the npm package. |
-| Run state / persistence | `src/runs/store.ts`, `src/handoff.ts`, `src/todos.ts` | State under `.ai/cezar/` must stay hand-editable (README promise): plain JSON, NDJSON, Markdown. Changes to on-disk formats must tolerate files written by older versions. |
-| Worktrees / git | `src/git-worktree.ts`, `src/server/git.ts`, `src/server/pr.ts`, `src/server/github.ts` | Each run gets its own worktree; never operate on the user's primary checkout. PRs open as drafts via `gh`; everything must degrade gracefully when `gh` is missing. |
-| Skills / workflows | `src/skills.ts`, `src/skills-remote.ts`, `src/workflows/` | Skills are Markdown, workflows are YAML (`src/workflows/types.ts` is the schema). Local skills must keep loading without network. |
-| Security-sensitive surfaces | `src/server/launch-key.ts`, `src/server/server.ts` | The launch key gates auto-start from bookmarklets (`/new?auto=1`); never expose it beyond `/api/launch-key`, never log it. Server is a localhost tool — do not add remote-exposure features casually. |
-| Feature design / specs | `.ai/specs/` | Specs are numbered `NNN-title.md`; read the relevant spec before changing the feature it defines. |
+| CLI entry, `serve`/`run`/`init` subcommands, flags | `src/index.ts` | Uses `node:util` `parseArgs`, no CLI framework. `serve` is the default command. Headless `run` treats `review` as a terminal success status (exit 0). `init` never overwrites existing files. Keep `.ai/cezar/.gitignore` maintenance (`ensureDataGitignore`) in sync with any new state file. |
+| Agent runners / backends | `src/core/agent-runner.ts`, then `src/core/runner-factory.ts`, `src/core/claude-cli-runner.ts`, `src/core/codex-app-server-runner.ts`, `src/core/opencode-server-runner.ts`, `src/core/backend-detect.ts` | One seam: every backend implements `AgentRunner`/`AgentSession` and emits normalized `AgentEvent`s. New backends slot in as one class — do not leak backend-specific types past the seam. `claude-cli` is a legacy backend id kept so old run records parse. `CEZ_DRY_RUN=1` must keep working (bundled mock, no real CLI). Tool access is default-deny via `allowedTools`. |
+| HTTP server & API routes | `src/server/server.ts` | Hono app, binds to `127.0.0.1` only. Every mutating route validates its body with a zod `safeParse` and returns `{ error }` with 400/404/409 — follow that pattern exactly. CORS is deliberately enabled for `/api/health` only (bookmarklets); never widen it. SSE endpoints replay from NDJSON then stream live, deduped by `seq`. |
+| Git / worktree logic | `src/git-worktree.ts`, `src/server/git.ts` | One worktree per task at `.ai/cezar/worktrees/<runId>`, branch `cez/<id8>` off the configured base branch. Helpers never throw (except `createWorktree`) — degradation is the caller's policy. Diffs are capped (`DIFF_CAP`). Orphaned worktrees are pruned at startup. |
+| GitHub integration (issues/PRs tab, draft PRs) | `src/server/github.ts`, `src/server/pr.ts` | Must degrade gracefully: no `gh`, no remote, offline all return `{ available: false, reason }` — never an error. `gh … --json` output is zod-validated at the boundary. `GITHUB_TOKEN` is the fallback when `gh` isn't authenticated. `createDraftPr` never throws; failures map to one-line human errors. `CEZ_DRY_RUN=1` fakes the PR URL. |
+| Workflows (YAML chains, steps, retries) | `src/workflows/types.ts`, then `src/workflows/load.ts`, `src/workflows/run.ts` | A step is agent (`prompt`/`skill`) XOR check (`command`); a file has `steps` XOR the portable `skills` shorthand — both enforced by zod refinements. `onFail.retry` may only reference an *earlier* step (`stepsIssue`). `{{task}}` is the substitution token. `quick-task` is the built-in zero-config workflow; built-ins always come back after delete. |
+| Skills (Markdown playbooks, team repos) | `src/skills.ts`, `src/skills-remote.ts` | A skill is a `.md` file with optional YAML frontmatter (`name`, `description`); its body becomes the agent's extra system prompt. Discovery precedence is local-first: `.ai/cezar/skills` → `.ai/skills` → `.agents/skills` + agent mirrors → global → team repo. Missing dirs are fine; team-skill loading never blocks on the network (background cache in `~/.cache/cez/`). |
+| Runs store / state persistence | `src/runs/store.ts` | Plain files in `.ai/cezar/`, no DB: `runs.json` index (zod-validated, atomic tmp+rename, debounced save) plus one append-only NDJSON event file per run. New `RunRecord` fields must be optional so old files still parse; corrupt files degrade to fresh, never crash. The store is also the in-process event bus for SSE. |
+| Web UI (cockpit) | `web/app.js`, `web/index.html`, `web/style.css` | Vanilla JS, no framework, no bundler, no build step — files are served as-is and read per request in dev. One `state` object, fetch + EventSource, SSE events deduped by `seq`. Dark/light theme must keep working. Do not introduce a build tool or dependency. |
+| Feature specs / design history | `.ai/specs/` (000–012) | Numbered specs are the design record — code comments cite them (`spec 006`, `#348`). Read the relevant spec before changing a feature it covers; keep new work consistent with it or update the spec. |
 
 ## Validation
 
-Run before every PR (also configured in `.ai/agentic.config.json`):
+Before any commit or PR, run in order:
 
 ```bash
-npm run typecheck
-npm run build
+npm run typecheck   # tsc --noEmit
+npm run build       # tsc → dist/
 ```
 
-There is no automated test suite yet (TODO); until one exists, verify behavior changes by running the cockpit locally (`npm run dev`) and exercising the affected flow.
+There is no test suite yet; `CEZ_DRY_RUN=1 npm run dev` exercises the whole cockpit offline for manual verification.
 
-## Process pointers
+## Related documents
 
 - `SDLC.md` — ticket flow, label state machine, QA gate, claim protocol.
-- `CODE_REVIEW.md` — review rules for this repo.
-- `BACKWARD_COMPATIBILITY.md` — protected contract surfaces; check before changing CLI flags, API routes, or on-disk formats.
-- `.ai/agentic.config.json` — pipeline config every `om-*` skill reads; tracker operations in `.ai/trackers/github.md`.
+- `CODE_REVIEW.md` — what reviewers check and how severities are assigned.
+- `BACKWARD_COMPATIBILITY.md` — the public surfaces you must not break silently.
+- `.ai/agentic.config.json` — machine-readable pipeline config every om-* skill reads (base branch, validation commands, labels).

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -1,51 +1,69 @@
-# Backward compatibility
+# Backward compatibility — protected surfaces
 
-Protected contract surfaces of this repository, and the required path for changing one. Review skills check diffs against this file; implementation skills must warn when a change violates it. cezar is distributed on npm (`@pat-lewczuk/cezar`, run via `npx cezar-cli`), so users upgrade independently of this repo — anything they invoke, script, or leave on disk is a contract.
+cezar is a published npm CLI (`@pat-lewczuk/cezar`, currently 0.x) whose state lives as plain files inside users' repos. Users upgrade with `npx cezar@latest` against `.ai/cezar/` directories written by older versions, and they script the CLI and hand-edit the files — the README promises "plain JSON, NDJSON and Markdown you can `cat` and fix by hand." That promise is the compatibility contract.
 
-## Protected surfaces
+**General rule for every surface below:** additive changes (new optional field, new flag, new route) are fine; anything that makes an existing input rejected, an existing output disappear, or an existing file unreadable is breaking. While the package is 0.x, a breaking change requires: a deprecation note in the README + CHANGELOG, a migration path (code that reads the old shape, or a documented manual fix), and a **minor** version bump called out as breaking. From 1.0 on, breaking = major bump.
 
-### 1. CLI commands and flags (`src/index.ts`)
+## 1. CLI commands, flags and exit codes (`src/index.ts`)
 
-The `cezar` / `cez` binaries, their subcommands (e.g. `run`), and documented flags (`-p/--port`, `--workflow`, `--model`, …).
+- **Bins:** `cezar` and `cez` (both in `package.json` `bin`). Removing either alias is breaking.
+- **Commands:** bare invocation = `serve` (cockpit); `cezar run "<task>"`; `cezar init`.
+- **Flags:** `-p/--port` (default 4321, auto-picks the next free port), `--repo <dir>`, `--workflow <name>` (default `quick-task`), `--model <model>`, `--no-open`, `-h/--help`.
+- **Exit codes:** `run` exits 0 on `done` **and** `review` (spec 009 — headless runs must not hang on the review gate), 1 on `failed`/`cancelled`/unknown workflow. CI scripts depend on this.
+- **Env vars:** `CEZ_DRY_RUN`, `CEZ_CLAUDE_BIN`, `CEZ_CODEX_BIN`, `CEZ_OPENCODE_BIN`, `GITHUB_TOKEN`.
 
-- **Breaking**: removing/renaming a command or flag, changing a default in a way that alters behavior, changing exit codes or machine-read output.
-- **Required path**: keep the old name as an alias for at least one minor release, print a deprecation note to stderr, document in the release notes.
+Breaking: renaming/removing a command, flag, alias or env var; changing a default (port, workflow); changing `run` exit-code semantics. Required path: keep the old spelling as a deprecated alias for at least one minor release, print a one-line deprecation warning, document the replacement.
 
-### 2. On-disk state under `.ai/cezar/` (`src/runs/store.ts`, `src/handoff.ts`, `src/todos.ts`, `src/server/launch-key.ts`)
+## 2. HTTP API of the cockpit server (`src/server/server.ts`)
 
-Run records, NDJSON transcripts, handoff/todo Markdown, the launch key. The README promises this state is plain-text and hand-editable, and it survives upgrades on users' machines.
+Consumed by `web/app.js` (shipped in lockstep — low risk) but also by the **bookmarklets users have already saved in their browsers** (spec 011) and by anyone scripting `localhost:4321`. Routes:
 
-- **Breaking**: renaming/moving files, changing JSON/NDJSON field meanings, or making a new version unable to read state written by an older one.
-- **Required path**: new readers must tolerate old files (missing fields get defaults; unknown fields are preserved or ignored, never a crash). A migration must be automatic and one-way-safe; call it out in release notes.
+- Static/GUI: `GET /`, `/new` (bookmarklet deep-link, query `?skill=&ref=&auto=&key=`), `/app.js`, `/style.css`, `/open-mercato.svg`
+- Meta: `GET /api/health` (the **only** CORS-open route — bookmarklets probe it cross-origin; its shape `{version, latestVersion, repoRoot, repo, checks, defaultRunner}` is the most externally-depended-on JSON in the app), `GET /api/launch-key`
+- Skills: `GET /api/skills`, `POST /api/skills/refresh`
+- Workflows: `GET/POST /api/workflows`, `DELETE /api/workflows/:name`, `POST /api/workflows/parse`, `POST /api/plan`
+- Runs: `GET/POST /api/runs`, `GET /api/runs/:id`, `POST /api/runs/:id/{cancel,messages,finish,continue,open-in-cli,pr,archive,remove-worktree}`, `POST /api/runs/archive-finished`, `DELETE /api/runs/:id`, `GET /api/runs/:id/{handoff,diff,events}`, `GET /api/runs/:id/images/:file`
+- Variants: `GET /api/groups/:groupId`, `POST /api/groups/:groupId/pick`
+- Inbox: `GET /api/todos`, `DELETE /api/todos/:id`, `POST /api/todos/:id/start`
+- SSE: `GET /api/events` (global), `GET /api/runs/:id/events` (replay + live, dedup by `seq`)
+- Repo/GitHub: `GET /api/github`, `GET /api/repo`, `GET /api/repo/diff`, `GET /api/repo/commit/:sha`, `PUT /api/config`, `GET/PUT /api/ui-state`
 
-### 3. HTTP API (`src/server/server.ts`)
+Breaking: removing/renaming a route; making a previously optional body field required; removing a response field; changing an SSE event name (`run`, `run-event`, `run-deleted`, `todos`, `usage`, `ping`) or the `seq` dedup contract; narrowing `/api/health` CORS or its fields; changing `/new` query parameters (breaks saved bookmarklets). Required path: additive first; if removal is unavoidable, keep the old route/field answering for one minor release and note it in the CHANGELOG. `/api/health` and `/new` deserve extra caution — they live in users' browsers, not in this repo.
 
-The `/api/*` routes and response shapes. Primary consumer is the bundled `web/app.js`, but bookmarklets (spec 011) and users' local scripts also hit these endpoints.
+## 3. `.ai/cezar/` state files (`src/runs/store.ts` and friends)
 
-- **Breaking**: removing a route, changing a response shape, adding a required request field, changing `/new` query parameters or the `/api/launch-key` contract.
-- **Required path**: server and `web/` change together in the same PR; for surfaces referenced by bookmarklets or specs, keep the old behavior working for one minor release.
+Written by one version, read by the next, and hand-editable by design:
 
-### 4. Workflow YAML and skill discovery (`src/workflows/types.ts`, `src/skills.ts`, `src/skills-remote.ts`)
+- **`runs.json`** — array of `RunRecord` (zod schema in `src/runs/store.ts`), atomic tmp+rename writes. New fields MUST be optional or defaulted (`archived` uses `.default(false)`); a required new field silently drops every pre-existing run because the loader `safeParse`s the whole array. The `runner` enum keeps legacy ids parseable (`claude-cli`) — follow that precedent.
+- **`runs/<id>.ndjson`** — append-only event log, one JSON object per line with `seq`, `ts`, `type`, free extra keys. Readers skip bad lines. Never rewrite, reorder or re-number an existing file; event `type` strings are part of the format (GUI replay + `cezar run` console rendering).
+- **`runs/<id>.handoff.md`**, **`runs/<id>-images/`** — Markdown journal and screenshots; deleted with the run.
+- **`ui-state.json`** — GUI prefs; schema is `.passthrough()` so unknown keys survive round-trips. Keep it that way — never strip keys you don't know.
+- **`config.json`** — user-owned (`src/config.ts`): missing/invalid degrades to defaults; the `PUT /api/config` handler merges into the raw file so user keys survive and defaults are never materialized. Renaming a key (`skillsRepos`, `maxParallel`, `defaultRunner`, `plannerModel`, `baseBranch`) or changing a default is breaking; accept the old key as an alias during migration.
+- **`todos.json`**, **`launch-key`** — inbox entries (spec 007) and the bookmarklet secret.
+- **`.gitignore`** — maintained by `ensureDataGitignore` in `src/index.ts`; any new run-data file must be added there in the same PR.
 
-Users keep workflow YAML files and Markdown skills in their repos (`.ai/skills`, workflow files).
+Breaking: any change that makes an existing file unparseable, silently discarded, or rewritten into a new shape without reading the old one. Required path: read old + new shapes for at least one minor release (a lazy upgrade-on-read is fine since writes go through the schema), or ship an explicit migration; never require the user to delete `.ai/cezar/`.
 
-- **Breaking**: a schema change that makes an existing workflow file fail to parse, or a discovery change that stops finding previously-found skills.
-- **Required path**: parse old shapes with defaults and a warning; never hard-fail on fields an older version accepted.
+## 4. Workflow YAML format (`src/workflows/types.ts`)
 
-### 5. npm package surface (`package.json`)
+Users commit these files (`.ai/cezar/workflows/*.yaml`) and share them across repos — the compact `skills:` form exists specifically to be portable. Protected shape: `name`, `description?`, and `steps` XOR `skills`; per step `id`, `name?`, agent fields (`prompt`, `skill`, `model`, `runner`, `allowedTools`, `bashAllowlist`) XOR check fields (`command`, `onFail: {retry, max}`); the `{{task}}` token; `onFail.retry` referencing an earlier step; the built-in `quick-task` name.
 
-Package name, `bin` names (`cezar`, `cez`), published `files` (`dist`, `web`, `scripts`), `engines` (Node >= 20).
+Breaking: renaming a key, tightening a refinement so previously valid files fail to load, changing `{{task}}` substitution, changing `onFail` semantics (retry target, `max` default of 2), or removing a `runner` value. Note the loader already degrades per file (bad files are reported in `issues` and skipped, `cezar run` prints `! skipped …`) — but "your existing workflow is now skipped" is still a break. Required path: accept the old spelling alongside the new, and have `POST /api/workflows` keep writing the most portable form.
 
-- **Breaking**: renaming binaries, dropping published files other tooling references, raising the Node floor.
-- **Required path**: semver — a major (or clearly announced minor pre-1.0) bump plus release notes.
+## 5. Skills Markdown format (`src/skills.ts`)
 
-## Not protected
+A skill is a `.md` file with optional YAML frontmatter (`name`, `description`); the body becomes the agent's extra system prompt. Protected: frontmatter keys; the `SKILL.md`-in-a-directory convention; the discovery locations and their precedence (`.ai/cezar/skills` → `.ai/skills` → `.agents/skills` + agent mirrors → `~/.agents/skills`, `~/.claude/skills` → team repos); name-collision resolution ("the user's repo is the source of truth"); the `config.json` `skillsRepos` source shape (`{repo, ref}` — GitHub shorthand, git URL, or local path).
 
-- Internal module structure under `src/` (imports between modules may change freely).
-- Cockpit UI layout/markup in `web/` (behavior contracts above still apply).
-- `.ai/cezar/` files explicitly documented as ephemeral (locks, temp worktree dirs).
-- Anything in `.ai/tmp/`.
+Breaking: requiring frontmatter, dropping a discovery directory, or inverting precedence so a team skill shadows a local one. Required path: additive discovery only; a precedence change needs a README callout and a minor bump.
 
-## Rule of thumb
+## 6. npm package surface (`package.json`)
 
-If a user could have scripted it, bookmarked it, or left it on disk before upgrading — it's a contract. When in doubt, treat it as protected and provide the deprecation path, or flag it as a `WARNING: breaking` in the PR body and summary comment so a human decides.
+- Name `@pat-lewczuk/cezar` (plus the `cezar-cli` npx alias documented in the README); `bin` entries `cezar` + `cez`; published `files`: `dist`, `web`, `scripts`, `README.md`; `engines.node >= 20`; `"type": "module"`.
+- There is **no** `exports`/library API — the package is CLI-only. Keep it that way deliberately: adding one creates a new compatibility surface; if it happens, this document gains a section first.
+- `dist/index.js` must remain the bin entry, and `web/` must stay resolvable relative to `dist/server` (`resolveWebDir` walks `../../web`).
+
+Breaking: dropping a bin alias, raising `engines.node`, removing `web/` or `scripts/` from `files`, renaming the package. Required path: raise `engines` only in a version bump flagged as breaking; keep old aliases through a deprecation release.
+
+## When in doubt
+
+If a change might break any surface above, say so in the PR description, label the PR `risk-high`, and route it through the review + QA gates in `SDLC.md`. A silent break found in review is a blocker per `CODE_REVIEW.md`.

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,30 +1,63 @@
 # Code review rules
 
-Review checklist for this repository, applied by human reviewers and by the `om-code-review` skill (which picks this file up automatically). Severity discipline and the label state machine are defined in `SDLC.md`.
+How to review a diff in this repository. Applies to humans and to the `om-code-review` skill alike. The validation gate (`npm run typecheck` && `npm run build`) must be green before a review verdict is meaningful — there is no test suite, so the review itself is the main correctness gate.
 
-## Review priorities, in order
+## Review priorities (in order)
 
-1. **Correctness** — the change does what the PR says, handles the empty/error paths, and does not regress an existing flow.
-2. **Contracts** — nothing in `BACKWARD_COMPATIBILITY.md` is broken silently: CLI flags, `/api/*` routes and shapes, on-disk state formats, workflow YAML schema, the published npm package surface.
-3. **Security** — see repo-specific checks below; cezar spawns child processes and serves HTTP on localhost, so the interesting risks are command construction and what the server exposes.
-4. **Scope** — the diff matches the plan/issue; no unrelated churn, no drive-by refactors.
+1. **Correctness of the run lifecycle** — runs, steps, worktrees, sessions. A bug here loses user work.
+2. **Graceful degradation** — the README's core promise: no `gh` → works without PRs, no network → local skills still load, no git repo → tasks run in place, `CEZ_DRY_RUN=1` → everything works offline. A diff that turns a degradation path into an error is a blocker.
+3. **State-file compatibility** — `.ai/cezar/` files outlive the process and the version that wrote them (see `BACKWARD_COMPATIBILITY.md`).
+4. **Security of the local server** — it binds to `127.0.0.1`, but it executes agents with file access; treat every request body as hostile.
+5. **Simplicity** — "every module is meant to be read in one sitting." Push back on new dependencies, frameworks, or abstractions the change doesn't need.
 
-## Repo-specific checks
+## Checklist
 
-- **TypeScript / ESM**: `npm run typecheck` and `npm run build` must pass; the project is `"type": "module"` on Node 20+ — no CommonJS `require`, no default-import of JSON.
-- **API handlers** (`src/server/server.ts`): request bodies validated with `zod` before use; errors return JSON with a sensible status, never a stack trace. Any new/changed route is exercised by `web/app.js` in the same PR.
-- **Child processes** (`src/core/*-runner.ts`, `src/server/open-in-terminal.ts`, git helpers): arguments passed as arrays, never interpolated into a shell string; user-supplied text (task briefs, branch names, file paths) must not reach a shell unquoted.
-- **Filesystem state** (`src/runs/store.ts`, `src/handoff.ts`, `src/todos.ts`): writes stay inside `.ai/cezar/` (or the run's worktree); reads tolerate missing/corrupt files (the README promises hand-editable state); no secrets written world-readable — follow the `launch-key` pattern (mode 0600).
-- **Launch key** (`src/server/launch-key.ts`): never logged, never embedded in pages beyond the documented bookmarklet flow, never required reading for any code path outside the server.
-- **Worktrees** (`src/git-worktree.ts`): operations target the run's worktree, never the primary checkout; failure paths clean up what they created.
-- **Graceful degradation**: no `gh` → cockpit works without PR features; no network → local skills still load. A change that turns a degradation path into a hard failure is a bug.
-- **Web UI** (`web/`): stays framework-free and build-free; no external CDN resources.
-- **Dependencies**: this package ships via `npx` — every new runtime dependency is startup cost for users; justify it in the PR.
+### TypeScript strictness
+
+- `tsconfig.json` has `strict`, `noUncheckedIndexedAccess`, `noImplicitOverride` — the diff must compile without weakening them.
+- No `any`, no non-null assertions to silence the checker; prefer narrowing, `unknown` + zod, or explicit optional handling. Indexed access is checked — `arr[0]` is `T | undefined`, handle it.
+- ESM with NodeNext resolution: relative imports carry the `.js` extension even in `.ts` files. `node:`-prefixed builtins.
+
+### Zod at every boundary
+
+- Every mutating API route parses its body with `schema.safeParse(await c.req.json().catch(() => null))` and returns `{ error: issues.join('; ') }` with 400 on failure — the established pattern in `src/server/server.ts`. New routes must follow it; a route that trusts `c.req.json()` raw is a blocker.
+- External process output crossing into the app (`gh … --json` in `src/server/github.ts`, agent CLI streams) is zod-validated at the boundary, extras stripped.
+- Persisted files read back in (`runs.json`, `config.json`, workflow YAML) go through their schema; parse failure degrades to a sane default, never a crash.
+- Schemas carry the limits (`.max()` on strings/arrays, image size caps, `variants` 1–3, steps ≤ 8). New inputs need explicit bounds — unbounded user input into a file write or a spawned process is a blocker.
+
+### Graceful degradation
+
+- Missing `gh` / no remote / offline: GitHub reads return `{ available: false, reason }`, PR creation returns `{ ok: false, error }` — never a throw, never a 500 for an expected absence.
+- Missing or malformed `.ai/cezar/config.json` behaves exactly like the defaults and never blocks startup (`src/config.ts`).
+- git helpers in `src/git-worktree.ts` never throw (except `createWorktree`); check the diff keeps that contract.
+- `CEZ_DRY_RUN=1` paths must still work after the change — that is the offline demo and the de-facto integration test.
+
+### Security
+
+- No secrets in state files: nothing under `.ai/cezar/` (runs.json, NDJSON events, handoff.md, ui-state.json, config.json) may contain tokens or credentials. `GITHUB_TOKEN` stays in the environment; the launch key stays in the gitignored `launch-key` file and is only served same-origin.
+- Server stays on `127.0.0.1`; CORS is for `/api/health` only (bookmarklet discovery, spec 011). Widening either is a blocker.
+- Path handling on user-supplied names: file-serving routes must sanitize (`basename()` as in `/api/runs/:id/images/:file`); workflow names are slugified before becoming filenames. Any user string that reaches a path or a shell needs the same treatment.
+- Spawned processes use `execFile`/`spawn` with argument arrays — never string-interpolated shell commands. Tool access for agents is default-deny (`allowedTools`).
+- Writes that must not clobber use `wx` or tmp+rename; check new file writes follow one of those.
+
+### State-file and API compatibility
+
+- New fields on `RunRecord`/`StepState` are optional (or defaulted) so old `runs.json` files still parse — the existing comments ("old runs.json files … have neither") show the convention.
+- NDJSON event logs are append-only; readers skip unparseable lines. Never rewrite or reorder an existing event file.
+- Renaming/removing an API route, an event `type`, or a persisted field is a breaking change — route it through `BACKWARD_COMPATIBILITY.md`.
+
+### Code quality
+
+- Comments cite the spec or issue that motivated the code (`spec 006`, `#348`); non-obvious behavior in the diff should too.
+- No new runtime dependencies without strong justification — the dependency budget is hono, @hono/node-server, yaml, zod.
+- Web UI changes stay framework-free and build-step-free; no npm packages, no bundler, theme toggle keeps working.
+- User-facing errors are one human-readable line (the `createDraftPr` pattern), not stack traces.
 
 ## Severity guidance
 
-- **Blocker** — breaks a protected contract without the documented path, security regression (shell injection, launch-key exposure, server listening beyond localhost), data-destroying bug in run state or worktree handling, validation gate red.
-- **Major** — correctness bug in a main flow, missing zod validation on a new route, degradation path removed, API/UI drift (route changed, `web/app.js` not updated).
-- **Minor** — naming, structure, missed edge case with low blast radius, docs drift.
+- **Blocker** (request changes): data loss or corruption in `.ai/cezar/`; a degradation path turned into a hard failure; unvalidated request body on a mutating route; secret written to disk; server exposed beyond localhost or CORS widened; path traversal; breaking a surface in `BACKWARD_COMPATIBILITY.md` without the required path; typecheck/build red.
+- **Major** (request changes unless trivially fixed in-review): incorrect run/step state transitions; SSE replay duplication or event loss; unbounded input reaching files or processes; a schema field added as required when old files carry it as absent.
+- **Minor** (approve with comments): missing spec citation on non-obvious code; inconsistent error shape; naming/style drift; missed `wx`/tmp+rename on a low-stakes write.
+- **Nit**: wording, formatting, comment polish. Never blocks.
 
-Request changes on any Blocker or Major; Minors alone can be approved with comments.
+Verdict: approve when there are no blockers or majors; otherwise request changes with each finding tagged by severity and file/line.

--- a/SDLC.md
+++ b/SDLC.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This file documents how work flows from ticket to merged PR in this repository. The agent skills configured in `.ai/agentic.config.json` enforce the process; humans read it here. PRs target `main`; issues and PRs live in github, with every tracker operation the skills run defined in `.ai/trackers/github.md` (edit that file to extend or override tracker behavior).
+This file documents how work flows from ticket to merged PR in this repository. The agent skills configured in `.ai/agentic.config.json` enforce the process; humans read it here. PRs target `main`; issues and PRs live in GitHub (via the `gh` CLI), with every tracker operation the skills run defined in `.ai/trackers/github.md` (edit that file to extend or override tracker behavior).
 
 Work enters through two paths: a free-form task brief handed to an agent, or a filed ticket. Both converge on the same review loop, the same validation gate, and the same merge gates.
 
@@ -17,7 +17,7 @@ Work enters through two paths: a free-form task brief handed to an agent, or a f
 
 | Stage | What happens | Driven by | Done when |
 |---|---|---|---|
-| Intake | A ticket or task brief is filed in github with enough detail to act on. | Anyone | Ticket exists |
+| Intake | A ticket or task brief is filed in GitHub with enough detail to act on. | Anyone | Ticket exists |
 | Triage | Confirm the issue is real, still unfixed on `main`, and not already claimed or covered by an open PR. Read-only; stops the chain cleanly when there is nothing to do. | `om-verify-in-repo` or a human | Confirmed actionable, or closed as no-action |
 | Claim | The author claims the ticket so concurrent agents back off. See the claim protocol below. | `om-fix` / `om-auto-create-pr`, or a human | Claim visible on the ticket |
 | Implement | Locate the minimal change surface (`om-root-cause`, read-only), then implement the change with regression tests and run the validation gate. Task briefs without a ticket go through `om-auto-create-pr`, which plans, implements phase by phase in an isolated worktree, and runs the same gate. | `om-root-cause` + `om-fix`, `om-auto-create-pr`, or a human author | Change complete, validation gate green |
@@ -45,20 +45,20 @@ Pipeline labels are mutually exclusive: a PR carries at most one, and it names w
 | Priority | `priority-low`, `priority-medium`, `priority-high`, `priority-extreme` | one at a time; unset = medium | Urgency of the work |
 | Risk | `risk-low`, `risk-medium`, `risk-high` | one at a time; unset = medium | Blast radius of the change |
 
-Priority is how urgent the work is; risk is how dangerous the change is to ship. A one-line fix for an outage can be `priority-extreme` and `risk-low`; a large auth refactor that can wait can be `priority-low` and `risk-high`. A PR inherits both from its source issue unless the scope clearly changed. When an automated skill adds or changes a pipeline or meta label, it leaves a short comment explaining why.
+Priority is how urgent the work is; risk is how dangerous the change is to ship. A one-line fix for a broken cockpit can be `priority-extreme` and `risk-low`; a large runner-seam refactor that can wait can be `priority-low` and `risk-high`. A PR inherits both from its source issue unless the scope clearly changed. When an automated skill adds or changes a pipeline or meta label, it leaves a short comment explaining why.
 
 When no priority label is set, infer one:
 
-- `priority-extreme` — production outage, data loss, or an active security incident.
+- `priority-extreme` — the published CLI is broken for users (`npx cezar` fails), data loss in `.ai/cezar/`, or an active security incident.
 - `priority-high` — security hardening or a release-blocking regression.
 - `priority-medium` — ordinary bug fixes and net-new features (also the default reading of unset).
 - `priority-low` — cosmetic, docs-only, dependency bumps, follow-up cleanup.
 
 When no risk label is set, infer one:
 
-- `risk-high` — auth, sessions, data scoping, money, schema migrations, shared contract surfaces, or broad cross-cutting edits.
-- `risk-medium` — an ordinary single-area change that ships with tests (also the default reading of unset).
-- `risk-low` — docs-only, test-only, typo, or isolated cosmetic changes.
+- `risk-high` — the runner seam (`src/core/agent-runner.ts`), worktree/branch handling, the `.ai/cezar/` state file formats, the HTTP API surface, or broad cross-cutting edits.
+- `risk-medium` — an ordinary single-area change (also the default reading of unset).
+- `risk-low` — docs-only, typo, or isolated cosmetic changes.
 
 When signals conflict, pick the higher label and say why in the label comment. A `risk-high` PR strengthens the case for `needs-qa` and deeper review even when it would otherwise look routine.
 
@@ -68,8 +68,8 @@ One label lives outside this taxonomy: `do-not-close`, applied by humans to issu
 
 The one hard rule of this process: **a PR carrying `needs-qa` must not merge until it also carries `qa-approved`, even when every other check is green.** `om-merge-buddy` classifies such a PR as blocked; `om-approve-merge-pr` refuses to merge it.
 
-- Apply `needs-qa` to UI changes, new features, and other user-facing behavior that needs manual exercise.
-- `skip-qa` is the explicit opt-out for docs-only, dependency-only, CI-only, test-only, and similarly low-risk non-user-facing changes. Never combine it with `needs-qa`.
+- Apply `needs-qa` to cockpit UI changes, new features, and other user-facing behavior that needs manual exercise (a `CEZ_DRY_RUN=1` session covers most cockpit flows without a real `claude` login).
+- `skip-qa` is the explicit opt-out for docs-only, dependency-only, CI-only, and similarly low-risk non-user-facing changes. Never combine it with `needs-qa`.
 - `qa-failed`, `do-not-merge`, and `blocked` are hard blocks regardless of every other signal. An active `qa` pipeline label means a tester is on the PR right now — never merge under an active tester.
 - The gate is satisfied when a QA reviewer tests the PR and applies `qa-approved`.
 - **Self-QA exception**: when no QA reviewer has capacity in time, any engineer may sign off instead — but only by (1) checking the PR out and running it locally, (2) exercising the affected flow, and (3) attaching evidence to the PR: a screenshot of it working, or a written account of what was exercised and the observed result. Then apply both `qa-approved` (so the gate passes) and `qa-self-verified` (so the exception is auditable). No evidence, no `qa-approved`.
@@ -87,7 +87,7 @@ Every PR passes the full validation gate before review sign-off, in this order:
 - `npm run typecheck`
 - `npm run build`
 
-Any non-zero exit fails the gate and blocks the PR. The implementing skills run the gate before opening a PR, and `om-check-and-commit` runs it before pushing a hand-worked branch. The command list lives in `.ai/agentic.config.json`; when it changes, update it there and in this section together.
+Any non-zero exit fails the gate and blocks the PR. There is no automated test suite yet — typecheck + build is the whole gate, which makes manual QA and the review checklist carry more weight. The implementing skills run the gate before opening a PR, and `om-check-and-commit` runs it before pushing a hand-worked branch. The command list lives in `.ai/agentic.config.json`; when it changes, update it there and in this section together.
 
 ## Amending this process
 


### PR DESCRIPTION
## Summary
- Regenerates the four agent-pipeline process docs (`AGENTS.md`, `SDLC.md`, `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`) via `om-setup-agent-pipeline` with deeper, repo-specific guidance: the runner seam contract, graceful-degradation review priorities, protected CLI/API/state surfaces with spec references, and cezar-specific priority/risk examples.
- Adds `.claude/skills` (local symlink into `.agents/skills`) to `.gitignore`.

The pipeline config, tracker descriptor, and `.ai/` scaffolding from the same setup run are already on `main` and are not part of this PR. `skills-lock.json` stays untracked per #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)