### PR TITLE
fix(ui): multi-keyword search and scroll-to-top for searchable dropdowns

### DIFF
--- a/web/app/src/lib/skills.test.ts
+++ b/web/app/src/lib/skills.test.ts
@@ -6,8 +6,10 @@ import {
   filterSkills,
   fuzzyMatch,
   isProjectSkill,
+  multiWordFilter,
   orderSkills,
   orderSkillsByRecency,
+  skillKeywords,
   skillUsedBy,
 } from './skills'
 
@@ -106,6 +108,45 @@ describe('filterSkills (#380: filter without re-sorting — project-first surviv
 
   it('no match → empty, never a throw', () => {
     expect(filterSkills(skills, 'zzz')).toEqual([])
+  })
+})
+
+describe('multiWordFilter (#411: multi-keyword search for cmdk)', () => {
+  it('empty search matches everything (score 1)', () => {
+    expect(multiWordFilter('skill om-auto-review-pr', '')).toBe(1)
+    expect(multiWordFilter('skill om-auto-review-pr', '   ')).toBe(1)
+  })
+
+  it('"auto review" matches "om-auto-review-pr" in the value', () => {
+    expect(multiWordFilter('skill om-auto-review-pr /path', 'auto review')).toBeGreaterThan(0)
+  })
+
+  it('"verify ui" matches via keywords (name parts)', () => {
+    expect(
+      multiWordFilter('skill om-auto-verify-pr-ui', 'verify ui', ['om', 'auto', 'verify', 'pr', 'ui']),
+    ).toBeGreaterThan(0)
+  })
+
+  it('every word must match — partial hits return 0', () => {
+    expect(multiWordFilter('skill om-fix /path', 'fix deploy')).toBe(0)
+  })
+
+  it('matching is case-insensitive', () => {
+    expect(multiWordFilter('skill Deploy /path', 'DEPLOY')).toBeGreaterThan(0)
+  })
+})
+
+describe('skillKeywords', () => {
+  it('splits hyphenated names into parts', () => {
+    expect(skillKeywords('om-auto-review-pr')).toEqual(['om', 'auto', 'review', 'pr'])
+  })
+
+  it('includes the description when provided', () => {
+    expect(skillKeywords('om-fix', 'Fix an issue')).toEqual(['om', 'fix', 'Fix an issue'])
+  })
+
+  it('works with a single-word name', () => {
+    expect(skillKeywords('deploy', null)).toEqual(['deploy'])
   })
 })
 

--- a/web/app/src/lib/skills.ts
+++ b/web/app/src/lib/skills.ts
@@ -69,6 +69,29 @@ export function skillUsedBy(workflows: readonly WorkflowDef[], name: string): st
   return out
 }
 
+/**
+ * Multi-word filter for cmdk `<Command filter={…}>`: splits the typed query on whitespace
+ * and requires every word to appear as a case-insensitive substring in the combined
+ * value + keywords text.  "auto review" finds "om-auto-review-pr", "verify ui" finds
+ * "om-auto-verify-ui".  Returns a 0–1 score (0 = no match) so cmdk hides non-matches
+ * and ranks the rest by coverage.
+ */
+export function multiWordFilter(value: string, search: string, keywords?: string[]): number {
+  const words = search.toLowerCase().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return 1
+  const haystack = [value, ...(keywords ?? [])].join(' ').toLowerCase()
+  if (!words.every((word) => haystack.includes(word))) return 0
+  const matched = words.reduce((sum, w) => sum + w.length, 0)
+  return 0.5 + Math.min(matched / haystack.length, 0.5)
+}
+
+/** Split a skill/workflow name on hyphens so each part is independently searchable as a
+ *  cmdk keyword — keeps the description keyword too. */
+export function skillKeywords(name: string, description?: string | null): string[] {
+  const parts = name.split('-').filter(Boolean)
+  return description ? [...parts, description] : parts
+}
+
 /** The `/` autocomplete's list for a typed query: ordered project-first, then filtered in
  *  place. Matches on the name and, as a fallback, the description ("review" should find
  *  `om-code-review` even when the name says less than the description does). */

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -412,6 +412,24 @@ describe('the hand-to-agent pickers (#385)', () => {
       preview.querySelector('[data-slot="skill-preview-manage"]')?.getAttribute('href'),
     ).toBe('/skills?skill=om-fix')
   })
