### PR TITLE
feat(workflows): auto chain creator + usage-sorted skill palette

### DIFF
--- a/scripts/mock-claude.mjs
+++ b/scripts/mock-claude.mjs
@@ -125,6 +125,7 @@ async function respond(userText, imageCount) {
   // its prompt — which is exactly the path worth exercising in dry runs.
   if (userText.includes('[cez-planner]')) {
     const plan = JSON.stringify({
+      title: 'implement-verify-review',
       steps: [
         { name: 'Implement', prompt: '{{task}}' },
         { name: 'Verify', command: 'npm test' },

--- a/src/planner.ts
+++ b/src/planner.ts
@@ -18,12 +18,15 @@ const PLANNER_TIMEOUT_MS = 60_000;
 
 const PLANNER_SYSTEM_PROMPT =
   'You are a planning assistant for an AI coding agent cockpit. Respond with ONLY a JSON object: ' +
-  '{"steps":[{"skill"?:string,"name":string,"prompt"?:string,"command"?:string}],"rationale":string}. ' +
+  '{"title":string,"steps":[{"skill"?:string,"name":string,"prompt"?:string,"command"?:string}],"rationale":string}. ' +
   'Rules: pick skills ONLY from the provided catalog; a step has either "prompt" (an agent step) or ' +
   '"command" (a shell verification check); include the {{task}} placeholder in agent prompts where ' +
-  "the user's task text belongs; 1-5 steps; prefer fewer.";
+  "the user's task text belongs; 1-5 steps; prefer fewer; \"title\" is a short kebab-case name for " +
+  'the whole workflow (2-4 words, e.g. "fix-and-review").';
 
 const plannerResponseSchema = z.object({
+  /** A short workflow name the builder pre-fills. Optional so older / partial answers still parse. */
+  title: z.string().optional(),
   steps: z
     .array(
       z.object({
@@ -39,6 +42,9 @@ const plannerResponseSchema = z.object({
 });
 
 export interface PlanResult {
+  /** The proposed workflow title (kebab-case slug), when the planner named one. The auto chain
+   *  creator pre-fills the builder's name field with it. Absent on the degraded fallback. */
+  name?: string;
   steps: WorkflowStepDef[];
   rationale: string;
   /** True when this is the degraded one-step quick-task plan. */
@@ -79,7 +85,8 @@ export async function planChain(repoRoot: string, task: string): Promise<PlanRes
     if (!parsed) continue;
     const steps = sanitizeSteps(parsed.steps, skillNames);
     if (steps.length === 0) break; // everything got rejected — degrade
-    return { steps, rationale: parsed.rationale, fallback: false };
+    const name = proposeWorkflowName(parsed.title);
+    return { ...(name ? { name } : {}), steps, rationale: parsed.rationale, fallback: false };
   }
 
   return {
@@ -182,6 +189,17 @@ export function slugify(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * The proposed workflow title, normalized to the same kebab-case slug the builder saves as a
+ * file name — so what the auto chain creator pre-fills is already a valid workflow name. A blank
+ * or slug-less title (e.g. all punctuation) answers undefined, and the caller keeps the current
+ * name instead of blanking it.
+ */
+export function proposeWorkflowName(raw: string | undefined): string | undefined {
+  const slug = slugify((raw ?? '').trim());
+  return slug || undefined;
 }
 
 function uniqueId(base: string, used: Set<string>): string {

--- a/test/unit/planner.test.ts
+++ b/test/unit/planner.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { z } from 'zod';
+import { parseStructured, proposeWorkflowName } from '../../src/planner.js';
+
+test('proposeWorkflowName slugs a title to the file-name form', () => {
+  assert.equal(proposeWorkflowName('Fix And Review'), 'fix-and-review');
+  assert.equal(proposeWorkflowName('  Ship it!  '), 'ship-it');
+  assert.equal(proposeWorkflowName('already-kebab'), 'already-kebab');
+});
+
+test('proposeWorkflowName degrades a blank / slug-less title to undefined', () => {
+  // The caller keeps the current name rather than blanking it when nothing survives.
+  assert.equal(proposeWorkflowName(undefined), undefined);
+  assert.equal(proposeWorkflowName('   '), undefined);
+  assert.equal(proposeWorkflowName('!!! ???'), undefined);
+});
+
+test('parseStructured reads the optional planner title alongside the steps', () => {
+  const schema = z.object({
+    title: z.string().optional(),
+    steps: z.array(z.object({ name: z.string() })),
+  });
+  const parsed = parseStructured(
+    '```json\n{"title":"fix-and-review","steps":[{"name":"Implement"}]}\n```',
+    schema,
+  );
+  assert.deepEqual(parsed, { title: 'fix-and-review', steps: [{ name: 'Implement' }] });
+});

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -360,6 +360,10 @@ export interface WorkflowsResponse {
  *  a missing CLI, a timeout or an unparseable answer degrade to the one-step quick-task plan
  *  with `fallback: true`, which the UI surfaces as a dim note. */
 export interface PlanResponse {
+  /** A short kebab-case workflow title the planner proposed (spec 008 follow-up / #414). The
+   *  workflow builder's auto chain creator pre-fills its name field with it. Absent on the
+   *  degraded fallback, and on older servers that never sent one. */
+  name?: string
   steps: WorkflowStepDef[]
   rationale: string
   fallback: boolean

--- a/web/app/src/lib/workflow-builder.test.ts
+++ b/web/app/src/lib/workflow-builder.test.ts
@@ -5,6 +5,7 @@ import type { WorkflowStepDef } from '@/api/types'
 
 import {
   WB_MAX_STEPS,
+  draftFromPlan,
   insertStep,
   moveStep,
   removeStep,
@@ -191,5 +192,46 @@ describe('stepCountLabel / workflowSlug', () => {
   it('slugs the export file name the way the server slugs the saved path', () => {
     expect(workflowSlug('My Great Flow!')).toBe('my-great-flow')
     expect(workflowSlug('  ---  ')).toBe('workflow')
+  })
+})
+
+describe('draftFromPlan (auto chain creator, #414)', () => {
+  it('adopts the planner’s proposed name and steps', () => {
+    const plan = {
+      name: 'fix-and-review',
+      steps: [
+        { id: 'implement', name: 'Implement', prompt: '{{task}}' },
+        { id: 'verify', name: 'Verify', command: 'npm test' },
+      ] satisfies WorkflowStepDef[],
+      rationale: 'do it',
+      fallback: false,
+    }
+    expect(draftFromPlan(plan, 'my-workflow')).toEqual({
+      name: 'fix-and-review',
+      steps: plan.steps,
+    })
+  })
+
+  it('keeps the current name when the plan proposed none (never blanks it)', () => {
+    const plan = { steps: [{ id: 'task', name: 'Do it', prompt: '{{task}}' }] }
+    expect(draftFromPlan(plan, 'my-workflow').name).toBe('my-workflow')
+    expect(draftFromPlan({ ...plan, name: '   ' }, 'my-workflow').name).toBe('my-workflow')
+  })
+
+  it('caps the chain at the server’s step limit', () => {
+    const steps = Array.from({ length: WB_MAX_STEPS + 3 }, (_, i) => ({
+      id: `s${i}`,
+      name: `Step ${i}`,
+      prompt: '{{task}}',
+    }))
+    expect(draftFromPlan({ steps }, 'x').steps).toHaveLength(WB_MAX_STEPS)
+  })
+
+  it('re-dedupes ids so a repaired plan can’t seed a duplicate-id canvas', () => {
+    const steps = [
+      { id: 'review', name: 'Review', prompt: '{{task}}' },
+      { id: 'review', name: 'Review again', prompt: '{{task}}' },
+    ]
+    expect(draftFromPlan({ steps }, 'x').steps.map((s) => s.id)).toEqual(['review', 'review-2'])
   })
 })

--- a/web/app/src/lib/workflow-builder.ts
+++ b/web/app/src/lib/workflow-builder.ts
@@ -1,4 +1,4 @@
-import type { SaveWorkflowInput, WorkflowStepDef } from '@/api/types'
+import type { PlanResponse, SaveWorkflowInput, WorkflowStepDef } from '@/api/types'
 
 /**
  * The workflow builder's pure rules (R6 Step 1.6, spec §"Skills, Workflows, Inbox"), ported
@@ -143,6 +143,29 @@ export function workflowSlug(name: string): string {
 export function stepCountLabel(steps: readonly WorkflowStepDef[]): string {
   const noun = skillStack(steps) ? 'skill' : 'step'
   return `${steps.length} ${noun}${steps.length === 1 ? '' : 's'}`
+}
+
+/**
+ * The canvas draft an approved auto-chain plan (`POST /api/plan`, #414) lands on: the planner's
+ * proposed `name` when it named one (else the current name is kept, never blanked), and its steps
+ * capped at the server's `WB_MAX_STEPS` limit with ids re-deduped so a repaired plan can never
+ * seed a duplicate-id canvas the server would reject. Pure so the "build me a chain" flow is
+ * table-testable without a runner.
+ */
+export function draftFromPlan(
+  plan: Pick<PlanResponse, 'name' | 'steps'>,
+  currentName: string,
+): { name: string; steps: WorkflowStepDef[] } {
+  const used = new Set<string>()
+  const steps: WorkflowStepDef[] = []
+  for (const step of plan.steps.slice(0, WB_MAX_STEPS)) {
+    const base = step.id || 'step'
+    let id = base
+    for (let n = 2; used.has(id); n++) id = `${base}-${n}`
+    used.add(id)
+    steps.push({ ...step, id })
+  }
+  return { name: plan.name?.trim() || currentName, steps }
 }
 
 /** The `POST /api/workflows` body: compact `skills` for pure stacks, full `steps` otherwise —

--- a/web/app/src/routes/workflows/workflows.test.tsx
+++ b/web/app/src/routes/workflows/workflows.test.tsx
@@ -84,6 +84,7 @@ function stubFetch(
         return jsonResponse({ workflows, issues: [] } satisfies WorkflowsResponse)
       }
       if (method === 'GET' && path === '/api/skills') return jsonResponse(SKILLS)
+      if (method === 'GET' && path === '/api/ui-state') return jsonResponse({})
       return jsonResponse({ error: 'not found' }, 404)
     }),
   )
@@ -232,6 +233,66 @@ describe('YAML import', () => {
       ),
     )
     expect(stepIds()).toEqual(['om-fix', 'om-review'])
+  })
+})
+
+// ---- auto chain creator (#414) -----------------------------------------------------------------
+
+describe('auto chain creator', () => {
+  it('a built plan lands its title + steps on the canvas', async () => {
+    const sent = stubFetch({
+      'POST /api/plan': [
+        () =>
+          jsonResponse({
+            name: 'fix-and-review',
+            steps: [
+              { id: 'implement', name: 'Implement', prompt: '{{task}}' },
+              { id: 'verify', name: 'Verify', command: 'npm test' },
+            ],
+            rationale: 'implement then verify',
+            fallback: false,
+          }),
+      ],
+    })
+    renderAt('/workflows')
+    await waitFor(() => expect(stepCards()).toHaveLength(2))
+
+    fireEvent.click(document.querySelector('[data-slot="wb-auto"]')!)
+    fireEvent.change(screen.getByLabelText('Describe the chain to build'), {
+      target: { value: 'Fix the bug and review it' },
+    })
+    fireEvent.click(document.querySelector('[data-slot="wb-auto-run"]')!)
+
+    await waitFor(() => expect(stepIds()).toEqual(['implement', 'verify']))
+    expect(nameInput().value).toBe('fix-and-review')
+    expect(sent.find((r) => r.path === '/api/plan')?.body).toEqual({ task: 'Fix the bug and review it' })
+    await screen.findByText('Built "fix-and-review" — review, tweak, then Save.')
+  })
+
+  it('a degraded (fallback) plan keeps the current name and warns', async () => {
+    stubFetch({
+      'POST /api/plan': [
+        () =>
+          jsonResponse({
+            steps: [{ id: 'task', name: 'Do the task', prompt: '{{task}}' }],
+            rationale: 'planner unavailable',
+            fallback: true,
+          }),
+      ],
+    })
+    renderAt('/workflows')
+    await waitFor(() => expect(stepCards()).toHaveLength(2))
+
+    fireEvent.click(document.querySelector('[data-slot="wb-auto"]')!)
+    fireEvent.change(screen.getByLabelText('Describe the chain to build'), {
+      target: { value: 'do something' },
+    })
+    fireEvent.click(document.querySelector('[data-slot="wb-auto-run"]')!)
+
+    await waitFor(() => expect(stepIds()).toEqual(['task']))
+    // No proposed title → the name the canvas already had (the seeded file) survives.
+    expect(nameInput().value).toBe('ship-it')
+    await screen.findByText('Planner unavailable — added a single step. Edit, then Save.')
   })
 })
 

--- a/web/app/src/routes/workflows/workflows.tsx
+++ b/web/app/src/routes/workflows/workflows.tsx
@@ -25,13 +25,14 @@ import {
   Trash2Icon,
   TriangleAlertIcon,
   UploadIcon,
+  WandSparklesIcon,
   XIcon,
 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 
-import { ApiError, createWorkflow, deleteWorkflow, parseWorkflow } from '@/api/client'
-import { queryKeys, useSkills, useWorkflows } from '@/api/queries'
+import { ApiError, createWorkflow, deleteWorkflow, parseWorkflow, postPlan } from '@/api/client'
+import { queryKeys, useSkills, useUiState, useWorkflows } from '@/api/queries'
 import type { Skill, WorkflowDef, WorkflowStepDef } from '@/api/types'
 import { CenteredState } from '@/components/centered-state'
 import {
@@ -48,10 +49,12 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/components/ui/toaster'
-import { isProjectSkill, orderSkills } from '@/lib/skills'
+import { isProjectSkill, orderSkillsByRecency } from '@/lib/skills'
 import { cn } from '@/lib/utils'
+import { recentSkillNames } from '@/routes/new-task-form'
 import {
   WB_MAX_STEPS,
+  draftFromPlan,
   insertStep,
   moveStep,
   removeStep,
@@ -120,6 +123,7 @@ export function WorkflowsRoute() {
 function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
   const workflowsQuery = useWorkflows()
   const skillsQuery = useSkills()
+  const uiStateQuery = useUiState()
   const queryClient = useQueryClient()
 
   const [draft, setDraft] = useState<Draft | null>(null)
@@ -127,6 +131,8 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
   const [importOpen, setImportOpen] = useState(false)
   const [importText, setImportText] = useState('')
   const [importError, setImportError] = useState('')
+  const [autoOpen, setAutoOpen] = useState(false)
+  const [autoText, setAutoText] = useState('')
   const [confirmOverwrite, setConfirmOverwrite] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [dragging, setDragging] = useState<DragItem | null>(null)
@@ -137,6 +143,9 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
 
   const workflows = workflowsQuery.data?.workflows ?? []
   const skills = skillsQuery.data ?? []
+  // The palette lists skills the way every other picker does (#408/#414): project skills first,
+  // then most-recently-run within each locality — so what you reach for floats to the top.
+  const paletteSkills = orderSkillsByRecency(skills, recentSkillNames(uiStateQuery.data?.recentSources))
 
   // First visit seeds the canvas with the deep-linked workflow when the URL names one, else
   // the repo's first saved workflow — "open the tab, see your flow" (legacy rule). No files
@@ -163,6 +172,30 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
       toast(`Imported "${parsed.name}" — review, then Save.`)
     },
     onError: (error) => setImportError(error.message),
+  })
+
+  // Auto chain creator (#414): the planner turns a plain-language brief into a proposed chain
+  // (title + steps) and drops it straight onto the canvas to review, tweak and Save. It never
+  // hard-fails — a degraded answer comes back as a one-step plan with `fallback: true`, which we
+  // surface as a dim note instead of an error.
+  const autoPlan = useMutation({
+    mutationFn: (task: string) => postPlan(task),
+    onSuccess: (plan) => {
+      setDraft((current) => {
+        const base = current ?? emptyDraft()
+        const { name, steps } = draftFromPlan(plan, base.name)
+        return { ...base, name, steps }
+      })
+      setAutoOpen(false)
+      setAutoText('')
+      toast(
+        plan.fallback
+          ? 'Planner unavailable — added a single step. Edit, then Save.'
+          : `Built "${plan.name ?? draft?.name ?? 'workflow'}" — review, tweak, then Save.`,
+        plan.fallback ? { tone: 'danger' } : undefined,
+      )
+    },
+    onError: (error) => toast(error instanceof Error ? error.message : String(error), { tone: 'danger' }),
   })
 
   const save = useMutation({
@@ -266,6 +299,12 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
     importMutation.mutate(text)
   }
 
+  const runAuto = () => {
+    const text = autoText.trim()
+    if (text === '' || autoPlan.isPending) return
+    autoPlan.mutate(text)
+  }
+
   const runSave = () => {
     if (trimmedName === '') {
       nameInput.current?.focus()
@@ -347,9 +386,25 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
                   type="button"
                   variant="ghost"
                   size="sm"
+                  data-slot="wb-auto"
+                  aria-expanded={autoOpen}
+                  title="Describe a chain — the agent builds it"
+                  onClick={() => {
+                    setImportOpen(false)
+                    setAutoOpen((open) => !open)
+                  }}
+                >
+                  <WandSparklesIcon aria-hidden="true" className="size-3" />
+                  Auto
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
                   data-slot="wb-import"
                   onClick={() => {
                     setImportError('')
+                    setAutoOpen(false)
                     setImportOpen((open) => !open)
                   }}
                 >
@@ -413,6 +468,59 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
                 + new
               </button>
             </div>
+
+            {autoOpen ? (
+              <div data-slot="wb-auto-panel" className="mt-4 rounded-lg border border-border bg-card p-3 shadow-xs">
+                <div className="text-[11px] font-medium tracking-wide text-soft-foreground uppercase">
+                  Build a chain from a prompt
+                </div>
+                <p className="mt-1 text-xs leading-relaxed text-soft-foreground">
+                  Describe what the chain should do. An agent proposes a title and an ordered set of
+                  skill / check steps — land it on the canvas, then tweak and Save.
+                </p>
+                <Textarea
+                  data-slot="wb-auto-text"
+                  aria-label="Describe the chain to build"
+                  rows={3}
+                  autoFocus
+                  placeholder="e.g. Fix the bug, run the tests, then review the diff for regressions."
+                  value={autoText}
+                  onChange={(event) => setAutoText(event.target.value)}
+                  onKeyDown={(event) => {
+                    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                      event.preventDefault()
+                      runAuto()
+                    }
+                  }}
+                  className="mt-2 min-h-20 text-[13px]"
+                />
+                <div className="mt-3 flex items-center gap-1.5">
+                  <Button
+                    type="button"
+                    variant="contrast"
+                    size="sm"
+                    data-slot="wb-auto-run"
+                    disabled={autoPlan.isPending || autoText.trim() === ''}
+                    onClick={runAuto}
+                  >
+                    <WandSparklesIcon aria-hidden="true" className="size-3" />
+                    {autoPlan.isPending ? 'Building…' : 'Build chain'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    data-slot="wb-auto-cancel"
+                    onClick={() => {
+                      setAutoOpen(false)
+                      setAutoText('')
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : null}
 
             {importOpen ? (
               <div data-slot="wb-import-panel" className="mt-4 rounded-lg border border-border bg-card p-3 shadow-xs">
@@ -487,7 +595,7 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
               className="mt-2.5 h-8 text-[13px]"
             />
             <Palette
-              skills={skills}
+              skills={paletteSkills}
               query={query}
               error={skillsQuery.isError ? skillsQuery.error.message : null}
               inFlow={new Set(steps.map((s) => s.skill).filter((s): s is string => Boolean(s)))}
@@ -819,8 +927,9 @@ function Palette({
     )
   }
   const needle = query.trim().toLowerCase()
-  // Project skills first (the #377 ordering rule) — same as every other skill list.
-  const shown = orderSkills(skills).filter(
+  // `skills` arrives already ordered (project-first, then recency — #408/#414); the filter
+  // preserves that order, it never re-sorts.
+  const shown = skills.filter(
     (skill) =>
       needle === '' ||
       skill.name.toLowerCase().includes(needle) ||


### PR DESCRIPTION
Fixes #414

## What & why

The workflow builder gains the two capabilities the issue asks for.

**Auto chain creator.** A new **Auto** panel in the builder header takes a plain-language brief and hands it to the coding-agent planner (`POST /api/plan`) for structured output. The proposed **title + ordered steps** land straight on the canvas to review, tweak and Save — "build me a chain" in one action. The planner (`src/planner.ts`) now also proposes a short kebab-case `title` (new optional field, backward-compatible on both request and response). A pure `draftFromPlan` helper adopts the plan: it keeps the current name when none was proposed (never blanks it), caps the chain at the server's `WB_MAX_STEPS` limit, and re-dedupes step ids so a repaired plan can't seed a duplicate-id canvas the server would reject. It never hard-fails — a degraded answer stays a one-step `fallback: true` plan surfaced as a dim note.

**Usage-sorted skill palette.** The palette now orders skills the way every other picker does (#408): **project skills first, then most-recently-run within each locality**, reusing the existing `orderSkillsByRecency` helper fed by ui-state `recentSources`. The palette filter preserves that order instead of re-sorting.

Zod refinements are respected — steps stay agent-XOR-check, the file stays steps-XOR-skills, and built-ins are untouched. New fields are optional for backward compatibility.

## Tests

- `test/unit/planner.test.ts` — `proposeWorkflowName` slug/degrade behaviour and `parseStructured` reading the new `title`.
- `web/app/src/lib/workflow-builder.test.ts` — `draftFromPlan` (adopt title+steps, keep name when unproposed, cap at limit, re-dedupe ids).
- `web/app/src/routes/workflows/workflows.test.tsx` — the auto-creator UI flow (built plan lands title+steps; degraded fallback keeps the name and warns).
- The dry-run mock (`scripts/mock-claude.mjs`) now returns a `title` so offline/e2e runs exercise the full flow.

`npm run typecheck`, `npm test` (2042 passed), and `npm run test:unit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)