### PR TITLE
feat: link the CI checks badge to the run on GitHub

### DIFF
--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -269,6 +269,18 @@ describe('the GitHub detail pane', () => {
     expect(checks?.textContent).toContain('checks failing')
   })
 
+  it('the checks badge links to the PR checks tab on GitHub, open in a new tab (#415)', async () => {
+    stubFetch()
+    renderAt('/github/prs/137')
+
+    await waitFor(() => expect(detail()).not.toBeNull())
+    const checks = document.querySelector('[data-slot="gh-checks"]')
+    expect(checks?.tagName).toBe('A')
+    expect(checks?.getAttribute('href')).toBe(`${PR_137.url}/checks`)
+    expect(checks?.getAttribute('target')).toBe('_blank')
+    expect(checks?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
   it('renders the issue body through the markdown pipeline', async () => {
     stubFetch()
     renderAt('/github/issues/142')

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -497,7 +497,7 @@ function GithubDetail({
           {item.labels.map((label) => (
             <LabelChip key={label} label={label} color={colors[label]} />
           ))}
-          {item.checks ? <ChecksBadge checks={item.checks} /> : null}
+          {item.checks ? <ChecksBadge checks={item.checks} url={item.url} /> : null}
         </div>
       ) : null}
 
@@ -514,20 +514,36 @@ function GithubDetail({
   )
 }
 
-/** The checks badge — the legacy tab's three phrases, tinted by outcome. */
-function ChecksBadge({ checks }: { checks: NonNullable<GithubItem['checks']> }) {
+/** The checks badge — the legacy tab's three phrases, tinted by outcome. Links out
+ *  to the PR's checks tab on GitHub (issue #415) when a URL is available. */
+function ChecksBadge({ checks, url }: { checks: NonNullable<GithubItem['checks']>; url?: string }) {
+  const className = cn(
+    'text-[11px] font-medium',
+    checks === 'passing' && 'text-success',
+    checks === 'failing' && 'text-danger',
+    checks === 'pending' && 'text-muted-foreground',
+    url && 'hover:underline',
+  )
+  const label = checks === 'passing' ? '✓ checks passing' : checks === 'failing' ? '✗ checks failing' : '○ checks pending'
+
+  if (!url) {
+    return (
+      <span data-slot="gh-checks" data-checks={checks} className={className}>
+        {label}
+      </span>
+    )
+  }
+
   return (
-    <span
+    <a
+      href={`${url}/checks`}
+      target="_blank"
+      rel="noopener noreferrer"
       data-slot="gh-checks"
       data-checks={checks}
-      className={cn(
-        'text-[11px] font-medium',
-        checks === 'passing' && 'text-success',
-        checks === 'failing' && 'text-danger',
-        checks === 'pending' && 'text-muted-foreground',
-      )}
+      className={className}
     >
-      {checks === 'passing' ? '✓ checks passing' : checks === 'failing' ? '✗ checks failing' : '○ checks pending'}
-    </span>
+      {label}
+    </a>
   )
 }


### PR DESCRIPTION
Fixes #415

## What & why

The GitHub tab's checks badge (`✓/✗/○ checks passing/failing/pending`) was a plain `<span>` with no way to jump to the actual check run — you had to go find the PR in a browser yourself. This ships the cheapest option from the issue: wrap `ChecksBadge` in a link to the item's own `url + '/checks'` (GitHub's PR checks tab), opened in a new tab, for all three states. No server/schema change needed — the existing `checks` enum plus the item's own `url` is enough.

- `ChecksBadge` now takes an optional `url` prop; when present it renders as an `<a target="_blank" rel="noopener noreferrer">` linking to `${url}/checks`, otherwise it falls back to the original `<span>` (no link when there's no PR URL).
- Render site passes `item.url` through.

## Tests

- Added a test asserting the checks badge renders as an anchor pointing at `${PR.url}/checks`, opened in a new tab (`rel="noopener noreferrer"`, `target="_blank"`).
- `npm run typecheck` — web passes; server fails only on a pre-existing, unrelated `@clack/prompts` module-resolution error in `src/server-install` (reproduces identically on `main`/unmodified tree — the package isn't in this worktree's `node_modules`, not something this PR touches).
- `npm test` — 1960/1960 tests pass; the 6 failing suites are the same pre-existing `@clack/prompts` resolution failures in `src/server-install`, unrelated to this change.
- `npm run test:unit` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)