### PR TITLE
fix(core): make approval gate opt-in (#435)

### DIFF
--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -10,7 +10,7 @@ cezar is a published npm CLI (`@pat-lewczuk/cezar`, currently 0.x) whose state l
 - **Commands:** bare invocation = `serve` (cockpit); `cezar run "<task>"`; `cezar init`.
 - **Flags:** `-p/--port` (default 4321, auto-picks the next free port), `--repo <dir>`, `--workflow <name>` (default `quick-task`), `--model <model>`, `--no-open`, `-h/--help`.
 - **Exit codes:** `run` exits 0 on `done` **and** `review` (spec 009 — headless runs must not hang on the review gate), 1 on `failed`/`cancelled`/unknown workflow. CI scripts depend on this.
-- **Env vars:** `CEZ_DRY_RUN`, `CEZ_CLAUDE_BIN`, `CEZ_CODEX_BIN`, `CEZ_OPENCODE_BIN`, `GITHUB_TOKEN`.
+- **Env vars:** `CEZ_DRY_RUN`, `CEZ_APPROVAL_GATE`, `CEZ_CLAUDE_BIN`, `CEZ_CODEX_BIN`, `CEZ_OPENCODE_BIN`, `GITHUB_TOKEN`.
 
 Breaking: renaming/removing a command, flag, alias or env var; changing a default (port, workflow); changing `run` exit-code semantics. Required path: keep the old spelling as a deprecated alias for at least one minor release, print a one-line deprecation warning, document the replacement.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ event live and parks the run at a review gate when there's a diff to inspect.
    ┌──────────────────────────────┐     ┌───────────────────────────────┐
    │  git worktree per task       │     │  agent CLI  (your login)      │
    │  (isolated branch, parallel) │◄───►│  claude · codex · opencode    │
-   └──────────────────────────────┘     │  default-deny · acceptEdits   │
+   └──────────────────────────────┘     │  default-deny · no prompts    │
         │                                 └───────────────────────────────┘
         │  agent text · tool calls · tool results · tokens · cost
         ▼
@@ -317,16 +317,19 @@ skills: [reproduce, root-cause, implement, self-review]
 cezar shells out to your locally installed, logged-in agent CLI —
 **your subscription, no API key**. With the default Claude Code backend that
 means headless `stream-json` mode, tool access default-deny via
-`--allowedTools`, and edits auto-accepted (`--permission-mode acceptEdits`)
-inside the task's worktree. Codex and OpenCode are driven through their own
-native protocols — see [Coding agent backends](#coding-agent-backends).
-Nothing runs on a server you don't own.
+`--allowedTools`, with unapproved tools denied without prompting
+(`--permission-mode dontAsk`) inside the task's worktree. Set
+`CEZ_APPROVAL_GATE=1` to opt into Claude's interactive approval UI. Codex and
+OpenCode are driven through their own native protocols — see
+[Coding agent backends](#coding-agent-backends). Nothing runs on a server you
+don't own.
 
 Useful environment variables:
 
 | Var | Effect |
 |---|---|
 | `CEZ_DRY_RUN=1` | Use the bundled mock instead of the real `claude` CLI — the entire cockpit works offline, for demos and development. |
+| `CEZ_APPROVAL_GATE=1` | Opt into Claude's interactive approval UI; by default, unapproved tools are denied without interrupting the run. |
 | `CEZ_CLAUDE_BIN=/path/to/claude` | Override which `claude` binary is used. |
 | `CEZ_CODEX_BIN=/path/to/codex` | Override which `codex` binary is used. |
 | `CEZ_OPENCODE_BIN=/path/to/opencode` | Override which `opencode` binary is used. |

--- a/src/core/claude-cli-runner.test.ts
+++ b/src/core/claude-cli-runner.test.ts
@@ -23,6 +23,22 @@ describe('buildClaudeArgs systemPrompt', () => {
   });
 });
 
+describe('buildClaudeArgs approval gate', () => {
+  const spec = { userPrompt: 'do it', cwd: '/tmp' };
+
+  it('denies unapproved tools without prompting by default', () => {
+    const args = buildClaudeArgs(spec, {});
+    const idx = args.indexOf('--permission-mode');
+    expect(args[idx + 1]).toBe('dontAsk');
+  });
+
+  it('enables Claude approval prompts only when explicitly requested', () => {
+    const args = buildClaudeArgs(spec, { CEZ_APPROVAL_GATE: '1' });
+    const idx = args.indexOf('--permission-mode');
+    expect(args[idx + 1]).toBe('acceptEdits');
+  });
+});
+
 describe('prependSystemPrompt (codex/opencode delivery)', () => {
   it('prepends the prompt as a leading block of the first user message', () => {
     expect(prependSystemPrompt('Extra rules.', 'do it')).toBe('Extra rules.\n\n---\n\ndo it');

--- a/src/core/claude-cli-runner.ts
+++ b/src/core/claude-cli-runner.ts
@@ -298,9 +298,14 @@ export class ClaudeCliRunner implements AgentRunner {
 /**
  * Build the headless argv. `--input-format stream-json` reads user messages
  * from stdin; `--output-format stream-json --verbose` gives per-event NDJSON;
- * `--permission-mode acceptEdits` lets edits through without a TTY prompt.
+ * `--permission-mode dontAsk` keeps headless runs non-interactive: tools in
+ * `--allowedTools` proceed and everything else is denied instead of prompting.
+ * `CEZ_APPROVAL_GATE=1` opts back into Claude's approval UI (#435).
  */
-export function buildClaudeArgs(spec: AgentRunSpec): string[] {
+export function buildClaudeArgs(
+  spec: AgentRunSpec,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
   const args: string[] = [
     '--input-format',
     'stream-json',
@@ -308,7 +313,7 @@ export function buildClaudeArgs(spec: AgentRunSpec): string[] {
     'stream-json',
     '--verbose',
     '--permission-mode',
-    'acceptEdits',
+    env.CEZ_APPROVAL_GATE === '1' ? 'acceptEdits' : 'dontAsk',
   ];
   if (spec.systemPrompt) {
     args.push('--append-system-prompt', spec.systemPrompt);


### PR DESCRIPTION
Fixes #435

## Problem
Autonomous Claude-backed tasks could pause on an interactive approval dialog even though autonomous skills are required to continue without user interruption.

## Root Cause
The Claude runner hardcoded `--permission-mode acceptEdits`. That mode accepts file edits but can still surface permission prompts for other tool calls, independently of cezar's autonomous turn-continuation setting.

## What Changed
- Default Claude sessions to `--permission-mode dontAsk`, so allowlisted tools proceed and every other tool is denied without prompting.
- Add `CEZ_APPROVAL_GATE=1` as an explicit opt-in for Claude's interactive `acceptEdits` approval mode.
- Document the new environment variable and protected surface.
- Add regression tests for both the default and opt-in argument sets.

## Tests
- `npx vitest run src/core/claude-cli-runner.test.ts` — 6 passed.
- `npm run typecheck` — passed.
- `npm test` — 122 files / 2,037 tests passed.
- `npm run test:unit` — 4 tests passed.
- `npm run build` — passed, including the package-content gate.
- `npm run test:package` — packaged CLI E2E passed.

## Breaking Changes
None. `CEZ_APPROVAL_GATE` is additive; the default behavior now matches the documented autonomous, non-interactive contract.

🤖 Generated by autofix.
