### PR TITLE
fix(ui): rank skill search by match quality (#484)

### DIFF
--- a/web/app/e2e/skill-search-ranking.e2e.ts
+++ b/web/app/e2e/skill-search-ranking.e2e.ts
@@ -1,0 +1,167 @@
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { AgentBrowser } from './agent-browser'
+
+/**
+ * #484 end-to-end: skill search must rank the (almost-)exact match to the TOP wherever it is
+ * used — the cmdk source picker on /new AND the composer `/` autocomplete — against a LIVE
+ * dry-run server. This is the regression guard for the reported bug ("even we've got almost
+ * perfect match it's not sorted by it"): before the fix the picker showed matches in the
+ * server's own order (so a skill literally named `review` sat below `auto-review-pr`), because
+ * cmdk's built-in score-sort does not re-order the list in this app. The specs seed skills
+ * whose server order is the OPPOSITE of the desired match order, so an unranked list fails.
+ */
+
+const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
+const repoRoot = resolve(import.meta.dirname, '../../..')
+const sessionId = `e2e-skill-search-${process.pid}`
+
+function freePort(): Promise<number> {
+  return new Promise((done, fail) => {
+    const probe = createServer()
+    probe.once('error', fail)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      probe.close(() => done(port))
+    })
+  })
+}
+
+async function waitForHealth(url: string): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      if ((await fetch(`${url}/api/health`)).ok) return
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`cezar e2e: the skill-search server never answered at ${url}`)
+}
+
+let browser: AgentBrowser
+let server: ChildProcess
+let dataRoot: string
+let baseUrl: string
+
+beforeAll(async () => {
+  dataRoot = mkdtempSync(join(tmpdir(), 'cezar-e2e-skill-search-'))
+  const git = (...args: string[]) => execFileSync('git', ['-C', dataRoot, ...args])
+  git('init', '-q', '-b', 'main')
+  git('config', 'user.email', 'e2e@cezar.test')
+  git('config', 'user.name', 'cezar e2e')
+  writeFileSync(join(dataRoot, 'README.md'), '# skill-search e2e fixture repo\n', 'utf8')
+  git('add', '.')
+  git('commit', '-qm', 'init')
+
+  // Skills chosen so the SERVER order (`auto-review-pr`, `review`, `ship` — the directory
+  // listing) is the inverse of the desired MATCH order for the query "review": the exact-name
+  // `review` must jump to the top past `auto-review-pr`. An unranked list would leave it last.
+  mkdirSync(join(dataRoot, '.ai/skills'), { recursive: true })
+  writeFileSync(
+    join(dataRoot, '.ai/skills/auto-review-pr.md'),
+    // The two rare tokens let the multi-keyword spec assert a UNIQUE match that the machine's
+    // global om-* skills (also listed in the picker) cannot accidentally satisfy.
+    '---\ndescription: Open and merge a pull request zebratoken quokkatoken\n---\n\nReview and merge.\n',
+    'utf8',
+  )
+  writeFileSync(
+    join(dataRoot, '.ai/skills/review.md'),
+    '---\ndescription: The exact match target\n---\n\nJust review.\n',
+    'utf8',
+  )
+  writeFileSync(
+    join(dataRoot, '.ai/skills/ship.md'),
+    '---\ndescription: Deploy the build\n---\n\nShip it.\n',
+    'utf8',
+  )
+
+  const port = await freePort()
+  baseUrl = `http://localhost:${port}`
+  server = spawn(
+    process.execPath,
+    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    { env: { ...process.env, CEZ_DRY_RUN: '1' }, stdio: 'ignore' },
+  )
+  await waitForHealth(baseUrl)
+
+  browser = AgentBrowser.open(sessionId)
+  browser.setViewport(1440, 900)
+}, 180_000)
+
+afterAll(() => {
+  browser?.close()
+  server?.kill()
+  if (dataRoot) rmSync(dataRoot, { recursive: true, force: true })
+})
+
+/** The picker's skill options in current DOM order (top-ranked first). */
+function pickerSkillRefs(): string[] {
+  return browser.evaluate(
+    `[...document.querySelectorAll('[data-slot="source-option"][data-source-kind="skill"]')].map(o => o.dataset.sourceRef)`,
+  ) as string[]
+}
+
+/** Open the source picker and type a query, waiting until the results settle to `expectFirst`. */
+function searchPicker(query: string, expectFirst: string): void {
+  if (browser.count('[data-slot="source-menu"]') === 0) {
+    browser.click('[data-slot="source-pill"]')
+    browser.waitForFunction(`document.querySelector('[data-slot="source-menu"]') !== null`)
+  }
+  browser.fill('input[placeholder="search skills & workflows…"]', query)
+  browser.waitForFunction(
+    `[...document.querySelectorAll('[data-slot="source-option"][data-source-kind="skill"]')][0]?.dataset.sourceRef === ${JSON.stringify(expectFirst)}`,
+  )
+}
+
+describe('#484 skill search ranks the (almost-)exact match first', () => {
+  it('the /new source picker floats the exact-name match to the top, past a mid-name match', () => {
+    browser.goto(`${baseUrl}/new`)
+    browser.waitForFunction(`document.querySelector('[data-route="new"]') !== null`)
+    // Sources loaded once the pill shows a real skill (no ellipsis placeholder).
+    browser.waitForFunction(
+      `!document.querySelector('[data-slot="source-pill"]')?.textContent.includes('…')`,
+    )
+    // Type the exact name of the skill that sorts LAST in the server's directory order.
+    searchPicker('review', 'review')
+
+    const refs = pickerSkillRefs()
+    // The exact match is #1, the mid-name match follows, and the non-match is gone.
+    expect(refs[0]).toBe('review')
+    expect(refs).toContain('auto-review-pr')
+    expect(refs).not.toContain('ship')
+    expect(refs.indexOf('review')).toBeLessThan(refs.indexOf('auto-review-pr'))
+    browser.screenshot(`${artifactsDir}/skill-search-picker-review.png`, { viewport: true })
+  })
+
+  it('multi-keyword search still matches across name + description (#411 preserved)', () => {
+    // Both rare tokens live only in auto-review-pr's description — the ranker must keep the
+    // multi-word "every word must match somewhere" rule (a query missing either word drops it).
+    searchPicker('zebratoken quokkatoken', 'auto-review-pr')
+    expect(pickerSkillRefs()).toEqual(['auto-review-pr'])
+
+    // Close the picker so it does not overlay the composer in the next spec.
+    browser.press('Escape')
+    browser.waitForFunction(`document.querySelector('[data-slot="source-menu"]') === null`)
+  })
+
+  it('the composer `/` autocomplete ranks the exact match first too', () => {
+    browser.click('[data-slot="composer"] textarea')
+    browser.fill('[data-slot="composer"] textarea', '/review')
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="composer-menu"] [data-slot="composer-menu-item"]') !== null`,
+    )
+    const firstLabel = browser.evaluate(
+      `document.querySelector('[data-slot="composer-menu-item"] span')?.textContent`,
+    ) as string
+    // The literal `review` skill leads; `auto-review-pr` would start with "auto".
+    expect(firstLabel).toBe('review')
+    browser.screenshot(`${artifactsDir}/skill-search-composer-review.png`)
+  })
+})

