### PR TITLE
fix(runs): auto-discover the task's PR from the conversation (#407)

### DIFF
--- a/.ai/specs/2026-07-16-pr-autodiscovery.md
+++ b/.ai/specs/2026-07-16-pr-autodiscovery.md
@@ -1,0 +1,77 @@
+# PR auto-discovery from the conversation (#407)
+
+Status: IMPLEMENTED 2026-07-16 · Fixes: #407 · Extends: the `#fake-pr` janitor guard in `src/runs/store.ts`, spec 009 (review gate / draft PR)
+
+## Problem
+
+The task list's PR chip is driven by one field, `RunRecord.pullRequestUrl`,
+with exactly two writers: the cockpit's own Draft-PR flow (authoritative) and
+the transcript janitor in `RunStore.appendEvent`. The janitor has two gaps:
+
+1. **It never sees protocol-v2 (ACP-style) events.** It scans only the
+   top-level v1 fields `text` / `result` / `message`; v2 events carry all
+   content nested under `item.*` (`item.text`, `item.title`, `item.input`,
+   `item.output`). A PR URL that only ever appears in a v2 item is persisted
+   to the NDJSON but never spotted.
+2. **A task that works ON an existing PR gets no chip at all.** The
+   `CREATED_PR_RE` guard (the `#fake-pr` rule) adopts a URL only when the
+   agent *created* the PR. That guard is correct — a reviewer must not be
+   mislabeled as the PR's author — but it leaves review/continue/merge tasks
+   (`om-auto-review-pr 4170`, …) with no PR association whatsoever, which is
+   issue #407.
+
+## Model: two tiers of PR association
+
+| Tier | Field | Meaning | Writers |
+|---|---|---|---|
+| created | `pullRequestUrl` | The PR this task **opened** | Draft-PR flow; janitor with the `CREATED_PR_RE` guard (unchanged semantics) |
+| referenced | `referencedPullRequestUrl` | The PR this task is **about** | janitor, from PR URLs referenced anywhere in the conversation |
+
+The created tier always wins. Both fields are additive and optional — old
+`runs.json` files keep parsing (store rule in `AGENTS.md`).
+
+## Discovery rules (janitor, `RunStore`)
+
+- **Sources scanned**, per persisted event: the v1 fields `text` / `result` /
+  `message`, plus for v2 events `item.text`, `item.title`, `item.output` and
+  `item.input` (stringified when not a string). `kind: 'reasoning'` items are
+  skipped — thinking text speculates about PRs it never touches. The initial
+  task prompt is scanned once at `createRun`, so a prompt that pastes a PR
+  URL gets its chip before the first event.
+- **Created detection (unchanged rule, wider sources):** a PR URL adopted
+  into `pullRequestUrl` only when the same event also matches
+  `CREATED_PR_RE`. Scanning v2 sources fixes creation detection for backends
+  that report `gh pr create` through tool items.
+- **Referenced detection:** every distinct PR URL spotted accumulates into
+  `referencedPrCandidates` (capped at 8 — beyond that the conversation is a
+  survey, not a subject). `referencedPullRequestUrl` is then resolved:
+  - exactly **one** distinct candidate → that URL;
+  - several candidates → the one whose PR **number appears in the task
+    prompt** (`om-auto-review-pr 4170` + `…/pull/4170`), and only when
+    exactly one candidate matches;
+  - otherwise → unset. Ambiguity **clears** a previously resolved value —
+    a wrong chip is worse than no chip.
+- Once `pullRequestUrl` (created tier) is set, all discovery stops.
+- Candidates persist on the record so a restart/resume re-evaluates from the
+  same working set instead of re-adopting the next URL as "the only one".
+
+## UI
+
+- **Display chips** read `pullRequestUrl ?? referencedPullRequestUrl` via the
+  `taskPrUrl()` helper (`web/app/src/lib/tasks-table.ts`): the sidebar
+  quick-list chip, both Tasks-table chips, and the thread footer's `PR ↗`.
+- **Action gates stay created-tier only**: the review panel's Draft-PR button
+  (`review-panel.tsx`) and the git-panel's Create-PR→View-PR flip
+  (`git-actions.ts`) still read `pullRequestUrl` alone — a task that reviewed
+  PR X must still be able to open its own PR from its branch.
+
+## Out of scope
+
+- Building a PR URL from a bare number in the prompt (needs remote inference;
+  the conversation reliably echoes the full URL anyway).
+- Parsing `todos.json` / handoff files for PR URLs — separate channels with
+  their own consumers.
+- A dedicated ACP metadata side-channel for the agent to *declare* its
+  subject PR. If discovery-by-reference proves too fuzzy, that is the next
+  step; the two-tier record model already accommodates it (the declaration
+  would simply write the referenced tier).

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -213,6 +213,30 @@ describe('RunStore — referenced-PR discovery (#407, spec 2026-07-16-pr-autodis
     );
   });
 
