### PR TITLE
fix(workflows): serialize repository-root runs (#438)

### DIFF
--- a/.ai/WORKLIST.md
+++ b/.ai/WORKLIST.md
@@ -8,4 +8,4 @@ PR: #441
 - [x] Stop isolated Git tasks before workflow execution when worktree creation remains unavailable — verified with a RunManager regression test that detects any repository-root command.
 - [x] Preserve serialized repository-root execution for explicit opt-out tasks — verified with two parallel opt-out runs and an overlap detector.
 - [x] Run the repository validation gate and review the complete PR diff — all commands in `.ai/agentic.config.json` passed.
-- [ ] Commit and push the extension to `fix/issue-438-worktrees-separation`, then update PR #441.
+- [x] Commit and push the extension to `fix/issue-438-worktrees-separation`, then update PR #441 — implementation commit `a9ebcf8`.

--- a/.ai/WORKLIST.md
+++ b/.ai/WORKLIST.md
@@ -1,0 +1,11 @@
+# Worklist — harden per-task worktree creation
+
+Updated: 2026-07-16
+PR: #441
+
+- [x] Record the fail-closed isolation contract in spec 006 — verify by reviewing the dated hardening acceptance checks.
+- [x] Make `createWorktree` idempotent and recover a surviving task branch after stale worktree metadata/path loss — verified with real-Git Vitest fixtures.
+- [x] Stop isolated Git tasks before workflow execution when worktree creation remains unavailable — verified with a RunManager regression test that detects any repository-root command.
+- [x] Preserve serialized repository-root execution for explicit opt-out tasks — verified with two parallel opt-out runs and an overlap detector.
+- [x] Run the repository validation gate and review the complete PR diff — all commands in `.ai/agentic.config.json` passed.
+- [ ] Commit and push the extension to `fix/issue-438-worktrees-separation`, then update PR #441.

--- a/.ai/runs/2026-07-16-harden-worktree-creation.md
+++ b/.ai/runs/2026-07-16-harden-worktree-creation.md
@@ -23,7 +23,7 @@ Request: Extend PR #441 so every isolated Git task either receives a proper work
 - [x] Fail an isolated Git run before its first step when worktree creation is unrecoverable — verified with a RunManager regression test.
 - [x] Keep explicit opt-out runs serialized — verified with a parallel overlap regression test.
 - [x] Run `npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, and `npm run test:package` in order.
-- [ ] Review, commit, push, and update PR #441.
+- [x] Review, commit, push, and update PR #441 — implementation commit `a9ebcf8`.
 
 ## Execution Log
 
@@ -52,8 +52,14 @@ Request: Extend PR #441 so every isolated Git task either receives a proper work
 - Ran: `npm run test:package` — packaged dry-run CLI E2E passed.
 - Reviewed: `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`, full local diff, and `git diff --check`; no protected API, state, CLI, workflow, or package surface changed.
 
+### 2026-07-16 19:34 Europe/Warsaw
+
+- Committed: `a9ebcf8 fix(worktrees): fail closed and recover task branches`.
+- Pushed: `HEAD` to `origin/fix/issue-438-worktrees-separation` without rewriting history.
+- Updated: PR #441 description and summary comment with recovery behavior, fail-closed semantics, verification, and residual risk.
+
 ## Final Status
 
-- Completed: diagnosis, specification, implementation, focused tests, full validation, and compatibility review.
-- Not completed: commit/push and PR update.
+- Completed: diagnosis, specification, implementation, focused tests, full validation, compatibility review, commit/push, and PR update.
+- Not completed: none.
 - Residual risks: a genuinely read-only or corrupt Git repository now fails an isolated task instead of allowing it to execute in the user's root; the error is retained on the run for recovery/action.

--- a/.ai/runs/2026-07-16-harden-worktree-creation.md
+++ b/.ai/runs/2026-07-16-harden-worktree-creation.md
@@ -63,3 +63,54 @@ Request: Extend PR #441 so every isolated Git task either receives a proper work
 - Completed: diagnosis, specification, implementation, focused tests, full validation, compatibility review, commit/push, and PR update.
 - Not completed: none.
 - Residual risks: a genuinely read-only or corrupt Git repository now fails an isolated task instead of allowing it to execute in the user's root; the error is retained on the run for recovery/action.
+
+### 2026-07-17 Review round 2 — code review findings on PR #441
+
+Addressed the `CHANGES_REQUESTED` review on the repository-root lease. The
+`git-worktree.ts` half of the PR was approved as-is; findings 5 and 6 were the
+only changes made there.
+
+- Finding 1 (major, verified regression): a lease waiter sat in `active` and
+  outside `waiting`, so it burned a `maxParallel` slot while idle and starved
+  isolated worktree runs — the exact parallelism this PR set out to preserve.
+  Lease waiters now park in `waiting` for the duration of the wait, following
+  the #347 precedent. The store status stays `running`, so the GUI never shows
+  a lease-blocked run as awaiting user input.
+- Finding 2 (major, architectural): decided to **accept and document** that a
+  parked root run holds the lease until its session ends. A parked session is
+  still live and writes to the working tree on resume, so releasing the lease
+  at the park would reintroduce the concurrent-edit bug #438 fixes. The
+  semantics are now stated in the `acquireRepoRoot` doc comment. Finding 1's
+  fix means isolated runs keep flowing regardless of a held root lease.
+- Finding 3 (minor): `cancel()` could not free a run blocked on the lease — it
+  reported success while the run kept its slot until the holder released. The
+  lease wait is now abortable via `interrupt`. This also surfaced a case the
+  review did not name: `cancel()` can land between the run going `running` and
+  reaching `acquireRepoRoot`, while `interrupt` is still the default no-op, so
+  the method now checks `cancelled` before entering the chain.
+- Finding 4 (latent): `state.releaseRepoRoot` is assigned before `await
+  previous`, so a `dropActive` during the wait can no longer strand the tail
+  pending forever. The pre-grant release is chained behind `previous` — a run
+  that has not yet acquired must not hand the tree to the next waiter.
+- Finding 5 (minor): the worktree reuse paths re-anchored `baseBranch` from the
+  current config, shifting `merge-base` under an existing task. A run that
+  already recorded a fork point now keeps it.
+- Finding 6 (nit): hoisted the per-entry `canonicalPath(absolutePath)` out of
+  both `.find()` predicates.
+
+Tests: added `src/workflows/run-lease.test.ts` — real-Git (worktree creation
+not mocked, unlike `run-isolation.test.ts`) coverage that a lease-blocked run
+does not consume a parallel slot, and that cancel-while-blocked settles without
+waiting for the holder. Both tests were confirmed to fail against the pre-fix
+commit and pass after, so they pin the regression rather than merely passing.
+
+- Ran: `npm run typecheck` — passed.
+- Ran: `npm test` — 124 files, 2,042 tests passed.
+- Ran: `npm run test:unit` — 4 tests passed.
+- Ran: `npm run build` — TypeScript, Vite, and check:pack passed.
+- Ran: `npm run test:package` — packaged dry-run CLI E2E passed.
+
+Residual risks: unchanged from the first round, plus the documented finding-2
+semantics — a `worktree: false` run parked for user input owns the working tree
+until its session ends, so other root runs queue for that period. This is
+deliberate: the alternative is concurrent edits to the user's tree.

--- a/.ai/runs/2026-07-16-harden-worktree-creation.md
+++ b/.ai/runs/2026-07-16-harden-worktree-creation.md
@@ -1,0 +1,59 @@
+# Run: harden worktree creation
+
+Date: 2026-07-16
+Branch: `fix/issue-438-worktrees-separation` (detached local worktree; push target is the PR branch)
+Start commit: `60df2c42e63b42b5a9596807e81c7b1bb4791ddd`
+Request: Extend PR #441 so every isolated Git task either receives a proper worktree or stops before executing.
+
+## Assumptions
+
+- PR #441 is the intended extension target based on the preceding conversation.
+- The original failure text is no longer present in retained local run events; all retained Git runs record `worktree ready`.
+- A deleted worktree with a surviving `cez/<id8>` branch is a concrete reproducible failure in the current one-shot `git worktree add -b` implementation.
+- Explicit `worktree: false` and non-Git operation are intentional repository-root modes and remain supported under the existing exclusive lease.
+
+## Spec Updates
+
+- `.ai/specs/006-worktree-queue.md`: added the 2026-07-16 fail-closed and recovery contract.
+- `.ai/WORKLIST.md`: added verifiable implementation and validation tasks.
+
+## Tasks
+
+- [x] Add idempotent/recovery behavior to `createWorktree` — verified with focused real-Git tests.
+- [x] Fail an isolated Git run before its first step when worktree creation is unrecoverable — verified with a RunManager regression test.
+- [x] Keep explicit opt-out runs serialized — verified with a parallel overlap regression test.
+- [x] Run `npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, and `npm run test:package` in order.
+- [ ] Review, commit, push, and update PR #441.
+
+## Execution Log
+
+### 2026-07-16 18:00 Europe/Warsaw
+
+- Inspected: issue #438, PR #441, spec 006, `src/git-worktree.ts`, `src/workflows/run.ts`, worktree tests, and retained local run records.
+- Found: retained Git runs all report successful worktree creation, so the original stderr is unavailable.
+- Found: `createWorktree` always calls `git worktree add -b`; a surviving task branch makes retries fail instead of recover.
+- Found: RunManager catches every creation error and silently executes in `repoRoot`, contrary to the isolation contract.
+
+### 2026-07-16 19:31 Europe/Warsaw
+
+- Changed: `createWorktree` now prunes stale metadata, recognizes registered worktrees through canonical filesystem paths, repairs recoverable paths, reattaches surviving task branches, and preserves unregistered non-empty directories.
+- Changed: isolated Git tasks now fail before workflow execution if worktree recovery remains impossible; explicit opt-out and non-Git runs retain the repository-root lease.
+- Ran: `npm test -- src/git-worktree.test.ts src/workflows/run-isolation.test.ts`.
+- Result: 2 files, 15 tests passed.
+- Ran: `npm run typecheck`.
+- Result: passed after installing the PR branch's locked dependencies with `npm ci`; the first attempt used the parent checkout's stale dependencies and could not resolve `@clack/prompts`.
+
+### 2026-07-16 19:32 Europe/Warsaw
+
+- Ran: `npm run typecheck` — passed.
+- Ran: `npm test` — 123 files, 2,040 tests passed.
+- Ran: `npm run test:unit` — 4 tests passed.
+- Ran: `npm run build` — TypeScript, Vite, and check:pack passed (231 package files, 68 built UI files).
+- Ran: `npm run test:package` — packaged dry-run CLI E2E passed.
+- Reviewed: `CODE_REVIEW.md`, `BACKWARD_COMPATIBILITY.md`, full local diff, and `git diff --check`; no protected API, state, CLI, workflow, or package surface changed.
+
+## Final Status
+
+- Completed: diagnosis, specification, implementation, focused tests, full validation, and compatibility review.
+- Not completed: commit/push and PR update.
+- Residual risks: a genuinely read-only or corrupt Git repository now fails an isolated task instead of allowing it to execute in the user's root; the error is retained on the run for recovery/action.

--- a/.ai/specs/006-worktree-queue.md
+++ b/.ai/specs/006-worktree-queue.md
@@ -80,3 +80,35 @@ pracę ("agent robi, ja dalej koduję u siebie").
 - Delete sprząta worktree i branch; restart procesu nie zostawia zombie
   worktrees (prune + raport w logu startowym).
 - W katalogu nie-git wszystko działa po staremu.
+
+## Hardening 2026-07-16 — issue #438
+
+The original degradation rule was too broad: a Git task that requested the
+default isolated mode could silently execute in the user's repository working
+tree after `git worktree add` failed. Serializing that fallback prevents two
+fallback agents from overlapping, but it still violates the primary isolation
+contract and lets an agent modify unrelated user changes.
+
+For a Git repository, an isolated task now has a fail-closed contract:
+
+- Worktree creation is idempotent for the same task. A registered, valid
+  worktree is reused.
+- Stale Git worktree metadata is pruned before creation. If the task branch
+  survived while its worktree directory did not, cezar reattaches that branch
+  instead of trying `-b` again and failing with “branch already exists”.
+- An existing managed path is repaired when Git can recover it. Cezar never
+  repurposes a worktree registered to another branch.
+- If isolation still cannot be established, the task fails before any workflow
+  step or agent process starts. It does not run in the repository root.
+- The explicit `worktree: false` opt-out and non-Git degradation remain
+  supported. Repository-root execution stays serialized for those intentional
+  modes.
+
+Hardening acceptance checks:
+
+- Re-running creation for the same task returns the same valid worktree.
+- Deleting a task worktree directory, pruning Git metadata, and creating it
+  again reattaches the surviving task branch and preserves its commits.
+- A forced worktree-creation error produces a failed run and executes no
+  workflow command in the repository root.
+- Two explicit worktree opt-out runs still serialize repository-root access.

--- a/src/git-worktree.test.ts
+++ b/src/git-worktree.test.ts
@@ -1,15 +1,31 @@
 import { execFile } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { parseShortstat, worktreeShortstat } from './git-worktree.js';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { branchFor, createWorktree, parseShortstat, worktreeShortstat } from './git-worktree.js';
 
 const run = promisify(execFile);
 
 /** Commit as a fixed identity so the fixture repo works on bare CI machines. */
 const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+
+const worktreeRoots: string[] = [];
+
+async function fixtureRepo(prefix: string): Promise<string> {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  worktreeRoots.push(root);
+  await run('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  writeFileSync(join(root, 'base.txt'), 'base\n');
+  await run('git', ['add', '-A'], { cwd: root });
+  await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: root });
+  return root;
+}
+
+afterEach(() => {
+  for (const root of worktreeRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
 
 describe('parseShortstat', () => {
   const cases: Array<{ name: string; input: string; expected: { adds: number; dels: number; files: number } }> = [
@@ -55,6 +71,52 @@ describe('parseShortstat', () => {
   // localizes, so matching the English words is stable by contract.
   it.each(cases)('$name', ({ input, expected }) => {
     expect(parseShortstat(input)).toEqual(expected);
+  });
+});
+
+describe('createWorktree recovery (real git)', () => {
+  it('is idempotent when the task worktree is already registered', async () => {
+    const repo = await fixtureRepo('cez-worktree-idempotent-');
+    const runId = '11111111-1111-4111-8111-111111111111';
+
+    const first = await createWorktree(repo, runId, 'main');
+    const second = await createWorktree(repo, runId, 'main');
+
+    expect(second).toEqual(first);
+    const listed = await run('git', ['worktree', 'list', '--porcelain'], { cwd: repo });
+    expect(listed.stdout.match(new RegExp(`branch refs/heads/${branchFor(runId)}`, 'g'))).toHaveLength(1);
+  });
+
+  it('reattaches a surviving task branch after its worktree directory is deleted', async () => {
+    const repo = await fixtureRepo('cez-worktree-reattach-');
+    const runId = '22222222-2222-4222-8222-222222222222';
+    const first = await createWorktree(repo, runId, 'main');
+    writeFileSync(join(first.path, 'progress.txt'), 'preserved\n');
+    await run('git', ['add', '-A'], { cwd: first.path });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'task progress'], { cwd: first.path });
+
+    rmSync(first.path, { recursive: true, force: true });
+    await run('git', ['worktree', 'prune'], { cwd: repo });
+
+    const recovered = await createWorktree(repo, runId, 'main');
+    const log = await run('git', ['log', '-1', '--format=%s'], { cwd: recovered.path });
+    expect(recovered.path).toBe(first.path);
+    expect(log.stdout.trim()).toBe('task progress');
+    expect(() => writeFileSync(join(recovered.path, 'still-usable.txt'), 'yes\n')).not.toThrow();
+  });
+
+  it('preserves an unregistered non-empty managed path instead of deleting it', async () => {
+    const repo = await fixtureRepo('cez-worktree-preserve-');
+    const runId = '33333333-3333-4333-8333-333333333333';
+    const path = join(repo, '.ai/cezar/worktrees', runId);
+    const marker = join(path, 'uncommitted.txt');
+    mkdirSync(path, { recursive: true });
+    writeFileSync(marker, 'do not delete\n');
+
+    await expect(createWorktree(repo, runId, 'main')).rejects.toThrow(
+      'managed worktree path already exists and could not be repaired',
+    );
+    expect(readFileSync(marker, 'utf8')).toBe('do not delete\n');
   });
 });
 

--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
-import type { Dirent } from 'node:fs';
+import { existsSync, realpathSync, type Dirent } from 'node:fs';
 import { readdir, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 
 /**
  * Git worktree per task (spec 006). Each run gets its own branch
@@ -21,6 +21,11 @@ interface GitResult {
   ok: boolean;
   stdout: string;
   stderr: string;
+}
+
+interface RegisteredWorktree {
+  path: string;
+  branch?: string;
 }
 
 /** Run git, never throw — degradation is the caller's policy. */
@@ -64,10 +69,47 @@ export interface WorktreeInfo {
   baseBranch: string;
 }
 
+/** Parse `git worktree list --porcelain` without assuming paths contain no spaces. */
+async function registeredWorktrees(repoRoot: string): Promise<RegisteredWorktree[]> {
+  const res = await git(repoRoot, ['worktree', 'list', '--porcelain']);
+  if (!res.ok) return [];
+  const worktrees: RegisteredWorktree[] = [];
+  let current: RegisteredWorktree | undefined;
+  for (const line of res.stdout.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current) worktrees.push(current);
+      current = { path: line.slice('worktree '.length) };
+    } else if (current && line.startsWith('branch ')) {
+      current.branch = line.slice('branch '.length);
+    } else if (!line && current) {
+      worktrees.push(current);
+      current = undefined;
+    }
+  }
+  if (current) worktrees.push(current);
+  return worktrees;
+}
+
+function worktreeInfo(path: string, branch: string, baseBranch: string): WorktreeInfo {
+  return { path, branch, baseBranch };
+}
+
+/** Git canonicalizes symlinked path prefixes (macOS `/var` → `/private/var`). */
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 /**
- * `git worktree add -b cez/<id8> .ai/cezar/worktrees/<runId> <base>`.
- * Throws with git's stderr when the worktree can't be created — the run
- * manager then falls back to running in the repo working tree.
+ * Establish the task worktree idempotently. Besides the fresh
+ * `git worktree add -b` path, recover the two normal restart/deletion cases:
+ * reuse an already-registered task worktree, or reattach a surviving task
+ * branch after its directory/registration was removed. Existing non-empty
+ * unregistered paths are never deleted because they may hold recoverable
+ * uncommitted work.
  */
 export async function createWorktree(
   repoRoot: string,
@@ -83,10 +125,68 @@ export async function createWorktree(
     base = head.stdout.trim();
   }
   const branch = branchFor(runId);
-  const path = worktreePathFor(repoRoot, runId);
-  const res = await git(repoRoot, ['worktree', 'add', '-b', branch, path, base]);
-  if (!res.ok) throw new Error(`git worktree add failed: ${res.stderr.trim() || res.stdout.trim()}`);
-  return { path, branch, baseBranch: base };
+  const absolutePath = join(canonicalPath(repoRoot), WORKTREES_DIR, runId);
+  const branchRef = `refs/heads/${branch}`;
+
+  // A missing directory can leave stale administrative metadata behind.
+  // Prune first so the checks below describe the filesystem as it exists now.
+  await git(repoRoot, ['worktree', 'prune']);
+  let registered = await registeredWorktrees(repoRoot);
+  let atPath = registered.find((item) => canonicalPath(item.path) === canonicalPath(absolutePath));
+  if (atPath) {
+    if (atPath.branch !== branchRef) {
+      throw new Error(
+        `managed worktree path is registered to ${atPath.branch ?? 'a detached HEAD'}, expected ${branchRef}`,
+      );
+    }
+    return worktreeInfo(atPath.path, branch, base);
+  }
+
+  // If the directory survived but its administrative entry did not, let Git
+  // repair it. This is non-destructive; an unrepairable non-empty directory is
+  // preserved and reported instead of being recursively removed.
+  if (existsSync(absolutePath)) {
+    await git(repoRoot, ['worktree', 'repair', absolutePath]);
+    registered = await registeredWorktrees(repoRoot);
+    atPath = registered.find((item) => canonicalPath(item.path) === canonicalPath(absolutePath));
+    if (atPath) {
+      if (atPath.branch !== branchRef) {
+        throw new Error(
+          `managed worktree path is registered to ${atPath.branch ?? 'a detached HEAD'}, expected ${branchRef}`,
+        );
+      }
+      return worktreeInfo(atPath.path, branch, base);
+    }
+    const entries = await readdir(absolutePath).catch(() => ['unreadable']);
+    if (entries.length > 0) {
+      throw new Error(`managed worktree path already exists and could not be repaired: ${absolutePath}`);
+    }
+  }
+
+  const branchExists = await git(repoRoot, ['show-ref', '--verify', '--quiet', branchRef]);
+  if (branchExists.ok) {
+    // The task branch may still be checked out after its directory was moved.
+    // Reuse only a path whose basename is the full run id; a same-prefix UUID
+    // collision must fail rather than point two tasks at one worktree.
+    const byBranch = registered.find((item) => item.branch === branchRef);
+    if (byBranch) {
+      if (basename(byBranch.path) !== runId) {
+        throw new Error(`task branch ${branch} is already checked out at ${byBranch.path}`);
+      }
+      return worktreeInfo(byBranch.path, branch, base);
+    }
+    const attach = await git(repoRoot, ['worktree', 'add', absolutePath, branch]);
+    if (!attach.ok) {
+      throw new Error(`git worktree reattach failed: ${attach.stderr.trim() || attach.stdout.trim()}`);
+    }
+    return worktreeInfo(absolutePath, branch, base);
+  }
+
+  const create = await git(repoRoot, ['worktree', 'add', '-b', branch, absolutePath, base]);
+  if (!create.ok) {
+    throw new Error(`git worktree add failed: ${create.stderr.trim() || create.stdout.trim()}`);
+  }
+  return worktreeInfo(absolutePath, branch, base);
 }
 
 /** Remove a task worktree and its branch. Best effort — never throws. */

--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -131,8 +131,9 @@ export async function createWorktree(
   // A missing directory can leave stale administrative metadata behind.
   // Prune first so the checks below describe the filesystem as it exists now.
   await git(repoRoot, ['worktree', 'prune']);
+  const canonicalTarget = canonicalPath(absolutePath);
   let registered = await registeredWorktrees(repoRoot);
-  let atPath = registered.find((item) => canonicalPath(item.path) === canonicalPath(absolutePath));
+  let atPath = registered.find((item) => canonicalPath(item.path) === canonicalTarget);
   if (atPath) {
     if (atPath.branch !== branchRef) {
       throw new Error(
@@ -148,7 +149,7 @@ export async function createWorktree(
   if (existsSync(absolutePath)) {
     await git(repoRoot, ['worktree', 'repair', absolutePath]);
     registered = await registeredWorktrees(repoRoot);
-    atPath = registered.find((item) => canonicalPath(item.path) === canonicalPath(absolutePath));
+    atPath = registered.find((item) => canonicalPath(item.path) === canonicalTarget);
     if (atPath) {
       if (atPath.branch !== branchRef) {
         throw new Error(

--- a/src/workflows/run-isolation.test.ts
+++ b/src/workflows/run-isolation.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -43,7 +43,28 @@ afterEach(() => {
 });
 
 describe('RunManager repository-root isolation', () => {
-  it('serializes parallel runs when worktree creation degrades to the repository root', async () => {
+  it('fails closed without executing a workflow step when worktree creation fails', async () => {
+    const root = fixtureRepo();
+    const store = RunStore.open(join(root, '.ai/cezar'));
+    const manager = new RunManager(store, root);
+    const workflow: WorkflowDef = {
+      name: 'must-not-run-in-root',
+      source: 'built-in',
+      steps: [{ id: 'check', command: 'node -e "require(\'node:fs\').writeFileSync(\'root-was-touched\',\'yes\')"' }],
+    };
+
+    const record = manager.startRun(workflow, { task: 'isolated task' });
+    await waitForRuns(store, [record.id]);
+
+    expect(store.getRun(record.id)?.status).toBe('failed');
+    expect(store.getRun(record.id)?.error).toContain('worktree creation failed');
+    expect(existsSync(join(root, 'root-was-touched'))).toBe(false);
+    const notes = store.readEvents(record.id).filter((event) => event.type === 'note');
+    expect(notes.some((event) => String(event.message).includes('stopped before workflow execution'))).toBe(true);
+    expect(notes.some((event) => String(event.message).includes('exclusive access'))).toBe(false);
+  });
+
+  it('serializes parallel runs that explicitly opt out of worktrees', async () => {
     const root = fixtureRepo();
     const store = RunStore.open(join(root, '.ai/cezar'));
     const manager = new RunManager(store, root);
@@ -59,15 +80,15 @@ describe('RunManager repository-root isolation', () => {
       ],
     };
 
-    const first = manager.startRun(workflow, { task: 'first' });
-    const second = manager.startRun(workflow, { task: 'second' });
+    const first = manager.startRun(workflow, { task: 'first', worktree: false });
+    const second = manager.startRun(workflow, { task: 'second', worktree: false });
     await waitForRuns(store, [first.id, second.id]);
 
     expect(store.getRun(first.id)?.status).toBe('done');
     expect(store.getRun(second.id)?.status).toBe('done');
     for (const id of [first.id, second.id]) {
       const notes = store.readEvents(id).filter((event) => event.type === 'note');
-      expect(notes.some((event) => String(event.message).includes('worktree creation failed'))).toBe(true);
+      expect(notes.some((event) => String(event.message).includes('worktree off'))).toBe(true);
       expect(notes.some((event) => String(event.message).includes('exclusive access'))).toBe(true);
     }
   });

--- a/src/workflows/run-isolation.test.ts
+++ b/src/workflows/run-isolation.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RunStore } from '../runs/store.js';
+import type { WorkflowDef } from './types.js';
+
+vi.mock('../git-worktree.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../git-worktree.js')>();
+  return {
+    ...actual,
+    createWorktree: vi.fn().mockRejectedValue(new Error('simulated worktree failure')),
+  };
+});
+
+import { RunManager } from './run.js';
+
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+const roots: string[] = [];
+
+function fixtureRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'cez-root-isolation-'));
+  roots.push(root);
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  execFileSync('git', [...GIT_ID, 'commit', '--allow-empty', '-q', '-m', 'base'], { cwd: root });
+  return root;
+}
+
+async function waitForRuns(store: RunStore, ids: string[]): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (ids.every((id) => ['done', 'failed', 'cancelled'].includes(store.getRun(id)?.status ?? ''))) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('runs did not finish');
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('RunManager repository-root isolation', () => {
+  it('serializes parallel runs when worktree creation degrades to the repository root', async () => {
+    const root = fixtureRepo();
+    const store = RunStore.open(join(root, '.ai/cezar'));
+    const manager = new RunManager(store, root);
+    const workflow: WorkflowDef = {
+      name: 'root-lock-check',
+      source: 'built-in',
+      steps: [
+        {
+          id: 'check',
+          command:
+            'node -e "const fs=require(\'node:fs\'); const p=\'root-run.lock\'; if(fs.existsSync(p)) process.exit(42); fs.writeFileSync(p,\'locked\'); setTimeout(()=>fs.rmSync(p),100)"',
+        },
+      ],
+    };
+
+    const first = manager.startRun(workflow, { task: 'first' });
+    const second = manager.startRun(workflow, { task: 'second' });
+    await waitForRuns(store, [first.id, second.id]);
+
+    expect(store.getRun(first.id)?.status).toBe('done');
+    expect(store.getRun(second.id)?.status).toBe('done');
+    for (const id of [first.id, second.id]) {
+      const notes = store.readEvents(id).filter((event) => event.type === 'note');
+      expect(notes.some((event) => String(event.message).includes('worktree creation failed'))).toBe(true);
+      expect(notes.some((event) => String(event.message).includes('exclusive access'))).toBe(true);
+    }
+  });
+});

--- a/src/workflows/run-lease.test.ts
+++ b/src/workflows/run-lease.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RunStore } from '../runs/store.js';
+import { RunManager } from './run.js';
+import type { WorkflowDef } from './types.js';
+
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+const roots: string[] = [];
+
+/** Real Git fixture — unlike `run-isolation.test.ts`, worktree creation is not
+ *  mocked here, so isolated runs genuinely succeed and can be observed
+ *  overtaking root runs that are queued behind the lease. */
+function fixtureRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'cez-root-lease-'));
+  roots.push(root);
+  execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  execFileSync('git', [...GIT_ID, 'commit', '--allow-empty', '-q', '-m', 'base'], { cwd: root });
+  return root;
+}
+
+async function waitFor(predicate: () => boolean, what: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+const settled = ['done', 'failed', 'cancelled', 'review'];
+
+/** Occupies the repo-root lease long enough to observe what queues behind it. */
+const SLOW_ROOT: WorkflowDef = {
+  name: 'slow-root',
+  source: 'built-in',
+  steps: [{ id: 'hold', command: 'node -e "setTimeout(()=>{},1500)"' }],
+};
+const INSTANT: WorkflowDef = {
+  name: 'instant',
+  source: 'built-in',
+  steps: [{ id: 'noop', command: 'node -e ""' }],
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('RunManager repository-root lease scheduling', () => {
+  it('does not let a lease-blocked run consume a parallel slot', async () => {
+    const root = fixtureRepo();
+    const store = RunStore.open(join(root, '.ai/cezar'));
+    const manager = new RunManager(store, root);
+
+    // maxParallel defaults to 2. `holder` takes the lease; `blocked` waits on
+    // it while idle and must hand its slot back, or `isolated` — which needs
+    // no lease at all — would be starved until the holder finishes (#438).
+    const holder = manager.startRun(SLOW_ROOT, { task: 'holder', worktree: false });
+    const blocked = manager.startRun(INSTANT, { task: 'blocked', worktree: false });
+    const isolated = manager.startRun(INSTANT, { task: 'isolated' });
+
+    await waitFor(
+      () => settled.includes(store.getRun(isolated.id)?.status ?? ''),
+      'the isolated worktree run to finish',
+    );
+    // The point of the assertion: it got through while the root lease holder
+    // was still running, instead of queueing behind an idle lease waiter.
+    expect(store.getRun(holder.id)?.status).toBe('running');
+
+    await waitFor(
+      () => [holder.id, blocked.id].every((id) => settled.includes(store.getRun(id)?.status ?? '')),
+      'the root runs to finish',
+    );
+    expect(store.getRun(holder.id)?.status).toBe('done');
+    expect(store.getRun(blocked.id)?.status).toBe('done');
+  });
+
+  it('cancels a run blocked on the lease without waiting for the holder', async () => {
+    const root = fixtureRepo();
+    const store = RunStore.open(join(root, '.ai/cezar'));
+    const manager = new RunManager(store, root);
+
+    const holder = manager.startRun(SLOW_ROOT, { task: 'holder', worktree: false });
+    const blocked = manager.startRun(INSTANT, { task: 'blocked', worktree: false });
+    // The note is emitted immediately before the lease is awaited, so it — not
+    // the `running` status, which lands well before — is what pins the run to
+    // the blocked state this test is about.
+    await waitFor(
+      () =>
+        store
+          .readEvents(blocked.id)
+          .some((event) => event.type === 'note' && String(event.message).includes('exclusive access')),
+      'the blocked run to reach the lease',
+    );
+
+    expect(manager.cancel(blocked.id)).toBe(true);
+    await waitFor(() => store.getRun(blocked.id)?.status === 'cancelled', 'the cancel to settle');
+    // Settled while the holder still owns the tree — the lease wait aborted
+    // rather than reporting success and sitting in `active` until the holder
+    // released.
+    expect(store.getRun(holder.id)?.status).toBe('running');
+
+    // The lease chain survives the cancel: a later root run still gets it.
+    const after = manager.startRun(INSTANT, { task: 'after', worktree: false });
+    await waitFor(() => settled.includes(store.getRun(after.id)?.status ?? ''), 'the later run to finish');
+    expect(store.getRun(after.id)?.status).toBe('done');
+  });
+});

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -414,18 +414,58 @@ export class RunManager {
   }
 
   /**
-   * Acquire the one-at-a-time lease for runs executing in `repoRoot`. The
-   * promise chain is intentionally independent from `maxParallel`: isolated
-   * worktrees keep using all configured slots while root fallbacks line up.
+   * Acquire the one-at-a-time lease for runs executing in `repoRoot`.
+   *
+   * A lease waiter is idle, so it parks in `waiting` and gives its
+   * `maxParallel` slot back (the #347 rule): isolated worktrees keep using
+   * every configured slot while root runs line up. The store status stays
+   * `running` — only the queue's busy count changes, so the GUI never shows a
+   * lease-blocked run as awaiting user input.
+   *
+   * The lease is held for the run's whole lifetime, including the idle
+   * `waiting` parks between agent turns. A parked session is still live and
+   * writes to the working tree the moment it resumes, so handing the tree to
+   * another run there would reintroduce the concurrent-edit bug (#438) this
+   * lease exists to prevent.
+   *
+   * Returns false when the run was cancelled while waiting: the lease was
+   * never granted and the caller must not touch the working tree.
    */
-  private async acquireRepoRoot(state: ActiveRun): Promise<void> {
+  private async acquireRepoRoot(runId: string, state: ActiveRun): Promise<boolean> {
+    // `cancel()` can land between the run going `running` and reaching here,
+    // while `interrupt` is still the default no-op — never enter the chain.
+    if (state.cancelled) return false;
     const previous = this.repoRootTail;
     let release: () => void = () => undefined;
     this.repoRootTail = new Promise<void>((resolve) => {
       release = resolve;
     });
-    await previous;
+    // Until `previous` resolves this run does not own the tree yet, so a drop
+    // during the wait must not hand the tree to the next waiter — chain our
+    // release behind `previous` instead of resolving the tail early.
+    state.releaseRepoRoot = () => {
+      void previous.then(release);
+    };
+    let abort: () => void = () => undefined;
+    const cancelled = new Promise<void>((resolve) => {
+      abort = resolve;
+    });
+    const parked = state.interrupt;
+    state.interrupt = () => {
+      parked();
+      abort();
+    };
+    this.waiting.add(runId);
+    void this.pump();
+    try {
+      await Promise.race([previous, cancelled]);
+    } finally {
+      state.interrupt = parked;
+      this.waiting.delete(runId);
+    }
+    if (state.cancelled) return false;
     state.releaseRepoRoot = release;
+    return true;
   }
 
   cancel(runId: string): boolean {
@@ -567,7 +607,17 @@ export class RunManager {
         type: 'note',
         message: 'waiting for exclusive access to the repository working tree',
       });
-      await this.acquireRepoRoot(state);
+      if (!(await this.acquireRepoRoot(runId, state))) {
+        this.store.updateRun(runId, {
+          status: 'cancelled',
+          finishedAt: new Date().toISOString(),
+          currentStepId: undefined,
+        });
+        this.store.appendEvent(runId, { type: 'lifecycle', message: 'run cancelled' });
+        this.dropActive(runId);
+        void this.pump();
+        return;
+      }
     }
     this.armAutosave(state);
     if (record) seedHandoffFile(this.dataDir, record); // idempotent — normally already there
@@ -762,8 +812,14 @@ export class RunManager {
       // Fork from the configured base branch (config.json `baseBranch`, e.g.
       // `develop`) — also the target of the eventual draft PR. Unresolvable
       // (typo, not fetched) → note + the currently checked-out branch.
-      let base = repo.branch;
-      const configured = config.baseBranch;
+      //
+      // A task that already recorded a fork point keeps it: its worktree is
+      // reused as-is, and re-resolving against a since-changed config would
+      // silently re-anchor the `merge-base` every diff/shortstat is measured
+      // from, shifting "what did this task change" under an existing task.
+      const recorded = this.store.getRun(runId)?.baseBranch;
+      let base = recorded ?? repo.branch;
+      const configured = recorded ? undefined : config.baseBranch;
       if (configured) {
         const resolved = await resolveBaseRef(this.repoRoot, configured);
         if (resolved) {
@@ -809,7 +865,10 @@ export class RunManager {
         type: 'note',
         message: 'waiting for exclusive access to the repository working tree',
       });
-      await this.acquireRepoRoot(state);
+      // A cancel during the wait leaves the lease ungranted; the step loop
+      // below breaks on `cancelled` before touching the tree and settles the
+      // run through the usual path.
+      await this.acquireRepoRoot(runId, state);
     }
 
     // Handoff journal (spec 007) — seeded after the worktree exists so the

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -61,6 +61,9 @@ interface ActiveRun {
    *  going until it signals done or the safety cap is hit. */
   autonomous?: boolean;
   autoContinues?: number;
+  /** Release for exclusive execution in the user's repository working tree.
+   *  Worktree-backed runs never need it; every degradation/opt-out path does. */
+  releaseRepoRoot?: () => void;
 }
 
 /** Safety cap on autonomous auto-continues per run — stops a stuck agent from nudging forever. */
@@ -154,6 +157,12 @@ export class RunManager {
   private readonly waiting = new Set<string>();
   private readonly pendingJobs = new Map<string, { workflow: WorkflowDef; input: StartRunInput }>();
   private pumping = false;
+  /**
+   * Runs normally isolate in worktrees and may execute in parallel. When that
+   * isolation is unavailable (or explicitly disabled), serialize access to
+   * `repoRoot` so two agents can never edit/revert the same files (#438).
+   */
+  private repoRootTail: Promise<void> = Promise.resolve();
 
   /** `.ai/cezar` — where the per-task handoff files and todos.json live. */
   private readonly dataDir: string;
@@ -396,9 +405,27 @@ export class RunManager {
 
   /** Remove a run from the live registries — keeps `waiting ⊆ active`. */
   private dropActive(runId: string): void {
+    const state = this.active.get(runId);
+    state?.releaseRepoRoot?.();
+    if (state) state.releaseRepoRoot = undefined;
     this.waiting.delete(runId);
     this.active.delete(runId);
     this.memoryPausing.delete(runId);
+  }
+
+  /**
+   * Acquire the one-at-a-time lease for runs executing in `repoRoot`. The
+   * promise chain is intentionally independent from `maxParallel`: isolated
+   * worktrees keep using all configured slots while root fallbacks line up.
+   */
+  private async acquireRepoRoot(state: ActiveRun): Promise<void> {
+    const previous = this.repoRootTail;
+    let release: () => void = () => undefined;
+    this.repoRootTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    state.releaseRepoRoot = release;
   }
 
   cancel(runId: string): boolean {
@@ -535,6 +562,13 @@ export class RunManager {
         : this.repoRoot;
     const state: ActiveRun = { cancelled: false, interrupt: () => undefined, cwd };
     this.active.set(runId, state);
+    if (state.cwd === this.repoRoot) {
+      this.store.appendEvent(runId, {
+        type: 'note',
+        message: 'waiting for exclusive access to the repository working tree',
+      });
+      await this.acquireRepoRoot(state);
+    }
     this.armAutosave(state);
     if (record) seedHandoffFile(this.dataDir, record); // idempotent — normally already there
 
@@ -756,6 +790,14 @@ export class RunManager {
       }
     } else {
       emit({ type: 'note', message: 'not a git repository — running in place, one task at a time' });
+    }
+
+    if (state.cwd === this.repoRoot) {
+      emit({
+        type: 'note',
+        message: 'waiting for exclusive access to the repository working tree',
+      });
+      await this.acquireRepoRoot(state);
     }
 
     // Handoff journal (spec 007) — seeded after the worktree exists so the

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -750,8 +750,9 @@ export class RunManager {
     emit({ type: 'lifecycle', message: `run started — workflow "${workflow.name}" (runner: ${taskBackend})` });
 
     // Worktree per task (spec 006): the agent works on its own branch in
-    // `.ai/cezar/worktrees/<id>`, never in the user's working tree. Not a git
-    // repo, or worktree creation failed → degrade to running in place.
+    // `.ai/cezar/worktrees/<id>`, never in the user's working tree. A Git task
+    // that requests isolation fails closed if the worktree cannot be
+    // established; only explicit opt-out and non-Git modes run in place.
     const repo = await getRepoInfo(this.repoRoot);
     if (repo && input.worktree === false) {
       // Composer opt-out: run in the repo working tree, no branch/worktree
@@ -786,7 +787,18 @@ export class RunManager {
         this.armAutosave(state);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        emit({ type: 'note', message: `worktree creation failed (${message}) — running in the repo working tree` });
+        const error = `worktree creation failed: ${message}`;
+        emit({ type: 'note', message: `${error} — task stopped before workflow execution` });
+        this.store.updateRun(runId, {
+          status: 'failed',
+          error,
+          finishedAt: new Date().toISOString(),
+          currentStepId: undefined,
+        });
+        emit({ type: 'lifecycle', message: `run failed — ${error}` });
+        this.dropActive(runId);
+        void this.pump();
+        return;
       }
     } else {
       emit({ type: 'note', message: 'not a git repository — running in place, one task at a time' });


### PR DESCRIPTION
Fixes #438

Status: complete
Tracking plan: `.ai/runs/2026-07-16-harden-worktree-creation.md`

## Problem

Runs that could not create their requested worktree silently executed in the repository working tree. With `maxParallel` above one, multiple fallback agents could edit or revert the same files. Even when serialized, the fallback still violated the default per-task isolation contract.

## Root Cause

- `RunManager` did not coordinate intentional repository-root execution or the unsafe worktree-failure fallback.
- `createWorktree` made one `git worktree add -b` attempt. A deleted worktree with a surviving `cez/<id8>` branch failed with “branch already exists” instead of recovering.
- Any unrecoverable creation error silently changed the task's execution directory to the user's repository root.

## What Changed

- Added a FIFO repository-root execution lease shared by explicit worktree opt-outs, non-Git degradation, and continuation fallback.
- Made task worktree creation idempotent and canonical-path aware, including macOS `/var` → `/private/var` resolution.
- Prune stale worktree metadata, repair recoverable registered paths, and reattach a surviving task branch while preserving its commits.
- Preserve non-empty unregistered managed paths instead of deleting potentially recoverable uncommitted work.
- Fail an isolated Git task before any workflow step or agent process starts when a proper worktree still cannot be established.
- Kept explicit `worktree: false` and non-Git repository-root execution serialized and supported.

## Tests

- Added/extended `src/git-worktree.test.ts` with real-Git coverage for idempotent creation, surviving-branch reattachment, commit preservation, and non-destructive path handling.
- Extended `src/workflows/run-isolation.test.ts` to prove creation failures execute no repository-root command and explicit opt-out runs remain serialized.
- `npm run typecheck`
- `npm test` — 123 files, 2,040 tests passed
- `npm run test:unit` — 4 tests passed
- `npm run build` — production build and check:pack passed
- `npm run test:package` — packaged CLI E2E passed

## Breaking Changes

No public API, state-file, CLI, workflow, or config format changed. Behavioral hardening: an isolated Git task now fails visibly if cezar cannot establish isolation, instead of silently running against the user's working tree.