+
+  it('multi-keyword search: "fix project" narrows the skills list to matches (#411)', async () => {
+    stubFetch()
+    await openDetail()
+
+    fireEvent.click(document.querySelector('[data-slot="gh-skills-trigger"]')!)
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-slot="gh-skill-option"]')).toHaveLength(3),
+    )
+
+    // "fix project" should match om-fix (name splits "om","fix" + description "project fixer")
+    fireEvent.change(screen.getByPlaceholderText('search skills…'), { target: { value: 'fix project' } })
+    await waitFor(() => {
+      const visible = [...document.querySelectorAll('[data-slot="gh-skill-option"]')]
+      expect(visible).toHaveLength(1)
+      expect(visible[0]?.getAttribute('data-skill')).toBe('om-fix')
+    })
+  })
 })
 
 describe('the hand-to-agent run (legacy three-way body)', () => {

--- a/web/app/src/routes/github/hand-to-agent.tsx
+++ b/web/app/src/routes/github/hand-to-agent.tsx
@@ -9,7 +9,7 @@ import {
   XIcon,
   ZapIcon,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link } from 'react-router'
 
 import { createRun } from '@/api/client'
@@ -29,7 +29,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { toast } from '@/components/ui/toaster'
 import { SkillPreviewDialog } from '@/components/skill-detail'
 import { githubRunBody } from '@/lib/github-task'
-import { isProjectSkill } from '@/lib/skills'
+import { isProjectSkill, multiWordFilter, skillKeywords } from '@/lib/skills'
 import { cn } from '@/lib/utils'
 
 /**
@@ -196,7 +196,7 @@ function WorkflowPicker({
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={8} className="w-[320px] max-w-[calc(100vw-2rem)] p-0">
-        <Command>
+        <Command filter={multiWordFilter}>
           <CommandInput placeholder="search workflows…" />
           <CommandList data-slot="gh-workflow-menu" className="max-h-64">
             <CommandEmpty>Nothing matches.</CommandEmpty>
@@ -207,7 +207,7 @@ function WorkflowPicker({
                   <CommandItem
                     key={workflowDef.name}
                     value={`workflow ${workflowDef.name}`}
-                    keywords={workflowDef.description ? [workflowDef.description] : undefined}
+                    keywords={skillKeywords(workflowDef.name, workflowDef.description)}
                     data-slot="gh-workflow-option"
                     data-workflow={workflowDef.name}
                     onSelect={() => {
@@ -252,6 +252,7 @@ function SkillsPicker({
 }) {
   const [open, setOpen] = useState(false)
   const [preview, setPreview] = useState<Skill | null>(null)
+  const listRef = useRef<HTMLDivElement>(null)
   const project = skills.filter(isProjectSkill)
   const global = skills.filter((skill) => !isProjectSkill(skill))
 
@@ -262,7 +263,7 @@ function SkillsPicker({
         key={skill.path}
         // The path suffix keeps values unique when a project skill shadows a global one.
         value={`skill ${skill.name} ${skill.path}`}
-        keywords={skill.description ? [skill.description] : undefined}
+        keywords={skillKeywords(skill.name, skill.description)}
         data-slot="gh-skill-option"
         data-skill={skill.name}
         data-selected={isSelected ? 'true' : undefined}
@@ -310,9 +311,9 @@ function SkillsPicker({
           </button>
         </PopoverTrigger>
         <PopoverContent align="start" sideOffset={8} className="w-[336px] max-w-[calc(100vw-2rem)] p-0">
-          <Command>
-            <CommandInput placeholder="search skills…" />
-            <CommandList data-slot="gh-skill-menu" className="max-h-64">
+          <Command filter={multiWordFilter}>
+            <CommandInput placeholder="search skills…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+            <CommandList ref={listRef} data-slot="gh-skill-menu" className="max-h-64">
               <CommandEmpty>Nothing matches.</CommandEmpty>
               {project.length > 0 ? (
                 <CommandGroup heading="Project skills">{project.map((skill) => skillItem(skill, true))}</CommandGroup>

--- a/web/app/src/routes/github/hand-to-agent.tsx
+++ b/web/app/src/routes/github/hand-to-agent.tsx
@@ -181,6 +181,7 @@ function WorkflowPicker({
   onChange: (workflow: string | null) => void
 }) {
   const [open, setOpen] = useState(false)
+  const listRef = useRef<HTMLDivElement>(null)
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -197,8 +198,8 @@ function WorkflowPicker({
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={8} className="w-[320px] max-w-[calc(100vw-2rem)] p-0">
         <Command filter={multiWordFilter}>
-          <CommandInput placeholder="search workflows…" />
-          <CommandList data-slot="gh-workflow-menu" className="max-h-64">
+          <CommandInput placeholder="search workflows…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+          <CommandList ref={listRef} data-slot="gh-workflow-menu" className="max-h-64">
             <CommandEmpty>Nothing matches.</CommandEmpty>
             <CommandGroup>
               {workflows.map((workflowDef) => {

--- a/web/app/src/routes/new-task.test.tsx
+++ b/web/app/src/routes/new-task.test.tsx
@@ -347,6 +347,37 @@ describe('picker data flows', () => {
     const headings = [...document.querySelectorAll('[cmdk-group-heading]')].map((h) => h.textContent)
     expect(headings).toEqual(['Project skills', 'Workflows', 'Global'])
   })
+
+  it('multi-keyword search: "fix issue" matches om-fix via hyphen-split keywords (#411)', async () => {
+    serve()
+    renderNewTask()
+    await pillReady()
+    fireEvent.click(sourcePill())
+    const input = await screen.findByPlaceholderText('search skills & workflows…')
+
+    // "fix issue" should match "om-fix" because both "fix" and "issue" appear in the
+    // combined value+keywords text (name splits: "om","fix" + description "Fix an issue end to end").
+    fireEvent.change(input, { target: { value: 'fix issue' } })
+    await waitFor(() => {
+      const visible = [...document.querySelectorAll('[data-slot="source-option"]')]
+      expect(visible.some((o) => o.getAttribute('data-source-ref') === 'om-fix')).toBe(true)
+    })
+  })
+
+  it('multi-keyword search hides items that do not match all words (#411)', async () => {
+    serve()
+    renderNewTask()
+    await pillReady()
+    fireEvent.click(sourcePill())
+    const input = await screen.findByPlaceholderText('search skills & workflows…')
+
+    fireEvent.change(input, { target: { value: 'deploy fix' } })
+    await waitFor(() => {
+      // "deploy" does not have "fix" in its name/description, and "om-fix" does not have "deploy"
+      const visible = [...document.querySelectorAll('[data-slot="source-option"]')]
+      expect(visible).toHaveLength(0)
+    })
+  })
 })
 
 // ---- submit bodies (the wire contract) ---------------------------------------------------------

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -33,7 +33,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { toast } from '@/components/ui/toaster'
-import { isProjectSkill, orderSkillsByRecency } from '@/lib/skills'
+import { isProjectSkill, multiWordFilter, orderSkillsByRecency, skillKeywords } from '@/lib/skills'
 import { submitShortcutHint } from '@/lib/use-submit-shortcut'
 import { cn } from '@/lib/utils'
 
@@ -510,6 +510,7 @@ function SourcePill({
 }) {
   const [open, setOpen] = useState(false)
   const [preview, setPreview] = useState<Skill | null>(null)
+  const listRef = useRef<HTMLDivElement>(null)
   const project = skills.filter(isProjectSkill)
   const global = skills.filter((skill) => !isProjectSkill(skill))
   const pick = (next: TaskSource) => {
@@ -524,7 +525,7 @@ function SourcePill({
         key={skill.path}
         // The path suffix keeps values unique when a project skill shadows a global one.
         value={`skill ${skill.name} ${skill.path}`}
-        keywords={skill.description ? [skill.description] : undefined}
+        keywords={skillKeywords(skill.name, skill.description)}
         data-slot="source-option"
         data-source-kind="skill"
         data-source-ref={skill.name}
@@ -585,9 +586,9 @@ function SourcePill({
           sideOffset={8}
           className="w-[336px] max-w-[calc(100vw-2rem)] p-0"
         >
-          <Command>
-            <CommandInput placeholder="search skills & workflows…" />
-            <CommandList data-slot="source-menu" className="max-h-72">
+          <Command filter={multiWordFilter}>
+            <CommandInput placeholder="search skills & workflows…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+            <CommandList ref={listRef} data-slot="source-menu" className="max-h-72">
               <CommandEmpty>Nothing matches.</CommandEmpty>
               {/* Project skills lead, Global trails everything — the closer a skill lives
                   to the repo, the more likely it's the one being picked. */}
@@ -604,7 +605,7 @@ function SourcePill({
                       <CommandItem
                         key={workflow.name}
                         value={`workflow ${workflow.name}`}
-                        keywords={workflow.description ? [workflow.description] : undefined}
+                        keywords={skillKeywords(workflow.name, workflow.description)}
                         data-slot="source-option"
                         data-source-kind="workflow"
                         data-source-ref={workflow.name}


### PR DESCRIPTION
## Summary

Fixes #411 — the skill/workflow searchable dropdowns now support multi-keyword search and scroll to the best match.

- **Multi-keyword search**: typing "auto review" now finds `om-auto-review-pr`, and "verify ui" finds `om-auto-verify-ui`. The new `multiWordFilter` splits the query on whitespace and requires every word to appear as a case-insensitive substring in the combined value + keywords text.
- **Enhanced keywords**: `skillKeywords` splits hyphenated skill/workflow names into individual parts (e.g., `om-auto-review-pr` → `["om", "auto", "review", "pr"]` + description), making each segment independently searchable by cmdk.
- **Scroll-to-top on filter**: the `CommandList` now scrolls to the top on every keystroke so the best-ranked match is always visible.

Applied to all three cmdk-based pickers: `SourcePill` (new-task), `SkillsPicker` and `WorkflowPicker` (hand-to-agent).

## Changed files

| File | Change |
|------|--------|
| `web/app/src/lib/skills.ts` | Add `multiWordFilter` and `skillKeywords` |
| `web/app/src/routes/new-task.tsx` | Apply filter, keywords, and scroll fix to `SourcePill` |
| `web/app/src/routes/github/hand-to-agent.tsx` | Apply filter, keywords, and scroll fix to `SkillsPicker` + `WorkflowPicker` |
| `web/app/src/lib/skills.test.ts` | Unit tests for `multiWordFilter` and `skillKeywords` |
| `web/app/src/routes/new-task.test.tsx` | Regression tests for multi-keyword search in source picker |
| `web/app/src/routes/github/github.test.tsx` | Regression test for multi-keyword search in skills picker |

## Validation

All five gate commands pass:
- `npm run typecheck` ✅
- `npm test` ✅ (1930 tests, 113 files)
- `npm run test:unit` ✅ (4 tests)
- `npm run build` ✅
- `npm run test:package` ✅

## Test plan

- [ ] Open the new-task page, type "auto review" in the skill picker → should show `om-auto-review-pr`
- [ ] Type "verify ui" → should show `om-auto-verify-ui`
- [ ] Type a single keyword like "fix" → should still work as before
- [ ] Scroll down the skill list, then type a search → list should scroll to top
- [ ] Verify the same behavior in the GitHub hand-to-agent skill/workflow pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)