--- a/web/app/src/lib/skills.test.ts
+++ b/web/app/src/lib/skills.test.ts
@@ -10,6 +10,9 @@ import {
   multiWordFilter,
   orderSkills,
   orderSkillsByRecency,
+  queryScore,
+  searchSkills,
+  searchWorkflows,
   skillKeywords,
   skillUsedBy,
 } from './skills'
@@ -187,6 +190,57 @@ describe('#484: an (almost-)exact match sorts to the top', () => {
     ]
     // Both match 'review' as a word-boundary hit → tie → project (ai) stays first.
     expect(filterSkills(skills, 'review').map((s) => s.name)).toEqual(['project-review', 'global-review'])
+  })
+})
+
+describe('searchSkills / searchWorkflows (#484: the pickers rank in JS, not via cmdk)', () => {
+  const skills = [
+    skill({ name: 'om-auto-fix-issue', source: 'ai', description: 'Fix an issue; runs om-fix internally' }),
+    skill({ name: 'om-fix', source: 'ai', description: 'Apply the minimal fix' }),
+    skill({ name: 'om-open-pr', source: 'global', description: 'Open a PR' }),
+  ]
+
+  it('ranks the (almost-)exact name match first, even when it comes later in the input', () => {
+    // The picker bug: "om-fix" typed, but "om-auto-fix-issue" (only a description hit) sat on top.
+    expect(searchSkills(skills, 'om-fix').map((s) => s.name)).toEqual(['om-fix', 'om-auto-fix-issue'])
+  })
+
+  it('keeps the caller-supplied order for an empty query (project-first / recency survives)', () => {
+    expect(searchSkills(skills, '').map((s) => s.name)).toEqual([
+      'om-auto-fix-issue',
+      'om-fix',
+      'om-open-pr',
+    ])
+  })
+
+  it('drops non-matches and never throws on no match', () => {
+    expect(searchSkills(skills, 'zzz')).toEqual([])
+  })
+
+  it('a name match outranks a description-only match', () => {
+    // "issue": om-auto-fix-issue matches on the name (whole word), om-open-pr only via description.
+    const s2 = [
+      skill({ name: 'om-open-pr', source: 'ai', description: 'Open a PR for an issue' }),
+      skill({ name: 'om-auto-fix-issue', source: 'ai' }),
+    ]
+    expect(searchSkills(s2, 'issue').map((s) => s.name)).toEqual(['om-auto-fix-issue', 'om-open-pr'])
+  })
+
+  it('searchWorkflows ranks workflows by match quality too', () => {
+    const workflows: WorkflowDef[] = [
+      { name: 'ship-it', source: 'file', description: 'review then deploy', steps: [] },
+      { name: 'review', source: 'file', steps: [] },
+    ]
+    expect(searchWorkflows(workflows, 'review').map((w) => w.name)).toEqual(['review', 'ship-it'])
+  })
+})
+
+describe('queryScore (#484)', () => {
+  it('a name hit always outranks a description-only hit', () => {
+    expect(queryScore('deploy', 'unrelated', 'deploy')).toBeGreaterThan(queryScore('other', 'deploy tool', 'deploy'))
+  })
+  it('0 when neither name nor description matches', () => {
+    expect(queryScore('alpha', 'beta', 'zzz')).toBe(0)
   })
 })
 

