### PR TITLE
feat(github): remember the last-selected tab

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -184,6 +184,9 @@ const uiStateSchema = z
     // Runs area presentation (#348): the sidebar-list + detail pane, or the
     // full-width table ("task manager") view.
     runsView: z.enum(['list', 'table']).optional(),
+    // The GitHub tab's last-selected sub-tab (#417): issues or PRs. ADDITIVE — an old
+    // ui-state.json without the key behaves as the default (issues).
+    githubView: z.enum(['issues', 'prs']).optional(),
     // Settings → Appearance (redesign R6): accent + density. ADDITIVE — the theme itself
     // stays in the browser (`cez-theme` localStorage, pre-paint). The cockpit always PUTs
     // the whole object because the top-level merge below is shallow.

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -487,6 +487,8 @@ export interface UiState {
   /** The last autonomous choice — remembered like lastWorktree. Absent → off. */
   lastAutonomous?: boolean
   runsView?: 'list' | 'table'
+  /** The GitHub tab's last-selected sub-tab (#417) — issues or PRs. Absent → issues. */
+  githubView?: 'issues' | 'prs'
   /** Settings → Appearance (redesign R6): accent + density. Theme itself stays in
    *  localStorage (`cez-theme`) — it must pre-paint, and it is per-browser by design. */
   appearance?: { accent?: 'lime' | 'violet'; density?: 'comfortable' | 'compact' | 'ultra' }

--- a/web/app/src/components/tab-link.tsx
+++ b/web/app/src/components/tab-link.tsx
@@ -7,11 +7,24 @@ import { cn } from '@/lib/utils'
  *  Session | Changes | Files row uses, extracted (R5 1.7) so the repo view's
  *  Changes | Commits | Branches row is the same component rather than a fork.
  *  A real `<Link>` on purpose: every segment is a URL (spec §"Routing"). */
-export function TabLink({ to, active = false, children }: { to: string; active?: boolean; children: ReactNode }) {
+export function TabLink({
+  to,
+  active = false,
+  onClick,
+  children,
+}: {
+  to: string
+  active?: boolean
+  /** Fires alongside the navigation (e.g. persisting the choice, #417) — it does not
+   *  intercept it; `<Link>` still navigates unless the handler itself prevents it. */
+  onClick?: () => void
+  children: ReactNode
+}) {
   return (
     <Link
       to={to}
       aria-current={active ? 'page' : undefined}
+      onClick={onClick}
       className={cn(
         '-mb-px flex h-8 items-center rounded-t-md border-b-2 px-3 text-[13px] font-medium',
         active

--- a/web/app/src/routes.tsx
+++ b/web/app/src/routes.tsx
@@ -52,6 +52,11 @@ const RepoGitRoute = lazy(() =>
 const GithubRoute = lazy(() =>
   import('./routes/github/github').then((m) => ({ default: m.GithubRoute })),
 )
+/** `/github`'s index (#417) — restores the last-selected tab. Same chunk as `GithubRoute`,
+ *  just a second named export off the same lazy import. */
+const GithubIndexRoute = lazy(() =>
+  import('./routes/github/github').then((m) => ({ default: m.GithubIndexRoute })),
+)
 
 /** Lazy because the builder carries dnd-kit (R6 Step 1.6) — drag machinery only this surface
  *  uses, so only this surface pays for it. */
@@ -171,12 +176,14 @@ export function AppRoutes() {
       />
       {/* The GitHub tab (R6 Step 1.1): issues and PRs are separate list URLs, each item a
           deep link. The nav item is forge-gated in the shell; the routes stay reachable so a
-          pasted link renders the honest unavailable explainer instead of a 404. */}
+          pasted link renders the honest unavailable explainer instead of a 404. The bare
+          `/github` is the one URL that restores the last-selected tab (#417) — `/github/prs`
+          and the `:n` deep links are always exactly what they say. */}
       <Route
         path="/github"
         element={
           <Suspense fallback={<GithubLoading />}>
-            <GithubRoute view="issues" />
+            <GithubIndexRoute />
           </Suspense>
         }
       />

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -7,7 +7,7 @@ import { createQueryClient } from '@/api/query-client'
 import type { GithubData, GithubItem, Skill, WorkflowsResponse } from '@/api/types'
 import { Toaster, resetToasts } from '@/components/ui/toaster'
 
-import { GithubRoute } from './github'
+import { GithubIndexRoute, GithubRoute } from './github'
 
 beforeAll(() => {
   // cmdk scrolls the selected item into view; jsdom has no scrollIntoView.
@@ -140,13 +140,15 @@ function stubFetch(overrides: Record<string, () => Response> = {}): SentRequest[
   return sent
 }
 
-/** Cold-load the tab at a URL, with the same route map routes.tsx registers. */
+/** Cold-load the tab at a URL, with the same route map routes.tsx registers — `/github` goes
+ *  through `GithubIndexRoute` (#417) exactly like production, so the remembered-tab redirect
+ *  is exercised the same way a real navigation would hit it. */
 function renderAt(entry: string) {
   render(
     <QueryClientProvider client={createQueryClient()}>
       <MemoryRouter initialEntries={[entry]}>
         <Routes>
-          <Route path="/github" element={<GithubRoute view="issues" />} />
+          <Route path="/github" element={<GithubIndexRoute />} />
           <Route path="/github/prs" element={<GithubRoute view="prs" />} />
           <Route path="/github/issues/:n" element={<GithubRoute view="issues" />} />
           <Route path="/github/prs/:n" element={<GithubRoute view="prs" />} />
@@ -246,6 +248,54 @@ describe('the GitHub tab lists', () => {
       expect.stringContaining('Fix GitHub issue #142: Login form drops session on refresh'),
     )
     expect(setData.mock.calls[0]?.[1]).toContain(ISSUE_142.url)
+  })
+})
+
+describe('remembering the last-selected tab (#417)', () => {
+  it('clicking Pull requests persists the choice via PUT /api/ui-state', async () => {
+    const sent = stubFetch()
+    renderAt('/github')
+    await waitFor(() => expect(rows()).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('link', { name: /Pull requests/ }))
+
+    await waitFor(() =>
+      expect(sent.some((request) => request.method === 'PUT' && request.path === '/api/ui-state')).toBe(
+        true,
+      ),
+    )
+    const put = sent.find((request) => request.method === 'PUT' && request.path === '/api/ui-state')
+    expect(put?.body).toEqual({ githubView: 'prs' })
+  })
+
+  it('opening /github restores "prs" when that was the last-selected tab', async () => {
+    stubFetch({ 'GET /api/ui-state': () => jsonResponse({ githubView: 'prs' }) })
+    renderAt('/github')
+
+    await waitFor(() => expect(rows()).toHaveLength(1))
+    expect(rows()[0]?.getAttribute('href')).toBe('/github/prs/137')
+  })
+
+  it('opening /github falls back to Issues when nothing was ever remembered', async () => {
+    stubFetch({ 'GET /api/ui-state': () => jsonResponse({}) })
+    renderAt('/github')
+
+    await waitFor(() => expect(rows()).toHaveLength(2))
+    expect(rows()[0]?.getAttribute('href')).toBe('/github/issues/142')
+  })
+
+  it('clicking Issues while "prs" is remembered switches to Issues instead of bouncing back', async () => {
+    // The regression this guards: without eagerly patching the query cache on click, the
+    // index route would still read the stale "prs" remembered choice and redirect the click
+    // straight back to /github/prs, making the Issues tab unclickable.
+    stubFetch({ 'GET /api/ui-state': () => jsonResponse({ githubView: 'prs' }) })
+    renderAt('/github/prs')
+    await waitFor(() => expect(rows()).toHaveLength(1))
+
+    fireEvent.click(screen.getByRole('link', { name: /^Issues/ }))
+
+    await waitFor(() => expect(rows()).toHaveLength(2))
+    expect(rows().map((row) => row.dataset.number)).toEqual(['142', '139'])
   })
 })
 

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -11,11 +11,11 @@ import {
   TriangleAlertIcon,
 } from 'lucide-react'
 import { useState, type DragEvent, type ReactNode } from 'react'
-import { Link, useParams } from 'react-router'
+import { Link, Navigate, useParams } from 'react-router'
 
-import { getGithub } from '@/api/client'
-import { queryKeys, useGithub, useSkills, useWorkflows } from '@/api/queries'
-import type { GithubItem } from '@/api/types'
+import { getGithub, putUiState } from '@/api/client'
+import { queryKeys, useGithub, useSkills, useUiState, useWorkflows } from '@/api/queries'
+import type { GithubItem, UiState } from '@/api/types'
 import { CenteredState } from '@/components/centered-state'
 import { GithubIcon } from '@/components/icons'
 import { TabLink } from '@/components/tab-link'
@@ -58,6 +58,23 @@ const FULL_LIMIT = 1000
 
 export type GithubView = 'issues' | 'prs'
 
+/**
+ * `/github`'s index (#417): restores the last-selected sub-tab instead of always defaulting
+ * to Issues. Only the bare path redirects — `/github/prs` and the `:n` deep links always
+ * render exactly what their URL says, memory or not, so a pasted link never surprises.
+ *
+ * A one-way check, not a live sync: it reads `ui-state.json` once per mount and either renders
+ * Issues or hands off to `/github/prs`. It never redirects back to Issues from `/github/prs` —
+ * that URL is authoritative on its own.
+ */
+export function GithubIndexRoute() {
+  const uiState = useUiState()
+  if (uiState.data?.githubView === 'prs') {
+    return <Navigate to="/github/prs" replace />
+  }
+  return <GithubRoute view="issues" />
+}
+
 export function GithubRoute({ view }: { view: GithubView }) {
   const { n } = useParams()
   const fast = useGithub()
@@ -69,6 +86,24 @@ export function GithubRoute({ view }: { view: GithubView }) {
   const isFull = full.data?.available === true
 
   const queryClient = useQueryClient()
+
+  // Persist the tab choice (#417), mirroring the appearance provider's read-then-write
+  // pattern. The cache is patched BEFORE the PUT resolves — not just for optimism, but so
+  // `GithubIndexRoute`'s check (which reads the same cache) sees the new choice immediately
+  // if the click just navigated `/github/prs` → `/github`: without the eager patch it would
+  // still read the stale "prs" and bounce the Issues tab straight back.
+  const saveGithubView = (next: GithubView) => {
+    queryClient.setQueryData<UiState>(queryKeys.uiState, (prev) => ({ ...prev, githubView: next }))
+    putUiState({ githubView: next })
+      .then((merged) => queryClient.setQueryData(queryKeys.uiState, merged))
+      .catch((error: unknown) => {
+        toast(error instanceof Error ? error.message : String(error), { tone: 'danger' })
+        // The write failed — fall back to the server's truth rather than keep the tab
+        // claiming a persistence it never got.
+        void queryClient.invalidateQueries({ queryKey: queryKeys.uiState })
+      })
+  }
+
   const refresh = useMutation({
     mutationFn: () => getGithub({ refresh: true }),
     onSuccess: (data) => {
@@ -187,10 +222,10 @@ export function GithubRoute({ view }: { view: GithubView }) {
             </button>
           </div>
           <div data-slot="gh-tabs" className="mt-2.5 flex items-end gap-1">
-            <TabLink to="/github" active={view === 'issues'}>
+            <TabLink to="/github" active={view === 'issues'} onClick={() => saveGithubView('issues')}>
               Issues · {countLabel(gh.issues.length, isFull)}
             </TabLink>
-            <TabLink to="/github/prs" active={view === 'prs'}>
+            <TabLink to="/github/prs" active={view === 'prs'} onClick={() => saveGithubView('prs')}>
               Pull requests · {countLabel(gh.prs.length, isFull)}
             </TabLink>
           </div>


### PR DESCRIPTION
Fixes #417

## What & why

The GitHub view always opened on **Issues**, even if you last worked in **Pull requests** — friction for anyone who lives on one tab. This persists the tab selection through the existing `ui-state.json` mechanism (the same additive/passthrough pattern `runsView` and `appearance` already use), and restores it when you return.

- `src/server/server.ts`: added `githubView: z.enum(['issues', 'prs']).optional()` to `uiStateSchema`, additive/passthrough — an old `ui-state.json` without the key still parses fine and behaves as the default.
- `web/app/src/api/types.ts`: added `githubView?: 'issues' | 'prs'` to the `UiState` type.
- `web/app/src/routes/github/github.tsx`:
  - `saveGithubView` writes the choice via `putUiState()` on tab click, patching the `ui-state` query cache eagerly (mirrors `appearance-provider.tsx`'s read-then-write pattern) so the index redirect below never bounces an intentional click back to the other tab.
  - New `GithubIndexRoute` — used only for the bare `/github` path — reads the remembered choice and redirects to `/github/prs` when that was last selected; falls back to Issues when unset. `/github/prs` and the `:n` deep links are untouched, always exactly what their URL says.
- `web/app/src/components/tab-link.tsx`: `TabLink` now accepts an optional `onClick`, used to fire the persistence write alongside navigation (it does not intercept the navigation).
- `web/app/src/routes.tsx`: `/github`'s route element now renders `GithubIndexRoute` instead of hardcoding the Issues view.

## Tests

- `web/app/src/routes/github/github.test.tsx`: 4 new cases —
  - clicking "Pull requests" issues `PUT /api/ui-state` with `{ githubView: 'prs' }`
  - opening `/github` restores "prs" when that was last remembered
  - opening `/github` falls back to Issues when nothing was ever remembered
  - clicking Issues while "prs" is remembered switches to Issues instead of bouncing back (regression guard for the eager-cache-patch fix)
- `npm run typecheck` — pass
- `npm test` — pass (2040/2040)
- `npm run test:unit` — pass (4/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)