### PR TITLE
fix(settings): restore bookmarklets subpage

### DIFF
--- a/.ai/runs/2026-07-15-restore-settings-bookmarklets.md
+++ b/.ai/runs/2026-07-15-restore-settings-bookmarklets.md
@@ -1,0 +1,54 @@
+# Restore Settings bookmarklets
+
+## Overview
+
+Goal: make the existing bookmarklet generator easy to find again as a first-class Settings subpage.
+
+Source docs: `.ai/specs/011-bookmarklets.md`, `.ai/specs/2026-07-14-cockpit-ui-redesign.md`
+
+## Scope
+
+- Add `/settings/bookmarklets` to the registry-driven Settings navigation and index.
+- Reuse the existing generic and per-skill bookmarklet generator without changing its protected `/new` contract.
+- Preserve the existing `/settings/skills?skill=__bm` entry point for compatibility.
+- Update affected specs and UI tests.
+
+## Non-goals
+
+- Change bookmarklet JavaScript, launch-key behavior, port discovery, or GitHub URL matching.
+- Add support for other forges or hosted bookmarklet pages.
+- Change server routes or API response shapes.
+
+## Implementation Plan
+
+### Phase 1: Promote the existing generator
+
+1. Extract the bookmarklet panel into a reusable Settings section component.
+2. Register the visible Bookmarklets Settings route while retaining the Skills deep link.
+
+### Phase 2: Verify navigation and behavior
+
+1. Update registry, route, and bookmarklet surface tests for the new subpage.
+2. Update the redesign spec route and Settings inventory, then run the configured validation gate.
+
+## Risks
+
+- The generator embeds the launch key; the implementation must retain its current same-origin fetch and protected `/new?skill=&ref=&auto=&key=` format.
+- The task sandbox cannot write Git metadata and cannot reach GitHub. The plan and implementation can be completed and tested in the existing isolated worktree, but commits, pushes, PR creation, labels, and remote review are blocked until those capabilities are restored.
+- Validation is infrastructure-blocked: `npm test` reaches 1,881/1,882 passing but the bundled OpenCode mock cannot start here and process sampling reports `spawn EPERM`; `npm run test:package` times out while exercising the spawned packaged CLI. Typecheck, all 1,454 web tests, `test:unit`, and the production build/package-content check pass.
+
+## Progress
+
+PR: #399
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Promote the existing generator
+
+- [x] 1.1 Extract the bookmarklet panel into a reusable Settings section component — squashed into this PR's single commit
+- [x] 1.2 Register the visible Bookmarklets Settings route while retaining the Skills deep link — squashed into this PR's single commit
+
+### Phase 2: Verify navigation and behavior
+
+- [x] 2.1 Update registry, route, and bookmarklet surface tests for the new subpage — squashed into this PR's single commit
+- [ ] 2.2 Update the redesign spec route and Settings inventory, then run the configured validation gate — spec updated in this PR's single commit; gate blocked by sandbox child-process restrictions