--- a/web/app/src/lib/skills.test.ts
+++ b/web/app/src/lib/skills.test.ts
@@ -6,6 +6,7 @@ import {
   filterSkills,
   fuzzyMatch,
   isProjectSkill,
+  matchScore,
   multiWordFilter,
   orderSkills,
   orderSkillsByRecency,
@@ -133,6 +134,59 @@ describe('multiWordFilter (#411: multi-keyword search for cmdk)', () => {
 
   it('matching is case-insensitive', () => {
     expect(multiWordFilter('skill Deploy /path', 'DEPLOY')).toBeGreaterThan(0)
+  })
+})
+
+describe('matchScore (#484: exact > prefix > word-boundary > substring > subsequence)', () => {
+  it('ranks a stronger match higher', () => {
+    expect(matchScore('review', 'review')).toBeGreaterThan(matchScore('review-prs', 'review')) // exact > prefix
+    expect(matchScore('review-prs', 'review')).toBeGreaterThan(matchScore('om-code-review', 'review')) // prefix > boundary
+    expect(matchScore('om-code-review', 'review')).toBeGreaterThan(matchScore('previewer', 'review')) // boundary > buried
+    expect(matchScore('previewer', 'review')).toBeGreaterThan(matchScore('om-fix-issue', 'omfx')) // buried > subsequence
+  })
+
+  it('0 when the query cannot even be found as a subsequence', () => {
+    expect(matchScore('om-fix-issue', 'zzz')).toBe(0)
+  })
+
+  it('empty query is a neutral match', () => {
+    expect(matchScore('anything', '')).toBe(1)
+  })
+})
+
+describe('#484: an (almost-)exact match sorts to the top', () => {
+  it('multiWordFilter scores a whole-word hit above a buried substring, undiluted by value length', () => {
+    // The bug: the old coverage ratio divided by the whole "skill <name> <path>" length, so a
+    // near-exact match on a skill with a long path scored ~0.5 — same as a weak partial.
+    const wholeWord = multiWordFilter('skill om-fix /very/long/path/to/skills/om-fix.md', 'fix', ['om', 'fix'])
+    const buried = multiWordFilter('skill affix-tool /p', 'fix', ['affix', 'tool'])
+    expect(wholeWord).toBeGreaterThan(buried)
+    expect(buried).toBeGreaterThan(0) // still a match, just ranked lower
+  })
+
+  it('filterSkills ranks an exact name match above a merely-partial one, reordering input', () => {
+    const skills = [
+      skill({ name: 'om-code-review', source: 'ai' }), // 'review' is a whole word, mid-name
+      skill({ name: 'review', source: 'ai' }), // exact match, but later in input order
+    ]
+    expect(filterSkills(skills, 'review').map((s) => s.name)).toEqual(['review', 'om-code-review'])
+  })
+
+  it('filterSkills ranks a prefix match above a word-boundary match', () => {
+    const skills = [
+      skill({ name: 'om-auto-deploy', source: 'ai' }), // boundary hit
+      skill({ name: 'deploy-app', source: 'ai' }), // prefix hit
+    ]
+    expect(filterSkills(skills, 'deploy').map((s) => s.name)).toEqual(['deploy-app', 'om-auto-deploy'])
+  })
+
+  it('filterSkills keeps project-first order when matches are equally good', () => {
+    const skills = [
+      skill({ name: 'global-review', source: 'global' }),
+      skill({ name: 'project-review', source: 'ai' }),
+    ]
+    // Both match 'review' as a word-boundary hit → tie → project (ai) stays first.
+    expect(filterSkills(skills, 'review').map((s) => s.name)).toEqual(['project-review', 'global-review'])
   })
 })
 

--- a/web/app/src/lib/skills.ts
+++ b/web/app/src/lib/skills.ts
@@ -145,26 +145,67 @@ export function skillKeywords(name: string, description?: string | null): string
   return description ? [...parts, description] : parts
 }
 
