### PR TITLE
fix(bookmarklet): stamp the repo name into bookmark labels

### DIFF
--- a/web/app/src/routes/settings/bookmarklets-section.test.tsx
+++ b/web/app/src/routes/settings/bookmarklets-section.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createQueryClient } from '@/api/query-client'
+import type { HealthResponse, Skill } from '@/api/types'
+import { BookmarkletPanel } from './bookmarklets-section'
+
+/**
+ * #422: the bookmark's visible label (what a browser stamps as the bookmark's name when it is
+ * dragged to the bookmarks bar) must include the current repo name so a person with several
+ * cezar cockpits open can tell their bookmarks apart.
+ */
+
+const fetchMock = vi.fn<typeof fetch>()
+
+const HEALTH: HealthResponse = {
+  version: '0.1.5',
+  repoRoot: '/home/me/Projects/cezar',
+  repo: { root: '/home/me/Projects/cezar', branch: 'main' },
+  checks: [],
+  defaultRunner: 'claude',
+  forge: null,
+  capabilities: { localHandoff: true },
+}
+
+const SKILLS: Skill[] = [
+  { name: 'om-fix', body: '', path: '.ai/skills/om-fix.md', source: 'ai' },
+]
+
+function serve(routes: Record<string, unknown>): void {
+  fetchMock.mockImplementation(async (input) => {
+    const path = String(input)
+    if (!(path in routes)) return new Response(JSON.stringify({ error: 'not found' }), { status: 404 })
+    return new Response(JSON.stringify(routes[path]), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  })
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  cleanup()
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+function renderPanel(skills: readonly Skill[] = SKILLS) {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <BookmarkletPanel skills={skills} />
+    </QueryClientProvider>,
+  )
+}
+
+const label = (text: string) =>
+  [...document.querySelectorAll('[data-slot="bm-link"]')].find((el) => el.textContent?.trim() === text)
+
+describe('BookmarkletPanel repo-name labels (#422)', () => {
+  it('stamps the repo name (the sidebar chip basename) into the generic and per-skill labels', async () => {
+    serve({ '/api/health': HEALTH, '/api/launch-key': { key: 'sekret' } })
+    renderPanel()
+
+    await waitFor(() => expect(label('cezar (cezar): this PR/issue')).toBeTruthy())
+    expect(label('/om-fix (cezar)')).toBeTruthy()
+  })
+
+  it('falls back to the plain, repo-less label while health is unknown', () => {
+    // A never-resolving fetch: health stays pending, so the repo name is not yet known.
+    fetchMock.mockImplementation(() => new Promise<Response>(() => {}))
+    renderPanel()
+
+    expect(label('cezar: this PR/issue')).toBeTruthy()
+    expect(label('/om-fix')).toBeTruthy()
+    expect(label('/om-fix (cezar)')).toBeFalsy()
+  })
+
+  it('falls back to the plain label outside a git repository', async () => {
+    serve({ '/api/health': { ...HEALTH, repo: null }, '/api/launch-key': { key: 'sekret' } })
+    renderPanel()
+
+    await waitFor(() => expect(label('cezar: this PR/issue')).toBeTruthy())
+    expect(label('/om-fix')).toBeTruthy()
+  })
+})

--- a/web/app/src/routes/settings/bookmarklets-section.tsx
+++ b/web/app/src/routes/settings/bookmarklets-section.tsx
@@ -1,8 +1,9 @@
 import { TriangleAlertIcon, ZapIcon } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
-import { useLaunchKey, useSkills } from '@/api/queries'
+import { useHealth, useLaunchKey, useSkills } from '@/api/queries'
 import type { Skill } from '@/api/types'
+import { repoChipOf } from '@/components/app-shell-container'
 import { CenteredState } from '@/components/centered-state'
 import { Input } from '@/components/ui/input'
 import { toast } from '@/components/ui/toaster'
@@ -53,12 +54,18 @@ export function BookmarkletsSection() {
  */
 export function BookmarkletPanel({ skills }: { skills: readonly Skill[] }) {
   const launchKey = useLaunchKey()
+  const health = useHealth()
   const [auto, setAuto] = useState(false)
   const [filter, setFilter] = useState('')
   const key = launchKey.data?.key ?? ''
   // Bake THIS cockpit's origin into the bookmarklets so a click opens the very instance that
   // generated them — no localhost port-scan (GitHub's CSP blocks that fetch). See bookmarklet.ts.
   const origin = window.location.origin
+  // Same repo name the sidebar chip shows (the repo root's basename) — stamped into the
+  // bookmark's visible label so a person with several cezar projects open can tell their
+  // bookmarks apart in the bookmarks bar (#422). Null outside a git repo: the label falls
+  // back to the plain, repo-less text rather than guessing a name.
+  const repoName = repoChipOf(health.data)?.name ?? null
   const needle = filter.trim().toLowerCase()
   const shown = skills.filter((skill) => skill.name.toLowerCase().includes(needle))
 
@@ -66,9 +73,8 @@ export function BookmarkletPanel({ skills }: { skills: readonly Skill[] }) {
     <div data-slot="bookmarklet-panel" className="mx-auto w-full max-w-2xl">
       <h2 className="text-base font-semibold">Run from GitHub</h2>
       <p className="mt-2 text-[13px] leading-relaxed text-muted-foreground">
-        Drag a button below to your browser&apos;s bookmarks bar. On any GitHub PR or issue, click it —
-        it finds your running cockpit on localhost (ports 4321–4330) and picks the one serving that
-        repo. The cockpit must be running: <span className="font-mono">npx cezar</span>.
+        Drag a button below to your browser&apos;s bookmarks bar. On any GitHub PR or issue, click it
+        to open this cockpit directly. The cockpit must be running: <span className="font-mono">npx cezar</span>.
       </p>
 
       <label className="mt-4 flex items-center gap-2 text-[13px] font-medium">
@@ -86,7 +92,7 @@ export function BookmarkletPanel({ skills }: { skills: readonly Skill[] }) {
       <div data-slot="bm-generic" className="mt-4">
         {/* Generic launcher: no skill, auto forced off — it only prefills the form. */}
         <BookmarkletRow
-          label="cezar: this PR/issue"
+          label={repoName ? `cezar (${repoName}): this PR/issue` : 'cezar: this PR/issue'}
           url={bookmarkletUrl('', false, key, origin)}
           hint="prefills the form — nothing starts by itself"
         />
@@ -105,7 +111,7 @@ export function BookmarkletPanel({ skills }: { skills: readonly Skill[] }) {
           shown.map((skill) => (
             <BookmarkletRow
               key={skill.path}
-              label={`/${skill.name}`}
+              label={repoName ? `/${skill.name} (${repoName})` : `/${skill.name}`}
               url={bookmarkletUrl(skill.name, auto, key, origin)}
               hint={skill.source}
             />


### PR DESCRIPTION
Fixes #422

## What & why

Multi-project users couldn't tell their cezar bookmarklets apart in the bookmarks bar — every generic and per-skill label read the same plain text (e.g. `cezar: this PR/issue`) no matter which repo generated it. This reuses the sidebar's existing `repoChipOf` helper (the repo root's basename — same identity already shown in the sidebar chip) and folds it into both labels: `cezar (cezar): this PR/issue` and `/om-fix (cezar)`. Outside a git repo, or while `/api/health` hasn't answered yet, the labels fall back to the original plain text rather than guessing a name.

The other two symptoms reported in #422 — the false "cezar is not running" alert and the health probe's 800ms abort racing `/api/health` — were already fixed by d04b565, which replaced the CSP-blocked localhost port-scan probe with a direct navigation to the cockpit's baked-in origin (no more probe, no more port mismatch with `pickPort`'s range). This PR also updates the panel's leftover copy that still described the old port-scan behavior, since it was now inaccurate.

`/api/health`'s health-only CORS rule is untouched — no route, schema, or CORS change was needed since the fix is purely a client-side label computed from data `useHealth()` already fetches.

## Tests

- Added `web/app/src/routes/settings/bookmarklets-section.test.tsx`: repo name is stamped into the generic and per-skill labels when health resolves with a repo, and both labels fall back to the plain text while health is pending or outside a git repo.
- `npm run typecheck` — pass
- `npm test` — pass (123 files / 2039 tests)
- `npm run test:unit` — pass (4 tests)