### PR TITLE
feat: show per-PR CI check status in the GitHub tab PR list

### DIFF
--- a/src/server/forge/github.test.ts
+++ b/src/server/forge/github.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { ghCheckRunSchema, rollupToChecks } from './github.js';
+
+/** `rollupToChecks` collapses a `gh … --json statusCheckRollup` array — already zod-validated
+ *  via `ghCheckRunSchema` at the call site — down to the single enum the GitHub tab renders,
+ *  both on PR rows (#400) and in the detail pane's `ChecksBadge`. */
+
+describe('ghCheckRunSchema', () => {
+  it('accepts a real gh rollup entry (conclusion + status, no state)', () => {
+    expect(ghCheckRunSchema.parse({ status: 'COMPLETED', conclusion: 'SUCCESS' })).toEqual({
+      status: 'COMPLETED',
+      conclusion: 'SUCCESS',
+      state: undefined,
+    });
+  });
+
+  it('accepts a check-context style entry (state, no status/conclusion)', () => {
+    expect(ghCheckRunSchema.parse({ state: 'PENDING' })).toEqual({
+      state: 'PENDING',
+      status: undefined,
+      conclusion: undefined,
+    });
+  });
+
+  it('accepts nulls for every field — gh omits fields depending on the check provider', () => {
+    expect(ghCheckRunSchema.parse({ state: null, status: null, conclusion: null })).toEqual({
+      state: null,
+      status: null,
+      conclusion: null,
+    });
+  });
+
+  it('rejects a non-object entry', () => {
+    expect(() => ghCheckRunSchema.parse('SUCCESS')).toThrow();
+  });
+});
+
+describe('rollupToChecks', () => {
+  it('returns null when the rollup is absent, null, or empty', () => {
+    expect(rollupToChecks(undefined)).toBeNull();
+    expect(rollupToChecks(null)).toBeNull();
+    expect(rollupToChecks([])).toBeNull();
+  });
+
+  it('returns "passing" when every entry concluded SUCCESS', () => {
+    expect(
+      rollupToChecks([
+        { conclusion: 'SUCCESS', status: 'COMPLETED', state: null },
+        { conclusion: 'SUCCESS', status: 'COMPLETED', state: null },
+      ]),
+    ).toBe('passing');
+  });
+
+  it.each(['FAILURE', 'ERROR', 'TIMED_OUT', 'ACTION_REQUIRED'])(
+    'returns "failing" when any entry concluded %s, even alongside passing ones',
+    (conclusion) => {
+      expect(
+        rollupToChecks([
+          { conclusion: 'SUCCESS', status: null, state: null },
+          { conclusion, status: null, state: null },
+        ]),
+      ).toBe('failing');
+    },
+  );
+
+  it.each(['PENDING', 'IN_PROGRESS', 'QUEUED', 'EXPECTED'])(
+    'returns "pending" when any entry is still %s and none have failed',
+    (status) => {
+      expect(
+        rollupToChecks([
+          { conclusion: 'SUCCESS', status: null, state: null },
+          { conclusion: null, status, state: null },
+        ]),
+      ).toBe('pending');
+    },
+  );
+
+  it('failing wins over pending when both are present', () => {
+    expect(
+      rollupToChecks([
+        { conclusion: null, status: 'IN_PROGRESS', state: null },
+        { conclusion: 'FAILURE', status: null, state: null },
+      ]),
+    ).toBe('failing');
+  });
+
+  it('falls back through conclusion → state → status, then treats a blank as pending', () => {
+    expect(rollupToChecks([{ conclusion: null, status: null, state: 'FAILURE' }])).toBe('failing');
+    expect(rollupToChecks([{ conclusion: null, status: null, state: null }])).toBe('pending');
+  });
+});

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -52,25 +52,32 @@ const ghIssueSchema = z.object({
   body: z.string().nullish(),
   url: z.string(),
 });
+// One check run's `gh --json statusCheckRollup` entry — every field optional/nullish because
+// gh's shape varies by check provider (exported so #400's unit tests can build fixtures).
+export const ghCheckRunSchema = z.object({
+  state: z.string().nullish(),
+  status: z.string().nullish(),
+  conclusion: z.string().nullish(),
+});
+const ghStatusCheckRollup = z.array(ghCheckRunSchema).nullish();
+
 const ghPrSchema = ghIssueSchema.extend({
   isDraft: z.boolean().default(false),
   additions: z.number().default(0),
   deletions: z.number().default(0),
-  statusCheckRollup: z
-    .array(z.object({ state: z.string().nullish(), status: z.string().nullish(), conclusion: z.string().nullish() }))
-    .nullish(),
+  statusCheckRollup: ghStatusCheckRollup,
 });
 const ghPrViewSchema = z.object({
   number: z.number(),
   url: z.string(),
   state: z.string().default('OPEN'),
   isDraft: z.boolean().default(false),
-  statusCheckRollup: z
-    .array(z.object({ state: z.string().nullish(), status: z.string().nullish(), conclusion: z.string().nullish() }))
-    .nullish(),
+  statusCheckRollup: ghStatusCheckRollup,
 });
 
