### PR TITLE
feat(tasks): add follow-up generation toggle

### DIFF
--- a/.ai/runs/2026-07-16-generate-followups-toggle.md
+++ b/.ai/runs/2026-07-16-generate-followups-toggle.md
@@ -1,0 +1,63 @@
+# Generate follow-ups per task
+
+## Overview
+
+Add a per-task **Generate follow-ups** choice to the New Task composer, defaulting on and remembered like the existing worktree/autonomous choices. When disabled, the run keeps its handoff journal and completion marker but agents receive neither `CEZ_TODOS_FILE` nor instructions for appending inbox entries.
+
+## Goal
+
+Let users prevent follow-up inbox clutter for individual tasks without changing the zero-config default or breaking old API clients and persisted runs.
+
+## Scope
+
+- Add an optional run/API field whose omitted value means follow-ups are enabled.
+- Persist the choice on `RunRecord` so Continue/recovery sessions retain the original contract.
+- Separate handoff instructions from follow-up inbox instructions and conditionally expose the latter in runner prompts and environment.
+- Add a default-on composer checkbox, draft persistence, last-used UI-state persistence, planned-run propagation, type mirrors, and regression tests.
+
+## Non-goals
+
+- No global config setting or required migration.
+- No changes to inbox storage, rendering, or existing entries.
+- No change to handoff journal seeding, progress logging, resume notes, or `CEZ:DONE` behavior.
+- No change to bookmarklet/inbox-start defaults; omitted fields continue to enable follow-ups.
+
+## Implementation Plan
+
+### Phase 1: Run contract and agent boundary
+
+1. Split the handoff and follow-up prompt contracts, add the optional persisted run flag, and make initial/continued agent prompts and environments conditional.
+2. Accept and forward the optional API field with omitted-as-enabled semantics, then add server, store, and dry-run runner regression coverage.
+
+### Phase 2: New Task UI and browser contract
+
+1. Add the default-on Generate follow-ups toggle, draft/UI-state persistence, create/planned-run payload propagation, and browser/server type mirrors.
+2. Add pure form, draft, plan, and component tests for default-on, remembered, and explicitly-off behavior.
+
+### Phase 3: Verification and review
+
+1. Run the full configured validation gate, apply code-review and backward-compatibility checks, and remove any scope drift.
+
+## Risks
+
+- A continuation could accidentally regain inbox access unless the optional flag is persisted and interpreted as enabled unless literally `false`.
+- Splitting the shared prompt must not remove the handoff journal or completion-marker instructions.
+- UI omission rules must send only `false`; old callers and old state records must continue to behave as enabled.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Run contract and agent boundary
+
+- [ ] 1.1 Split the handoff and follow-up prompt contracts, add the optional persisted run flag, and make initial/continued agent prompts and environments conditional.
+- [ ] 1.2 Accept and forward the optional API field with omitted-as-enabled semantics, then add server, store, and dry-run runner regression coverage.
+
+### Phase 2: New Task UI and browser contract
+
+- [ ] 2.1 Add the default-on Generate follow-ups toggle, draft/UI-state persistence, create/planned-run payload propagation, and browser/server type mirrors.
+- [ ] 2.2 Add pure form, draft, plan, and component tests for default-on, remembered, and explicitly-off behavior.
+
+### Phase 3: Verification and review
+
+- [ ] 3.1 Run the full configured validation gate, apply code-review and backward-compatibility checks, and remove any scope drift.

--- a/.ai/runs/2026-07-16-generate-followups-toggle.md
+++ b/.ai/runs/2026-07-16-generate-followups-toggle.md
@@ -50,8 +50,8 @@ Let users prevent follow-up inbox clutter for individual tasks without changing 
 
 ### Phase 1: Run contract and agent boundary
 
-- [ ] 1.1 Split the handoff and follow-up prompt contracts, add the optional persisted run flag, and make initial/continued agent prompts and environments conditional.
-- [ ] 1.2 Accept and forward the optional API field with omitted-as-enabled semantics, then add server, store, and dry-run runner regression coverage.
+- [x] 1.1 Split the handoff and follow-up prompt contracts, add the optional persisted run flag, and make initial/continued agent prompts and environments conditional. — 38d2f74
+- [x] 1.2 Accept and forward the optional API field with omitted-as-enabled semantics, then add server, store, and dry-run runner regression coverage. — 38d2f74
 
 ### Phase 2: New Task UI and browser contract
 

--- a/.ai/runs/2026-07-16-generate-followups-toggle.md
+++ b/.ai/runs/2026-07-16-generate-followups-toggle.md
@@ -46,6 +46,8 @@ Let users prevent follow-up inbox clutter for individual tasks without changing 
 
 ## Progress
 
+PR: #444
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Run contract and agent boundary

--- a/.ai/runs/2026-07-16-generate-followups-toggle.md
+++ b/.ai/runs/2026-07-16-generate-followups-toggle.md
@@ -55,8 +55,8 @@ Let users prevent follow-up inbox clutter for individual tasks without changing 
 
 ### Phase 2: New Task UI and browser contract
 
-- [ ] 2.1 Add the default-on Generate follow-ups toggle, draft/UI-state persistence, create/planned-run payload propagation, and browser/server type mirrors.
-- [ ] 2.2 Add pure form, draft, plan, and component tests for default-on, remembered, and explicitly-off behavior.
+- [x] 2.1 Add the default-on Generate follow-ups toggle, draft/UI-state persistence, create/planned-run payload propagation, and browser/server type mirrors. — 1646b5c
+- [x] 2.2 Add pure form, draft, plan, and component tests for default-on, remembered, and explicitly-off behavior. — 1646b5c
 
 ### Phase 3: Verification and review
 

--- a/.ai/runs/2026-07-16-generate-followups-toggle.md
+++ b/.ai/runs/2026-07-16-generate-followups-toggle.md
@@ -60,4 +60,4 @@ Let users prevent follow-up inbox clutter for individual tasks without changing 
 
 ### Phase 3: Verification and review
 
-- [ ] 3.1 Run the full configured validation gate, apply code-review and backward-compatibility checks, and remove any scope drift.
+- [x] 3.1 Run the full configured validation gate, apply code-review and backward-compatibility checks, and remove any scope drift. — 98db454

