### PR TITLE
feat: show the session's coding agent and model next to token usage

### DIFF
--- a/web/app/src/routes/task-thread/run-header.test.tsx
+++ b/web/app/src/routes/task-thread/run-header.test.tsx
@@ -385,7 +385,7 @@ describe('meta line, tabs, pill and resume hint', () => {
     expect(badge.getAttribute('data-slot')).toBe('agent-badge')
   })
 
-  it('the agent badge reveals runner and model on click — works for all three runners, and "auto" when unset', async () => {
+  it('the agent badge reveals runner and model on click, reading "auto" when the model is unset', async () => {
     stubFetch()
     renderHeader(run('done', { runner: 'opencode' }))
     const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
@@ -393,6 +393,19 @@ describe('meta line, tabs, pill and resume hint', () => {
     const menu = await screen.findByRole('menu')
     expect(within(menu).getByText('runner: opencode')).not.toBeNull()
     expect(within(menu).getByText('model: auto')).not.toBeNull()
+  })
+
+  // #416: the record persists only the runner the caller ASKED for (`src/runs/store.ts`), while
+  // the run executes as `input.runner ?? config.defaultRunner` (`src/workflows/run.ts`). So a
+  // record without a runner must name the repo's DEFAULT agent — hardcoding 'claude' here would
+  // confidently name the wrong agent on a codex/opencode repo, which is the exact question the
+  // badge exists to answer.
+  it('a run with no explicit runner names the repo default from health, not a hardcoded claude', async () => {
+    stubFetch({ '/api/health': () => jsonResponse({ defaultRunner: 'codex' }) })
+    renderHeader(run('done', { runner: undefined }))
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    const badge = await within(meta).findByRole('button', { name: /Agent: codex, model auto/ })
+    expect(badge.getAttribute('data-slot')).toBe('agent-badge')
   })
 
   it('a claude run still gets an agent badge — Claude is the default, not a hidden runner', () => {

--- a/web/app/src/routes/task-thread/run-header.test.tsx
+++ b/web/app/src/routes/task-thread/run-header.test.tsx
@@ -358,7 +358,7 @@ describe('notes panel', () => {
 })
 
 describe('meta line, tabs, pill and resume hint', () => {
-  it('meta shows workflow · model · branch chip · ± · tokens · cost; runner only when not claude', () => {
+  it('meta shows workflow · branch chip · ± · tokens · cost, with runner/model tucked into the agent badge', () => {
     stubFetch()
     renderHeader(
       run('done', {
@@ -371,20 +371,36 @@ describe('meta line, tabs, pill and resume hint', () => {
     )
     const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
     expect(meta.textContent).toContain('quick-task')
-    expect(meta.textContent).toContain('codex')
-    expect(meta.textContent).toContain('gpt-5.2-codex')
+    // Runner/model are no longer loose text next to the workflow — they live in the badge.
+    expect(meta.textContent).not.toContain('codex')
+    expect(meta.textContent).not.toContain('gpt-5.2-codex')
     expect(within(meta).getByText('cez/r1').getAttribute('data-slot')).toBe('branch-chip')
     expect(meta.querySelector('[data-slot="diff-stat"]')?.textContent).toBe('+42 −7')
     expect(meta.textContent).toContain('27.0k tokens')
     expect(meta.textContent).toContain('$0.04')
     // No context gauge: RunRecord carries no context-window data to draw one from.
     expect(meta.querySelector('[data-slot="context-gauge"]')).toBeNull()
+
+    const badge = within(meta).getByRole('button', { name: /Agent: codex, model gpt-5.2-codex/ })
+    expect(badge.getAttribute('data-slot')).toBe('agent-badge')
   })
 
-  it('a claude run keeps the runner out of the meta line', () => {
+  it('the agent badge reveals runner and model on click — works for all three runners, and "auto" when unset', async () => {
+    stubFetch()
+    renderHeader(run('done', { runner: 'opencode' }))
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    fireEvent.pointerDown(within(meta).getByRole('button', { name: /Agent: opencode/ }))
+    const menu = await screen.findByRole('menu')
+    expect(within(menu).getByText('runner: opencode')).not.toBeNull()
+    expect(within(menu).getByText('model: auto')).not.toBeNull()
+  })
+
+  it('a claude run still gets an agent badge — Claude is the default, not a hidden runner', () => {
     stubFetch()
     renderHeader(run('done', { runner: 'claude' }))
-    expect(document.querySelector('[data-slot="run-meta"]')?.textContent).not.toContain('claude')
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    expect(meta.textContent).not.toContain('claude')
+    expect(within(meta).getByRole('button', { name: /Agent: claude, model auto/ })).not.toBeNull()
   })
 
   it('tabs: Session is current; Changes and Files link to the routed surfaces', () => {

--- a/web/app/src/routes/task-thread/run-header.tsx
+++ b/web/app/src/routes/task-thread/run-header.tsx
@@ -18,7 +18,7 @@ import { Fragment, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router'
 
 import { ApiError, archiveRun, cancelRun, continueRun, deleteRun, openRunIn, openRunInCli } from '@/api/client'
-import { queryKeys, useOpenTargets, usePatchRun, useRunHandoff, useRuns } from '@/api/queries'
+import { queryKeys, useHealth, useOpenTargets, usePatchRun, useRunHandoff, useRuns } from '@/api/queries'
 import type { ApiRun } from '@/api/types'
 import { DiffStatLabel } from '@/components/diff-stat'
 import { TitleEditInput, useTitleEditor } from '@/components/editable-title'
@@ -448,7 +448,15 @@ function MetaRow({ run }: { run: ApiRun }) {
  *  reads "auto" when the runner picks it), and reuses the same click/keyboard-accessible
  *  `DropdownMenu` as the rest of this header instead of inventing a hover-only affordance. */
 function AgentBadge({ run }: { run: ApiRun }) {
-  const runner = run.runner ?? 'claude'
+  // The record keeps only what the caller ASKED for: `POST /api/runs` persists the raw optional
+  // `runner` (`src/runs/store.ts`), while the run actually executes as
+  // `input.runner ?? config.defaultRunner` (`src/workflows/run.ts`). Mirror that resolution —
+  // hardcoding 'claude' would name the wrong agent on a repo whose `defaultRunner` is
+  // codex/opencode, and "which agent produced this?" is the one question #416 exists to answer.
+  // 'claude' stays the last resort only while health is in flight (it is `config.defaultRunner`'s
+  // own default).
+  const health = useHealth()
+  const runner = run.runner ?? health.data?.defaultRunner ?? 'claude'
   const model = run.model ?? 'auto'
   return (
     <DropdownMenu>

--- a/web/app/src/routes/task-thread/run-header.tsx
+++ b/web/app/src/routes/task-thread/run-header.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ArchiveIcon,
   ArchiveRestoreIcon,
+  BotIcon,
   CheckIcon,
   CircleStopIcon,
   CopyIcon,
@@ -38,6 +39,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
@@ -367,15 +369,15 @@ function EditableTitle({ run }: { run: ApiRun }) {
   )
 }
 
-/** workflow · runner · model · branch chip · ± · tokens · cost (mockup `.meta-row`). Each part
- *  renders only when the record carries it — absence is absence, not a placeholder. */
+/** workflow · branch chip · ± on the left; tokens · cost · agent icon on the right (mockup
+ *  `.meta-row`, #416). Each part renders only when the record carries it — absence is absence,
+ *  not a placeholder. Runner and model no longer sit in the loose dot-list (#416): they read as
+ *  a status for the *active* session, so they move into the agent badge next to the token
+ *  count, revealed on hover/focus rather than always-on text. */
 function MetaRow({ run }: { run: ApiRun }) {
   // `workflowLabel` so an inline chain shows its first step's name, not the bare "(planned)"
   // placeholder — which reads like a status next to the live status pill.
   const parts: ReactNode[] = [<span key="workflow">{workflowLabel(run)}</span>]
-  // Runner only when it is a choice worth noting — Claude is the default everywhere.
-  if (run.runner && run.runner !== 'claude') parts.push(<span key="runner">{run.runner}</span>)
-  if (run.model) parts.push(<span key="model">{run.model}</span>)
   if (run.branch) {
     parts.push(
       <span
@@ -388,18 +390,20 @@ function MetaRow({ run }: { run: ApiRun }) {
     )
   }
   if (run.diffStat) parts.push(<DiffStatLabel key="diff" stat={run.diffStat} />)
+
+  const usage: ReactNode[] = []
   if (run.tokensUsed > 0) {
     // Tokens WITHOUT the mockup's context gauge, on purpose: the gauge needs "used / window",
     // and RunRecord carries only the lifetime `tokensUsed` — no context-window size, no
     // per-session usage. When the protocol starts persisting one, the bar goes here.
-    parts.push(
+    usage.push(
       <span key="tokens" className="tabular-nums">
         {compactTokens(run.tokensUsed)} tokens
       </span>,
     )
   }
   if (run.costUsd) {
-    parts.push(
+    usage.push(
       <span key="cost" className="tabular-nums">
         {formatCost(run.costUsd)}
       </span>,
@@ -421,7 +425,53 @@ function MetaRow({ run }: { run: ApiRun }) {
           {part}
         </Fragment>
       ))}
+      <span className="ml-auto flex shrink-0 items-center gap-1.5">
+        {usage.map((part, index) => (
+          <Fragment key={index}>
+            {index > 0 ? (
+              <span className="text-soft-foreground" aria-hidden="true">
+                ·
+              </span>
+            ) : null}
+            {part}
+          </Fragment>
+        ))}
+        <AgentBadge run={run} />
+      </span>
     </div>
+  )
+}
+
+/** The agent icon by the token counter (#416): hover/focus reveals the runner and model — the
+ *  answer to "what am I actually running here?" — without turning them into permanent text next
+ *  to the live status pill. Always rendered (a run always has an effective runner, `model`
+ *  reads "auto" when the runner picks it), and reuses the same click/keyboard-accessible
+ *  `DropdownMenu` as the rest of this header instead of inventing a hover-only affordance. */
+function AgentBadge({ run }: { run: ApiRun }) {
+  const runner = run.runner ?? 'claude'
+  const model = run.model ?? 'auto'
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-slot="agent-badge"
+          title={`${runner} · ${model}`}
+          aria-label={`Agent: ${runner}, model ${model}`}
+          className="flex shrink-0 items-center justify-center rounded-sm p-1 text-soft-foreground hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+        >
+          <BotIcon className="size-3.5" aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[9rem]">
+        <DropdownMenuLabel className="font-mono text-[11px] font-normal text-muted-foreground">
+          runner: {runner}
+        </DropdownMenuLabel>
+        <DropdownMenuLabel className="font-mono text-[11px] font-normal text-muted-foreground">
+          model: {model}
+        </DropdownMenuLabel>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 


### PR DESCRIPTION
Fixes #416

## What & why

While a session runs, the token counter tells you *how much* but not *which agent/model* produced it. The run header's `MetaRow` already rendered `runner` and `model` — but as loose, left-aligned text next to the workflow label, disconnected from the token usage it actually describes, and hidden entirely for the default (`claude`) runner.

This moves runner/model out of the dot-separated metadata list and into a small agent-icon badge grouped with the token/cost cluster on the right of the meta row (`web/app/src/routes/task-thread/run-header.tsx`). The badge:

- Always renders (a run always has an effective runner — `claude` by default — and an effective model, "auto" when unset), so it works identically for all three runners (`claude` / `codex` / `opencode`).
- Reveals `runner: <name>` and `model: <id or auto>` via the existing `DropdownMenu` primitive already used elsewhere in this header (`OpenInMenu`, `ActionsKebab`) — click or keyboard focus + Enter/Space opens it, so it's keyboard accessible by construction; a native `title` attribute gives a plain hover tooltip too.
- Carries an `aria-label` (`Agent: <runner>, model <model>`) for screen readers without relying on the dropdown being open.

Purely presentational — no server or protocol change, since `ApiRun.runner` / `ApiRun.model` / `ApiRun.tokensUsed` were already on the run record.

## Tests

- Updated `web/app/src/routes/task-thread/run-header.test.tsx`:
  - The old "meta shows workflow · model · branch chip · …" test now asserts runner/model are **not** loose text in the meta row, and that the agent badge (`data-slot="agent-badge"`) carries the right `aria-label`.
  - New test: clicking the badge opens the dropdown and shows `runner: opencode` / `model: auto` (unset model case).
  - New test: a `claude` run still gets an agent badge (previously the runner was hidden entirely for `claude`).
- `npm run typecheck` — pass
- `npm test` — 2037 passed
- `npm run test:unit` — 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)