### PR TITLE
fix(workflows): periodic autosave commits are opt-in via CEZ_AUTOSAVE (#471)

### DIFF
--- a/.ai/specs/006-worktree-queue.md
+++ b/.ai/specs/006-worktree-queue.md
@@ -34,6 +34,11 @@ pracę ("agent robi, ja dalej koduję u siebie").
    `git add -A && git commit --no-verify -m "cez autosave"` w worktree —
    postęp agenta zawsze odzyskiwalny z historii. Commity autosave squashuje
    krok PR (009) — na razie zostają w branchu.
+   *Aneks (2026-07-17, #471):* okresowy timer 90 s jest **opt-in** przez
+   `CEZ_AUTOSAVE=1` (domyślnie wyłączony — commity autosave w środku runa
+   zaśmiecały historię PR-ów). Flushe na końcu tury i przed draft-PR zostają
+   bez zmian, więc branch nadal kończy z pełnym stanem, a diff/review/PR
+   działają jak dotąd.
 3. **Kolejka + `maxParallel`**: `RunManager` dostaje prostą kolejkę
    (`queue: runId[]`, `pump()` po każdym starcie/końcu); limit z config.json
    (`maxParallel`, default **2**); zbiór `starting` łatający race przy

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,13 @@
 # Codex's default network-blocked sandbox.
 # CEZ_CODEX_NETWORK=0
 
+# ---- periodic autosave -------------------------------------------------------
+# Off by default. Set to 1 to re-enable the janitor-style "cezar autosave" commit every 90 s
+# in each task worktree (spec 006). Left off, a task branch carries only the agent's own
+# commits — plus the turn-end and pre-PR flushes, which always run so the branch still ends
+# holding the finished state and the diff/review/PR views stay complete.
+# CEZ_AUTOSAVE=1
+
 # ---- GitHub -----------------------------------------------------------------
 # Used for the GitHub tab / PR actions. The `gh` CLI's own auth is preferred; set
 # this only if you drive git/gh through a token instead.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Useful environment variables:
 |---|---|
 | `CEZ_DRY_RUN=1` | Use the bundled mock instead of the real `claude` CLI — the entire cockpit works offline, for demos and development. |
 | `CEZ_APPROVAL_GATE=1` | Opt into Claude's interactive approval UI; by default, unapproved tools are denied without interrupting the run. |
+| `CEZ_AUTOSAVE=1` | Re-enable the periodic (90 s) `cezar autosave` commit in task worktrees. Off by default (#471) — turn-end and pre-PR flushes always run, so branches still end complete. |
 | `CEZ_CLAUDE_BIN=/path/to/claude` | Override which `claude` binary is used. |
 | `CEZ_CODEX_BIN=/path/to/codex` | Override which `codex` binary is used. |
 | `CEZ_OPENCODE_BIN=/path/to/opencode` | Override which `opencode` binary is used. |

--- a/src/workflows/autosave-gate.test.ts
+++ b/src/workflows/autosave-gate.test.ts
@@ -1,0 +1,103 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { autosaveCommit, createWorktree } from '../git-worktree.js';
+import { RunStore } from '../runs/store.js';
+import { AUTOSAVE_INTERVAL_MS, periodicAutosaveEnabled, RunManager } from './run.js';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+
+/** The slice of ActiveRun that armAutosave/clearAutosaveTimer read and write. */
+interface TimerState {
+  cancelled: boolean;
+  interrupt: () => void;
+  cwd: string;
+  autosaveTimer?: NodeJS.Timeout;
+}
+
+interface TimerSeam {
+  armAutosave(state: TimerState): void;
+  clearAutosaveTimer(state: TimerState): void;
+}
+
+/**
+ * The periodic autosave timer is opt-in via CEZ_AUTOSAVE=1 (#471). armAutosave is
+ * driven directly (the recordTurnEnd precedent) because a live agent session is the
+ * only other way to reach it. The turn-end/pre-PR flushes are a separate, ungated
+ * call to autosaveCommit — proven env-independent below.
+ */
+describe('periodic autosave gate (#471)', () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: TimerSeam;
+  let worktreePath: string;
+  const savedEnv = process.env.CEZ_AUTOSAVE;
+
+  beforeAll(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-autosave-gate-'));
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'base\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot) as unknown as TimerSeam;
+    const record = store.createRun({ title: 't', workflow: 'quick-task', task: 't', steps: [] });
+    worktreePath = (await createWorktree(repoRoot, record.id, 'main')).path;
+  });
+
+  afterAll(() => {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CEZ_AUTOSAVE;
+    else process.env.CEZ_AUTOSAVE = savedEnv;
+  });
+
+  it('is off by default, on only for the exact value "1"', () => {
+    expect(periodicAutosaveEnabled({})).toBe(false);
+    expect(periodicAutosaveEnabled({ CEZ_AUTOSAVE: '0' })).toBe(false);
+    expect(periodicAutosaveEnabled({ CEZ_AUTOSAVE: 'true' })).toBe(false);
+    expect(periodicAutosaveEnabled({ CEZ_AUTOSAVE: '1' })).toBe(true);
+    delete process.env.CEZ_AUTOSAVE;
+    expect(periodicAutosaveEnabled()).toBe(false); // defaults to process.env
+  });
+
+  it('does not arm the timer when the env is off (default)', () => {
+    delete process.env.CEZ_AUTOSAVE;
+    const state: TimerState = { cancelled: false, interrupt: () => undefined, cwd: worktreePath };
+    manager.armAutosave(state);
+    expect(state.autosaveTimer).toBeUndefined();
+  });
+
+  it('arms the timer when CEZ_AUTOSAVE=1, but never for a repo-root run', () => {
+    process.env.CEZ_AUTOSAVE = '1';
+    const state: TimerState = { cancelled: false, interrupt: () => undefined, cwd: worktreePath };
+    manager.armAutosave(state);
+    expect(state.autosaveTimer).toBeDefined();
+    manager.armAutosave(state); // idempotent — the second call must not double-arm
+    manager.clearAutosaveTimer(state);
+    expect(state.autosaveTimer).toBeUndefined();
+
+    const rootState: TimerState = { cancelled: false, interrupt: () => undefined, cwd: repoRoot };
+    manager.armAutosave(rootState);
+    expect(rootState.autosaveTimer).toBeUndefined();
+  });
+
+  it('AUTOSAVE_INTERVAL_MS stays the spec-006 90 s contract', () => {
+    expect(AUTOSAVE_INTERVAL_MS).toBe(90_000);
+  });
+
+  it('the flush path (autosaveCommit) still commits with the env off', async () => {
+    delete process.env.CEZ_AUTOSAVE;
+    writeFileSync(join(worktreePath, 'work.txt'), 'progress\n');
+    expect(await autosaveCommit(worktreePath)).toBe(true);
+    const { stdout } = await run('git', ['log', '-1', '--format=%s'], { cwd: worktreePath });
+    expect(stdout.trim()).toBe('cezar autosave');
+  });
+});

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -46,6 +46,14 @@ function stripDoneMarker(text: string): string {
 /** Periodic "cezar autosave" commit in the task worktree (spec 006). */
 export const AUTOSAVE_INTERVAL_MS = 90_000;
 
+/** The periodic autosave timer is opt-in (#471): off, a task branch carries only the
+ *  agent's own commits plus the turn-end/pre-PR flushes — no mid-run "cezar autosave"
+ *  noise interleaving PR history. The flushes (`autosaveCommit` at turn end and before
+ *  a draft PR) are NOT gated: the branch must still end holding the finished state. */
+export function periodicAutosaveEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CEZ_AUTOSAVE === '1';
+}
+
 interface ActiveRun {
   cancelled: boolean;
   interrupt: () => void;
@@ -1225,8 +1233,10 @@ export class RunManager {
     }
   }
 
-  /** Autosave-commit the worktree every 90 s while the run lives (spec 006). */
+  /** Autosave-commit the worktree every 90 s while the run lives (spec 006).
+   *  Opt-in via CEZ_AUTOSAVE=1 (#471) — see periodicAutosaveEnabled. */
   private armAutosave(state: ActiveRun): void {
+    if (!periodicAutosaveEnabled()) return;
     if (state.cwd === this.repoRoot || state.autosaveTimer) return;
     state.autosaveTimer = setInterval(() => {
       void autosaveCommit(state.cwd);

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -148,8 +148,9 @@ const VARIANT_HINTS: Record<string, string | undefined> = {
  * checks with bounded retry loops, plus live sessions: the last agent step
  * stays open for follow-ups (`waiting`) until "finish", idle timeout, or
  * cancel. Runs queue behind `maxParallel` slots and each run executes in its
- * own git worktree on a `cez/<id8>` branch (spec 006), autosave-committed
- * every 90 s — the user's working tree is never touched.
+ * own git worktree on a `cez/<id8>` branch (spec 006), autosave-committed at
+ * turn end and before a draft PR — plus every 90 s when opted in via
+ * CEZ_AUTOSAVE=1 (#471). The user's working tree is never touched.
  */
 export class RunManager {
   private readonly active = new Map<string, ActiveRun>();


### PR DESCRIPTION
Refs #471 (the "…and autosaves" half — complements the follow-up-inbox PR from branch `fix/disable-global-inbox`)

## Problem

Issue #471 asks for the global task list **and autosaves** to be disabled by default, re-enabled with a default-off global env var. The follow-up-inbox half is handled on `fix/disable-global-inbox`; this PR handles the autosave half: the janitor-style **periodic 90 s `cezar autosave` commit** (spec 006) fires in every task worktree and interleaves noise commits into PR history — the inbox branch itself accumulated nine of them between its real steps.

## Root cause / design

`autosaveCommit` serves two distinct roles that were coupled:

1. the **periodic timer** (`armAutosave`, every 90 s) — mid-run crash-recovery snapshots, the source of the noise;
2. the **on-demand flushes** — turn end (`run.ts`) and before draft-PR creation (`forge/github.ts`) — which the diff/review/PR pipeline depends on ("the branch always ends holding the finished state").

Only role 1 is gated. `armAutosave` now no-ops unless `CEZ_AUTOSAVE=1` (new exported `periodicAutosaveEnabled(env)`, default **off** per the zero-config rule "the zero-config default is also the safe default"). Role 2 is untouched, so branches still end complete and the Changes/Commit/PR views work exactly as before.

## Changes

- `src/workflows/run.ts` — `periodicAutosaveEnabled()` + the gate in `armAutosave`.
- `src/workflows/autosave-gate.test.ts` — new: env parsing, timer not armed by default, armed with `CEZ_AUTOSAVE=1` (never for repo-root runs), idempotent arm/clear, 90 s contract pinned, and the flush path proven ungated.
- Docs: `.env.example`, `README.md` env table, `.ai/specs/006-worktree-queue.md` amendment.

## Behavioral default change (deliberate)

Mid-run periodic autosave commits no longer happen by default. What is lost: a hard-crash (SIGKILL) mid-turn leaves progress uncommitted in the worktree on disk (still recoverable from the filesystem, no longer from branch history). Turn-end and pre-PR flushes always run. Explicit owner instruction in #471; called out per BACKWARD_COMPATIBILITY.md's waiver path.

## Verification

Full gate green: `typecheck`, `test` (128 files / 2111), `test:unit`, `build` + `check:pack`, `test:package`.