--- a/.ai/specs/007-handoff-file-todos.md
+++ b/.ai/specs/007-handoff-file-todos.md
@@ -35,6 +35,15 @@ jednego inboxa, z którego kolejny task odpala się jednym klikiem.
      suggestedSkill?, suggestedArgs?, suggestedPrompt? }`,
    - agent dostaje env `CEZ_TODOS_FILE` + instrukcję: „po skończeniu dopisz
      wpis JSON do tablicy; nigdy nie modyfikuj istniejących",
+   - **poprawka (PR #444)**: generowanie follow-upów jest przełącznikiem per
+     task (`generateFollowups`, domyślnie ON; brak pola = ON, żeby stare runy
+     i starsi klienci nie zmienili zachowania). Gdy run się wypisze, agent nie
+     dostaje ani instrukcji follow-upów, ani użytecznego `CEZ_TODOS_FILE` —
+     dziennik `handoff.md` i marker `CEZ:DONE` działają bez zmian. Uwaga
+     implementacyjna: runnery startują z `{ ...process.env, ...spec.env }`,
+     więc przy wypisaniu `CEZ_TODOS_FILE` musi być **przesłonięty** pustą
+     wartością, a nie pominięty — inaczej zagnieżdżony cezar (agent odpalający
+     `cez serve`/testy) odziedziczy ścieżkę rodzica i dopisze do jego inboxa,
    - zapis serwerowy pod lockiem (nasz store ma już atomic write; dodajemy
      `withLock` — 15-liniowy port z janitorowego `storage.ts`),
    - watch pliku (fs.watch + debounce) → SSE → licznik na zakładce,
@@ -76,3 +85,7 @@ jednego inboxa, z którego kolejny task odpala się jednym klikiem.
   „▶ Odpal" tworzy poprawny task; odhaczenie usuwa wpis.
 - Ręcznie zepsuty JSON w todos.json nie wywala serwera (plik leczony:
   nieparsowalne wpisy pomijane, log ostrzeżenia).
+- (PR #444) Task z `generateFollowups: false` nie dopisuje nic do żadnego
+  inboxa — także wtedy, gdy proces cezara sam ma ustawione `CEZ_TODOS_FILE` —
+  a mimo to prowadzi `handoff.md` i kończy markerem `CEZ:DONE`. Task bez tego
+  pola (stary run, stary klient) zachowuje się jak dotychczas.

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -113,8 +113,8 @@ export function deleteHandoff(dataDir: string, runId: string): void {
 
 /**
  * Appended to every agent step's `--append-system-prompt` (spec 007). The
- * matching env vars (CEZ_HANDOFF_FILE / CEZ_TODOS_FILE / CEZ_TASK_ID) are set
- * on the spawned claude process.
+ * matching handoff/task env vars are set on every agent process;
+ * CEZ_TODOS_FILE is present only when follow-up generation is enabled.
  */
 export const HANDOFF_ONLY_INSTRUCTIONS = `## Handoff (cezar)
 

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -114,7 +114,9 @@ export function deleteHandoff(dataDir: string, runId: string): void {
 /**
  * Appended to every agent step's `--append-system-prompt` (spec 007). The
  * matching handoff/task env vars are set on every agent process;
- * CEZ_TODOS_FILE is present only when follow-up generation is enabled.
+ * CEZ_TODOS_FILE carries a usable path only when follow-up generation is
+ * enabled (#444) — opted-out runs get it empty, never absent, so an inherited
+ * value from a parent cezar cannot shine through (`RunManager.agentEnv`).
  */
 export const HANDOFF_ONLY_INSTRUCTIONS = `## Handoff (cezar)
 

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -116,15 +116,20 @@ export function deleteHandoff(dataDir: string, runId: string): void {
  * matching env vars (CEZ_HANDOFF_FILE / CEZ_TODOS_FILE / CEZ_TASK_ID) are set
  * on the spawned claude process.
  */
-export const HANDOFF_INSTRUCTIONS = `## Handoff & follow-ups (cezar)
+export const HANDOFF_ONLY_INSTRUCTIONS = `## Handoff (cezar)
 
 CEZ_HANDOFF_FILE (env) is the absolute path to this task's rolling handoff file. Treat it like a HANDOFF.md:
 1. At the start of work, read it — "Resume notes" left by a previous session is your starting context.
 2. After every meaningful milestone (passing tests, a commit, a PR, a scope decision), append one terse timestamped line under "## Progress log", newest at the top.
 3. Before finishing or pausing, update "## Resume notes" with what's done, what's next and any blockers. Leave it empty only when the task is truly complete.
 
-Task completion marker: when the task's goal is fully achieved and you have no question for the user, end your final message with a line containing exactly CEZ:DONE — cez then closes the session and marks the task finished. If you are waiting on the user (a question, a decision, missing input), just end your message normally; the session stays open for their reply. Never emit CEZ:DONE while anything is unfinished or unverified.
+Task completion marker: when the task's goal is fully achieved and you have no question for the user, end your final message with a line containing exactly CEZ:DONE — cez then closes the session and marks the task finished. If you are waiting on the user (a question, a decision, missing input), just end your message normally; the session stays open for their reply. Never emit CEZ:DONE while anything is unfinished or unverified.`;
+
+export const FOLLOWUP_INSTRUCTIONS = `## Follow-ups (cezar)
 
 CEZ_TODOS_FILE (env) is the absolute path to the user's follow-up inbox — a JSON array. When you finish the task and a concrete follow-up remains for the user or a next agent, read the file (treat a missing file as []), append ONE object and write the whole array back:
 { "ts": "<ISO 8601>", "taskId": "<value of CEZ_TASK_ID>", "summary": "<one sentence: what was done / what's next>", "action": "<imperative user action, optional>", "prUrl": "<optional>", "suggestedSkill": "<optional skill name for the follow-up>", "suggestedArgs": "<optional>", "suggestedPrompt": "<optional freeform prompt for the follow-up task>" }
 Never modify or remove existing entries — append only.`;
+
+/** Default-on combined contract retained for old callers and runs. */
+export const HANDOFF_INSTRUCTIONS = `${HANDOFF_ONLY_INSTRUCTIONS}\n\n${FOLLOWUP_INSTRUCTIONS}`;

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -57,6 +57,29 @@ describe('RunStore — titleSummary + diffStat (#389)', () => {
     expect(run?.title).toBe('fix the login bug');
     expect(run?.titleSummary).toBeUndefined();
     expect(run?.diffStat).toBeUndefined();
+    expect(run?.generateFollowups).toBeUndefined();
+  });
+
+  it('persists an explicit follow-up opt-out while omission stays compatible', () => {
+    const store = RunStore.open(dataDir);
+    const disabled = store.createRun({
+      title: 'quiet task',
+      workflow: 'quick-task',
+      task: 'quiet task',
+      generateFollowups: false,
+      steps: [],
+    });
+    const defaulted = store.createRun({
+      title: 'default task',
+      workflow: 'quick-task',
+      task: 'default task',
+      steps: [],
+    });
+    store.flush();
+
+    const reopened = RunStore.open(dataDir);
+    expect(reopened.getRun(disabled.id)?.generateFollowups).toBe(false);
+    expect(reopened.getRun(defaulted.id)?.generateFollowups).toBeUndefined();
   });
 
   it('updateRun fans the new fields out on the run channel (the SSE feed)', () => {

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -57,6 +57,8 @@ const runRecordSchema = z.object({
    *  contract are derivable from the persisted workflow and would bloat the
    *  index. Resolved at execute time (a queued run picks up config edits). */
   systemPrompt: z.string().optional(),
+  /** Per-task follow-up inbox contract. Missing on old runs means enabled. */
+  generateFollowups: z.boolean().optional(),
   status: z.enum(['queued', 'running', 'waiting', 'review', 'done', 'failed', 'cancelled']),
   createdAt: z.string(),
   startedAt: z.string().optional(),
@@ -248,6 +250,7 @@ export class RunStore extends EventEmitter {
     task: string;
     model?: string;
     runner?: 'claude' | 'codex' | 'opencode';
+    generateFollowups?: boolean;
     groupId?: string;
     variant?: string;
     steps: Array<Pick<StepState, 'id' | 'name' | 'kind'>>;
@@ -259,6 +262,7 @@ export class RunStore extends EventEmitter {
       task: input.task,
       model: input.model,
       runner: input.runner,
+      generateFollowups: input.generateFollowups,
       groupId: input.groupId,
       variant: input.variant,
       status: 'queued',

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -57,7 +57,8 @@ const runRecordSchema = z.object({
    *  contract are derivable from the persisted workflow and would bloat the
    *  index. Resolved at execute time (a queued run picks up config edits). */
   systemPrompt: z.string().optional(),
-  /** Per-task follow-up inbox contract. Missing on old runs means enabled. */
+  /** Per-task follow-up inbox contract (spec 007, #444). Missing on old runs
+   *  means enabled — the historical behavior. */
   generateFollowups: z.boolean().optional(),
   status: z.enum(['queued', 'running', 'waiting', 'review', 'done', 'failed', 'cancelled']),
   createdAt: z.string(),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -111,7 +111,8 @@ const startRunSchema = z
     // Autonomous mode (#autonomous): the run never parks at `waiting` — it
     // auto-continues until the agent signals done. No "needs you" is raised.
     autonomous: z.boolean().optional(),
-    // Generate follow-up inbox entries. Omitted means enabled for old clients.
+    // Generate follow-up inbox entries (spec 007, #444). Omitted means enabled
+    // for old clients — the handoff journal is unaffected either way.
     generateFollowups: z.boolean().optional(),
     // Per-run system-prompt override (R2 2.3) — programmatic callers only
     // (bookmarklets, scripts); deliberately NOT a composer-UI control. Wins

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -111,6 +111,8 @@ const startRunSchema = z
     // Autonomous mode (#autonomous): the run never parks at `waiting` — it
     // auto-continues until the agent signals done. No "needs you" is raised.
     autonomous: z.boolean().optional(),
+    // Generate follow-up inbox entries. Omitted means enabled for old clients.
+    generateFollowups: z.boolean().optional(),
     // Per-run system-prompt override (R2 2.3) — programmatic callers only
     // (bookmarklets, scripts); deliberately NOT a composer-UI control. Wins
     // over the config.json default; whitespace-only degrades to absent.
@@ -512,6 +514,7 @@ export function createApp(deps: ServerDeps): Hono {
       systemPrompt: parsed.data.systemPrompt,
       worktree: parsed.data.worktree,
       autonomous: parsed.data.autonomous,
+      generateFollowups: parsed.data.generateFollowups,
     };
     const variants = parsed.data.variants ?? 1;
     if (variants > 1) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -183,6 +183,7 @@ const uiStateSchema = z
       .optional(),
     lastWorktree: z.boolean().optional(),
     lastAutonomous: z.boolean().optional(),
+    lastGenerateFollowups: z.boolean().optional(),
     // Runs area presentation (#348): the sidebar-list + detail pane, or the
     // full-width table ("task manager") view.
     runsView: z.enum(['list', 'table']).optional(),

--- a/src/server/start-run.test.ts
+++ b/src/server/start-run.test.ts
@@ -60,6 +60,18 @@ describe('POST /api/runs systemPrompt', () => {
     expect(captured?.systemPrompt).toBeUndefined();
   });
 
+  it('forwards an explicit generateFollowups=false choice', async () => {
+    const res = await post({ ...base, generateFollowups: false });
+    expect(res.status).toBe(201);
+    expect(captured?.generateFollowups).toBe(false);
+  });
+
+  it('keeps generateFollowups absent for old clients (enabled by default)', async () => {
+    const res = await post(base);
+    expect(res.status).toBe(201);
+    expect(captured?.generateFollowups).toBeUndefined();
+  });
+
   it('a whitespace-only systemPrompt degrades to absent (not a 400, not an empty string)', async () => {
     const res = await post({ ...base, systemPrompt: '   ' });
     expect(res.status).toBe(201);

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -61,8 +61,6 @@ interface ActiveRun {
   /** Autonomous mode (#autonomous): never park at `waiting` — auto-nudge the agent to keep
    *  going until it signals done or the safety cap is hit. */
   autonomous?: boolean;
-  /** Follow-up inbox generation. Omitted means enabled for compatibility. */
-  generateFollowups?: boolean;
   autoContinues?: number;
 }
 
@@ -92,6 +90,8 @@ export interface StartRunInput {
    *  user — turn-ends auto-continue until the agent signals done or the safety
    *  cap is hit. No "needs you" is ever raised. */
   autonomous?: boolean;
+  /** Follow-up inbox generation. Omitted means enabled for compatibility. */
+  generateFollowups?: boolean;
 }
 
 /**

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -7,6 +7,7 @@ import { onUsage, registerRunProcess, unregisterRunProcess, type ProcessUsage } 
 import { createRunner } from '../core/runner-factory.js';
 import type { RunnerId } from '../core/agent-runner.js';
 import {
+  HANDOFF_ONLY_INSTRUCTIONS,
   HANDOFF_INSTRUCTIONS,
   appendHandoffHeartbeat,
   handoffPath,
@@ -60,6 +61,8 @@ interface ActiveRun {
   /** Autonomous mode (#autonomous): never park at `waiting` — auto-nudge the agent to keep
    *  going until it signals done or the safety cap is hit. */
   autonomous?: boolean;
+  /** Follow-up inbox generation. Omitted means enabled for compatibility. */
+  generateFollowups?: boolean;
   autoContinues?: number;
 }
 
@@ -210,11 +213,11 @@ export class RunManager {
 
   /** Env the spawned claude gets so the agent can find its handoff file and
    *  the global inbox (spec 007). */
-  private agentEnv(runId: string): Record<string, string> {
+  private agentEnv(runId: string, generateFollowups = true): Record<string, string> {
     return {
       CEZ_HANDOFF_FILE: handoffPath(this.dataDir, runId),
-      CEZ_TODOS_FILE: todosPath(this.dataDir),
       CEZ_TASK_ID: runId,
+      ...(generateFollowups ? { CEZ_TODOS_FILE: todosPath(this.dataDir) } : {}),
     };
   }
 
@@ -229,6 +232,7 @@ export class RunManager {
       task: input.task,
       model: input.model,
       runner: input.runner,
+      generateFollowups: input.generateFollowups,
       groupId: group?.groupId,
       variant: group?.variant,
       steps: workflow.steps.map((s) => ({ id: s.id, name: s.name ?? s.id, kind: stepKind(s) })),
@@ -326,7 +330,12 @@ export class RunManager {
         if (workflow) {
           this.pendingJobs.set(run.id, {
             workflow,
-            input: { task: run.task, model: run.model, runner: run.runner },
+            input: {
+              task: run.task,
+              model: run.model,
+              runner: run.runner,
+              generateFollowups: run.generateFollowups,
+            },
           });
           this.queue.push(run.id);
           this.store.appendEvent(run.id, { type: 'lifecycle', message: 'cezar restarted — task re-queued' });
@@ -529,6 +538,7 @@ export class RunManager {
     // Continuation runs in the task's worktree when it still exists (spec
     // 006) — the resumed session sees exactly what the original run left.
     const record = this.store.getRun(runId);
+    const generateFollowups = record?.generateFollowups !== false;
     const cwd =
       record?.worktreePath && existsSync(record.worktreePath)
         ? record.worktreePath
@@ -630,12 +640,15 @@ export class RunManager {
         // The Continue step is a fresh agent session on the same run — the
         // run's extra system prompt (already resolved at execute time and
         // echoed on the record) rides along with the handoff contract.
-        systemPrompt: composeSystemPrompt(record?.systemPrompt, HANDOFF_INSTRUCTIONS),
+        systemPrompt: composeSystemPrompt(
+          record?.systemPrompt,
+          generateFollowups ? HANDOFF_INSTRUCTIONS : HANDOFF_ONLY_INSTRUCTIONS,
+        ),
         userPrompt: prompt,
         cwd: state.cwd,
         allowedTools: DEFAULT_ALLOWED_TOOLS,
         additionalDirectories: [join(this.dataDir, 'runs')],
-        env: this.agentEnv(runId),
+        env: this.agentEnv(runId, generateFollowups),
         sessionId,
         resume: true,
         timeoutMs: 0,
@@ -1012,7 +1025,11 @@ export class RunManager {
         {
           // Skill body, then the run's extra prompt (POST override or config
           // default), then the handoff/todos contract — every agent step.
-          systemPrompt: composeSystemPrompt(systemPrompt, extraSystemPrompt, HANDOFF_INSTRUCTIONS),
+          systemPrompt: composeSystemPrompt(
+            systemPrompt,
+            extraSystemPrompt,
+            input.generateFollowups === false ? HANDOFF_ONLY_INSTRUCTIONS : HANDOFF_INSTRUCTIONS,
+          ),
           userPrompt,
           images,
           cwd: state.cwd,
@@ -1020,7 +1037,7 @@ export class RunManager {
           bashAllowlist: step.bashAllowlist,
           // The handoff file lives outside the worktree — grant access.
           additionalDirectories: [join(this.dataDir, 'runs')],
-          env: this.agentEnv(runId),
+          env: this.agentEnv(runId, input.generateFollowups !== false),
           model: step.model ?? input.model,
           sessionId,
           // Interactive sessions have no wall clock — the idle timer rules.

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -90,7 +90,8 @@ export interface StartRunInput {
    *  user — turn-ends auto-continue until the agent signals done or the safety
    *  cap is hit. No "needs you" is ever raised. */
   autonomous?: boolean;
-  /** Follow-up inbox generation. Omitted means enabled for compatibility. */
+  /** Follow-up inbox generation (spec 007, #444). Omitted means enabled for
+   *  compatibility; the handoff journal runs either way. */
   generateFollowups?: boolean;
 }
 
@@ -212,12 +213,19 @@ export class RunManager {
   }
 
   /** Env the spawned claude gets so the agent can find its handoff file and
-   *  the global inbox (spec 007). */
+   *  the global inbox (spec 007; the inbox only when the run opted in).
+   *
+   *  `CEZ_TODOS_FILE` is set to `''` rather than omitted when follow-ups are
+   *  off: runners spawn with `{ ...process.env, ...spec.env }`, so omitting the
+   *  key would let a value inherited from *this* process through — a nested
+   *  cezar (an agent running `cez serve`/`cez run`/the test suite) would then
+   *  write follow-ups into the parent's inbox despite the opt-out. Empty is the
+   *  established "absent" spelling — consumers guard with `if (todosFile)`. */
   private agentEnv(runId: string, generateFollowups = true): Record<string, string> {
     return {
       CEZ_HANDOFF_FILE: handoffPath(this.dataDir, runId),
       CEZ_TASK_ID: runId,
-      ...(generateFollowups ? { CEZ_TODOS_FILE: todosPath(this.dataDir) } : {}),
+      CEZ_TODOS_FILE: generateFollowups ? todosPath(this.dataDir) : '',
     };
   }
 

--- a/src/workflows/system-prompt.test.ts
+++ b/src/workflows/system-prompt.test.ts
@@ -114,10 +114,10 @@ describe('systemPrompt end-to-end (dry run)', () => {
     return record.id;
   }
 
-  function capturedSystemPrompt(): string {
+  function capturedSystemPrompt(index = 0): string {
     const lines = readFileSync(argsFile, 'utf8').trim().split('\n');
-    expect(lines.length).toBeGreaterThan(0);
-    const argv = JSON.parse(lines[0] as string) as string[];
+    expect(lines.length).toBeGreaterThan(index);
+    const argv = JSON.parse(lines[index] as string) as string[];
     const idx = argv.indexOf('--append-system-prompt');
     expect(idx).toBeGreaterThanOrEqual(0);
     return argv[idx + 1] as string;
@@ -154,5 +154,17 @@ describe('systemPrompt end-to-end (dry run)', () => {
     expect(readFileSync(join(repoRoot, '.ai/cezar/runs', `${id}.handoff.md`), 'utf8')).toContain(
       'mock: implemented the change',
     );
+
+    expect(manager.continueRun(id, 'continue without generating follow-ups')).toEqual({ ok: true });
+    const deadline = Date.now() + 20_000;
+    while (readFileSync(argsFile, 'utf8').trim().split('\n').length < 2) {
+      if (Date.now() > deadline) throw new Error('continuation did not start in time');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    expect(capturedSystemPrompt(1)).toBe(
+      composeSystemPrompt(CONFIG_PROMPT, HANDOFF_ONLY_INSTRUCTIONS),
+    );
+    expect(capturedSystemPrompt(1)).not.toContain('CEZ_TODOS_FILE');
+    expect(existsSync(todosFile)).toBe(false);
   }, 30_000);
 });

--- a/src/workflows/system-prompt.test.ts
+++ b/src/workflows/system-prompt.test.ts
@@ -1,10 +1,10 @@
 import { execFile } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { HANDOFF_INSTRUCTIONS } from '../handoff.js';
+import { HANDOFF_INSTRUCTIONS, HANDOFF_ONLY_INSTRUCTIONS } from '../handoff.js';
 import { RunStore } from '../runs/store.js';
 import type { WorkflowDef } from './types.js';
 import { RunManager, composeSystemPrompt, resolveExtraSystemPrompt } from './run.js';
@@ -98,7 +98,11 @@ describe('systemPrompt end-to-end (dry run)', () => {
     ],
   };
 
-  async function runToEnd(input: { task: string; systemPrompt?: string }): Promise<string> {
+  async function runToEnd(input: {
+    task: string;
+    systemPrompt?: string;
+    generateFollowups?: boolean;
+  }): Promise<string> {
     writeFileSync(argsFile, '', 'utf8'); // fresh capture per run
     const record = manager.startRun(workflow, input);
     const terminal = new Set(['done', 'review', 'failed', 'cancelled']);
@@ -136,5 +140,19 @@ describe('systemPrompt end-to-end (dry run)', () => {
     const prompt = capturedSystemPrompt();
     expect(prompt).toBe(composeSystemPrompt(OVERRIDE_PROMPT, HANDOFF_INSTRUCTIONS));
     expect(prompt).not.toContain(CONFIG_PROMPT);
+  }, 30_000);
+
+  it('explicit opt-out keeps handoff behavior but removes inbox prompt and environment', async () => {
+    const todosFile = join(repoRoot, '.ai/cezar/todos.json');
+    rmSync(todosFile, { force: true });
+    const id = await runToEnd({ task: 'do the thing quietly', generateFollowups: false });
+    const record = store.getRun(id);
+    expect(record?.generateFollowups).toBe(false);
+    expect(capturedSystemPrompt()).toBe(composeSystemPrompt(CONFIG_PROMPT, HANDOFF_ONLY_INSTRUCTIONS));
+    expect(capturedSystemPrompt()).not.toContain('CEZ_TODOS_FILE');
+    expect(existsSync(todosFile)).toBe(false);
+    expect(readFileSync(join(repoRoot, '.ai/cezar/runs', `${id}.handoff.md`), 'utf8')).toContain(
+      'mock: implemented the change',
+    );
   }, 30_000);
 });

--- a/src/workflows/system-prompt.test.ts
+++ b/src/workflows/system-prompt.test.ts
@@ -52,6 +52,7 @@ describe('systemPrompt end-to-end (dry run)', () => {
   const OVERRIDE_PROMPT = 'PER-RUN OVERRIDE: answer in bullet points.';
   let repoRoot: string;
   let argsFile: string;
+  let inheritedTodos: string;
   let store: RunStore;
   let manager: RunManager;
   const savedEnv: Record<string, string | undefined> = {};
@@ -59,10 +60,18 @@ describe('systemPrompt end-to-end (dry run)', () => {
   beforeAll(async () => {
     repoRoot = mkdtempSync(join(tmpdir(), 'cez-sysprompt-'));
     argsFile = join(repoRoot, 'mock-args.ndjson');
+    inheritedTodos = join(repoRoot, 'inherited-todos.json');
     savedEnv.CEZ_DRY_RUN = process.env.CEZ_DRY_RUN;
     savedEnv.CEZ_MOCK_ARGS_FILE = process.env.CEZ_MOCK_ARGS_FILE;
+    savedEnv.CEZ_TODOS_FILE = process.env.CEZ_TODOS_FILE;
     process.env.CEZ_DRY_RUN = '1';
     process.env.CEZ_MOCK_ARGS_FILE = argsFile;
+    // Simulate a nested cezar (an agent running `cez serve` / the test suite):
+    // the parent process already carries CEZ_TODOS_FILE. Runners spawn with
+    // `{ ...process.env, ...spec.env }`, so `agentEnv` must *shadow* this for
+    // every run — never merely omit the key — or an opted-out agent writes
+    // follow-ups into the parent's inbox. Asserted per test below.
+    process.env.CEZ_TODOS_FILE = inheritedTodos;
     await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
     writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
     await run('git', ['add', '-A'], { cwd: repoRoot });
@@ -142,15 +151,32 @@ describe('systemPrompt end-to-end (dry run)', () => {
     expect(prompt).not.toContain(CONFIG_PROMPT);
   }, 30_000);
 
+  // The positive control for the opt-out test below: without this, flipping the
+  // `generateFollowups` default or mistyping the `!== false` guard would stop
+  // every run from producing inbox entries with the whole suite still green.
+  it('by default the agent gets the run own inbox, never an inherited one', async () => {
+    const todosFile = join(repoRoot, '.ai/cezar/todos.json');
+    rmSync(todosFile, { force: true });
+    rmSync(inheritedTodos, { force: true });
+    await runToEnd({ task: 'do the thing with follow-ups' });
+    expect(capturedSystemPrompt()).toContain('CEZ_TODOS_FILE');
+    expect(existsSync(todosFile)).toBe(true);
+    expect(existsSync(inheritedTodos)).toBe(false);
+  }, 30_000);
+
   it('explicit opt-out keeps handoff behavior but removes inbox prompt and environment', async () => {
     const todosFile = join(repoRoot, '.ai/cezar/todos.json');
     rmSync(todosFile, { force: true });
+    rmSync(inheritedTodos, { force: true });
     const id = await runToEnd({ task: 'do the thing quietly', generateFollowups: false });
     const record = store.getRun(id);
     expect(record?.generateFollowups).toBe(false);
     expect(capturedSystemPrompt()).toBe(composeSystemPrompt(CONFIG_PROMPT, HANDOFF_ONLY_INSTRUCTIONS));
     expect(capturedSystemPrompt()).not.toContain('CEZ_TODOS_FILE');
     expect(existsSync(todosFile)).toBe(false);
+    // The opt-out must survive an inherited CEZ_TODOS_FILE (nested cezar):
+    // omitting the key instead of shadowing it leaks into the parent's inbox.
+    expect(existsSync(inheritedTodos)).toBe(false);
     expect(readFileSync(join(repoRoot, '.ai/cezar/runs', `${id}.handoff.md`), 'utf8')).toContain(
       'mock: implemented the change',
     );
@@ -166,5 +192,6 @@ describe('systemPrompt end-to-end (dry run)', () => {
     );
     expect(capturedSystemPrompt(1)).not.toContain('CEZ_TODOS_FILE');
     expect(existsSync(todosFile)).toBe(false);
+    expect(existsSync(inheritedTodos)).toBe(false);
   }, 30_000);
 });

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -72,6 +72,8 @@ export interface RunRecord {
   runner?: Runner
   /** Echo of the extra system prompt the run used (POST override or config default). */
   systemPrompt?: string
+  /** false when the run deliberately disabled follow-up todo generation. Absent means enabled. */
+  generateFollowups?: boolean
   status: RunStatus
   createdAt: string
   startedAt?: string
@@ -486,6 +488,8 @@ export interface UiState {
   lastWorktree?: boolean
   /** The last autonomous choice — remembered like lastWorktree. Absent → off. */
   lastAutonomous?: boolean
+  /** Whether new runs should ask agents to append follow-up work. Absent → on. */
+  lastGenerateFollowups?: boolean
   runsView?: 'list' | 'table'
   /** Settings → Appearance (redesign R6): accent + density. Theme itself stays in
    *  localStorage (`cez-theme`) — it must pre-paint, and it is per-browser by design. */
@@ -520,6 +524,9 @@ export interface CreateRunInput {
   worktree?: boolean
   /** true → autonomous run: never parks at "waiting" for the user; auto-continues until done. */
   autonomous?: boolean
+  /** false → keep the handoff journal but do not expose or request a follow-up todos file.
+   *  Omit for the default (enabled). */
+  generateFollowups?: boolean
 }
 
 export interface MessageInput {

--- a/web/app/src/routes/new-task-draft.test.ts
+++ b/web/app/src/routes/new-task-draft.test.ts
@@ -15,6 +15,7 @@ describe('the new-task draft store', () => {
       planFirst: false,
       worktree: null,
       autonomous: null,
+      generateFollowups: null,
     })
   })
 
@@ -28,10 +29,12 @@ describe('the new-task draft store', () => {
       planFirst: false,
       worktree: false,
       autonomous: null,
+      generateFollowups: false,
     })
     const first = readDraft()
     expect(first.text).toBe('fix it')
     expect(first.worktree).toBe(false)
+    expect(first.generateFollowups).toBe(false)
     first.text = 'mutated'
     expect(readDraft().text).toBe('fix it')
   })
@@ -46,6 +49,7 @@ describe('the new-task draft store', () => {
       planFirst: true,
       worktree: null,
       autonomous: null,
+      generateFollowups: true,
     })
     clearDraftText()
     expect(readDraft()).toEqual({
@@ -57,6 +61,7 @@ describe('the new-task draft store', () => {
       planFirst: true,
       worktree: null,
       autonomous: null,
+      generateFollowups: true,
     })
   })
 
@@ -70,6 +75,7 @@ describe('the new-task draft store', () => {
       planFirst: true,
       worktree: false,
       autonomous: null,
+      generateFollowups: false,
     })
     // A fresh page has no in-memory cache but keeps localStorage: resetDraft removes storage, so
     // instead drop only the cache by round-tripping through a raw storage read.
@@ -79,6 +85,7 @@ describe('the new-task draft store', () => {
       variants: 2,
       worktree: false,
       autonomous: null,
+      generateFollowups: false,
       planFirst: true,
     })
   })
@@ -96,6 +103,7 @@ describe('the new-task draft store', () => {
       planFirst: false,
       worktree: null,
       autonomous: null,
+      generateFollowups: null,
     })
 
     resetDraft()
@@ -109,6 +117,7 @@ describe('the new-task draft store', () => {
       planFirst: false,
       worktree: null,
       autonomous: null,
+      generateFollowups: null,
     })
   })
 })

--- a/web/app/src/routes/new-task-draft.ts
+++ b/web/app/src/routes/new-task-draft.ts
@@ -25,6 +25,8 @@ export interface NewTaskDraft {
   /** Autonomous (#autonomous): true never pauses for the user. null → remembered
    *  `lastAutonomous` / default (off). */
   autonomous: boolean | null
+  /** Follow-up generation is default-on. null → remembered value / on. */
+  generateFollowups: boolean | null
 }
 
 const EMPTY: NewTaskDraft = {
@@ -36,6 +38,7 @@ const EMPTY: NewTaskDraft = {
   planFirst: false,
   worktree: null,
   autonomous: null,
+  generateFollowups: null,
 }
 
 const STORAGE_KEY = 'cez-new-task-draft'
@@ -53,6 +56,8 @@ function normalize(raw: unknown): NewTaskDraft {
     planFirst: obj.planFirst === true,
     worktree: typeof obj.worktree === 'boolean' ? obj.worktree : null,
     autonomous: typeof obj.autonomous === 'boolean' ? obj.autonomous : null,
+    generateFollowups:
+      typeof obj.generateFollowups === 'boolean' ? obj.generateFollowups : null,
   }
 }
 

--- a/web/app/src/routes/new-task-form.test.ts
+++ b/web/app/src/routes/new-task-form.test.ts
@@ -196,6 +196,16 @@ describe('buildCreateRunBody — the exact POST /api/runs payloads legacy sends'
     expect(variant.worktree).toBeUndefined()
   })
 
+  it('generateFollowups=false is sent only when follow-up generation is disabled', () => {
+    const base = {
+      task: 't', source: { source: 'skill' as const, ref: 'om-review' }, model: '',
+      runner: 'claude' as const, runnerCount: 1, variants: 1, images: [],
+    }
+    expect(buildCreateRunBody({ ...base, generateFollowups: false }).generateFollowups).toBe(false)
+    expect(buildCreateRunBody({ ...base, generateFollowups: true }).generateFollowups).toBeUndefined()
+    expect(buildCreateRunBody(base).generateFollowups).toBeUndefined()
+  })
+
   it('variants > 1 and images ride along; ×1 and no images are omitted', () => {
     const body = buildCreateRunBody({
       task: 't', source: { source: 'workflow', ref: 'quick-task' }, model: '',

--- a/web/app/src/routes/new-task-form.ts
+++ b/web/app/src/routes/new-task-form.ts
@@ -179,8 +179,21 @@ export function buildCreateRunBody(opts: {
   worktree?: boolean
   /** true → autonomous run (never pauses for the user). Sent only when on. */
   autonomous?: boolean
+  /** false → do not ask the agent for follow-up todos. Sent only when off. */
+  generateFollowups?: boolean
 }): CreateRunInput {
-  const { task, source, model, runner, runnerCount, variants, images, worktree, autonomous } = opts
+  const {
+    task,
+    source,
+    model,
+    runner,
+    runnerCount,
+    variants,
+    images,
+    worktree,
+    autonomous,
+    generateFollowups,
+  } = opts
   return {
     task,
     ...(source.source === 'skill'
@@ -193,6 +206,7 @@ export function buildCreateRunBody(opts: {
     // Off only matters for a single run — variants always isolate.
     worktree: worktree === false && variants <= 1 ? false : undefined,
     autonomous: autonomous === true ? true : undefined,
+    generateFollowups: generateFollowups === false ? false : undefined,
   }
 }
 

--- a/web/app/src/routes/new-task-plan.test.ts
+++ b/web/app/src/routes/new-task-plan.test.ts
@@ -119,6 +119,7 @@ describe('buildPlannedRunBody — the POST /api/runs wire contract for approved 
       runner: undefined,
       variants: undefined,
       images: undefined,
+      generateFollowups: undefined,
     })
   })
 
@@ -146,5 +147,10 @@ describe('buildPlannedRunBody — the POST /api/runs wire contract for approved 
     const body = buildPlannedRunBody(base)
     expect(body.steps).toEqual(STEPS)
     expect(body.steps).not.toBe(STEPS)
+  })
+
+  it('sends only the opt-out value for follow-up generation', () => {
+    expect(buildPlannedRunBody({ ...base, generateFollowups: false }).generateFollowups).toBe(false)
+    expect(buildPlannedRunBody({ ...base, generateFollowups: true }).generateFollowups).toBeUndefined()
   })
 })

--- a/web/app/src/routes/new-task-plan.ts
+++ b/web/app/src/routes/new-task-plan.ts
@@ -88,8 +88,9 @@ export function buildPlannedRunBody(opts: {
   runnerCount: number
   variants: number
   images: readonly ImageInput[]
+  generateFollowups?: boolean
 }): CreateRunInput {
-  const { task, steps, model, runner, runnerCount, variants, images } = opts
+  const { task, steps, model, runner, runnerCount, variants, images, generateFollowups } = opts
   return {
     task,
     steps: [...steps],
@@ -97,5 +98,6 @@ export function buildPlannedRunBody(opts: {
     runner: runnerCount > 1 ? runner : undefined,
     variants: variants > 1 ? variants : undefined,
     images: images.length > 0 ? [...images] : undefined,
+    generateFollowups: generateFollowups === false ? false : undefined,
   }
 }

--- a/web/app/src/routes/new-task.test.tsx
+++ b/web/app/src/routes/new-task.test.tsx
@@ -406,6 +406,7 @@ describe('submit', () => {
         // (skills default autonomous on).
         lastWorktree: true,
         lastAutonomous: true,
+        lastGenerateFollowups: true,
       }),
     )
   })
@@ -457,6 +458,39 @@ describe('submit', () => {
     fireEvent.change(textarea(), { target: { value: 'no runner key' } })
     await startTask()
     expect((postedBody() as Record<string, unknown>).runner).toBeUndefined()
+  })
+
+  it('defaults follow-up generation on, but posts and remembers an explicit opt-out', async () => {
+    serve()
+    renderNewTask()
+    await pillReady()
+    const toggle = document.querySelector(
+      '[data-slot="generate-followups-toggle"]',
+    ) as HTMLButtonElement
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    fireEvent.change(textarea(), { target: { value: 'No follow-up inbox items' } })
+    await startTask()
+
+    expect((postedBody() as Record<string, unknown>).generateFollowups).toBe(false)
+    await waitFor(() =>
+      expect(requests.find((r) => r.method === 'PUT' && r.url === '/api/ui-state')?.body).toMatchObject({
+        lastGenerateFollowups: false,
+      }),
+    )
+  })
+
+  it('uses the remembered follow-up preference when the draft has no choice', async () => {
+    serve({ uiState: { lastGenerateFollowups: false } })
+    renderNewTask()
+    await pillReady()
+    expect(
+      document
+        .querySelector('[data-slot="generate-followups-toggle"]')
+        ?.getAttribute('aria-checked'),
+    ).toBe('false')
   })
 })
 
@@ -807,6 +841,24 @@ describe('the plan flow', () => {
       ],
     })
     await waitFor(() => expect(location()).toBe('/tasks/planned-1'))
+  })
+
+  it('▶ Start carries the follow-up opt-out from the composer and remembers it', async () => {
+    serve({ createRun: { id: 'planned-no-followups' } })
+    renderNewTask()
+    await pillReady()
+    fireEvent.click(
+      document.querySelector('[data-slot="generate-followups-toggle"]') as HTMLElement,
+    )
+    await planTask('Plan without follow-ups')
+    fireEvent.click(document.querySelector('[data-slot="plan-start"]') as HTMLElement)
+
+    await waitFor(() => expect((postedBody() as Record<string, unknown>).generateFollowups).toBe(false))
+    await waitFor(() =>
+      expect(requests.find((r) => r.method === 'PUT' && r.url === '/api/ui-state')?.body).toEqual({
+        lastGenerateFollowups: false,
+      }),
+    )
   })
 
   it('Discard closes the overlay and hands back the draft untouched', async () => {

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -140,6 +140,11 @@ export function NewTaskRoute() {
     ? false
     : (draft.autonomous ?? (source.source === 'skill' ? true : (uiState.data?.lastAutonomous ?? false)))
 
+  // Follow-up generation is opt-out. A draft choice wins, then the remembered UI preference;
+  // absent state from older installs keeps the historical enabled behavior.
+  const generateFollowupsOn =
+    draft.generateFollowups ?? uiState.data?.lastGenerateFollowups ?? true
+
   // ---- plan mode (#383 + spec 008) ----------------------------------------------------------
   const [plan, setPlan] = useState<PendingPlan | null>(null)
   const [planning, setPlanning] = useState(false)
@@ -248,6 +253,7 @@ export function NewTaskRoute() {
         images,
         worktree: worktreeOn,
         autonomous: autonomousOn,
+        generateFollowups: generateFollowupsOn,
       }),
     )
     // Remember what was actually run so the next visit preselects it (legacy
@@ -258,6 +264,7 @@ export function NewTaskRoute() {
       recentSources: pushRecentSource(recentSources, source),
       ...(worktreeToggleShown ? { lastWorktree: worktreeOn } : {}),
       lastAutonomous: autonomousOn,
+      lastGenerateFollowups: generateFollowupsOn,
     })
       .then(() => queryClient.invalidateQueries({ queryKey: queryKeys.uiState }))
       .catch(() => {})
@@ -281,8 +288,12 @@ export function NewTaskRoute() {
           runnerCount: runners.length,
           variants,
           images: plan.images,
+          generateFollowups: generateFollowupsOn,
         }),
       )
+      void putUiState({ lastGenerateFollowups: generateFollowupsOn })
+        .then(() => queryClient.invalidateQueries({ queryKey: queryKeys.uiState }))
+        .catch(() => {})
       clearDraftText()
       setPlan(null)
       void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
@@ -383,6 +394,10 @@ export function NewTaskRoute() {
                 disabled={draft.planFirst}
                 onChange={(on) => update({ autonomous: on })}
               />
+              <GenerateFollowupsToggle
+                on={generateFollowupsOn}
+                onChange={(on) => update({ generateFollowups: on })}
+              />
               {repo.data ? <BaseBranchPill repo={repo.data} /> : null}
             </>
           }
@@ -480,6 +495,39 @@ function AutonomousToggle({
         <SquareIcon aria-hidden="true" className="size-3 shrink-0 text-soft-foreground" />
       )}
       Autonomous
+    </button>
+  )
+}
+
+/** Follow-up toggle: checked lets agents append newly discovered work to the task inbox.
+ *  Handoff journaling remains active either way. */
+function GenerateFollowupsToggle({
+  on,
+  onChange,
+}: {
+  on: boolean
+  onChange: (on: boolean) => void
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      data-slot="generate-followups-toggle"
+      onClick={() => onChange(!on)}
+      title={
+        on
+          ? 'Agents can add newly discovered follow-up work to the task inbox'
+          : 'Follow-up generation is off; agents still maintain the handoff journal'
+      }
+      className={cn(chipClass, on && 'border-primary/60 text-foreground')}
+    >
+      {on ? (
+        <CheckIcon aria-hidden="true" className="size-3 shrink-0 text-primary" />
+      ) : (
+        <SquareIcon aria-hidden="true" className="size-3 shrink-0 text-soft-foreground" />
+      )}
+      Follow-ups
     </button>
   )
 }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-16-generate-followups-toggle.md
Status: complete

## Goal
- Add a remembered, default-on per-task control for follow-up inbox generation while preserving handoff behavior and backward compatibility.

## What Changed
- Added an optional `generateFollowups` run/API field whose omitted value remains enabled for old clients and persisted runs.
- Split the handoff and follow-up agent contracts so disabled runs keep journals and completion markers without `CEZ_TODOS_FILE` or todo instructions, including Continue/recovery sessions.
- Added the New Task Follow-ups toggle, draft and UI-state persistence, normal/planned payload propagation, and browser type mirrors.
- Added server, store, dry-run runner, form, draft, plan, and component regression coverage.

## Tests
- `npm run typecheck`
- `npm test` — 122 files, 2044 tests passed
- `npm run test:unit` — 4 tests passed
- `npm run build` — production build and package-content gate passed
- `npm run test:package` — release tarball install/CLI workflow passed

## Breaking Changes
- None. The new API and persisted fields are optional; omission retains follow-up generation.

## Progress
See the Progress section in the tracking plan.