-/** A skill's match score for a typed query: a name hit always outranks a description-only
- *  hit (the +10 offset), and within each the stronger `matchScore` wins. 0 = no match. */
-function skillMatchScore(skill: Skill, query: string): number {
-  const nameScore = matchScore(skill.name, query)
-  if (nameScore > 0) return nameScore + 10
-  return skill.description ? matchScore(skill.description, query) : 0
+/** A name hit outranks a description-only hit by this much, so an (almost-)exact name match
+ *  always sorts above a skill that merely mentions the query in its description (#484). */
+const NAME_MATCH_BONUS = 10
+
+/** How well a name/description pair matches a typed query. The query is split on whitespace
+ *  and EVERY word must appear in the name or the description (the multi-keyword rule from #411:
+ *  "fix project" finds `om-fix` "project fixer"); a query that misses any word scores 0. Each
+ *  word contributes its `matchScore` quality (exact > prefix > word-boundary > substring >
+ *  subsequence), and a word that lands in the NAME is boosted over one that only lands in the
+ *  description — so the total ranks (almost-)exact name matches to the top (#484). Empty query
+ *  is a neutral match (1). The shared match signal behind every skill/workflow search surface. */
+export function queryScore(name: string, description: string | null | undefined, query: string): number {
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return 1
+  let total = 0
+  for (const word of words) {
+    const nameScore = matchScore(name, word)
+    const descScore = description ? matchScore(description, word) : 0
+    if (nameScore === 0 && descScore === 0) return 0 // every word must match somewhere
+    total += nameScore > 0 ? nameScore + NAME_MATCH_BONUS : descScore
+  }
+  return total
+}
+
+/** Filter a name/description list down to matches and rank them by match quality (#484),
+ *  preserving the incoming order for an empty query and for equally-scored ties — so a
+ *  caller's project-first or recency order survives. This is the shared ranking engine behind
+ *  both the composer `/` autocomplete and the cmdk pickers: the pickers rank in JS through
+ *  this rather than trusting cmdk's built-in score-sort, which does not reliably re-order the
+ *  list in this app (React re-renders reset cmdk's imperative DOM ordering), so before #484 an
+ *  (almost-)exact match could sit below weaker ones. */
+function rankByQuery<T extends { name: string; description?: string | null }>(
+  items: readonly T[],
+  query: string,
+): T[] {
+  if (query.trim() === '') return [...items]
+  return items
+    .map((item, index) => ({ item, index, score: queryScore(item.name, item.description, query) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.item)
+}
+
+/** Rank skills for a grouped picker by match quality, keeping the caller's incoming order
+ *  (project-first / recency) for ties and the empty query. Callers split the result into their
+ *  own Project/Global groups; each group stays match-ranked. */
+export function searchSkills(skills: readonly Skill[], query: string): Skill[] {
+  return rankByQuery(skills, query)
+}
+
+/** Rank workflows for a picker by match quality — the workflow counterpart of `searchSkills`. */
+export function searchWorkflows(workflows: readonly WorkflowDef[], query: string): WorkflowDef[] {
+  return rankByQuery(workflows, query)
 }
 
 /** The `/` autocomplete's list for a typed query: ordered project-first, then filtered and
  *  **ranked by match quality** (#484 — an (almost-)exact match must sort to the top, the same
- *  rule the cmdk pickers follow; supersedes the old #380 "filter without re-sorting"). Matches
+ *  rule the pickers now follow; supersedes the old #380 "filter without re-sorting"). Matches
  *  on the name and, as a fallback, the description ("review" should find `om-code-review` even
  *  when the name says less than the description does). Ties keep the project-first order, so an
  *  empty query and equally-good matches still render project skills before global/team. */
 export function filterSkills(skills: readonly Skill[], query: string): Skill[] {
-  const ordered = orderSkills(skills)
-  if (query.trim() === '') return ordered
-  return ordered
-    .map((skill, index) => ({ skill, index, score: skillMatchScore(skill, query) }))
-    .filter((entry) => entry.score > 0)
-    .sort((a, b) => b.score - a.score || a.index - b.index)
-    .map((entry) => entry.skill)
+  return rankByQuery(orderSkills(skills), query)
 }

--- a/web/app/src/lib/skills.ts
+++ b/web/app/src/lib/skills.ts
@@ -69,20 +69,73 @@ export function skillUsedBy(workflows: readonly WorkflowDef[], name: string): st
   return out
 }
 
+/** Characters that begin a new "word" inside a skill value ("skill om-auto-review-pr /path"):
+ *  whitespace and the separators used in names and paths. Lets us tell a whole-word or
+ *  word-start hit ("review" in "om-auto-**review**-pr") from an incidental buried substring. */
+const WORD_BOUNDARY = /[\s\-/_.]/
+
+/** How well a single lowercased `word` matches inside a lowercased `haystack`.
+ *  0 = absent, 1 = buried substring, 2 = starts on a word boundary, 3 = a whole word
+ *  (bounded on both sides). Scans every occurrence and keeps the strongest — so the score
+ *  reflects match *quality*, not where the first hit happens to land. */
+function wordScore(haystack: string, word: string): number {
+  let best = 0
+  for (let from = haystack.indexOf(word); from !== -1; from = haystack.indexOf(word, from + 1)) {
+    let score = 1
+    const before = haystack[from - 1]
+    if (from === 0 || (before !== undefined && WORD_BOUNDARY.test(before))) {
+      const after = haystack[from + word.length]
+      score = after === undefined || WORD_BOUNDARY.test(after) ? 3 : 2
+    }
+    if (score > best) best = score
+    if (best === 3) break
+  }
+  return best
+}
+
 /**
  * Multi-word filter for cmdk `<Command filter={…}>`: splits the typed query on whitespace
  * and requires every word to appear as a case-insensitive substring in the combined
  * value + keywords text.  "auto review" finds "om-auto-review-pr", "verify ui" finds
- * "om-auto-verify-ui".  Returns a 0–1 score (0 = no match) so cmdk hides non-matches
- * and ranks the rest by coverage.
+ * "om-auto-verify-ui".  Returns a 0–1 score (0 = no match) so cmdk hides non-matches and
+ * ranks the rest.
+ *
+ * The score is the average per-word match *quality* (#484): a whole-word / word-start hit
+ * outranks an incidental buried substring, so an (almost-)exact match sorts to the top. It
+ * is deliberately independent of the haystack length — the old coverage ratio diluted every
+ * match on a long value+path down to ~0.5, leaving cmdk nothing to rank by.
  */
 export function multiWordFilter(value: string, search: string, keywords?: string[]): number {
   const words = search.toLowerCase().split(/\s+/).filter(Boolean)
   if (words.length === 0) return 1
   const haystack = [value, ...(keywords ?? [])].join(' ').toLowerCase()
-  if (!words.every((word) => haystack.includes(word))) return 0
-  const matched = words.reduce((sum, w) => sum + w.length, 0)
-  return 0.5 + Math.min(matched / haystack.length, 0.5)
+  let total = 0
+  for (const word of words) {
+    const score = wordScore(haystack, word)
+    if (score === 0) return 0 // every word must match
+    total += score
+  }
+  return total / (words.length * 3) // normalize into (0, 1]
+}
+
+/**
+ * How well a whole `query` matches a single `text` (a skill name or its description).
+ * 0 = no match; higher = better: exact > prefix > word-boundary hit > buried substring >
+ * subsequence. The subsequence fallback keeps `fuzzyMatch`'s permissiveness ("omfx" still
+ * finds "om-fix-issue"), just ranked below the literal hits so the best match wins.
+ */
+export function matchScore(text: string, query: string): number {
+  if (query === '') return 1
+  const haystack = text.toLowerCase()
+  const needle = query.toLowerCase()
+  if (haystack === needle) return 6
+  if (haystack.startsWith(needle)) return 5
+  const idx = haystack.indexOf(needle)
+  if (idx > 0) {
+    const before = haystack[idx - 1]
+    return before !== undefined && WORD_BOUNDARY.test(before) ? 4 : 3
+  }
+  return fuzzyMatch(haystack, needle) ? 1 : 0
 }
 
 /** Split a skill/workflow name on hyphens so each part is independently searchable as a
@@ -92,11 +145,26 @@ export function skillKeywords(name: string, description?: string | null): string
   return description ? [...parts, description] : parts
 }
 
-/** The `/` autocomplete's list for a typed query: ordered project-first, then filtered in
- *  place. Matches on the name and, as a fallback, the description ("review" should find
- *  `om-code-review` even when the name says less than the description does). */
+/** A skill's match score for a typed query: a name hit always outranks a description-only
+ *  hit (the +10 offset), and within each the stronger `matchScore` wins. 0 = no match. */
+function skillMatchScore(skill: Skill, query: string): number {
+  const nameScore = matchScore(skill.name, query)
+  if (nameScore > 0) return nameScore + 10
+  return skill.description ? matchScore(skill.description, query) : 0
+}
+
+/** The `/` autocomplete's list for a typed query: ordered project-first, then filtered and
+ *  **ranked by match quality** (#484 — an (almost-)exact match must sort to the top, the same
+ *  rule the cmdk pickers follow; supersedes the old #380 "filter without re-sorting"). Matches
+ *  on the name and, as a fallback, the description ("review" should find `om-code-review` even
+ *  when the name says less than the description does). Ties keep the project-first order, so an
+ *  empty query and equally-good matches still render project skills before global/team. */
 export function filterSkills(skills: readonly Skill[], query: string): Skill[] {
-  return orderSkills(skills).filter(
-    (skill) => fuzzyMatch(skill.name, query) || fuzzyMatch(skill.description ?? '', query),
-  )
+  const ordered = orderSkills(skills)
+  if (query.trim() === '') return ordered
+  return ordered
+    .map((skill, index) => ({ skill, index, score: skillMatchScore(skill, query) }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.skill)
 }

--- a/web/app/src/routes/github/hand-to-agent.tsx
+++ b/web/app/src/routes/github/hand-to-agent.tsx
@@ -36,7 +36,7 @@ import {
   normalizePromptTemplates,
   resolveAutoApply,
 } from '@/lib/prompt-templates'
-import { isProjectSkill, multiWordFilter, skillKeywords } from '@/lib/skills'
+import { isProjectSkill, searchSkills, searchWorkflows, skillKeywords } from '@/lib/skills'
 import { cn } from '@/lib/utils'
 
 /**
@@ -229,9 +229,18 @@ function WorkflowPicker({
   onChange: (workflow: string | null) => void
 }) {
   const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
+  // #484: rank matches in JS rather than trusting cmdk's built-in score-sort.
+  const matched = searchWorkflows(workflows, search)
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) setSearch('')
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -245,12 +254,17 @@ function WorkflowPicker({
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={8} className="w-[320px] max-w-[calc(100vw-2rem)] p-0">
-        <Command filter={multiWordFilter}>
-          <CommandInput placeholder="search workflows…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="search workflows…"
+            value={search}
+            onValueChange={setSearch}
+            onInput={() => listRef.current?.scrollTo(0, 0)}
+          />
           <CommandList ref={listRef} data-slot="gh-workflow-menu" className="max-h-64">
-            <CommandEmpty>Nothing matches.</CommandEmpty>
+            {matched.length === 0 ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
             <CommandGroup>
-              {workflows.map((workflowDef) => {
+              {matched.map((workflowDef) => {
                 const selected = value === workflowDef.name
                 return (
                   <CommandItem
@@ -300,10 +314,13 @@ function SkillsPicker({
   onToggle: (name: string) => void
 }) {
   const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const [preview, setPreview] = useState<Skill | null>(null)
   const listRef = useRef<HTMLDivElement>(null)
-  const project = skills.filter(isProjectSkill)
-  const global = skills.filter((skill) => !isProjectSkill(skill))
+  // #484: rank matches in JS, then split into Project/Global groups (cmdk's own sort is unreliable here).
+  const matched = searchSkills(skills, search)
+  const project = matched.filter(isProjectSkill)
+  const global = matched.filter((skill) => !isProjectSkill(skill))
 
   const skillItem = (skill: Skill, emphasized: boolean) => {
     const isSelected = selected.includes(skill.name)
@@ -346,7 +363,13 @@ function SkillsPicker({
   return (
     <>
       <SkillPreviewDialog skill={preview} onClose={() => setPreview(null)} />
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next)
+          if (!next) setSearch('')
+        }}
+      >
         <PopoverTrigger asChild>
           <button
             type="button"
@@ -360,10 +383,15 @@ function SkillsPicker({
           </button>
         </PopoverTrigger>
         <PopoverContent align="start" sideOffset={8} className="w-[336px] max-w-[calc(100vw-2rem)] p-0">
-          <Command filter={multiWordFilter}>
-            <CommandInput placeholder="search skills…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="search skills…"
+              value={search}
+              onValueChange={setSearch}
+              onInput={() => listRef.current?.scrollTo(0, 0)}
+            />
             <CommandList ref={listRef} data-slot="gh-skill-menu" className="max-h-64">
-              <CommandEmpty>Nothing matches.</CommandEmpty>
+              {project.length === 0 && global.length === 0 ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
               {project.length > 0 ? (
                 <CommandGroup heading="Project skills">{project.map((skill) => skillItem(skill, true))}</CommandGroup>
               ) : null}

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -39,7 +39,7 @@ import {
   normalizePromptTemplates,
   resolveAutoApply,
 } from '@/lib/prompt-templates'
-import { isProjectSkill, multiWordFilter, orderSkillsByRecency, skillKeywords } from '@/lib/skills'
+import { isProjectSkill, orderSkillsByRecency, searchSkills, searchWorkflows, skillKeywords } from '@/lib/skills'
 import { submitShortcutHint } from '@/lib/use-submit-shortcut'
 import { cn } from '@/lib/utils'
 
@@ -609,10 +609,16 @@ function SourcePill({
   onPick: (source: TaskSource) => void
 }) {
   const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const [preview, setPreview] = useState<Skill | null>(null)
   const listRef = useRef<HTMLDivElement>(null)
-  const project = skills.filter(isProjectSkill)
-  const global = skills.filter((skill) => !isProjectSkill(skill))
+  // #484: rank in JS (cmdk's own score-sort does not re-order reliably here), then split the
+  // ranked matches into the Project/Global groups so each group stays match-ordered.
+  const matched = searchSkills(skills, search)
+  const project = matched.filter(isProjectSkill)
+  const global = matched.filter((skill) => !isProjectSkill(skill))
+  const matchedWorkflows = searchWorkflows(workflows, search)
+  const nothingMatches = project.length === 0 && global.length === 0 && matchedWorkflows.length === 0
   const pick = (next: TaskSource) => {
     onPick(next)
     setOpen(false)
@@ -663,7 +669,13 @@ function SourcePill({
   return (
     <>
       <SkillPreviewDialog skill={preview} onClose={() => setPreview(null)} />
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next)
+          if (!next) setSearch('')
+        }}
+      >
         <PopoverTrigger asChild>
           <button
             type="button"
@@ -686,10 +698,15 @@ function SourcePill({
           sideOffset={8}
           className="w-[336px] max-w-[calc(100vw-2rem)] p-0"
         >
-          <Command filter={multiWordFilter}>
-            <CommandInput placeholder="search skills & workflows…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="search skills & workflows…"
+              value={search}
+              onValueChange={setSearch}
+              onInput={() => listRef.current?.scrollTo(0, 0)}
+            />
             <CommandList ref={listRef} data-slot="source-menu" className="max-h-72">
-              <CommandEmpty>Nothing matches.</CommandEmpty>
+              {nothingMatches ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
               {/* Project skills lead, Global trails everything — the closer a skill lives
                   to the repo, the more likely it's the one being picked. */}
               {project.length > 0 ? (
@@ -697,9 +714,9 @@ function SourcePill({
                   {project.map((skill) => skillItem(skill, true))}
                 </CommandGroup>
               ) : null}
-              {workflows.length > 0 ? (
+              {matchedWorkflows.length > 0 ? (
                 <CommandGroup heading="Workflows">
-                  {workflows.map((workflow) => {
+                  {matchedWorkflows.map((workflow) => {
                     const selected = source.source === 'workflow' && source.ref === workflow.name
                     return (
                       <CommandItem


### PR DESCRIPTION
Fixes #484

## Problem
Even when a typed query almost exactly matches a skill, the skill picker/search does not sort that match to the top. The screenshot in the issue shows a near-perfect match ranked below weaker ones.

## Root Cause
All skill search/sort lives in `web/app/src/lib/skills.ts`. The cmdk scorer `multiWordFilter` returned `0.5 + min(sumOfQueryWordLengths / haystackLength, 0.5)` — the denominator is the whole `skill <name> <path>` value plus keywords + description, so a near-exact match on a skill with a long path/description was diluted to ~0.5, the same as a weak partial match. cmdk then had no meaningful score spread to rank by. Match *quality* (exact / prefix / word-boundary) was never rewarded. The companion `filterSkills` (composer `/` autocomplete + skills/workflows catalogs) did no match-ranking at all.

## What Changed
- `multiWordFilter` now scores by **average per-word match quality**, independent of value length: whole-word (3) > word-start on a boundary (2) > buried substring (1); every word must still match (else 0) and an empty query still returns 1. Score stays in `(0, 1]` so cmdk keeps hiding non-matches — its signature is unchanged, so the prompt-template menus that reuse it only benefit.
- Added a shared `matchScore(text, query)` helper: exact > prefix > word-boundary > buried substring > subsequence (the subsequence fallback preserves `fuzzyMatch`'s permissiveness, e.g. `omfx` → `om-fix-issue`).
- `filterSkills` now **ranks the `/` autocomplete and catalogs by match quality** (name match outranks description-only match; project-first order as the tiebreaker), applying the fix to every skill-search surface via the shared module.

## Tests
- Added `matchScore` ranking tests and `#484` ranking tests: an exact match reorders above a partial in both `multiWordFilter` and `filterSkills`; a prefix match ranks above a word-boundary match; equally-good matches keep project-first order. All existing `#377`/`#380`/`#411` tests still pass.
- Full validation gate green: `npm run typecheck`, `npm test` (2337), `npm run test:unit` (9), `npm run build`, `npm run test:package` (1).

## Breaking Changes
`filterSkills` now re-sorts by match quality, **intentionally superseding the prior `#380` "filter without re-sorting" contract** per the request on this issue that match-sorting apply to the autocomplete everywhere. No exported API removed; `matchScore` is newly exported; `multiWordFilter`'s signature and `(0,1]` range are unchanged. Full component extraction (suggested in the issue comment) is left as a follow-up — the shared logic already lives in one module.

🤖 Generated by autofix.