--- a/.ai/runs/2026-07-15-restore-settings-bookmarklets.md
+++ b/.ai/runs/2026-07-15-restore-settings-bookmarklets.md
@@ -34,8 +34,9 @@ Source docs: `.ai/specs/011-bookmarklets.md`, `.ai/specs/2026-07-14-cockpit-ui-r
 ## Risks
 
 - The generator embeds the launch key; the implementation must retain its current same-origin fetch and protected `/new?skill=&ref=&auto=&key=` format.
-- The task sandbox cannot write Git metadata and cannot reach GitHub. The plan and implementation can be completed and tested in the existing isolated worktree, but commits, pushes, PR creation, labels, and remote review are blocked until those capabilities are restored.
-- Validation is infrastructure-blocked: `npm test` reaches 1,881/1,882 passing but the bundled OpenCode mock cannot start here and process sampling reports `spawn EPERM`; `npm run test:package` times out while exercising the spawned packaged CLI. Typecheck, all 1,454 web tests, `test:unit`, and the production build/package-content check pass.
+- The task sandbox that drafted this plan could not write Git metadata or reach GitHub. Resolved: the branch was re-authored, rebased onto the base tip, and pushed as PR #399.
+- Validation was reported infrastructure-blocked in the sandbox (`npm test` 1,881/1,882, `npm run test:package` timing out). Resolved: the full gate — `typecheck`, `test` (1,908 passing), `test:unit`, `build`, `test:package` — runs green outside that sandbox.
+- The `feat/cockpit-ui-r1-platform-shell` base branch carries pre-existing e2e failures unrelated to this change (`smoke` ⌘N accelerator, `settings-agents`, `github`, `repo-git`, `review-gate`, `task-changes`, `task-thread`, `workflows`). They fail identically at the base tip and are out of scope here.
 
 ## Progress
 
@@ -51,4 +52,5 @@ PR: #399
 ### Phase 2: Verify navigation and behavior
 
 - [x] 2.1 Update registry, route, and bookmarklet surface tests for the new subpage — squashed into this PR's single commit
-- [ ] 2.2 Update the redesign spec route and Settings inventory, then run the configured validation gate — spec updated in this PR's single commit; gate blocked by sandbox child-process restrictions
+- [x] 2.2 Update the redesign spec route and Settings inventory, then run the configured validation gate — spec updated in this PR's single commit; full gate green (typecheck, 1,908 tests, test:unit, build, test:package)
+- [x] Post-review: add the `settings-bookmarklets` e2e spec and correct the settings-nav count in `settings-appearance.e2e.ts`

--- a/.ai/specs/2026-07-14-cockpit-ui-redesign.md
+++ b/.ai/specs/2026-07-14-cockpit-ui-redesign.md
@@ -180,7 +180,8 @@ cezar's default stays exactly `npx cezar-cli` in a repo: zero config, zero flags
 
 New nav tab, registry-driven so sections grow without layout changes:
 
-- **Skills** (now): the current skills catalog + refresh + bookmarklet panel move here, with project-first ordering (#377).
+- **Skills** (now): the current skills catalog + refresh move here, with project-first ordering (#377).
+- **Bookmarklets** (now): the generic launcher and the available per-skill bookmarklets get a dedicated, discoverable Settings subpage; the former Skills deep link remains compatible.
 - **Appearance** (now): theme light/dark/system, accent choice (lime default), UI density. Persisted in `ui-state.json` (additive keys).
 - **Agents** (now): default runner, per-runner model presets, **the system prompt** (the single place it is edited), base branch — today's scattered `PUT /api/config` knobs in one place. Coding-agent-agnostic: sections describe capabilities (`runner`, `model`, `system prompt`), never vendor-specific config formats.
 - **MCP, notifications, keyboard** (later): placeholder sections listed in the registry but hidden until implemented.
@@ -208,7 +209,7 @@ Deep-linkable, pasteable, refresh-safe navigation (react-router; the Hono server
 /compare/:groupId      → variants compare
 /git                   /github    /github/issues/:n   /github/prs/:n
 /inbox                 /workflows /workflows/:name
-/settings              /settings/skills  /settings/appearance  /settings/agents
+/settings              /settings/skills  /settings/bookmarklets  /settings/appearance  /settings/agents
 ```
 
 Selected run, active tab, review-gate state — all restorable from the URL; sharing a `/tasks/:id/changes` link drops a teammate (same machine/tailnet, or hosted mode) exactly where you are. Unknown routes → CenteredState 404 with a "Back to tasks" action. The legacy `/new` contract and launch-key auto-start keep working verbatim.
