### PR TITLE
fix(web): stop truncating task name mid-word in delete confirm button

### DIFF
--- a/web/app/src/routes/task-thread/run-header.test.tsx
+++ b/web/app/src/routes/task-thread/run-header.test.tsx
@@ -239,7 +239,7 @@ describe('actions hit their endpoints', () => {
 
     expect(sent.some((r) => r.method === 'DELETE')).toBe(false)
     const dialog = await screen.findByRole('alertdialog')
-    fireEvent.click(within(dialog).getByRole('button', { name: /^Delete / }))
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
     await waitFor(() => {
       expect(sent.some((r) => r.method === 'DELETE' && r.path === '/api/runs/r1')).toBe(true)
     })
@@ -247,6 +247,16 @@ describe('actions hit their endpoints', () => {
     await waitFor(() => {
       expect(document.querySelector('[data-slot="home-probe"]')).not.toBeNull()
     })
+  })
+
+  it('the delete confirm button stays "Delete" even for a long task name, which appears in the description instead (#403)', async () => {
+    const longTitle = 'create a github issue for saving unsuccessfully finished tasks automatically'
+    renderHeader(run('failed', { titleSummary: longTitle }))
+    fireEvent.click(actionBar().getByRole('button', { name: 'Delete' }))
+
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByRole('button', { name: 'Delete' })).not.toBeNull()
+    expect(within(dialog).getByText(longTitle)).not.toBeNull()
   })
 
   it('dismissing the confirm keeps the run', async () => {

--- a/web/app/src/routes/task-thread/run-header.tsx
+++ b/web/app/src/routes/task-thread/run-header.tsx
@@ -494,9 +494,17 @@ function ConfirmDialog({ run, actions }: { run: ApiRun; actions: RunActions }) {
         <AlertDialogHeader>
           <AlertDialogTitle>{confirming === 'delete' ? 'Delete this task?' : 'Cancel this task?'}</AlertDialogTitle>
           <AlertDialogDescription>
-            {confirming === 'delete'
-              ? 'This removes the run, its transcript, its worktree and its branch. There is no undo.'
-              : 'The agent is stopped and the run completes as cancelled. The worktree stays.'}
+            {confirming === 'delete' ? (
+              <>
+                This removes the run, its transcript, its worktree and its branch. There is no
+                undo.
+                <span className="mt-1 block truncate font-medium text-foreground" title={runTitle(run)}>
+                  {runTitle(run)}
+                </span>
+              </>
+            ) : (
+              'The agent is stopped and the run completes as cancelled. The worktree stays.'
+            )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -509,7 +517,7 @@ function ConfirmDialog({ run, actions }: { run: ApiRun; actions: RunActions }) {
               actions.setConfirming(null)
             }}
           >
-            {confirming === 'delete' ? `Delete ${runTitle(run).slice(0, 40)}` : 'Cancel the run'}
+            {confirming === 'delete' ? 'Delete' : 'Cancel the run'}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
Fixes #403

## What & why

The delete-confirmation button on the task-thread header (`web/app/src/routes/task-thread/run-header.tsx`) embedded the run's task name with `.slice(0, 40)`, which cut long names mid-word (e.g. `Delete create a github issue for saving unsuces`) and made the button stretch far wider than its "Keep it" sibling.

The button label is now a fixed `Delete` string. The task name moved into the `AlertDialogDescription` instead, appended below the existing explanatory copy, styled with `truncate` so it clips cleanly with an ellipsis rather than mid-word if it's too long to fit — matching the issue's suggested fix.

## Tests

- Updated the existing delete-confirm test (`within(dialog).getByRole('button', { name: /^Delete / })` → exact `'Delete'`) since the button label is no longer dynamic.
- Added a new test asserting the confirm button stays `"Delete"` even for a long task name, and that the name shows up in the dialog description instead (#403).
- `npm run typecheck:web` — clean.
- `npm run typecheck:server` — pre-existing, unrelated failure (`Cannot find module '@clack/prompts'`, missing in the shared `node_modules` install for this worktree; reproduced identically on unmodified `main`).
- `npm test` — 1960/1960 tests pass; the same 6 suites fail to import for the same pre-existing `@clack/prompts` reason (all in `src/server-install/`, untouched by this change).
- `npm run test:unit` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)