### PR TITLE
fix: poll useHealth so the top-bar branch chip catches an external checkout

### DIFF
--- a/web/app/src/api/global-events.tsx
+++ b/web/app/src/api/global-events.tsx
@@ -50,11 +50,11 @@ const EVENT_NAMES = ['run', 'run-deleted', 'todos', 'usage', 'ping'] as const
  * - runs: the summaries the stream patches (`invalidate(['runs'])` covers the list and every
  *   single-run query under it — that is what the hierarchical keys in queries.ts are for);
  * - todos: the inbox the `todos` event replaces;
- * - health: the repo/branch chip. Health is deliberately *not* on the stream — nothing server-side
- *   watches for a branch switch — so a chip read once at boot goes stale the moment the reader
- *   checks out another branch (#369, the legacy UI's bug). Refetching it here is the honest
- *   mechanism: one local request when we already know we were away, rather than a poll that asks
- *   a question nobody has, forever.
+ * - health: the repo/branch chip. Health is not on the stream — nothing server-side watches for a
+ *   branch switch — so this reconcile alone only catches a switch across a reconnect or a tab
+ *   coming back; a checkout in a foreground, connected tab is covered by `useHealth`'s own poll
+ *   instead (#369). Invalidating it here too costs nothing extra and keeps this list a complete
+ *   "everything the stream can leave stale" note.
  *
  * `invalidateQueries` and not `refetchQueries`: it refetches what is actually rendered and marks
  * the rest stale for whenever it next mounts. A background tab with fifty cached runs should not

--- a/web/app/src/api/queries.test.tsx
+++ b/web/app/src/api/queries.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -93,6 +93,25 @@ describe('useHealth', () => {
     expect(result.current.data).toBeUndefined()
     expect(result.current.error).toBeInstanceOf(ApiError)
     expect((result.current.error as ApiError).message).toBe('boom')
+  })
+
+  // #369: a `git checkout` in a foreground, connected tab fires none of reconnect/visibility/
+  // pageshow, so the branch chip needs its own poll rather than relying solely on those.
+  it('polls, so a branch switched outside the cockpit is caught without a reconnect', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockResolvedValue(json(HEALTH))
+      const { result } = renderHook(() => useHealth(), { wrapper: wrapper() })
+
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(result.current.isSuccess).toBe(true)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      await act(() => vi.advanceTimersByTimeAsync(5000))
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/web/app/src/api/queries.ts
+++ b/web/app/src/api/queries.ts
@@ -69,11 +69,20 @@ export const queryKeys = {
 } as const
 
 /** Version + update check + repo/branch + tool probes. Feeds the sidebar's repo and version
- *  chips and (Step 4.2) the Tools menu. */
+ *  chips and (Step 4.2) the Tools menu.
+ *
+ * Polled on a `useRunChanges`-style interval rather than left to reconnect/visibility alone
+ * (#369): a `git checkout` in a terminal, in a foreground tab whose SSE connection never drops,
+ * fires none of those triggers, so the branch chip would sit stale until something else woke the
+ * query up. The stream still carries nothing for this — no server-side watcher on `.git/HEAD` —
+ * so a light poll is the honest fix, the same trade `useRunChanges` already makes for the
+ * Changes tab. `git rev-parse` is cheap enough that a few-second interval per open tab is not
+ * worth a heavier watch mechanism. */
 export function useHealth() {
   return useQuery({
     queryKey: queryKeys.health,
     queryFn: ({ signal }) => getHealth({ signal }),
+    refetchInterval: 5000,
   })
 }
 

--- a/web/app/src/components/app-shell-container.tsx
+++ b/web/app/src/components/app-shell-container.tsx
@@ -36,7 +36,8 @@ export function repoChipOf(health: HealthResponse | undefined): RepoChip | null 
  *
  * Nothing here caches boot-time values (#369: the legacy UI read the branch once at startup and
  * then showed a stale branch forever). The chips read whatever is currently in the health query,
- * so making them live is Step 3.2's job of invalidating that query — not a change here.
+ * so keeping them live is `useHealth`'s job — its poll plus Step 3.2's reconnect/visibility
+ * reconcile — not a change here.
  */
 export function AppShellContainer({ children }: { children: ReactNode }) {
   const health = useHealth()


### PR DESCRIPTION
Fixes #369

## What & why

The repo/branch chip in the top bar only refreshed on SSE reconnect, a
`visibilitychange` → visible flip, or a bfcache `pageshow` — none of which
fire when a `git checkout`/`switch` happens in a terminal against a
foreground tab whose SSE connection stays up. `useHealth()` had no
`refetchInterval`, so a chip read once at mount stayed stale until reload.

- `web/app/src/api/queries.ts`: `useHealth()` now polls every 5s
  (`refetchInterval: 5000`), the same precedent `useRunChanges` already
  sets for the Changes tab. `git rev-parse` (`src/server/git.ts`) is cheap
  enough that a per-tab poll at this interval isn't worth a server-side
  `.git/HEAD` watcher and a new SSE event type (option 2 in the issue).
- `web/app/src/api/global-events.tsx` and
  `web/app/src/components/app-shell-container.tsx`: updated the two
  code comments the issue flagged, which asserted the non-reactive
  behavior was intentional — they now point at `useHealth`'s poll as the
  mechanism that keeps the chip live.

No server or SSE-contract changes; the fix is entirely client-side.

## Tests

- Added a `useHealth` test in `web/app/src/api/queries.test.tsx` that uses
  fake timers to assert a second fetch fires after 5s without any
  reconnect/visibility event.
- `npm run typecheck` — `typecheck:web` passes; `typecheck:server` fails
  only on a pre-existing, unrelated missing dependency
  (`@clack/prompts`, `src/server-install/ui.ts`) present on `main` too,
  confirmed by running the same command against the primary checkout.
- `npm test` — 1960 tests pass; the same 6 `server-install` suites fail
  to import for the identical pre-existing `@clack/prompts` reason.
- `npm run test:unit` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)