@@ -260,7 +261,7 @@ Tabs sit in the run detail next to the thread: **Session | Changes | Files** (mo
 
 ### Skills, Workflows, Inbox
 
-- **Skills** moves under Settings (catalog + detail + refresh + bookmarklets) — project skills first and bold (#377), stable scroll/selection (#384). A read-only skills browser remains reachable from pickers ("View skill" preview in the dropdown).
+- **Skills** moves under Settings (catalog + detail + refresh) — project skills first and bold (#377), stable scroll/selection (#384). Bookmarklets have their own Settings subpage while the former Skills deep link stays compatible. A read-only skills browser remains reachable from pickers ("View skill" preview in the dropdown).
 - **Workflows builder**: same capabilities (canvas, drag from palette, YAML import/export/preview, 8-step limit), rebuilt on dnd-kit + shadcn — visual language only, no behavior change.
 - **Inbox**: card list restyled (CenteredState empty state, status dots, Run/Dismiss buttons); badge logic unchanged.
 
@@ -314,7 +315,7 @@ Each phase is independently shippable; issues in parentheses close in that phase
 - **R3 — Thread**: full task detail — turns, tool cards, context groups, reasoning, plan dock, step rail, Streamdown+Shiki, virtua, composer (skills `/`, `@` files, dictation, attachments), review gate, variants compare. (#381, #382, #379, #380, dictation)
 - **R4 — New task + list**: full-screen composer with plan-mode toggle + variants; task list/table upgrades with editable titles + ± stats. (#386, #383, #389)
 - **R5 — Git view + forge seam**: structured changes/files endpoints, git actions (commit/push/branch), forge driver extraction, Changes/Files tabs, repo view rebuild, Create/View PR, open-in-editor/VS Code handoff. (#390, #385-adjacent forge gating)
-- **R6 — Remaining views + Settings**: GitHub tab (searchable dropdowns), Skills→Settings, Workflows builder, Inbox, Settings (skills/appearance/agents), notifications. (#385, #377, #384)
+- **R6 — Remaining views + Settings**: GitHub tab (searchable dropdowns), Skills→Settings, Workflows builder, Inbox, Settings (skills/bookmarklets/appearance/agents), notifications. (#385, #377, #384)
 - **R7 — Retirement + polish**: delete legacy `web/app.js`/`style.css`, packaging flip to `web/dist`, design-guardian in gate, iOS pass on every view, docs/screenshots refresh.
 
 ## Implementation Plan
@@ -351,7 +352,7 @@ Steps are sized for autonomous runs (om-auto-create-pr / -loop, one PR per phase
 
 ### Phase R6 — Views + Settings
 19. GitHub tab (cmdk dropdowns, forge gating); Inbox restyle.
-20. Workflows builder on dnd-kit; Skills under Settings (+ ordering, bookmarklets); Settings shell (registry: skills/appearance/agents) + notifications toggle.
+20. Workflows builder on dnd-kit; Skills under Settings (+ ordering); dedicated Bookmarklets subpage; Settings shell (registry: skills/bookmarklets/appearance/agents) + notifications toggle.
 
 ### Phase R7 — Retirement
 21. Delete legacy web app; packaging flip (`files: web/dist`, prepublish build); design-guardian + bundle check in validation gate; full iOS + degradation-matrix QA sweep.

--- a/web/app/e2e/settings-appearance.e2e.ts
+++ b/web/app/e2e/settings-appearance.e2e.ts
@@ -59,9 +59,11 @@ describe('settings → appearance against the live dry-run server', () => {
     browser.waitForFunction(`document.querySelector('[data-route="settings-appearance"]') !== null`)
 
     const nav = '[data-slot="settings-nav"]'
-    expect(browser.count(`${nav} [data-section]`)).toBe(4)
+    expect(browser.count(`${nav} [data-section]`)).toBe(6)
     expect(browser.count(`${nav} [data-section="skills"]`)).toBe(1)
+    expect(browser.count(`${nav} [data-section="bookmarklets"]`)).toBe(1)
     expect(browser.count(`${nav} [data-section="agents"]`)).toBe(1)
+    expect(browser.count(`${nav} [data-section="resources"]`)).toBe(1)
     expect(browser.count(`${nav} [data-section="notifications"]`)).toBe(1)
     // Hidden registry entries: no nav, and the URL is an honest 404 (asserted in unit tests).
     expect(browser.count(`${nav} [data-section="mcp"]`)).toBe(0)

--- a/web/app/e2e/settings-bookmarklets.e2e.ts
+++ b/web/app/e2e/settings-bookmarklets.e2e.ts
@@ -1,0 +1,156 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { AgentBrowser, readTestEnv } from './agent-browser'
+
+/**
+ * Settings → Bookmarklets end-to-end against the shared dry-run environment.
+ *
+ * Reachability: fully reachable. The generator needs only the skills catalog (discovered
+ * fresh on every GET, so the suite seeds two real project skills into this worktree's
+ * `.ai/skills/` and removes them in afterAll) and the launch-key route. Nothing here
+ * executes a `javascript:` URL — the page is a drag source only (spec 011 §5), so the specs
+ * assert on the generated `href`, which is exactly what a user would drag to their bar.
+ *
+ * The `/new?skill=&auto=&key=&ref=` grammar these links bake is a PROTECTED contract
+ * (BACKWARD_COMPATIBILITY.md §1): promoting the generator to its own subpage must not
+ * change a single character of it, and the legacy `/settings/skills?skill=__bm` entry point
+ * must keep working. Both are pinned below.
+ */
+
+const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
+const sessionId = `e2e-settings-bookmarklets-${process.pid}`
+
+const DESKTOP = { width: 1440, height: 900 }
+
+const skillsDir = resolve(import.meta.dirname, '../../../.ai/skills')
+const ALPHA = 'e2e-bm-alpha-skill'
+const BETA = 'e2e-bm-beta-skill'
+
+let browser: AgentBrowser
+let baseUrl: string
+let createdSkillsDir = false
+
+const linkIn = (slot: string) => `[data-slot="${slot}"] [data-slot="bm-link"]`
+const hrefOf = (selector: string) =>
+  decodeURIComponent(String(browser.evaluate(`document.querySelector('${selector}').getAttribute('href')`)))
+/** The generated href lands imperatively after mount — never read it before it is a real URL. */
+const waitForGeneratedHref = (selector: string) =>
+  browser.waitForFunction(
+    `(document.querySelector('${selector}')?.getAttribute('href') ?? '').startsWith('javascript:')`,
+  )
+/**
+ * Backspace the filter empty the way a user does. `fill(selector, '')` cannot do this: it
+ * assigns `.value` directly, which a controlled React input never observes — the DOM would
+ * read empty while the component still filtered on the old needle.
+ */
+const clearFilter = () => {
+  const selector = '[data-slot="bm-filter"]'
+  browser.click(selector)
+  const length = Number(browser.evaluate(`document.querySelector('${selector}').value.length`))
+  for (let i = 0; i < length; i += 1) browser.press('Backspace')
+}
+
+beforeAll(() => {
+  baseUrl = readTestEnv().baseUrl
+  createdSkillsDir = !existsSync(skillsDir)
+  mkdirSync(skillsDir, { recursive: true })
+  writeFileSync(
+    resolve(skillsDir, `${ALPHA}.md`),
+    `---\nname: ${ALPHA}\ndescription: An e2e-seeded project skill\n---\n\nDo the alpha thing.\n`,
+    'utf8',
+  )
+  writeFileSync(
+    resolve(skillsDir, `${BETA}.md`),
+    `---\nname: ${BETA}\ndescription: The second seeded skill\n---\n\nDo the beta thing.\n`,
+    'utf8',
+  )
+  browser = AgentBrowser.open(sessionId)
+  browser.setViewport(DESKTOP.width, DESKTOP.height)
+})
+
+afterAll(() => {
+  // Never leave test skills in a developer's catalog.
+  rmSync(resolve(skillsDir, `${ALPHA}.md`), { force: true })
+  rmSync(resolve(skillsDir, `${BETA}.md`), { force: true })
+  if (createdSkillsDir) rmSync(skillsDir, { recursive: true, force: true })
+  browser?.close()
+})
+
+describe('settings → bookmarklets against the live dry-run server', () => {
+  it('is a first-class subpage: /settings/bookmarklets renders the generator and the nav marks it current', () => {
+    browser.goto(`${baseUrl}/settings/bookmarklets`)
+    browser.waitForFunction(`document.querySelector('[data-slot="bookmarklet-panel"]') !== null`)
+
+    // The point of the change (#399): reachable by URL and findable in the nav, not buried
+    // behind a Skills deep link.
+    const nav = '[data-slot="settings-nav"]'
+    expect(browser.count(`${nav} [data-section="bookmarklets"]`)).toBe(1)
+    expect(
+      browser.evaluate(`document.querySelector('${nav} [aria-current="page"]').getAttribute('data-section')`),
+    ).toBe('bookmarklets')
+    browser.screenshot(`${artifactsDir}/settings-bookmarklets.png`)
+  })
+
+  it('the generic launcher bakes the protected /new grammar with the server real launch key', () => {
+    waitForGeneratedHref(linkIn('bm-generic'))
+    const generic = hrefOf(linkIn('bm-generic'))
+
+    // The protected deep-link grammar (BACKWARD_COMPATIBILITY.md §1), baked with the real key.
+    expect(generic).toContain(`'/new?'+q`)
+    expect(generic).toMatch(/auto=0&key=[^&]+&ref=/)
+    // A real key, not the empty-string fallback of a failed fetch.
+    expect(generic).toMatch(/key=[^&]+&/)
+    // The generic launcher carries no skill — it only prefills the form.
+    expect(generic).not.toContain('skill=')
+  })
+
+  it('one launcher per catalog skill, and the filter narrows the list', () => {
+    browser.waitForFunction(
+      `[...document.querySelectorAll('[data-slot="bm-list"] [data-slot="bm-link"]')].some((a) => a.textContent.includes('/${ALPHA}'))`,
+    )
+    expect(browser.count('[data-slot="bm-list"] [data-slot="bm-row"]')).toBeGreaterThanOrEqual(2)
+
+    browser.fill('[data-slot="bm-filter"]', ALPHA)
+    browser.waitForFunction(
+      `document.querySelectorAll('[data-slot="bm-list"] [data-slot="bm-row"]').length === 1`,
+    )
+    expect(browser.text('[data-slot="bm-list"]')).toContain(`/${ALPHA}`)
+    expect(browser.text('[data-slot="bm-list"]')).not.toContain(`/${BETA}`)
+
+    // A filter that matches nothing says so rather than rendering an empty void.
+    browser.fill('[data-slot="bm-filter"]', 'zzz-no-such-skill')
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="bm-list"]').textContent.includes('(no skills match)')`,
+    )
+    clearFilter()
+    browser.waitForFunction(
+      `[...document.querySelectorAll('[data-slot="bm-list"] [data-slot="bm-link"]')].some((a) => a.textContent.includes('/${BETA}'))`,
+    )
+  })
+
+  it('one-click launch arms the per-skill launchers but never the generic one', () => {
+    const skillLink = `[data-slot="bm-list"] [data-slot="bm-row"] [data-slot="bm-link"]`
+    waitForGeneratedHref(skillLink)
+    expect(hrefOf(skillLink)).toContain('auto=0')
+
+    browser.click('[data-slot="bm-auto"]')
+    browser.waitForFunction(
+      `decodeURIComponent(document.querySelector('${skillLink}').getAttribute('href')).includes('auto=1')`,
+    )
+    expect(hrefOf(skillLink)).toContain('auto=1')
+
+    // The generic launcher forces auto off no matter what the checkbox says: it has no skill
+    // to run, so auto-submitting it would arm nothing.
+    expect(hrefOf(linkIn('bm-generic'))).toContain('auto=0')
+  })
+
+  it('the legacy /settings/skills?skill=__bm entry point still opens the same generator', () => {
+    // Compatibility: bookmarks and docs pointing at the old deep link must not 404 or go blank.
+    browser.goto(`${baseUrl}/settings/skills?skill=__bm`)
+    browser.waitForFunction(`document.querySelector('[data-slot="bookmarklet-panel"]') !== null`)
+    waitForGeneratedHref(linkIn('bm-generic'))
+    expect(hrefOf(linkIn('bm-generic'))).toContain(`'/new?'+q`)
+  })
+})

--- a/web/app/src/routes.test.tsx
+++ b/web/app/src/routes.test.tsx
@@ -81,6 +81,7 @@ describe('route map', () => {
     ['/workflows/ship-it', 'workflows', 'Loading workflows…'],
     ['/settings', 'settings', 'Settings'],
     ['/settings/skills', 'settings-skills', 'Skills'],
+    ['/settings/bookmarklets', 'settings-bookmarklets', 'Bookmarklets'],
     ['/settings/appearance', 'settings-appearance', 'Appearance'],
     ['/settings/agents', 'settings-agents', 'Agents'],
     ['/settings/notifications', 'settings-notifications', 'Notifications'],

--- a/web/app/src/routes/settings/bookmarklets-section.tsx
+++ b/web/app/src/routes/settings/bookmarklets-section.tsx
@@ -14,6 +14,15 @@ import { orderSkills } from '@/lib/skills'
 export function BookmarkletsSection() {
   const skillsQuery = useSkills()
 
+  // Without this the in-flight catalog renders as the panel's empty state, which tells the
+  // user "(no skills yet)" — a claim that is simply false while the fetch is still running.
+  if (skillsQuery.isPending) {
+    return (
+      <p data-slot="bookmarklets-loading" className="p-4 text-[13px] text-soft-foreground md:p-6">
+        Loading bookmarklets…
+      </p>
+    )
+  }
   if (skillsQuery.isError) {
     return (
       <CenteredState

--- a/web/app/src/routes/settings/bookmarklets-section.tsx
+++ b/web/app/src/routes/settings/bookmarklets-section.tsx
@@ -1,0 +1,160 @@
+import { TriangleAlertIcon, ZapIcon } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+
+import { useLaunchKey, useSkills } from '@/api/queries'
+import type { Skill } from '@/api/types'
+import { CenteredState } from '@/components/centered-state'
+import { Input } from '@/components/ui/input'
+import { toast } from '@/components/ui/toaster'
+import { bookmarkletUrl } from '@/lib/bookmarklet'
+import { orderSkills } from '@/lib/skills'
+
+/** Settings → Bookmarklets (spec 011): the legacy generic and per-skill launchers promoted
+ *  to a first-class, discoverable Settings subpage. */
+export function BookmarkletsSection() {
+  const skillsQuery = useSkills()
+
+  if (skillsQuery.isError) {
+    return (
+      <CenteredState
+        icon={<TriangleAlertIcon />}
+        tone="danger"
+        heading="h2"
+        title="Could not load bookmarklets"
+        subtitle={skillsQuery.error.message}
+      />
+    )
+  }
+
+  return (
+    <div className="flex min-h-full flex-1 overflow-y-auto px-4 py-5 md:px-7">
+      <BookmarkletPanel skills={orderSkills(skillsQuery.data ?? [])} />
+    </div>
+  )
+}
+
+/**
+ * The bookmarklet generator panel (spec 011, ported from the legacy cockpit): draggable
+ * `javascript:` links against the protected `/new?skill=&key=` contract (`lib/bookmarklet`).
+ * A failed key fetch degrades exactly like legacy — the links still generate, auto-start
+ * just will not arm.
+ *
+ * Exported so the former Settings → Skills deep link remains compatible while the same
+ * generator also has its own Settings subpage.
+ */
+export function BookmarkletPanel({ skills }: { skills: readonly Skill[] }) {
+  const launchKey = useLaunchKey()
+  const [auto, setAuto] = useState(false)
+  const [filter, setFilter] = useState('')
+  const key = launchKey.data?.key ?? ''
+  const needle = filter.trim().toLowerCase()
+  const shown = skills.filter((skill) => skill.name.toLowerCase().includes(needle))
+
+  return (
+    <div data-slot="bookmarklet-panel" className="mx-auto w-full max-w-2xl">
+      <h2 className="text-base font-semibold">Run from GitHub</h2>
+      <p className="mt-2 text-[13px] leading-relaxed text-muted-foreground">
+        Drag a button below to your browser&apos;s bookmarks bar. On any GitHub PR or issue, click it —
+        it finds your running cockpit on localhost (ports 4321–4330) and picks the one serving that
+        repo. The cockpit must be running: <span className="font-mono">npx cezar</span>.
+      </p>
+
+      <label className="mt-4 flex items-center gap-2 text-[13px] font-medium">
+        <input
+          type="checkbox"
+          data-slot="bm-auto"
+          checked={auto}
+          onChange={(event) => setAuto(event.target.checked)}
+          className="size-3.5"
+        />
+        One-click launch (auto-submit){' '}
+        <span className="font-normal text-soft-foreground">— re-drag the buttons after changing this</span>
+      </label>
+
+      <div data-slot="bm-generic" className="mt-4">
+        {/* Generic launcher: no skill, auto forced off — it only prefills the form. */}
+        <BookmarkletRow
+          label="cezar: this PR/issue"
+          url={bookmarkletUrl('', false, key)}
+          hint="prefills the form — nothing starts by itself"
+        />
+      </div>
+
+      <Input
+        data-slot="bm-filter"
+        placeholder="Filter skills…"
+        aria-label="Filter bookmarklet skills"
+        value={filter}
+        onChange={(event) => setFilter(event.target.value)}
+        className="mt-5 h-8 text-[13px]"
+      />
+      <div data-slot="bm-list" className="mt-3 flex flex-col gap-2">
+        {shown.length > 0 ? (
+          shown.map((skill) => (
+            <BookmarkletRow
+              key={skill.path}
+              label={`/${skill.name}`}
+              url={bookmarkletUrl(skill.name, auto, key)}
+              hint={skill.source}
+            />
+          ))
+        ) : (
+          <p className="text-xs text-soft-foreground">
+            {skills.length > 0
+              ? '(no skills match)'
+              : '(no skills yet — the generic launcher above still works)'}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function BookmarkletRow({ label, url, hint }: { label: string; url: string; hint?: string }) {
+  // React (rightly) refuses `javascript:` hrefs at render time — but a bookmarklet IS one by
+  // definition, and dragging to the bookmarks bar needs the real href on the DOM node. The
+  // link is a drag source only (the click handler below never lets it execute), so setting
+  // the attribute imperatively is the honest escape hatch.
+  const anchor = useRef<HTMLAnchorElement>(null)
+  useEffect(() => {
+    anchor.current?.setAttribute('href', url)
+  }, [url])
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url)
+      toast('Bookmarklet URL copied.')
+    } catch {
+      toast('Copy failed — drag the button instead.', { tone: 'danger' })
+    }
+  }
+  return (
+    <div data-slot="bm-row" className="flex min-w-0 items-center gap-2.5">
+      {/* A drag SOURCE only — the cockpit page never executes the javascript: URL itself
+          (spec 011 §5), so a plain click just explains the gesture. */}
+      <a
+        ref={anchor}
+        draggable
+        data-slot="bm-link"
+        title="Drag me to your bookmarks bar"
+        onClick={(event) => {
+          event.preventDefault()
+          toast('Drag me to your bookmarks bar')
+        }}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 font-mono text-xs font-medium text-foreground shadow-xs transition-colors hover:bg-muted"
+      >
+        <ZapIcon aria-hidden="true" className="size-3 text-primary" />
+        {label}
+      </a>
+      <button
+        type="button"
+        data-slot="bm-copy"
+        title="Copy the bookmarklet URL"
+        onClick={() => void copy()}
+        className="shrink-0 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        Copy
+      </button>
+      {hint ? <span className="min-w-0 truncate text-[11px] text-soft-foreground">{hint}</span> : null}
+    </div>
+  )
+}

--- a/web/app/src/routes/settings/registry.tsx
+++ b/web/app/src/routes/settings/registry.tsx
@@ -1,5 +1,6 @@
 import {
   BellIcon,
+  BookmarkIcon,
   BotIcon,
   GaugeIcon,
   KeyboardIcon,
@@ -12,6 +13,7 @@ import type { ComponentType, SVGProps } from 'react'
 import { CenteredState } from '@/components/centered-state'
 import { AgentsSection } from './agents-section'
 import { AppearanceSection } from './appearance'
+import { BookmarkletsSection } from './bookmarklets-section'
 import { NotificationsSection } from './notifications-section'
 import { ResourcesSection } from './resources-section'
 import { SkillsSection } from './skills-section'
@@ -28,6 +30,7 @@ import { SkillsSection } from './skills-section'
 
 export type SettingsSectionId =
   | 'skills'
+  | 'bookmarklets'
   | 'appearance'
   | 'agents'
   | 'resources'
@@ -68,6 +71,13 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     description: 'Markdown playbooks agents can follow.',
     icon: SparklesIcon,
     component: SkillsSection,
+  },
+  {
+    id: 'bookmarklets',
+    title: 'Bookmarklets',
+    description: 'Launch skills from a GitHub PR or issue.',
+    icon: BookmarkIcon,
+    component: BookmarkletsSection,
   },
   {
     id: 'appearance',

--- a/web/app/src/routes/settings/settings.test.tsx
+++ b/web/app/src/routes/settings/settings.test.tsx
@@ -66,7 +66,7 @@ afterEach(() => {
 describe('the section registry', () => {
   it('declares the spec §Settings sections, later ones hidden', () => {
     const byId = new Map(SETTINGS_SECTIONS.map((s) => [s.id, s]))
-    for (const id of ['skills', 'appearance', 'agents', 'resources', 'notifications']) {
+    for (const id of ['skills', 'bookmarklets', 'appearance', 'agents', 'resources', 'notifications']) {
       expect(byId.get(id as never)?.hidden).toBeUndefined()
     }
     // Listed in the registry but hidden until implemented (later phases).
@@ -75,6 +75,7 @@ describe('the section registry', () => {
     }
     expect(visibleSettingsSections().map((s) => s.id)).toEqual([
       'skills',
+      'bookmarklets',
       'appearance',
       'agents',
       'resources',
@@ -88,19 +89,22 @@ describe('the settings shell', () => {
     renderAt('/settings/appearance')
     const nav = document.querySelector('[data-slot="settings-nav"]')!
     const ids = [...nav.querySelectorAll('[data-section]')].map((el) => el.getAttribute('data-section'))
-    expect(ids).toEqual(['skills', 'appearance', 'agents', 'resources', 'notifications'])
+    expect(ids).toEqual(['skills', 'bookmarklets', 'appearance', 'agents', 'resources', 'notifications'])
     // The active section is marked for assistive tech, not just by color.
     expect(nav.querySelector('[aria-current="page"]')?.getAttribute('data-section')).toBe('appearance')
     // The mobile pill row renders through the same registry — the two can never disagree.
     const pills = document.querySelector('[data-slot="settings-nav-mobile"]')!
-    expect([...pills.querySelectorAll('[data-section]')].length).toBe(5)
+    expect([...pills.querySelectorAll('[data-section]')].length).toBe(6)
   })
 
   it('/settings is the registry as an index — one card per visible section', () => {
     renderAt('/settings')
     const index = document.querySelector('[data-slot="settings-index"]')!
     const ids = [...index.querySelectorAll('[data-section]')].map((el) => el.getAttribute('data-section'))
-    expect(ids).toEqual(['skills', 'appearance', 'agents', 'resources', 'notifications'])
+    expect(ids).toEqual(['skills', 'bookmarklets', 'appearance', 'agents', 'resources', 'notifications'])
+    expect(index.querySelector('[data-section="bookmarklets"]')?.getAttribute('href')).toBe(
+      '/settings/bookmarklets',
+    )
     expect(index.querySelector('[data-section="appearance"]')?.getAttribute('href')).toBe(
       '/settings/appearance',
     )

--- a/web/app/src/routes/settings/skills-section.test.tsx
+++ b/web/app/src/routes/settings/skills-section.test.tsx
@@ -205,6 +205,30 @@ describe('refresh (#384: selection and scroll survive)', () => {
 })
 
 describe('the bookmarklet panel (spec 011)', () => {
+  it('says it is loading rather than claiming there are no skills while the catalog is in flight', async () => {
+    // The panel's empty state reads "(no skills yet …)". Rendering it against an unresolved
+    // catalog would state that as fact on every cold load of the subpage — so the section
+    // must gate on the pending query the way its sibling sections do.
+    const json = (payload: unknown) =>
+      new Response(JSON.stringify(payload), { status: 200, headers: { 'content-type': 'application/json' } })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url === '/api/launch-key') return json({ key: 'sekret' })
+        if (url === '/api/ui-state') return json({})
+        return new Promise<never>(() => {}) // /api/skills never settles
+      }),
+    )
+    renderAt('/settings/bookmarklets')
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="bookmarklets-loading"]')).not.toBeNull(),
+    )
+    expect(document.querySelector('[data-slot="bookmarklet-panel"]')).toBeNull()
+    expect(document.body.textContent).not.toContain('no skills yet')
+  })
+
   it('is a first-class Settings page that generates protected links and auto-arms per-skill links only', async () => {
     serve()
     renderAt('/settings/bookmarklets')

--- a/web/app/src/routes/settings/skills-section.test.tsx
+++ b/web/app/src/routes/settings/skills-section.test.tsx
@@ -205,9 +205,9 @@ describe('refresh (#384: selection and scroll survive)', () => {
 })
 
 describe('the bookmarklet panel (spec 011)', () => {
-  it('generates the protected /new links from the launch key; auto arms per-skill links only', async () => {
+  it('is a first-class Settings page that generates protected links and auto-arms per-skill links only', async () => {
     serve()
-    renderAt('/settings/skills?skill=__bm')
+    renderAt('/settings/bookmarklets')
 
     await waitFor(() => expect(document.querySelector('[data-slot="bookmarklet-panel"]')).not.toBeNull())
     // The key landed in the links (the panel is its one legitimate DOM use).

--- a/web/app/src/routes/settings/skills-section.tsx
+++ b/web/app/src/routes/settings/skills-section.tsx
@@ -1,18 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeftIcon, RefreshCwIcon, SparklesIcon, TriangleAlertIcon, ZapIcon } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { Link, useSearchParams } from 'react-router'
 
 import { refreshSkills } from '@/api/client'
-import { queryKeys, useLaunchKey, useSkills, useWorkflows } from '@/api/queries'
+import { queryKeys, useSkills, useWorkflows } from '@/api/queries'
 import type { Skill } from '@/api/types'
 import { CenteredState } from '@/components/centered-state'
 import { SkillDetailBody, SkillSourceTag } from '@/components/skill-detail'
 import { Input } from '@/components/ui/input'
 import { toast } from '@/components/ui/toaster'
-import { bookmarkletUrl } from '@/lib/bookmarklet'
 import { filterSkills, isProjectSkill, orderSkills, skillUsedBy } from '@/lib/skills'
 import { cn } from '@/lib/utils'
+import { BookmarkletPanel } from './bookmarklets-section'
 
 /**
  * Settings → Skills (R6 Step 1.4, spec §"Skills, Workflows, Inbox"): the legacy Skills tab
@@ -232,128 +232,5 @@ function SkillRow({ skill, active }: { skill: Skill; active: boolean }) {
         ) : null}
       </Link>
     </li>
-  )
-}
-
-/**
- * The bookmarklet generator panel (spec 011, ported from the legacy cockpit): draggable
- * `javascript:` links against the protected `/new?skill=&key=` contract (`lib/bookmarklet`).
- * A failed key fetch degrades exactly like legacy — the links still generate, auto-start
- * just will not arm.
- */
-function BookmarkletPanel({ skills }: { skills: readonly Skill[] }) {
-  const launchKey = useLaunchKey()
-  const [auto, setAuto] = useState(false)
-  const [filter, setFilter] = useState('')
-  const key = launchKey.data?.key ?? ''
-  const needle = filter.trim().toLowerCase()
-  const shown = skills.filter((skill) => skill.name.toLowerCase().includes(needle))
-
-  return (
-    <div data-slot="bookmarklet-panel" className="mx-auto w-full max-w-2xl">
-      <h2 className="text-base font-semibold">Run from GitHub</h2>
-      <p className="mt-2 text-[13px] leading-relaxed text-muted-foreground">
-        Drag a button below to your browser&apos;s bookmarks bar. On any GitHub PR or issue, click it —
-        it finds your running cockpit on localhost (ports 4321–4330) and picks the one serving that
-        repo. The cockpit must be running: <span className="font-mono">npx cezar</span>.
-      </p>
-
-      <label className="mt-4 flex items-center gap-2 text-[13px] font-medium">
-        <input
-          type="checkbox"
-          data-slot="bm-auto"
-          checked={auto}
-          onChange={(event) => setAuto(event.target.checked)}
-          className="size-3.5"
-        />
-        One-click launch (auto-submit){' '}
-        <span className="font-normal text-soft-foreground">— re-drag the buttons after changing this</span>
-      </label>
-
-      <div data-slot="bm-generic" className="mt-4">
-        {/* Generic launcher: no skill, auto forced off — it only prefills the form. */}
-        <BookmarkletRow
-          label="cezar: this PR/issue"
-          url={bookmarkletUrl('', false, key)}
-          hint="prefills the form — nothing starts by itself"
-        />
-      </div>
-
-      <Input
-        data-slot="bm-filter"
-        placeholder="Filter skills…"
-        aria-label="Filter bookmarklet skills"
-        value={filter}
-        onChange={(event) => setFilter(event.target.value)}
-        className="mt-5 h-8 text-[13px]"
-      />
-      <div data-slot="bm-list" className="mt-3 flex flex-col gap-2">
-        {shown.length > 0 ? (
-          shown.map((skill) => (
-            <BookmarkletRow
-              key={skill.path}
-              label={`/${skill.name}`}
-              url={bookmarkletUrl(skill.name, auto, key)}
-              hint={skill.source}
-            />
-          ))
-        ) : (
-          <p className="text-xs text-soft-foreground">
-            {skills.length > 0
-              ? '(no skills match)'
-              : '(no skills yet — the generic launcher above still works)'}
-          </p>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function BookmarkletRow({ label, url, hint }: { label: string; url: string; hint?: string }) {
-  // React (rightly) refuses `javascript:` hrefs at render time — but a bookmarklet IS one by
-  // definition, and dragging to the bookmarks bar needs the real href on the DOM node. The
-  // link is a drag source only (the click handler below never lets it execute), so setting
-  // the attribute imperatively is the honest escape hatch.
-  const anchor = useRef<HTMLAnchorElement>(null)
-  useEffect(() => {
-    anchor.current?.setAttribute('href', url)
-  }, [url])
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(url)
-      toast('Bookmarklet URL copied.')
-    } catch {
-      toast('Copy failed — drag the button instead.', { tone: 'danger' })
-    }
-  }
-  return (
-    <div data-slot="bm-row" className="flex min-w-0 items-center gap-2.5">
-      {/* A drag SOURCE only — the cockpit page never executes the javascript: URL itself
-          (spec 011 §5), so a plain click just explains the gesture. */}
-      <a
-        ref={anchor}
-        draggable
-        data-slot="bm-link"
-        title="Drag me to your bookmarks bar"
-        onClick={(event) => {
-          event.preventDefault()
-          toast('Drag me to your bookmarks bar')
-        }}
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 font-mono text-xs font-medium text-foreground shadow-xs transition-colors hover:bg-muted"
-      >
-        <ZapIcon aria-hidden="true" className="size-3 text-primary" />
-        {label}
-      </a>
-      <button
-        type="button"
-        data-slot="bm-copy"
-        title="Copy the bookmarklet URL"
-        onClick={() => void copy()}
-        className="shrink-0 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-      >
-        Copy
-      </button>
-      {hint ? <span className="min-w-0 truncate text-[11px] text-soft-foreground">{hint}</span> : null}
-    </div>
   )
 }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-15-restore-settings-bookmarklets.md
Status: in-progress

## Goal
- Restore the available bookmarklet list as a first-class Settings subpage.

## What Changed
- Added Settings → Bookmarklets at /settings/bookmarklets.
- Preserved the former Settings → Skills bookmarklet deep link.
- Added route, registry, and bookmarklet behavior coverage.

## Tests
- npm run typecheck
- npx vitest run --project web (1454 passed)
- npm run test:unit
- npm_config_cache=/tmp/cezar-npm-cache npm run build
- Full npm test/package gates remain sandbox-blocked by child-process restrictions.

## Breaking Changes
- None. The protected /new bookmarklet contract is unchanged.

## Progress
See the Progress section in the tracking plan.