+  it('disambiguates by a PR number the prompt names as a pasted URL, not just a bare number', () => {
+    const { store, run } = freshRun('review https://github.com/open-mercato/cezar/pull/3777 please');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'It supersedes https://github.com/open-mercato/cezar/pull/12.',
+    });
+    // Two candidates now (3777 seeded from the prompt, 12 from the event); the
+    // prompt names 3777 even though it only appears inside the URL path.
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/3777',
+    );
+  });
+
+  it('does not treat a substring of a longer number as a prompt match', () => {
+    const { store, run } = freshRun('om-auto-review-pr 4170');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'https://github.com/open-mercato/cezar/pull/170 and https://github.com/open-mercato/cezar/pull/70',
+    });
+    // Neither 170 nor 70 is named (only "4170" is in the prompt) → ambiguous.
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+
   it('the created tier still wins and stops discovery', () => {
     const { store, run } = freshRun();
     store.appendEvent(run.id, {

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -110,4 +110,148 @@ describe('RunStore — PR auto-link only on real creation (#fake-pr)', () => {
     } as never);
     expect(store.getRun(run.id)?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/7');
   });
+
+  it('spots creation reported through a v2 tool item (nested under `item`)', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'item.completed',
+      item: {
+        kind: 'tool',
+        id: 't1',
+        name: 'Bash',
+        toolKind: 'execute',
+        title: 'Ran gh pr create',
+        status: 'completed',
+        input: { command: 'gh pr create --draft --title "fix"' },
+        output: 'https://github.com/open-mercato/cezar/pull/9',
+      },
+    });
+    expect(store.getRun(run.id)?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/9');
+  });
+});
+
+describe('RunStore — referenced-PR discovery (#407, spec 2026-07-16-pr-autodiscovery)', () => {
+  let dataDir: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'cez-store-'));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  const freshRun = (task = 'task') => {
+    const store = RunStore.open(dataDir);
+    const run = store.createRun({ title: 't', workflow: 'w', task, steps: [] });
+    return { store, run };
+  };
+
+  it('adopts the referenced tier for a reviewed PR — without touching the created tier', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Reviewed https://github.com/open-mercato/cezar/pull/1 — looks good.',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.pullRequestUrl).toBeUndefined();
+    expect(loaded?.referencedPullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/1');
+  });
+
+  it('sees PR URLs nested in v2 message items', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'item.completed',
+      item: {
+        kind: 'message',
+        id: 'm1',
+        role: 'assistant',
+        text: 'Working on https://github.com/open-mercato/cezar/pull/4170 now.',
+      },
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/4170',
+    );
+  });
+
+  it('ignores reasoning items — thinking text speculates about PRs it never touches', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'item.completed',
+      item: {
+        kind: 'reasoning',
+        id: 'r1',
+        text: 'Maybe similar to https://github.com/open-mercato/cezar/pull/99?',
+      },
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+
+  it('clears the referenced tier when a second distinct PR makes the subject ambiguous', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/open-mercato/cezar/pull/1',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/1',
+    );
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Also related: https://github.com/open-mercato/cezar/pull/2',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+
+  it('disambiguates several referenced PRs by the number named in the task prompt', () => {
+    const { store, run } = freshRun('om-auto-review-pr 4170');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'Reviewing https://github.com/open-mercato/cezar/pull/4170; it supersedes https://github.com/open-mercato/cezar/pull/12.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/4170',
+    );
+  });
+
+  it('the created tier still wins and stops discovery', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Opened a draft pull request: https://github.com/open-mercato/cezar/pull/42',
+    });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Compare with https://github.com/open-mercato/cezar/pull/50',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/42');
+    expect(loaded?.referencedPullRequestUrl).toBeUndefined();
+  });
+
+  it('seeds the referenced tier from a PR URL pasted into the task prompt', () => {
+    const { store, run } = freshRun('review https://github.com/open-mercato/cezar/pull/3777 please');
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/3777',
+    );
+  });
+
+  it('round-trips the new fields through runs.json and keeps loading old files', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/open-mercato/cezar/pull/1',
+    });
+    store.flush();
+    const reopened = RunStore.open(dataDir);
+    expect(reopened.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/1',
+    );
+    expect(reopened.getRun(run.id)?.referencedPrCandidates).toEqual([
+      'https://github.com/open-mercato/cezar/pull/1',
+    ]);
+    // legacy record without the fields still parses (see LEGACY_RUN above)
+    writeFileSync(join(dataDir, 'runs.json'), JSON.stringify([LEGACY_RUN]), 'utf8');
+    const legacyStore = RunStore.open(dataDir);
+    expect(legacyStore.getRun('legacy-1')?.referencedPullRequestUrl).toBeUndefined();
+  });
 });

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -168,7 +168,9 @@ function resolveReferencedPr(candidates: string[], task: string): string | undef
   if (candidates.length === 1) return candidates[0];
   const named = candidates.filter((url) => {
     const num = url.split('/').pop() ?? '';
-    return num !== '' && new RegExp(`(?<![\\d/])#?${num}(?!\\d)`).test(task);
+    // `\d` boundaries only: they reject `170` inside `4170` yet still match a
+    // number written as `#4170`, ` 4170`, or inside a pasted `…/pull/4170`.
+    return num !== '' && new RegExp(`(?<!\\d)#?${num}(?!\\d)`).test(task);
   });
   return named.length === 1 ? named[0] : undefined;
 }

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -65,6 +65,15 @@ const runRecordSchema = z.object({
   costUsd: z.number().optional(),
   /** First GitHub PR URL spotted in the transcript (the janitor trick). */
   pullRequestUrl: z.string().optional(),
+  /** The PR this task is ABOUT (#407, spec 2026-07-16-pr-autodiscovery):
+   *  auto-discovered from conversation references for tasks that work on an
+   *  existing PR (review/continue/merge). Display-only tier — `pullRequestUrl`
+   *  (the PR this task CREATED) always wins, and action gates ignore this. */
+  referencedPullRequestUrl: z.string().optional(),
+  /** Distinct PR URLs spotted so far — the referenced tier's working set,
+   *  persisted so a resumed run keeps disambiguating against the full history
+   *  instead of re-adopting the next URL as "the only one". Capped. */
+  referencedPrCandidates: z.array(z.string()).optional(),
   /** Task worktree (spec 006) — absent when the run executed in the repo root. */
   worktreePath: z.string().optional(),
   /** The task's own branch (`cez/<id8>`), created off `baseBranch`. */
@@ -113,6 +122,56 @@ const PR_URL_RE = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
 // reviews or merely references an existing PR must not get mislabeled with its number (#fake-pr).
 const CREATED_PR_RE =
   /\b(?:gh\s+pr\s+create|pull\s*request\s+created|created\s+(?:a\s+)?(?:draft\s+)?(?:pr|pull\s*request)|opened\s+(?:a\s+)?(?:draft\s+)?pull\s*request)\b/i;
+
+/** Referenced-tier working-set cap (spec 2026-07-16-pr-autodiscovery): past
+ *  this many distinct PRs the conversation is a survey, not a subject. */
+const MAX_PR_CANDIDATES = 8;
+
+/**
+ * Every scannable string of one persisted event: the v1 top-level fields plus
+ * the protocol-v2 `item.*` content (nested — the reason v2 streams were
+ * invisible to the janitor, #407). Reasoning items are skipped: thinking text
+ * speculates about PRs the task never touches.
+ */
+function eventTextFragments(event: Record<string, unknown>): string[] {
+  const fragments: string[] = [];
+  for (const key of ['text', 'result', 'message'] as const) {
+    const value = event[key];
+    if (typeof value === 'string') fragments.push(value);
+  }
+  const item = event.item;
+  if (item && typeof item === 'object' && (item as Record<string, unknown>).kind !== 'reasoning') {
+    const it = item as Record<string, unknown>;
+    for (const key of ['text', 'title', 'output'] as const) {
+      const value = it[key];
+      if (typeof value === 'string') fragments.push(value);
+    }
+    if (typeof it.input === 'string') {
+      fragments.push(it.input);
+    } else if (it.input !== undefined) {
+      try {
+        fragments.push(JSON.stringify(it.input));
+      } catch {
+        // circular input — skip it
+      }
+    }
+  }
+  return fragments;
+}
+
+/**
+ * The referenced tier's resolution rule: one distinct URL is the subject;
+ * among several, the one whose PR number the task prompt names (and only when
+ * exactly one matches); otherwise ambiguous — no chip beats a wrong chip.
+ */
+function resolveReferencedPr(candidates: string[], task: string): string | undefined {
+  if (candidates.length === 1) return candidates[0];
+  const named = candidates.filter((url) => {
+    const num = url.split('/').pop() ?? '';
+    return num !== '' && new RegExp(`(?<![\\d/])#?${num}(?!\\d)`).test(task);
+  });
+  return named.length === 1 ? named[0] : undefined;
+}
 
 /**
  * File-backed run store: `runs.json` index (atomic tmp+rename writes, the
@@ -211,6 +270,9 @@ export class RunStore extends EventEmitter {
         tokensUsed: 0,
       })),
     };
+    // A prompt that pastes a PR URL is already about that PR — seed the
+    // referenced tier so the chip exists before the first event (#407).
+    this.trackReferencedPrs(run, input.task);
     this.runs.set(run.id, run);
     this.pruneOldRuns();
     this.touch(run);
@@ -278,15 +340,40 @@ export class RunStore extends EventEmitter {
     this.emit('event', { runId, event: full });
 
     // The janitor trick: agents print the PR URL after `gh pr create` — the
-    // first one spotted in the transcript becomes the run's PR link.
+    // first one spotted in the transcript becomes the run's PR link. Scans v1
+    // fields AND nested v2 `item.*` content (#407). A URL without the created
+    // phrasing still feeds the referenced tier (the PR the task is about).
     if (!run.pullRequestUrl) {
-      const haystack = [full.text, full.result, full.message]
-        .filter((s): s is string => typeof s === 'string')
-        .join(' ');
-      const match = PR_URL_RE.exec(haystack);
-      if (match && CREATED_PR_RE.test(haystack)) this.updateRun(runId, { pullRequestUrl: match[0] });
+      const haystack = eventTextFragments(full).join(' ');
+      if (haystack.length > 0) {
+        const match = PR_URL_RE.exec(haystack);
+        if (match && CREATED_PR_RE.test(haystack)) {
+          this.updateRun(runId, { pullRequestUrl: match[0] });
+        } else if (match && this.trackReferencedPrs(run, haystack)) {
+          this.touch(run);
+        }
+      }
     }
     return full;
+  }
+
+  /**
+   * Fold every PR URL in `haystack` into the run's referenced-tier working
+   * set and re-resolve `referencedPullRequestUrl` (spec
+   * 2026-07-16-pr-autodiscovery). Mutates the record in place — the caller
+   * owns persistence/fan-out — and reports whether anything changed.
+   */
+  private trackReferencedPrs(run: RunRecord, haystack: string): boolean {
+    const seen = new Set(run.referencedPrCandidates ?? []);
+    const before = seen.size;
+    for (const match of haystack.matchAll(new RegExp(PR_URL_RE.source, 'g'))) {
+      if (seen.size >= MAX_PR_CANDIDATES) break;
+      seen.add(match[0]);
+    }
+    if (seen.size === before) return false;
+    run.referencedPrCandidates = [...seen];
+    run.referencedPullRequestUrl = resolveReferencedPr(run.referencedPrCandidates, run.task);
+    return true;
   }
 
   /**

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -79,6 +79,12 @@ export interface RunRecord {
   tokensUsed: number
   costUsd?: number
   pullRequestUrl?: string
+  /** The PR this task is ABOUT (#407) — auto-discovered from conversation references.
+   *  Display tier only: `pullRequestUrl` (the PR this task CREATED) wins, and the
+   *  Draft-PR / Create-PR action gates ignore it. Read via `taskPrUrl()`. */
+  referencedPullRequestUrl?: string
+  /** The referenced tier's working set (distinct PR URLs spotted, capped server-side). */
+  referencedPrCandidates?: string[]
   /** Absent when the run executed in the repo working tree rather than its own worktree. */
   worktreePath?: string
   branch?: string

--- a/web/app/src/components/task-quick-list.test.tsx
+++ b/web/app/src/components/task-quick-list.test.tsx
@@ -183,6 +183,23 @@ describe('TaskQuickList', () => {
       expect(document.querySelector('[data-run-id="without"] [data-slot="pr-chip"]')).toBeNull()
     })
 
+    it('also appears for a referenced PR — the task worked ON it (#407)', () => {
+      renderList({
+        runs: [
+          run({
+            id: 'ref',
+            title: 'Review task',
+            status: 'review',
+            referencedPullRequestUrl: 'https://github.com/o/r/pull/4170',
+          }),
+        ],
+      })
+      const chip = within(row('ref') as HTMLElement).getByRole('link', {
+        name: 'Open the pull request for Review task',
+      })
+      expect(chip.getAttribute('href')).toBe('https://github.com/o/r/pull/4170')
+    })
+
     it('is a sibling of the row link, not nested inside it', () => {
       // Two independent targets: the row opens the task, the chip opens the PR. An anchor inside
       // an anchor is invalid HTML, and only one of them would ever fire.

--- a/web/app/src/components/task-quick-list.tsx
+++ b/web/app/src/components/task-quick-list.tsx
@@ -10,6 +10,7 @@ import { StatusDot } from '@/components/status-dot'
 import { deriveAttention } from '@/lib/attention'
 import { compactTokens, shortAge } from '@/lib/format'
 import { groupRuns, listCounts, runTitle, type ListView, type QuickListRow } from '@/lib/task-groups'
+import { taskPrUrl } from '@/lib/tasks-table'
 import { useNow } from '@/lib/use-now'
 import { cn } from '@/lib/utils'
 
@@ -209,6 +210,7 @@ function RunRow({
 }) {
   const attention = deriveAttention(run)
   const isActive = run.id === currentRunId
+  const prUrl = taskPrUrl(run)
   // A variant row spends its width on what distinguishes the variants (runner and spend) rather
   // than on an age they all share — they started together. Per the mockup.
   const age = variant
@@ -251,17 +253,17 @@ function RunRow({
             sidebar row has no column to hold an em dash open for. */}
         {run.diffStat ? <DiffStatLabel stat={run.diffStat} className="shrink-0 text-[10.5px]" /> : null}
         {/* The PR chip takes the age's slot when there is one — same as the mockup. */}
-        {run.pullRequestUrl || !age ? null : (
+        {prUrl || !age ? null : (
           <span className="shrink-0 text-[11px] text-soft-foreground tabular-nums">{age}</span>
         )}
       </Link>
-      {run.pullRequestUrl ? (
+      {prUrl ? (
         <a
           data-slot="pr-chip"
-          href={run.pullRequestUrl}
+          href={prUrl}
           target="_blank"
           rel="noopener noreferrer"
-          title={run.pullRequestUrl}
+          title={prUrl}
           aria-label={`Open the pull request for ${runTitle(run)}`}
           className="mr-2.5 inline-flex shrink-0 items-center gap-[3px] rounded-full border border-violet/35 px-1.5 py-px font-mono text-[10.5px] font-semibold text-violet hover:bg-violet/10"
         >

--- a/web/app/src/lib/tasks-table.test.ts
+++ b/web/app/src/lib/tasks-table.test.ts
@@ -8,6 +8,7 @@ import {
   formatCost,
   formatMem,
   prNumber,
+  taskPrUrl,
   usageCells,
   workflowLabel,
 } from '@/lib/tasks-table'
@@ -147,6 +148,25 @@ describe('finishedRunCount', () => {
         run({ status: 'done', archived: true }),
       ]),
     ).toBe(3)
+  })
+})
+
+describe('taskPrUrl', () => {
+  it('prefers the PR the task created over the one it referenced', () => {
+    const r = run({
+      pullRequestUrl: 'https://github.com/o/r/pull/7',
+      referencedPullRequestUrl: 'https://github.com/o/r/pull/4170',
+    })
+    expect(taskPrUrl(r)).toBe('https://github.com/o/r/pull/7')
+  })
+
+  it('falls back to the referenced PR (#407 — review tasks never create one)', () => {
+    const r = run({ referencedPullRequestUrl: 'https://github.com/o/r/pull/4170' })
+    expect(taskPrUrl(r)).toBe('https://github.com/o/r/pull/4170')
+  })
+
+  it('is undefined when the task has no PR association at all', () => {
+    expect(taskPrUrl(run())).toBeUndefined()
   })
 })
 

--- a/web/app/src/lib/tasks-table.ts
+++ b/web/app/src/lib/tasks-table.ts
@@ -74,6 +74,14 @@ export function finishedRunCount(runs: readonly RunRecord[]): number {
   return runs.filter((run) => !run.archived && FINISHED_STATUSES.has(run.status)).length
 }
 
+/** The URL a PR *display* chip shows: the PR the task created, else the PR the conversation
+ *  is about (#407 — review/continue tasks reference an existing PR instead of opening one).
+ *  Action gates (Draft PR, Create PR→View PR) must keep reading `pullRequestUrl` directly:
+ *  a task that reviewed PR X must still be able to open its own PR from its branch. */
+export function taskPrUrl(run: RunRecord): string | undefined {
+  return run.pullRequestUrl ?? run.referencedPullRequestUrl
+}
+
 /** The PR chip's `#402`. Null when the URL's last segment is not a number — a forge we don't
  *  recognize still gets a working chip, just without a number we'd be inventing. */
 export function prNumber(url: string): string | null {

--- a/web/app/src/routes/task-thread/task-thread.tsx
+++ b/web/app/src/routes/task-thread/task-thread.tsx
@@ -13,6 +13,7 @@ import { StatusDot } from '@/components/status-dot'
 import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/toaster'
 import { useKeyboardInsetVar } from '@/lib/keyboard-inset'
+import { taskPrUrl } from '@/lib/tasks-table'
 import { cn } from '@/lib/utils'
 
 import {
@@ -173,12 +174,12 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
             )}
           >
             {footer.label}
-            {run.pullRequestUrl ? (
-              // The run shipped as a PR (review-gate Draft PR, or agent-opened) — the link
-              // stays reachable after the panel is gone, like the legacy list badge.
+            {taskPrUrl(run) ? (
+              // The run shipped as a PR (review-gate Draft PR, or agent-opened), or worked on
+              // one (#407) — the link stays reachable after the panel is gone.
               <a
                 data-slot="pr-link"
-                href={run.pullRequestUrl}
+                href={taskPrUrl(run)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-medium text-foreground underline-offset-2 hover:underline"

--- a/web/app/src/routes/tasks-overview.tsx
+++ b/web/app/src/routes/tasks-overview.tsx
@@ -32,6 +32,7 @@ import {
   finishedRunCount,
   formatCost,
   prNumber,
+  taskPrUrl,
   usageCells,
   workflowLabel,
   type UsageCell,
@@ -333,6 +334,7 @@ function TableRow({
   const attention = deriveAttention(run)
   const to = `/tasks/${run.id}`
   const cost = formatCost(run.costUsd)
+  const prUrl = taskPrUrl(run)
 
   return (
     <tr
@@ -357,7 +359,7 @@ function TableRow({
       {/* ± — refreshed on every turn-end (#389); still an honest dash on records that predate it. */}
       <td className={TD_BASE}>{run.diffStat ? <DiffStatLabel stat={run.diffStat} /> : <Dash />}</td>
       <td className={TD_BASE}>
-        {run.pullRequestUrl ? <PrChip url={run.pullRequestUrl} taskTitle={runTitle(run)} /> : <Dash />}
+        {prUrl ? <PrChip url={prUrl} taskTitle={runTitle(run)} /> : <Dash />}
       </td>
       <td className={cn(TD_BASE, 'text-right font-mono text-xs text-muted-foreground tabular-nums')}>
         {compactTokens(run.tokensUsed)}
@@ -471,6 +473,7 @@ function TaskCard({
   const navigate = useNavigate()
   const attention = deriveAttention(run)
   const to = `/tasks/${run.id}`
+  const prUrl = taskPrUrl(run)
 
   return (
     <div
@@ -523,8 +526,8 @@ function TaskCard({
             ) : null}
           </>
         )}
-        {run.pullRequestUrl ? (
-          <PrChip url={run.pullRequestUrl} taskTitle={runTitle(run)} className="h-5" />
+        {prUrl ? (
+          <PrChip url={prUrl} taskTitle={runTitle(run)} className="h-5" />
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
Fixes #407

## What

The task list never showed a PR number for tasks that work **on** an existing PR (`om-auto-review-pr N`, continue/merge tasks), and conversation-based PR discovery was completely blind to protocol-v2 (ACP-style) events. As #407 asked, this PR **specifies the behavior first** (`.ai/specs/2026-07-16-pr-autodiscovery.md`) and implements it in the same change.

## Root cause

`RunStore.appendEvent`'s janitor was the only conversation-based writer of `pullRequestUrl`, and it:

1. scanned only the v1 top-level fields `text`/`result`/`message` — v2 events nest all content under `item.*` (`item.text`, `item.title`, `item.input`, `item.output`), so their PR URLs were persisted to NDJSON but never seen;
2. required the `CREATED_PR_RE` phrasing (the `#fake-pr` guard) — correct for not mislabeling a reviewer as the PR's author, but it left "the PR this task is about" with no representation at all.

## Fix — two tiers of PR association

- **created** (`pullRequestUrl`) — unchanged semantics, now fed from v1 **and** v2 sources (fixes creation detection for backends reporting `gh pr create` through tool items).
- **referenced** (`referencedPullRequestUrl`, new, additive) — the PR the conversation is about: adopted when exactly one distinct PR URL is referenced, or among several the one whose number the **task prompt** names (`om-auto-review-pr 4170` ↔ `…/pull/4170`); ambiguity clears it (no chip beats a wrong chip). Reasoning items are skipped. Candidates persist on the record (capped at 8) so restarts keep disambiguating. The task prompt itself is scanned at `createRun`, so a pasted PR URL gets its chip immediately.
- **UI**: display chips (sidebar quick list, Tasks table + cards, thread footer) read `pullRequestUrl ?? referencedPullRequestUrl` via a new `taskPrUrl()` helper. The **action gates stay created-tier only** — the review panel's Draft-PR button and the git panel's Create-PR→View-PR flip still read `pullRequestUrl` alone, so a task that reviewed PR X can still open its own PR.

Both new `RunRecord` fields are optional — old `runs.json` files keep parsing (store BC rule), and the server/web type mirror (`api-types.test.ts` `Exact<>`) is updated.

## Testing

- `npm run typecheck` ✓ (server + web)
- `npm test` ✓ — 113 files / 1932 tests, including 9 new store cases (#407 describe block: v2 nested discovery, reasoning skip, ambiguity clearing, prompt disambiguation, created-tier precedence + v2 creation detection, prompt seeding, runs.json round-trip + legacy parse) and new web cases (`taskPrUrl` precedence/fallback, referenced-PR chip in the quick list)
- `npm run test:unit` ✓
- `npm run build` ✓ (`check:pack` ok)
- `npm run test:package` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
