### PR TITLE
ci(github): add PR and release validation

### DIFF
--- a/.ai/agentic.config.json
+++ b/.ai/agentic.config.json
@@ -3,7 +3,13 @@
   "baseBranch": "auto",
   "tracker": "github",
   "validation": {
-    "commands": ["npm run typecheck", "npm run build"]
+    "commands": [
+      "npm run typecheck",
+      "npm run test:unit",
+      "npm run build",
+      "npm run test:e2e",
+      "npm pack --dry-run --ignore-scripts"
+    ]
   },
   "labels": {
     "enabled": true,

--- a/.ai/runs/2026-07-15-ci-pr-release-validation.md
+++ b/.ai/runs/2026-07-15-ci-pr-release-validation.md
@@ -51,5 +51,5 @@ Source docs: `.ai/specs/001-packaging-npx.md`, `.ai/specs/009-diff-review-gate.m
 
 ### Phase 2: GitHub CI
 
-- [ ] 2.1 Add a least-privilege GitHub Actions workflow for pull requests and `main` pushes.
-- [ ] 2.2 Execute the complete CI sequence locally and verify release-package contents.
+- [x] 2.1 Add a least-privilege GitHub Actions workflow for pull requests and `main` pushes. — de0c458
+- [x] 2.2 Execute the complete CI sequence locally and verify release-package contents. — de0c458

--- a/.ai/runs/2026-07-15-ci-pr-release-validation.md
+++ b/.ai/runs/2026-07-15-ci-pr-release-validation.md
@@ -48,6 +48,7 @@ Source docs: `.ai/specs/001-packaging-npx.md`, `.ai/specs/009-diff-review-gate.m
 
 - [x] 1.1 Add unit and packaged CLI end-to-end tests with npm scripts. — 8000f1f
 - [x] 1.2 Align the autonomous validation gate and contributor documentation with the new tests. — 7e5cd72
+- [x] Post-review fix: make test discovery compatible with Node 20. — 033e00b
 
 ### Phase 2: GitHub CI
 

--- a/.ai/runs/2026-07-15-ci-pr-release-validation.md
+++ b/.ai/runs/2026-07-15-ci-pr-release-validation.md
@@ -46,8 +46,8 @@ Source docs: `.ai/specs/001-packaging-npx.md`, `.ai/specs/009-diff-review-gate.m
 
 ### Phase 1: Test foundations
 
-- [ ] 1.1 Add unit and packaged CLI end-to-end tests with npm scripts.
-- [ ] 1.2 Align the autonomous validation gate and contributor documentation with the new tests.
+- [x] 1.1 Add unit and packaged CLI end-to-end tests with npm scripts. — 8000f1f
+- [x] 1.2 Align the autonomous validation gate and contributor documentation with the new tests. — 7e5cd72
 
 ### Phase 2: GitHub CI
 

--- a/.ai/runs/2026-07-15-ci-pr-release-validation.md
+++ b/.ai/runs/2026-07-15-ci-pr-release-validation.md
@@ -1,0 +1,55 @@
+# CI PR and release validation
+
+## Overview
+
+Goal: establish a GitHub Actions gate that validates every pull request update and every push to `main` with unit tests, a production build, end-to-end package checks, and release-package verification.
+
+Source docs: `.ai/specs/001-packaging-npx.md`, `.ai/specs/009-diff-review-gate.md`
+
+## Scope
+
+- Add dependency-free unit tests for stable workflow primitives.
+- Add an end-to-end test that packs and installs the built npm package, then exercises the published CLI contract in `CEZ_DRY_RUN=1` mode.
+- Add package scripts and keep the repository validation configuration and contributor guidance aligned with the new test gates.
+- Add GitHub Actions CI for pull requests targeting `main`, pushes to `main`, and manual runs.
+- Validate the same commands locally, then confirm the workflow on the PR created by this run.
+
+## Non-goals
+
+- Publishing a release or changing the package version.
+- Changing application, CLI, API, workflow, or UI behavior.
+- Reusing or modifying any branch or worktree owned by another active coding agent.
+
+## Implementation Plan
+
+### Phase 1: Test foundations
+
+1.1 Add unit and packaged CLI end-to-end tests with npm scripts.
+
+1.2 Align the autonomous validation gate and contributor documentation with the new tests.
+
+### Phase 2: GitHub CI
+
+2.1 Add a least-privilege GitHub Actions workflow for pull requests and `main` pushes.
+
+2.2 Execute the complete CI sequence locally and verify release-package contents.
+
+## Risks
+
+- The packaged CLI E2E test creates temporary git repositories and installs the generated tarball; it must clean up reliably and avoid relying on developer-global git identity.
+- Pull-request workflows run untrusted branch code, so the workflow must stay read-only and must not expose release credentials.
+- GitHub-hosted execution can only be confirmed after the PR exists; a failing run will be diagnosed and fixed before this run is reported complete.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Test foundations
+
+- [ ] 1.1 Add unit and packaged CLI end-to-end tests with npm scripts.
+- [ ] 1.2 Align the autonomous validation gate and contributor documentation with the new tests.
+
+### Phase 2: GitHub CI
+
+- [ ] 2.1 Add a least-privilege GitHub Actions workflow for pull requests and `main` pushes.
+- [ ] 2.2 Execute the complete CI sequence locally and verify release-package contents.

--- a/.ai/runs/2026-07-15-ci-pr-release-validation.md
+++ b/.ai/runs/2026-07-15-ci-pr-release-validation.md
@@ -42,6 +42,8 @@ Source docs: `.ai/specs/001-packaging-npx.md`, `.ai/specs/009-diff-review-gate.m
 
 ## Progress
 
+PR: #398
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Test foundations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Unit, build, E2E, and package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Build application
+        run: npm run build
+
+      - name: Run packaged CLI E2E tests
+        run: npm run test:e2e
+
+      - name: Verify release package
+        run: npm pack --dry-run --ignore-scripts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,14 @@ cezar is a **parallel coding-agents orchestrator**: a local cockpit (CLI + brows
 Before any commit or PR, run in order:
 
 ```bash
-npm run typecheck   # tsc --noEmit
-npm run build       # tsc → dist/
+npm run typecheck                    # tsc --noEmit
+npm run test:unit                    # fast node:test coverage of core modules
+npm run build                        # tsc → dist/
+npm run test:e2e                     # pack/install and exercise the built CLI
+npm pack --dry-run --ignore-scripts  # verify the release tarball contents
 ```
 
-There is no test suite yet; `CEZ_DRY_RUN=1 npm run dev` exercises the whole cockpit offline for manual verification.
+`CEZ_DRY_RUN=1 npm run dev` still exercises the whole cockpit offline for manual verification.
 
 ## Related documents
 

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,6 +1,6 @@
 # Code review rules
 
-How to review a diff in this repository. Applies to humans and to the `om-code-review` skill alike. The validation gate (`npm run typecheck` && `npm run build`) must be green before a review verdict is meaningful — there is no test suite, so the review itself is the main correctness gate.
+How to review a diff in this repository. Applies to humans and to the `om-code-review` skill alike. The full validation gate in `.ai/agentic.config.json` must be green before a review verdict is meaningful: typecheck, unit tests, build, packaged CLI E2E, and a release-tarball dry run.
 
 ## Review priorities (in order)
 

--- a/README.md
+++ b/README.md
@@ -344,8 +344,11 @@ git-ignored automatically; your workflows and skills stay committable.
 ```bash
 npm install
 npm run dev          # tsx src/index.ts — the cockpit, live-reloaded
-npm run build        # tsc → dist/
 npm run typecheck    # tsc --noEmit
+npm run test:unit    # fast core-module tests
+npm run build        # tsc → dist/
+npm run test:e2e     # pack/install and exercise the built CLI
+npm test             # unit tests + build + E2E
 ```
 
 The stack is deliberately small: **TypeScript** (strict, ESM), **Hono** + SSE for

--- a/SDLC.md
+++ b/SDLC.md
@@ -85,9 +85,12 @@ The claim is released when the work finishes — on success and on failure alike
 Every PR passes the full validation gate before review sign-off, in this order:
 
 - `npm run typecheck`
+- `npm run test:unit`
 - `npm run build`
+- `npm run test:e2e`
+- `npm pack --dry-run --ignore-scripts`
 
-Any non-zero exit fails the gate and blocks the PR. There is no automated test suite yet — typecheck + build is the whole gate, which makes manual QA and the review checklist carry more weight. The implementing skills run the gate before opening a PR, and `om-check-and-commit` runs it before pushing a hand-worked branch. The command list lives in `.ai/agentic.config.json`; when it changes, update it there and in this section together.
+Any non-zero exit fails the gate and blocks the PR. Unit tests cover stable module behavior; the packaged CLI E2E test builds a release tarball, installs it into an isolated consumer, and exercises the offline CLI workflow. The implementing skills run the gate before opening a PR, and `om-check-and-commit` runs it before pushing a hand-worked branch. The command list lives in `.ai/agentic.config.json`; when it changes, update it there and in this section together.
 
 ## Amending this process
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "test": "npm run test:unit && npm run build && npm run test:e2e",
-    "test:unit": "node --import tsx --test test/unit/**/*.test.ts",
-    "test:e2e": "node --import tsx --test test/e2e/**/*.test.ts",
+    "test:unit": "node --import tsx --test test/unit/*.test.ts",
+    "test:e2e": "node --import tsx --test test/e2e/*.test.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
+    "test": "npm run test:unit && npm run build && npm run test:e2e",
+    "test:unit": "node --import tsx --test test/unit/**/*.test.ts",
+    "test:e2e": "node --import tsx --test test/e2e/**/*.test.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/test/e2e/package-cli.test.ts
+++ b/test/e2e/package-cli.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { execFile as execFileCallback } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCallback);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+test('the release tarball installs and runs the dry-run CLI workflow', { timeout: 120_000 }, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'cezar-package-e2e-'));
+
+  try {
+    const packDir = join(root, 'pack');
+    await mkdir(packDir);
+    const packed = await execFile(
+      npm,
+      ['pack', '--json', '--ignore-scripts', '--pack-destination', packDir],
+      { cwd: repoRoot, maxBuffer: 10 * 1024 * 1024 },
+    );
+    const records = JSON.parse(packed.stdout) as Array<{
+      filename: string;
+      files: Array<{ path: string }>;
+    }>;
+    const record = records[0];
+    assert.ok(record, 'npm pack should describe the generated tarball');
+
+    const packagedPaths = new Set(record.files.map((file) => file.path));
+    for (const requiredPath of ['dist/index.js', 'web/index.html', 'scripts/mock-claude.mjs', 'README.md']) {
+      assert.ok(packagedPaths.has(requiredPath), `release tarball should contain ${requiredPath}`);
+    }
+    assert.equal(packagedPaths.has('src/index.ts'), false, 'release tarball should not contain TypeScript sources');
+    assert.equal(packagedPaths.has('test/e2e/package-cli.test.ts'), false, 'release tarball should not contain tests');
+
+    const consumerDir = join(root, 'consumer');
+    await mkdir(consumerDir);
+    await writeFile(join(consumerDir, 'package.json'), '{"private":true}\n', 'utf8');
+    const tarball = join(packDir, record.filename);
+    await execFile(
+      npm,
+      ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--no-package-lock', tarball],
+      { cwd: consumerDir, maxBuffer: 10 * 1024 * 1024 },
+    );
+
+    const packageRoot = join(consumerDir, 'node_modules', '@pat-lewczuk', 'cezar');
+    const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8')) as {
+      bin: { cezar: string; cez: string };
+    };
+    assert.equal(manifest.bin.cezar, 'dist/index.js');
+    assert.equal(manifest.bin.cez, 'dist/index.js');
+    const cliPath = join(packageRoot, manifest.bin.cezar);
+
+    const help = await execFile(process.execPath, [cliPath, '--help'], {
+      cwd: consumerDir,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    assert.match(help.stdout, /cezar — local cockpit/);
+    assert.match(help.stdout, /cezar run "<task>"/);
+
+    const fixtureRepo = join(root, 'fixture-repo');
+    await mkdir(fixtureRepo);
+    await execFile('git', ['init', '--initial-branch=main'], { cwd: fixtureRepo });
+    await writeFile(join(fixtureRepo, 'README.md'), '# E2E fixture\n', 'utf8');
+    await execFile('git', ['add', 'README.md'], { cwd: fixtureRepo });
+    await execFile(
+      'git',
+      ['-c', 'user.name=Cezar CI', '-c', 'user.email=ci@example.invalid', 'commit', '-m', 'test fixture'],
+      { cwd: fixtureRepo },
+    );
+
+    const run = await execFile(process.execPath, [cliPath, 'run', 'mock:done', '--repo', fixtureRepo], {
+      cwd: consumerDir,
+      env: { ...process.env, CEZ_DRY_RUN: '1' },
+      timeout: 60_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    assert.match(run.stdout, /run (done|review)/);
+
+    const runs = JSON.parse(await readFile(join(fixtureRepo, '.ai', 'cezar', 'runs.json'), 'utf8')) as Array<{
+      status: string;
+    }>;
+    assert.equal(runs.length, 1);
+    assert.ok(['done', 'review'].includes(runs[0]?.status ?? ''), 'the dry-run workflow should finish successfully');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/workflow-types.test.ts
+++ b/test/unit/workflow-types.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  normalizeWorkflowDoc,
+  skillStackOf,
+  skillsToSteps,
+  stepsIssue,
+  workflowFileSchema,
+} from '../../src/workflows/types.js';
+
+test('portable skill stacks normalize into unique agent steps', () => {
+  const parsed = workflowFileSchema.parse({
+    name: 'review-twice',
+    skills: ['code-review', 'code-review'],
+  });
+
+  assert.deepEqual(normalizeWorkflowDoc(parsed), {
+    name: 'review-twice',
+    steps: [
+      { id: 'code-review', name: 'code-review', skill: 'code-review', prompt: '{{task}}' },
+      { id: 'code-review-2', name: 'code-review', skill: 'code-review', prompt: '{{task}}' },
+    ],
+  });
+});
+
+test('workflow files require exactly one step representation', () => {
+  assert.equal(workflowFileSchema.safeParse({ name: 'empty' }).success, false);
+  assert.equal(
+    workflowFileSchema.safeParse({
+      name: 'ambiguous',
+      skills: ['review'],
+      steps: [{ id: 'review', prompt: '{{task}}' }],
+    }).success,
+    false,
+  );
+});
+
+test('retry targets must refer to an earlier unique step', () => {
+  assert.equal(
+    stepsIssue([
+      { id: 'implement', prompt: '{{task}}' },
+      { id: 'verify', command: 'npm test', onFail: { retry: 'implement', max: 2 } },
+    ]),
+    null,
+  );
+  assert.equal(
+    stepsIssue([
+      { id: 'verify', command: 'npm test', onFail: { retry: 'implement', max: 2 } },
+      { id: 'implement', prompt: '{{task}}' },
+    ]),
+    'step "verify": onFail.retry must reference an earlier step (got "implement")',
+  );
+  assert.equal(
+    stepsIssue([
+      { id: 'duplicate', prompt: '{{task}}' },
+      { id: 'duplicate', command: 'npm test' },
+    ]),
+    'duplicate step id "duplicate"',
+  );
+});
+
+test('only plain agent skill steps compact back to a portable stack', () => {
+  assert.deepEqual(skillStackOf(skillsToSteps(['implement', 'review'])), ['implement', 'review']);
+  assert.equal(skillStackOf([{ id: 'verify', command: 'npm test' }]), null);
+  assert.equal(
+    skillStackOf([{ id: 'review', name: 'Custom name', skill: 'review', prompt: '{{task}}' }]),
+    null,
+  );
+});


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-15-ci-pr-release-validation.md
Status: in-progress

## Goal
- Validate every pull request update and every push to `main` with unit tests, a production build, packaged E2E coverage, and release-package checks.

## What Changed
- Added least-privilege GitHub Actions CI with concurrency cancellation for superseded PR runs.
- Added dependency-free unit coverage for workflow normalization and validation behavior.
- Added an E2E test that packs and installs the npm release artifact, verifies its contents and CLI aliases, and completes a `CEZ_DRY_RUN=1` workflow in a temporary git repository.
- Updated package scripts, the autonomous validation gate, and contributor/process documentation to run the new checks consistently.

## Tests
- `npm run typecheck`
- `npm run test:unit` (4 passing tests)
- `npm run build`
- `npm run test:e2e` (1 passing packaged CLI scenario)
- `npm pack --dry-run --ignore-scripts` (92 release files verified)
- Node 20.20.2 compatibility check for both test suites

## Breaking Changes
- None. CLI commands, flags, outputs, runtime minimum, APIs, state formats, and package entry points are unchanged.

## Progress
See the Progress section in the tracking plan.

Automated review is clean, but GitHub requires a different account to submit the formal approval because the PR author and automation user are both `pkarw`.