-function rollupToChecks(rollup: Array<{ state?: string | null; status?: string | null; conclusion?: string | null }> | null | undefined): GithubItem['checks'] {
+/** Exported for unit tests (#400) — collapses a zod-validated `statusCheckRollup` array down to
+ *  the single enum the GitHub tab (list rows + detail badge) renders. */
+export function rollupToChecks(rollup: z.infer<typeof ghStatusCheckRollup>): GithubItem['checks'] {
   if (!rollup || rollup.length === 0) return null;
   const states = rollup.map((r) => (r.conclusion || r.state || r.status || '').toUpperCase());
   if (states.some((s) => ['FAILURE', 'ERROR', 'TIMED_OUT', 'ACTION_REQUIRED'].includes(s))) return 'failing';

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -199,6 +199,35 @@ describe('the GitHub tab lists', () => {
     expect(rows()[0]?.getAttribute('href')).toBe('/github/prs/137')
   })
 
+  it('a PR row shows a checks glyph tinted by outcome (#400); an issue row shows none', async () => {
+    const passing: GithubItem = { ...PR_137, number: 201, url: 'u201', checks: 'passing' }
+    const pending: GithubItem = { ...PR_137, number: 202, url: 'u202', checks: 'pending' }
+    const none: GithubItem = { ...PR_137, number: 203, url: 'u203', checks: null }
+    stubFetch({
+      'GET /api/github': () => jsonResponse({ ...GITHUB, prs: [PR_137, passing, pending, none] }),
+    })
+    renderAt('/github/prs')
+
+    await waitFor(() => expect(rows()).toHaveLength(4))
+    const glyph = (number: string) =>
+      document.querySelector(`[data-slot="gh-row"][data-number="${number}"] [data-slot="gh-row-checks"]`)
+
+    expect(glyph('137')?.getAttribute('data-checks')).toBe('failing')
+    expect(glyph('137')?.textContent).toBe('✗')
+    expect(glyph('201')?.getAttribute('data-checks')).toBe('passing')
+    expect(glyph('201')?.textContent).toBe('✓')
+    expect(glyph('202')?.getAttribute('data-checks')).toBe('pending')
+    expect(glyph('202')?.textContent).toBe('○')
+    expect(glyph('203')).toBeNull()
+
+    // Issues never carry `checks` — no glyph on their rows either.
+    cleanup()
+    stubFetch()
+    renderAt('/github')
+    await waitFor(() => expect(rows().length).toBeGreaterThan(0))
+    expect(document.querySelector('[data-slot="gh-row-checks"]')).toBeNull()
+  })
+
   it('counts at the fast-batch cap render as 30+ until the full fetch lands', async () => {
     const many: GithubData = {
       ...GITHUB,

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -37,7 +37,8 @@ import { HandToAgent } from './hand-to-agent'
  * functionally the legacy tab — issues/PRs lists, a detail pane with markdown body + label
  * chips + checks badge, drag-to-composer, hand-to-agent — with the chip walls replaced by
  * searchable cmdk dropdowns (#385) and every surface a URL: `/github` (issues),
- * `/github/prs`, `/github/issues/:n`, `/github/prs/:n`.
+ * `/github/prs`, `/github/issues/:n`, `/github/prs/:n`. PR rows also carry a compact checks
+ * glyph (#400) — the same tones as the detail pane's `ChecksBadge`, just the symbol.
  *
  * Data keeps the legacy two-shot load (feedback 2026-07-11: the 30-item `gh` default hid the
  * rest): the fast default batch paints the tab, then a background everything-open fetch
@@ -341,6 +342,7 @@ function GithubRow({
           <span>#{item.number}</span>
           <span className="min-w-0 truncate">{item.author}</span>
           <span>{shortAge(item.createdAt)}</span>
+          {item.checks ? <ChecksGlyph checks={item.checks} /> : null}
           {queued ? (
             <span data-slot="gh-queued-flag" className="font-sans font-medium text-violet">
               ↗ run queued
@@ -514,17 +516,21 @@ function GithubDetail({
   )
 }
 
+/** Glyph + tone shared by the list row's compact indicator and the detail pane's full badge
+ *  (#400) — one source of truth so the two surfaces can't drift out of sync. */
+type Checks = NonNullable<GithubItem['checks']>
+const CHECKS_GLYPH: Record<Checks, string> = { passing: '✓', failing: '✗', pending: '○' }
+const CHECKS_TONE: Record<Checks, string> = {
+  passing: 'text-success',
+  failing: 'text-danger',
+  pending: 'text-muted-foreground',
+}
+
 /** The checks badge — the legacy tab's three phrases, tinted by outcome. Links out
  *  to the PR's checks tab on GitHub (issue #415) when a URL is available. */
-function ChecksBadge({ checks, url }: { checks: NonNullable<GithubItem['checks']>; url?: string }) {
-  const className = cn(
-    'text-[11px] font-medium',
-    checks === 'passing' && 'text-success',
-    checks === 'failing' && 'text-danger',
-    checks === 'pending' && 'text-muted-foreground',
-    url && 'hover:underline',
-  )
-  const label = checks === 'passing' ? '✓ checks passing' : checks === 'failing' ? '✗ checks failing' : '○ checks pending'
+function ChecksBadge({ checks, url }: { checks: Checks; url?: string }) {
+  const className = cn('text-[11px] font-medium', CHECKS_TONE[checks], url && 'hover:underline')
+  const label = `${CHECKS_GLYPH[checks]} checks ${checks}`
 
   if (!url) {
     return (
@@ -545,5 +551,22 @@ function ChecksBadge({ checks, url }: { checks: NonNullable<GithubItem['checks']
     >
       {label}
     </a>
+  )
+}
+
+/** The PR row's compact checks indicator (#400) — same tones as `ChecksBadge`, just the glyph
+ *  (the row is too narrow for the full phrase). Issues never have `checks`, so this only ever
+ *  shows up on PR rows. */
+function ChecksGlyph({ checks }: { checks: Checks }) {
+  return (
+    <span
+      data-slot="gh-row-checks"
+      data-checks={checks}
+      title={`checks ${checks}`}
+      aria-label={`checks ${checks}`}
+      className={cn('shrink-0 font-sans text-[11px] font-semibold', CHECKS_TONE[checks])}
+    >
+      {CHECKS_GLYPH[checks]}
+    </span>
   )
 }


### PR DESCRIPTION
Fixes #400

## What & why

The GitHub tab's PR list showed no CI status — you had to open a PR to see whether it was green (`ChecksBadge` only rendered in the detail pane). This adds a compact checks glyph (✓/✗/○) to each PR row in `GithubRow` (`web/app/src/routes/github/github.tsx`), tinted the same as the detail pane's badge, so you can scan pass/fail without clicking into every item.

- Row glyph and detail badge now share one source of truth (`CHECKS_GLYPH`/`CHECKS_TONE` maps) instead of each hardcoding the passing/failing/pending → color/symbol mapping — no drift risk between the two surfaces.
- New `ChecksGlyph` component renders just the symbol (`data-slot="gh-row-checks"`) since the row is too narrow for the full "checks passing" phrase; `ChecksBadge` (`data-slot="gh-checks"`) is otherwise unchanged in markup/behavior.
- Issues never carry a `checks` field, so the glyph is naturally PR-only — no extra gating needed.
- No server change needed: `fetchGithub` already computed `checks` from `statusCheckRollup` via `rollupToChecks` (`src/server/forge/github.ts`). That function had no direct test coverage, so I exported it (plus the per-entry `ghCheckRunSchema`) purely for testability — behavior is unchanged, both call sites (list + `pr view` for hand-off) still route through it identically.

**Overlap with #415/#446:** a sibling PR (#446, fixing #415) makes `ChecksBadge` into a link (`<a>` wrapping the same badge, pointing at `${url}/checks`) via a new optional `url` prop. This change doesn't touch that prop and only adds the separate `ChecksGlyph` for rows, so both should merge independent of order.

## Tests

- `src/server/forge/github.test.ts` (new): `ghCheckRunSchema` accepts gh's varying shapes (conclusion+status, state-only, all-null) and rejects a non-object; `rollupToChecks` covers empty/absent rollup → `null`, all-success → `passing`, each failing conclusion → `failing` (even mixed with passing), each pending status → `pending`, failing-wins-over-pending, and the conclusion→state→status fallback chain.
- `web/app/src/routes/github/github.test.tsx`: new case asserts the row glyph's tone/glyph/`data-checks` for passing/failing/pending, that a `checks: null` PR renders no glyph, and that issue rows never render `gh-row-checks`.
- `npm run typecheck` — pass (server + web).
- `npm test` — 123/123 files, 2053/2053 tests pass.
- `npm run test:unit` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)