### PR TITLE
docs(agents): document the zero-config principle

### DIFF
--- a/.ai/runs/2026-07-16-zero-config-principle.md
+++ b/.ai/runs/2026-07-16-zero-config-principle.md
@@ -18,6 +18,8 @@ Add a top-level `## Zero config` section to `AGENTS.md` capturing cezar's zero-c
 
 - None to runtime. Doctrine binds future work by intent — that is the point, and why it is a standalone PR.
 
+PR: #409
+
 ## Progress
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.

--- a/.ai/runs/2026-07-16-zero-config-principle.md
+++ b/.ai/runs/2026-07-16-zero-config-principle.md
@@ -1,0 +1,27 @@
+# Execution plan: document the zero-config principle
+
+**Related:** `.ai/specs/2026-07-16-multi-project-switcher.md` (appendix drafted this text); split out per explicit decision so the doctrine is reviewed as repo-wide law, not a spec checkbox.
+
+## Goal
+
+Add a top-level `## Zero config` section to `AGENTS.md` capturing cezar's zero-config principle: nothing the user must configure before it works; new state may be written but never required; exposure/cost is opt-in behind `CEZ_*` flags; degrade rather than fail.
+
+## Scope
+
+- Edit exactly one file: `AGENTS.md` — insert the section between the intro paragraph and `## Task routing`.
+
+## Non-goals
+
+- Any code change; any other doc.
+
+## Risks
+
+- None to runtime. Doctrine binds future work by intent — that is the point, and why it is a standalone PR.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Add the section
+
+- [ ] 1.1 Insert `## Zero config` into AGENTS.md before `## Task routing`

--- a/.ai/runs/2026-07-16-zero-config-principle.md
+++ b/.ai/runs/2026-07-16-zero-config-principle.md
@@ -24,4 +24,4 @@ Add a top-level `## Zero config` section to `AGENTS.md` capturing cezar's zero-c
 
 ### Phase 1: Add the section
 
-- [ ] 1.1 Insert `## Zero config` into AGENTS.md before `## Task routing`
+- [x] 1.1 Insert `## Zero config` into AGENTS.md before `## Task routing` — d2593cc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,20 @@
 
 cezar is a **parallel coding-agents orchestrator**: a local cockpit (CLI + browser GUI) for running and tracking AI coding-agent tasks in a repo. You type a task, pick a workflow and a backend — Claude Code, Codex or OpenCode, or a mix per step — and watch it work live: steps, tool calls, tokens, diffs. Each task runs in its own git worktree, ends at a review gate (never auto-merges), and can be pushed as a draft PR through `gh`. Everything is local: no accounts, no database, no cloud — state is plain JSON, NDJSON and Markdown under `.ai/cezar/`. The server stack stays deliberately small: strict TypeScript (ESM, Node 20+), Hono + SSE, Zod at every boundary, and YAML workflows. The cockpit is React 19 + Vite + Tailwind v4 + shadcn/ui, compiled to static assets (the legacy vanilla UI was retired in R7). Every module is meant to be read in one sitting.
 
+## Zero config
+
+cezar ships no config file the user must create and no setting they must set before it works. Every capability is discovered from what is already there — the repo, the environment, `gh`, the running processes — or it degrades quietly to a smaller cezar. `.ai/cezar/config.json` is optional and every key has a working default; `.env` is never auto-loaded.
+
+New state may be **written**, never **required**: `.ai/cezar/`, `~/.cache/cez/`, `~/.cezar/`. Delete any of them and cezar rebuilds what it needs on the next run. State that a user must author, migrate, or repair is not state — it is configuration, and it needs a reason.
+
+Practical rules:
+
+- When a feature seems to need configuration, the design is wrong. Discover it, or default it.
+- Features that widen exposure or cost (network, other processes) are opt-in behind a `CEZ_*` flag, off by default — the zero-config default is also the safe default.
+- A missing dependency, an absent peer, a read-only home: degrade to a smaller working cockpit, never fail the boot.
+- Prefer a proxy-free, daemon-free mechanism when one exists — and when it doesn't, keep the mechanism invisible: no process to manage, no port to remember, no file to edit.
+- Never trade a working default for a knob.
+
 ## Task routing
 
 | When the task involves… | Read first | Key rules |


### PR DESCRIPTION
## Summary

Adds a top-level **`## Zero config`** section to `AGENTS.md`, documenting a principle cezar already follows but had never written down: no config file the user must create, no setting they must set before it works. New state may be *written* (`.ai/cezar/`, `~/.cache/cez/`, `~/.cezar/`) but never *required* — delete it and cezar rebuilds it. Anything that widens exposure or cost is opt-in behind a `CEZ_*` flag, off by default. Missing dep / absent peer / read-only home → degrade to a smaller working cockpit, never fail the boot.

## Why a separate PR

The text was drafted in the appendix of the multi-project switcher spec (#406), where it justifies that feature's design (flag-gated, delete-and-rebuild registry, proxy-free). But it is **repo-wide doctrine binding all future work**, so it is split out to be reviewed as doctrine rather than waved through as one spec's Phase 4 checkbox.

## Non-goals

- No code. One section added to `AGENTS.md`.

## How to verify

Read the new `## Zero config` section (between the intro and `## Task routing`). Sanity-check it against how cezar already behaves — `.env` is never auto-loaded, `.ai/cezar/config.json` is optional with defaults, `CEZ_REMOTE` gates host affordances — i.e. the doctrine describes the codebase as it is, not a new requirement.

## What can go wrong

Nothing at runtime — a docs-only edit to `AGENTS.md`. The only "risk" is intentional: it sets a bar future PRs are expected to clear.

Tracking plan: `.ai/runs/2026-07-16-zero-config-principle.md`

Status: complete