### PR TITLE
feat(runs): optional review gate — default-off env + Settings toggle + autonomous skip (#489)

### DIFF
--- a/.ai/runs/2026-07-18-optional-review-gate.md
+++ b/.ai/runs/2026-07-18-optional-review-gate.md
@@ -1,0 +1,40 @@
+# Execution plan — Optional review gate (FR #489)
+
+Source doc: `.ai/specs/2026-07-18-optional-review-gate.md`
+Tracking issue: #489
+Branch: `feat/issue-489-optional-review-gate`
+Base: `main`
+
+The Progress phases mirror the spec's Implementation Plan (Phases → Steps). Each
+step is independently testable and leaves the app green. Every code change ships
+with tests; the docs phase runs the configured lint/check only.
+
+## Goal
+
+Make the diff-first review gate (spec 009) **opt-in**: OFF by default, enabled by
+`CEZ_REVIEW_GATE=1` overridable by a `reviewGate` Settings toggle, and **always
+skipped for autonomous runs**. A successful run with changes then settles straight
+to `done` (diff stays in the worktree) unless the gate applies.
+
+## Progress
+
+### Phase 1 — Engine + persistence (the #489 fix)
+- [ ] 1. Persist `autonomous?: boolean` on `runRecordSchema` (`src/runs/store.ts`) and write it from `startRun` (`src/workflows/run.ts`) as `autonomous: input.autonomous === true`. Test: record round-trips `autonomous`.
+- [ ] 2. Add `reviewGateEnabled(config, env)` (`src/runs/review-gate.ts`), default-off precedence. Unit-test the matrix (`src/runs/review-gate.test.ts`).
+- [ ] 3. Gate `settleSuccess` (`src/workflows/run.ts`) on `diff && reviewGateEnabled(config) && !run.autonomous`, else `done`. Engine test: gate-off / autonomous / gate-on+manual / no-diff.
+- [ ] 4. Re-thread `autonomous` through `recover()`'s rebuilt `input` (`src/workflows/run.ts`). Test: recovered queued autonomous run stays autonomous.
+- [ ] 5. Gate the group-pick winner-park (`POST /api/groups/:groupId/pick`, `src/server/server.ts`). Test: autonomous / gate-off winner stays `done`.
+
+### Phase 2 — Config surface (env + Settings)
+- [ ] 6. Add `reviewGate` to config schema (`src/config.ts`), GET `/api/config` and PUT `/api/config` (`src/server/server.ts`). Test in `src/server/config-api.test.ts`.
+- [ ] 7. Add `reviewGate` to client GET/PUT config types (`web/app/src/api/types.ts`).
+- [ ] 8. Add the Settings → Agents Switch (`web/app/src/routes/settings/agents-section.tsx`), `checked={config.reviewGate ?? false}`. Test in `agents-section.test.tsx`.
+
+### Phase 3 — Docs
+- [ ] 9. Document `CEZ_REVIEW_GATE` (default off) in `.env.example` and the `README.md` env table.
+
+## Validation gate (before marking ready)
+`npm run typecheck` · `npm test` · `npm run test:unit` · `npm run build` · `npm run test:package`
+
+## PR
+PR: (pending)

--- a/.ai/runs/2026-07-18-optional-review-gate.md
+++ b/.ai/runs/2026-07-18-optional-review-gate.md
@@ -25,13 +25,13 @@ to `done` (diff stays in the worktree) unless the gate applies.
 - [x] 4. Re-thread `autonomous` through `recover()`'s rebuilt `input` (`src/workflows/run.ts`). Test: recovered queued autonomous run stays autonomous.
 - [x] 5. Gate the group-pick winner-park (`POST /api/groups/:groupId/pick`, `src/server/server.ts`). Test: autonomous / gate-off winner stays `done`. (Also added the additive `reviewGate` config schema key here — the engine's config path depends on it to typecheck.)
 
-### Phase 2 — Config surface (env + Settings)
-- [ ] 6. Add `reviewGate` to config schema (`src/config.ts`), GET `/api/config` and PUT `/api/config` (`src/server/server.ts`). Test in `src/server/config-api.test.ts`.
-- [ ] 7. Add `reviewGate` to client GET/PUT config types (`web/app/src/api/types.ts`).
-- [ ] 8. Add the Settings → Agents Switch (`web/app/src/routes/settings/agents-section.tsx`), `checked={config.reviewGate ?? false}`. Test in `agents-section.test.tsx`.
+### Phase 2 — Config surface (env + Settings) — done @ 17aaf8f
+- [x] 6. Add `reviewGate` to config schema (`src/config.ts` — landed in Phase 1), GET `/api/config` and PUT `/api/config` (`src/server/server.ts`). Test in `src/server/config-api.test.ts`.
+- [x] 7. Add `reviewGate` to client GET/PUT config types (`web/app/src/api/types.ts`).
+- [x] 8. Add the Settings → Agents Switch (`web/app/src/routes/settings/agents-section.tsx`), `checked={config.reviewGate ?? false}`. Test in `agents-section.test.tsx`.
 
 ### Phase 3 — Docs
-- [ ] 9. Document `CEZ_REVIEW_GATE` (default off) in `.env.example` and the `README.md` env table.
+- [x] 9. Document `CEZ_REVIEW_GATE` (default off) in `.env.example` and the `README.md` env table.
 
 ## Validation gate (before marking ready)
 `npm run typecheck` · `npm test` · `npm run test:unit` · `npm run build` · `npm run test:package`

--- a/.ai/runs/2026-07-18-optional-review-gate.md
+++ b/.ai/runs/2026-07-18-optional-review-gate.md
@@ -18,12 +18,12 @@ to `done` (diff stays in the worktree) unless the gate applies.
 
 ## Progress
 
-### Phase 1 — Engine + persistence (the #489 fix)
-- [ ] 1. Persist `autonomous?: boolean` on `runRecordSchema` (`src/runs/store.ts`) and write it from `startRun` (`src/workflows/run.ts`) as `autonomous: input.autonomous === true`. Test: record round-trips `autonomous`.
-- [ ] 2. Add `reviewGateEnabled(config, env)` (`src/runs/review-gate.ts`), default-off precedence. Unit-test the matrix (`src/runs/review-gate.test.ts`).
-- [ ] 3. Gate `settleSuccess` (`src/workflows/run.ts`) on `diff && reviewGateEnabled(config) && !run.autonomous`, else `done`. Engine test: gate-off / autonomous / gate-on+manual / no-diff.
-- [ ] 4. Re-thread `autonomous` through `recover()`'s rebuilt `input` (`src/workflows/run.ts`). Test: recovered queued autonomous run stays autonomous.
-- [ ] 5. Gate the group-pick winner-park (`POST /api/groups/:groupId/pick`, `src/server/server.ts`). Test: autonomous / gate-off winner stays `done`.
+### Phase 1 — Engine + persistence (the #489 fix) — done @ b958703
+- [x] 1. Persist `autonomous?: boolean` on `runRecordSchema` (`src/runs/store.ts`) and write it from `startRun` (`src/workflows/run.ts`) as `autonomous: input.autonomous === true`. Test: record round-trips `autonomous`.
+- [x] 2. Add `reviewGateEnabled(config, env)` (`src/runs/review-gate.ts`), default-off precedence. Unit-test the matrix (`src/runs/review-gate.test.ts`).
+- [x] 3. Gate `settleSuccess` (`src/workflows/run.ts`) on `diff && reviewGateEnabled(config) && !run.autonomous`, else `done`. Engine test: gate-off / autonomous / gate-on+manual / no-diff.
+- [x] 4. Re-thread `autonomous` through `recover()`'s rebuilt `input` (`src/workflows/run.ts`). Test: recovered queued autonomous run stays autonomous.
+- [x] 5. Gate the group-pick winner-park (`POST /api/groups/:groupId/pick`, `src/server/server.ts`). Test: autonomous / gate-off winner stays `done`. (Also added the additive `reviewGate` config schema key here — the engine's config path depends on it to typecheck.)
 
 ### Phase 2 — Config surface (env + Settings)
 - [ ] 6. Add `reviewGate` to config schema (`src/config.ts`), GET `/api/config` and PUT `/api/config` (`src/server/server.ts`). Test in `src/server/config-api.test.ts`.

--- a/.ai/runs/2026-07-18-optional-review-gate.md
+++ b/.ai/runs/2026-07-18-optional-review-gate.md
@@ -37,4 +37,4 @@ to `done` (diff stays in the worktree) unless the gate applies.
 `npm run typecheck` · `npm test` · `npm run test:unit` · `npm run build` · `npm run test:package`
 
 ## PR
-PR: (pending)
+PR: #494 — https://github.com/open-mercato/cezar/pull/494 (ready, all phases done, gate green, self-review approved)

--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,15 @@
 # CEZ_TITLE_UPDATES=0
 # CEZ_AUTONAME=0
 
+# ---- review gate -------------------------------------------------------------
+# Optional diff-first review gate (#489). OFF by default: a successful run with
+# changes settles straight to `done`, leaving the diff in the worktree. Set
+# CEZ_REVIEW_GATE=1 to make a changed non-autonomous run park at `review` for a
+# human to Accept / Send back / open a Draft PR. Only the exact string "1"
+# enables it ("true"/"yes" are treated as off). The Settings → Agents toggle,
+# when set, wins over this env default. Autonomous runs ALWAYS skip the gate.
+# CEZ_REVIEW_GATE=1
+
 # ---- periodic autosave -------------------------------------------------------
 # Off by default. Set to 1 to re-enable the janitor-style "cezar autosave" commit every 90 s
 # in each task worktree (spec 006). Left off, a task branch carries only the agent's own

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Useful environment variables:
 | `GITHUB_TOKEN` | Fallback for GitHub reads/PRs when `gh` isn't authenticated. |
 | `CEZ_TITLE_UPDATES=0` | Turn off the live task-title refresh (namer re-runs on each turn end). The Settings → Agents toggle overrides this default. |
 | `CEZ_AUTONAME=0` | Disable ALL LLM task naming (creation + live) — titles stay heuristic (`437: /om-auto-review-pr`). Under `CEZ_DRY_RUN=1` naming is already off unless forced with `CEZ_AUTONAME=1`. |
+| `CEZ_REVIEW_GATE=1` | Turn ON the optional diff-first review gate (#489): a successful, non-autonomous run with changes parks at `review` (Accept / Send back / Draft PR) instead of finishing. Off by default — changed runs settle to `done` with the diff left in the worktree. Only `1` enables. The Settings → Agents toggle overrides this; autonomous runs always skip it. |
 | `CEZ_NO_BANNER=1` | Skip the `open-mercato/skills` banner on `cezar serve` startup. Dismissing the same banner in the cockpit silences the terminal one too. |
 
 ---

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,11 @@ const configSchema = z.object({
    *  turn end. Absent = the `CEZ_TITLE_UPDATES` env decides (default ON — owner
    *  decision on PR #479). */
   liveTitleUpdates: z.boolean().optional(),
+  /** Optional diff-first review gate (#489): when a successful run with changes
+   *  should park at `review` for a human. Absent = the `CEZ_REVIEW_GATE` env
+   *  decides (default OFF — the deliberate inverse of `liveTitleUpdates`).
+   *  Autonomous runs always skip the gate regardless of this. */
+  reviewGate: z.boolean().optional(),
   /**
    * Branch task worktrees fork from and draft PRs target (e.g. `develop`).
    * Unset = the branch currently checked out. Settable from the Repo tab.

--- a/src/runs/review-gate.test.ts
+++ b/src/runs/review-gate.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { reviewGateEnabled } from './review-gate.js';
+
+describe('reviewGateEnabled', () => {
+  const saved = process.env.CEZ_REVIEW_GATE;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CEZ_REVIEW_GATE;
+    else process.env.CEZ_REVIEW_GATE = saved;
+  });
+
+  it('defaults OFF (the deliberate inverse of liveTitleUpdates, #489)', () => {
+    delete process.env.CEZ_REVIEW_GATE;
+    expect(reviewGateEnabled({})).toBe(false);
+  });
+
+  it('the env default turns it on with exactly "1"', () => {
+    expect(reviewGateEnabled({}, { CEZ_REVIEW_GATE: '1' })).toBe(true);
+    expect(reviewGateEnabled({}, { CEZ_REVIEW_GATE: '0' })).toBe(false);
+    // Malformed truthy strings are OFF — only '1' enables.
+    expect(reviewGateEnabled({}, { CEZ_REVIEW_GATE: 'true' })).toBe(false);
+    expect(reviewGateEnabled({}, { CEZ_REVIEW_GATE: 'yes' })).toBe(false);
+    expect(reviewGateEnabled({}, {})).toBe(false);
+  });
+
+  it('the Settings toggle (config) wins over the env in both directions', () => {
+    expect(reviewGateEnabled({ reviewGate: true }, {})).toBe(true);
+    expect(reviewGateEnabled({ reviewGate: false }, { CEZ_REVIEW_GATE: '1' })).toBe(false);
+    expect(reviewGateEnabled({ reviewGate: true }, { CEZ_REVIEW_GATE: '0' })).toBe(true);
+  });
+});

--- a/src/runs/review-gate.ts
+++ b/src/runs/review-gate.ts
@@ -1,0 +1,22 @@
+/**
+ * Optional diff-first review gate (#489, spec `2026-07-18-optional-review-gate`).
+ *
+ * The review gate (spec 009) used to fire for EVERY successful run whose worktree
+ * held changes — parking it at `review` until a human accepts. This resolver makes
+ * that opt-in. It mirrors `liveTitleUpdatesEnabled` (`src/runs/auto-name.ts`) but
+ * with the OPPOSITE default: OFF unless explicitly turned on.
+ *
+ * Precedence: the `config.reviewGate` Settings toggle wins when set; otherwise the
+ * `CEZ_REVIEW_GATE` env decides — enabled ONLY by the exact string `'1'` (anything
+ * else, including `'true'`/`'yes'`/unset, is off); otherwise off.
+ *
+ * Autonomy is applied by the callers, not here: a run parks at `review` only when
+ * `worktreeHasDiff && reviewGateEnabled(config) && !run.autonomous`.
+ */
+export function reviewGateEnabled(
+  config: { reviewGate?: boolean },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (config.reviewGate !== undefined) return config.reviewGate;
+  return env.CEZ_REVIEW_GATE === '1';
+}

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -98,6 +98,29 @@ describe('RunStore — titleSummary + diffStat (#389)', () => {
     expect(reopened.getRun(defaulted.id)?.generateFollowups).toBeUndefined();
   });
 
+  it('round-trips the autonomous flag while omission stays compatible (#489)', () => {
+    const store = RunStore.open(dataDir);
+    const autonomous = store.createRun({
+      title: 'autonomous task',
+      workflow: 'quick-task',
+      task: 'autonomous task',
+      autonomous: true,
+      steps: [],
+    });
+    const interactive = store.createRun({
+      title: 'interactive task',
+      workflow: 'quick-task',
+      task: 'interactive task',
+      steps: [],
+    });
+    store.flush();
+
+    const reopened = RunStore.open(dataDir);
+    expect(reopened.getRun(autonomous.id)?.autonomous).toBe(true);
+    // Absent = falsy = "not autonomous" — old records and interactive runs alike.
+    expect(reopened.getRun(interactive.id)?.autonomous).toBeUndefined();
+  });
+
   it('updateRun fans the new fields out on the run channel (the SSE feed)', () => {
     const store = RunStore.open(dataDir);
     const run = store.createRun({ title: 't', workflow: 'w', task: 'task', steps: [] });

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -60,6 +60,12 @@ const runRecordSchema = z.object({
   /** Per-task follow-up inbox contract (spec 007, #444). Missing on old runs
    *  means enabled — the historical behavior. */
   generateFollowups: z.boolean().optional(),
+  /** Autonomous mode (#489): the run was started with the "autonomous" checkbox,
+   *  so it never parks at `waiting` (auto-nudge) and — once persisted here —
+   *  never parks at the terminal `review` gate either (`settleSuccess` + the
+   *  group-pick winner-park read it). Additive-safe: absent = falsy = not
+   *  autonomous. Set at creation from `WorkflowInput.autonomous`. */
+  autonomous: z.boolean().optional(),
   status: z.enum(['queued', 'running', 'waiting', 'review', 'done', 'failed', 'cancelled']),
   createdAt: z.string(),
   startedAt: z.string().optional(),
@@ -266,6 +272,7 @@ export class RunStore extends EventEmitter {
     model?: string;
     runner?: 'claude' | 'codex' | 'opencode';
     generateFollowups?: boolean;
+    autonomous?: boolean;
     groupId?: string;
     variant?: string;
     steps: Array<Pick<StepState, 'id' | 'name' | 'kind'>>;
@@ -278,6 +285,7 @@ export class RunStore extends EventEmitter {
       model: input.model,
       runner: input.runner,
       generateFollowups: input.generateFollowups,
+      autonomous: input.autonomous,
       groupId: input.groupId,
       variant: input.variant,
       status: 'queued',

--- a/src/server/config-api.test.ts
+++ b/src/server/config-api.test.ts
@@ -58,6 +58,7 @@ describe('the config API', () => {
       memoryLimitMb: null,
       worktreeRetention: 10,
       liveTitleUpdates: null,
+      reviewGate: null,
     });
   });
 
@@ -115,6 +116,7 @@ describe('the config API', () => {
       memoryLimitMb: null,
       worktreeRetention: 10,
       liveTitleUpdates: null,
+      reviewGate: null,
     });
   });
 
@@ -188,5 +190,49 @@ describe('liveTitleUpdates round-trip (task auto-naming spec)', () => {
     const cleared = (await (await put({ liveTitleUpdates: null })).json()) as Record<string, unknown>;
     expect(cleared.liveTitleUpdates).toBeNull();
     expect(rawFile().liveTitleUpdates).toBeUndefined();
+  });
+});
+
+describe('reviewGate round-trip (optional review gate, #489)', () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let app: Hono;
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-configapi-gate-'));
+    mkdirSync(join(repoRoot, '.ai/cezar'), { recursive: true });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    app = createApp({ repoRoot, store, manager: {} as RunManager, version: '0.0.0-test' });
+  });
+
+  afterEach(() => {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  const put = (body: unknown) =>
+    app.request('/api/config', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  const rawFile = () =>
+    JSON.parse(readFileSync(join(repoRoot, '.ai/cezar', 'config.json'), 'utf8')) as Record<string, unknown>;
+
+  it('GET exposes reviewGate; PUT true/false/null round-trips and clears the raw key', async () => {
+    // Default (no config key) is null — the CEZ_REVIEW_GATE env (OFF) decides.
+    expect(((await (await app.request('/api/config')).json()) as Record<string, unknown>).reviewGate).toBeNull();
+
+    const on = (await (await put({ reviewGate: true })).json()) as Record<string, unknown>;
+    expect(on.reviewGate).toBe(true);
+    expect(rawFile().reviewGate).toBe(true);
+
+    const off = (await (await put({ reviewGate: false })).json()) as Record<string, unknown>;
+    expect(off.reviewGate).toBe(false);
+    expect(rawFile().reviewGate).toBe(false);
+
+    const cleared = (await (await put({ reviewGate: null })).json()) as Record<string, unknown>;
+    expect(cleared.reviewGate).toBeNull();
+    expect(rawFile().reviewGate).toBeUndefined();
   });
 });

--- a/src/server/group-pick.test.ts
+++ b/src/server/group-pick.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RunStore, type RunRecord } from '../runs/store.js';
+import type { RunManager } from '../workflows/run.js';
+import { createApp } from './server.js';
+
+/**
+ * Group-pick winner-park under the optional review gate (#489). The
+ * `POST /api/groups/:groupId/pick` endpoint inlines the `settleSuccess`
+ * review-park rule; it must honor the same gate — flip the winner to `review`
+ * only when the gate is enabled AND the winner is not autonomous. Driven against
+ * a real fixture worktree with a genuine diff vs its base.
+ */
+function g(dir: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+}
+function initRepo(dir: string): void {
+  g(dir, 'init', '-b', 'main');
+  g(dir, 'config', 'user.email', 'test@cezar.local');
+  g(dir, 'config', 'user.name', 'cezar-test');
+  g(dir, 'config', 'commit.gpgsign', 'false');
+}
+
+describe('POST /api/groups/:groupId/pick — review gate', () => {
+  const savedGate = process.env.CEZ_REVIEW_GATE;
+  let repoRoot: string;
+  let worktree: string;
+  let store: RunStore;
+  let app: Hono;
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-pick-'));
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    app = createApp({
+      repoRoot,
+      store,
+      // The endpoint only asks the manager whether the winner is still active.
+      manager: { isActive: () => false, cancel: () => {} } as unknown as RunManager,
+      version: '0.0.0-test',
+    });
+    worktree = join(repoRoot, 'wt');
+    mkdirSync(worktree);
+    initRepo(worktree);
+    writeFileSync(join(worktree, 'base.txt'), 'base\n');
+    g(worktree, 'add', '-A');
+    g(worktree, 'commit', '-m', 'base');
+    g(worktree, 'checkout', '-b', 'task');
+  });
+
+  afterEach(() => {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+    if (savedGate === undefined) delete process.env.CEZ_REVIEW_GATE;
+    else process.env.CEZ_REVIEW_GATE = savedGate;
+  });
+
+  /** A finished (`done`) group winner whose worktree holds a real diff vs base. */
+  function winnerRun(autonomous?: boolean): RunRecord {
+    const run = store.createRun({ title: 't', workflow: 'w', task: 't', autonomous, steps: [] });
+    store.updateRun(run.id, {
+      groupId: 'g1',
+      variant: 'A',
+      status: 'done',
+      worktreePath: worktree,
+      baseBranch: 'main',
+      branch: 'task',
+    });
+    writeFileSync(join(worktree, 'base.txt'), 'base changed\n'); // uncommitted diff vs main
+    return store.getRun(run.id) as RunRecord;
+  }
+
+  const pick = (id: string) =>
+    app.request('/api/groups/g1/pick', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ runId: id }),
+    });
+
+  it('gate off (default): a changed winner stays done', async () => {
+    delete process.env.CEZ_REVIEW_GATE;
+    const winner = winnerRun();
+    const res = await pick(winner.id);
+    expect(res.status).toBe(200);
+    expect(store.getRun(winner.id)?.status).toBe('done');
+  });
+
+  it('gate on + non-autonomous: the changed winner flips to review', async () => {
+    process.env.CEZ_REVIEW_GATE = '1';
+    const winner = winnerRun();
+    await pick(winner.id);
+    expect(store.getRun(winner.id)?.status).toBe('review');
+  });
+
+  it('gate on + autonomous: the winner stays done (autonomous wins)', async () => {
+    process.env.CEZ_REVIEW_GATE = '1';
+    const winner = winnerRun(true);
+    await pick(winner.id);
+    expect(store.getRun(winner.id)?.status).toBe('done');
+  });
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -43,6 +43,7 @@ import {
   readWorktreePath,
 } from './git-changes.js';
 import { loadConfig, type CezConfig } from '../config.js';
+import { reviewGateEnabled } from '../runs/review-gate.js';
 import { readUiState, uiStatePath } from '../ui-state.js';
 import { resolveCapabilities } from './capabilities.js';
 import { resolveForge } from './forge/index.js';
@@ -648,8 +649,17 @@ export function createApp(deps: ServerDeps): Hono {
     }
 
     // Winner: a non-review terminal state with a non-empty diff flips to
-    // `review` (the settleSuccess rule); an empty diff (or no worktree) stays.
-    if (winner.status !== 'review' && winner.worktreePath && existsSync(winner.worktreePath)) {
+    // `review` (the settleSuccess rule) — but only when the review gate applies
+    // (#489): it is enabled (`reviewGateEnabled`, default off) AND the winner is
+    // not autonomous. An autonomous / gate-off winner keeps its `done` state with
+    // the diff left in the worktree; an empty diff (or no worktree) stays too.
+    if (
+      winner.status !== 'review' &&
+      winner.worktreePath &&
+      existsSync(winner.worktreePath) &&
+      winner.autonomous !== true &&
+      reviewGateEnabled(await loadConfig(repoRoot))
+    ) {
       const diff = await worktreeDiff(winner.worktreePath, winner.baseBranch ?? 'HEAD');
       if (diff.trim().length > 0 && !diff.startsWith('(diff failed')) {
         store.updateRun(winner.id, { status: 'review' });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1263,6 +1263,9 @@ export function createApp(deps: ServerDeps): Hono {
     // Live title updates (task auto-naming spec): tri-state — null means "no
     // config key, the CEZ_TITLE_UPDATES env default (ON) decides".
     liveTitleUpdates: config.liveTitleUpdates ?? null,
+    // Optional review gate (#489): tri-state — null means "no config key, the
+    // CEZ_REVIEW_GATE env default (OFF) decides".
+    reviewGate: config.reviewGate ?? null,
   });
   app.get('/api/config', async (c) => c.json(configAnswer(await loadConfig(repoRoot))));
 
@@ -1295,6 +1298,9 @@ export function createApp(deps: ServerDeps): Hono {
     // Live title updates toggle (Settings → Agents): null clears the key back
     // to the env-default behavior.
     liveTitleUpdates: z.boolean().nullable().optional(),
+    // Optional review gate toggle (Settings → Agents, #489): null clears the key
+    // back to the env-default behavior (OFF).
+    reviewGate: z.boolean().nullable().optional(),
   });
   app.put('/api/config', async (c) => {
     const parsed = setConfigSchema.safeParse(await c.req.json().catch(() => null));
@@ -1332,6 +1338,10 @@ export function createApp(deps: ServerDeps): Hono {
     if (parsed.data.liveTitleUpdates !== undefined) {
       if (parsed.data.liveTitleUpdates === null) delete raw.liveTitleUpdates;
       else raw.liveTitleUpdates = parsed.data.liveTitleUpdates;
+    }
+    if (parsed.data.reviewGate !== undefined) {
+      if (parsed.data.reviewGate === null) delete raw.reviewGate;
+      else raw.reviewGate = parsed.data.reviewGate;
     }
     if (parsed.data.memoryLimitMb !== undefined) {
       // null or 0 both mean "no ceiling" — drop the key back to the default.

--- a/src/workflows/recover-autonomous.test.ts
+++ b/src/workflows/recover-autonomous.test.ts
@@ -1,0 +1,79 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RunStore } from '../runs/store.js';
+import { RunManager } from './run.js';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+
+/**
+ * Restart recovery vs the autonomous flag (#489). `recover()` re-queues a
+ * `queued` run by rebuilding its StartRunInput from the persisted record — the
+ * one engine path that does NOT go through `startRun`. It must re-thread
+ * `autonomous` (H2 in the spec) so a recovered autonomous run stays autonomous.
+ *
+ * The review-gate outcome after recovery is driven by the *record's* persisted
+ * `autonomous` (which `settleSuccess`/group-pick read and which recover never
+ * overwrites); this test pins that invariant. `maxParallel: 0` keeps the queue
+ * from dispatching, so nothing spawns.
+ */
+describe('recover() and the autonomous flag (#489)', () => {
+  let repoRoot: string;
+  let store: RunStore;
+
+  beforeEach(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-recover-auto-'));
+    mkdirSync(join(repoRoot, '.ai/cezar'), { recursive: true });
+    writeFileSync(join(repoRoot, '.ai/cezar', 'config.json'), JSON.stringify({ maxParallel: 0 }), 'utf8');
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+  });
+
+  afterEach(() => {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  const WORKFLOW_DEF = {
+    name: 'quick-task',
+    description: 'x',
+    source: 'built-in',
+    steps: [{ id: 'work', name: 'Work', prompt: '{{task}}' }],
+  };
+
+  const queuedRun = (autonomous: boolean): string => {
+    const { id } = store.createRun({
+      title: 't',
+      workflow: 'quick-task',
+      task: 'do it',
+      autonomous,
+      steps: [{ id: 'work', name: 'Work', kind: 'agent' }],
+    });
+    store.updateRun(id, { workflowDef: WORKFLOW_DEF as unknown as Record<string, unknown> });
+    return id;
+  };
+
+  it('keeps a recovered queued run autonomous (the invariant settleSuccess reads)', async () => {
+    const id = queuedRun(true);
+    expect(store.getRun(id)?.autonomous).toBe(true);
+
+    await new RunManager(store, repoRoot).recover();
+
+    // Still recovered (queued), still autonomous — so a later settleSuccess lands it at `done`.
+    expect(store.getRun(id)?.status).toBe('queued');
+    expect(store.getRun(id)?.autonomous).toBe(true);
+  });
+
+  it('leaves a non-autonomous recovered run non-autonomous', async () => {
+    const id = queuedRun(false);
+    await new RunManager(store, repoRoot).recover();
+    expect(store.getRun(id)?.autonomous).toBe(false);
+  });
+});

--- a/src/workflows/run.test.ts
+++ b/src/workflows/run.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createWorktree } from '../git-worktree.js';
 import { RunStore, type RunRecord } from '../runs/store.js';
 import { RunManager } from './run.js';
@@ -97,6 +97,95 @@ describe('RunManager.recordTurnEnd', () => {
 
   it('is a quiet no-op for an unknown run', async () => {
     await expect(manager.recordTurnEnd('nope', TURN_TEXT)).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * Optional review gate (#489, spec 2026-07-18-optional-review-gate): the
+ * terminal `settleSuccess` transition parks a changed run at `review` ONLY when
+ * the gate is enabled (config toggle over `CEZ_REVIEW_GATE`, default off) and the
+ * run is not autonomous. Driven directly through the private `settleSuccess`
+ * (the same method `execute`, `runContinuation`, and `recover`'s waiting-run path
+ * all call) against a real fixture worktree.
+ */
+describe('RunManager.settleSuccess — optional review gate', () => {
+  const savedGate = process.env.CEZ_REVIEW_GATE;
+  const savedAutoname = process.env.CEZ_AUTONAME;
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: RunManager;
+
+  beforeAll(async () => {
+    process.env.CEZ_AUTONAME = '0';
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-reviewgate-'));
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\ntwo\nthree\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot);
+  });
+
+  afterAll(() => {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+    if (savedGate === undefined) delete process.env.CEZ_REVIEW_GATE;
+    else process.env.CEZ_REVIEW_GATE = savedGate;
+    if (savedAutoname === undefined) delete process.env.CEZ_AUTONAME;
+    else process.env.CEZ_AUTONAME = savedAutoname;
+  });
+
+  afterEach(() => {
+    delete process.env.CEZ_REVIEW_GATE;
+    // Reset the config file each test so config.reviewGate never leaks across cases.
+    rmSync(join(repoRoot, '.ai/cezar', 'config.json'), { force: true });
+  });
+
+  /** A fresh run + worktree holding a real diff (edit + new file) vs main. */
+  async function changedRun(autonomous?: boolean): Promise<RunRecord> {
+    const record = store.createRun({ title: 't', workflow: 'w', task: 'task', autonomous, steps: [] });
+    const wt = await createWorktree(repoRoot, record.id, 'main');
+    store.updateRun(record.id, { worktreePath: wt.path, branch: wt.branch, baseBranch: wt.baseBranch });
+    writeFileSync(join(wt.path, 'a.txt'), 'one\nTWO\nthree\n');
+    writeFileSync(join(wt.path, 'new.txt'), 'x\n');
+    return store.getRun(record.id) as RunRecord;
+  }
+
+  /** A fresh run + worktree with no changes vs main (empty diff). */
+  async function cleanRun(): Promise<RunRecord> {
+    const record = store.createRun({ title: 't', workflow: 'w', task: 'task', steps: [] });
+    const wt = await createWorktree(repoRoot, record.id, 'main');
+    store.updateRun(record.id, { worktreePath: wt.path, branch: wt.branch, baseBranch: wt.baseBranch });
+    return store.getRun(record.id) as RunRecord;
+  }
+
+  const settle = (id: string) => (manager as unknown as { settleSuccess(id: string): Promise<void> }).settleSuccess(id);
+
+  it('gate off (default) + changes → done, diff left in the worktree', async () => {
+    const record = await changedRun();
+    await settle(record.id);
+    expect(store.getRun(record.id)?.status).toBe('done');
+  });
+
+  it('gate on (env) + non-autonomous + changes → review', async () => {
+    process.env.CEZ_REVIEW_GATE = '1';
+    const record = await changedRun();
+    await settle(record.id);
+    expect(store.getRun(record.id)?.status).toBe('review');
+  });
+
+  it('gate on + autonomous + changes → done (autonomous wins — the #489 fix)', async () => {
+    process.env.CEZ_REVIEW_GATE = '1';
+    const record = await changedRun(true);
+    await settle(record.id);
+    expect(store.getRun(record.id)?.status).toBe('done');
+  });
+
+  it('gate on + no changes → done (the diff check stays first)', async () => {
+    process.env.CEZ_REVIEW_GATE = '1';
+    const record = await cleanRun();
+    await settle(record.id);
+    expect(store.getRun(record.id)?.status).toBe('done');
   });
 });
 

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -26,6 +26,7 @@ import type { RunRecord, RunStore } from '../runs/store.js';
 import { reclaimWorktrees, rematerializeReclaimedWorktree } from '../runs/retention.js';
 import { extractTaskRefs, refineTaskRefs, titleRefNumber } from '../runs/task-refs.js';
 import { autoNamingActive, generateRunName, liveTitleUpdatesEnabled } from '../runs/auto-name.js';
+import { reviewGateEnabled } from '../runs/review-gate.js';
 import { UiEventSink } from '../runs/ui-event-sink.js';
 import { chainStepNote, DEFAULT_ALLOWED_TOOLS, stepKind, type WorkflowDef, type WorkflowStepDef } from './types.js';
 
@@ -265,6 +266,11 @@ export class RunManager {
       // at the HTTP route because `cezar run`, the inbox's own "▶ Run" and variants all reach
       // startRun directly — a route-level gate would leave those writing todos.json.
       generateFollowups: followupsEnabled() ? input.generateFollowups : false,
+      // Persist autonomy on the record (#489) so the terminal review gate
+      // (`settleSuccess`) and the group-pick winner-park can honor it — mid-run
+      // auto-nudge reads `input.autonomous` (`execute`), but the record is the
+      // only source those after-the-fact consumers have.
+      autonomous: input.autonomous === true,
       groupId: group?.groupId,
       variant: group?.variant,
       steps: workflow.steps.map((s) => ({ id: s.id, name: s.name ?? s.id, kind: stepKind(s) })),
@@ -390,6 +396,11 @@ export class RunManager {
               model: run.model,
               runner: run.runner,
               generateFollowups,
+              // Re-thread autonomy (#489): the rebuilt input feeds `execute`,
+              // whose mid-run auto-nudge reads `input.autonomous`. Without this a
+              // recovered queued autonomous run would run non-autonomously (no
+              // auto-nudge) and later wrongly park at `review`.
+              autonomous: run.autonomous,
             },
           });
           this.queue.push(run.id);
@@ -1402,13 +1413,20 @@ export class RunManager {
    * at `review` instead of `done` — the user inspects the diff first, then
    * sends feedback back, opens a draft PR, or just finishes. Failed/cancelled
    * runs never enter review; no worktree or an empty diff means plain `done`.
+   *
+   * The gate is opt-in (#489): the review park happens only when it is enabled
+   * (`reviewGateEnabled` — config toggle over the `CEZ_REVIEW_GATE` env, default
+   * OFF) AND the run is not autonomous. Autonomous runs — and runs with the gate
+   * off — settle straight to `done`, leaving the diff in the worktree untouched.
    */
   private async settleSuccess(runId: string): Promise<void> {
     const run = this.store.getRun(runId);
     let review = false;
     if (run?.worktreePath && existsSync(run.worktreePath)) {
       const diff = await worktreeDiff(run.worktreePath, run.baseBranch ?? 'HEAD');
-      review = diff.trim().length > 0 && !diff.startsWith('(diff failed');
+      const hasDiff = diff.trim().length > 0 && !diff.startsWith('(diff failed');
+      const config = await loadConfig(this.repoRoot);
+      review = hasDiff && reviewGateEnabled(config) && run.autonomous !== true;
     }
     this.store.updateRun(runId, {
       status: review ? 'review' : 'done',

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -581,6 +581,9 @@ export interface ConfigResponse {
   /** Live title updates (task auto-naming): null = no config key, the
    *  CEZ_TITLE_UPDATES env default (ON) decides. */
   liveTitleUpdates: boolean | null
+  /** Optional review gate (#489): null = no config key, the CEZ_REVIEW_GATE env
+   *  default (OFF) decides. */
+  reviewGate: boolean | null
 }
 
 /** `PUT /api/config` (Settings → Agents; the Repo tab's base-branch picker). `baseBranch: null`
@@ -600,6 +603,8 @@ export interface SetConfigInput {
   worktreeRetention?: number | null
   /** null clears the key back to the env-default behavior. */
   liveTitleUpdates?: boolean | null
+  /** null clears the key back to the env-default behavior (OFF). */
+  reviewGate?: boolean | null
 }
 
 /** The PUT answer: the same shape GET serves (the pre-R6 fields stayed, the rest is additive). */

--- a/web/app/src/routes/settings/agents-section.test.tsx
+++ b/web/app/src/routes/settings/agents-section.test.tsx
@@ -41,6 +41,7 @@ function serve({
     memoryLimitMb: null,
     worktreeRetention: 10,
     liveTitleUpdates: null,
+    reviewGate: null,
     ...config,
   }
   const json = (payload: unknown, status = 200) =>
@@ -63,6 +64,9 @@ function serve({
         }
         if (body?.liveTitleUpdates !== undefined) {
           state.liveTitleUpdates = body.liveTitleUpdates as boolean | null
+        }
+        if (body?.reviewGate !== undefined) {
+          state.reviewGate = body.reviewGate as boolean | null
         }
         if (body?.defaultModels !== undefined) {
           for (const [runner, model] of Object.entries(body.defaultModels as Record<string, string | null>)) {
@@ -133,6 +137,19 @@ describe('the agents form', () => {
     await waitFor(() => expect(puts()).toHaveLength(1))
     expect(puts()[0]?.body).toEqual({ liveTitleUpdates: false })
     await waitFor(() => expect(screen.getByText('Off')).toBeTruthy())
+  })
+
+  it('review gate: the switch defaults OFF and PUTs the toggle (#489)', async () => {
+    serve()
+    renderAt('/settings/agents')
+    await waitFor(() => expect(form()).not.toBeNull())
+
+    const toggle = screen.getByLabelText('Review changes before finishing')
+    // Default off — the mirror image of live-title-updates.
+    expect(toggle.getAttribute('aria-checked') ?? toggle.getAttribute('data-state')).toMatch(/false|unchecked/)
+    fireEvent.click(toggle)
+    await waitFor(() => expect(puts()).toHaveLength(1))
+    expect(puts()[0]?.body).toEqual({ reviewGate: true })
   })
 
   it('default runner round-trips: click PUTs the patch and the control follows the answer', async () => {

--- a/web/app/src/routes/settings/agents-section.tsx
+++ b/web/app/src/routes/settings/agents-section.tsx
@@ -222,6 +222,30 @@ function AgentsForm({ config }: { config: ConfigResponse }) {
       </Field>
 
       <Field
+        title="Review changes before finishing"
+        hint="When on, a task with changes pauses so you can Accept, Send back, or open a Draft PR. Autonomous tasks always skip this and finish on their own. Default: off — tasks finish without asking."
+      >
+        <label className="flex w-fit items-center gap-3">
+          <Switch
+            aria-label="Review changes before finishing"
+            data-slot="agents-review-gate"
+            checked={config.reviewGate ?? false}
+            disabled={save.isPending}
+            onCheckedChange={(checked) =>
+              save.mutate(
+                { reviewGate: checked },
+                { onSuccess: () => toast(checked ? 'Review gate on' : 'Review gate off') },
+              )
+            }
+          />
+          <span className="text-[13px] text-muted-foreground">
+            {(config.reviewGate ?? false) ? 'On' : 'Off'}
+            {config.reviewGate === null && ' (default)'}
+          </span>
+        </label>
+      </Field>
+
+      <Field
         title="Base branch"
         hint="New task worktrees branch from this and draft PRs target it. Also settable from the Git view."
       >

--- a/web/app/src/routes/settings/resources-section.test.tsx
+++ b/web/app/src/routes/settings/resources-section.test.tsx
@@ -28,6 +28,7 @@ function serve(config: Partial<ConfigResponse> = {}) {
     memoryLimitMb: null,
     worktreeRetention: 10,
     liveTitleUpdates: null,
+    reviewGate: null,
     ...config,
   }
   const json = (payload: unknown, status = 200) =>


### PR DESCRIPTION
Closes #489
Tracking plan: .ai/runs/2026-07-18-optional-review-gate.md
Source doc: .ai/specs/2026-07-18-optional-review-gate.md
Status: in-progress

## Goal
- Make the diff-first review gate (spec 009) opt-in: OFF by default, enabled by `CEZ_REVIEW_GATE=1` (overridable by a `reviewGate` Settings toggle), and **always skipped for autonomous runs** — the #489 fix.

## Design
- Spec: `.ai/specs/2026-07-18-optional-review-gate.md` — merged to `main` via design PR #493; this PR implements it.

## What Changed
- Phase 1 — Engine + persistence: persist `autonomous` on the run record; new `reviewGateEnabled` resolver (default off); gate `settleSuccess` + `recover()` + group-pick winner-park.
- Phase 2 — Config surface: `reviewGate` config key, GET/PUT `/api/config`, client types, Settings → Agents Switch.
- Phase 3 — Docs: document `CEZ_REVIEW_GATE`.

## Tests
- Unit: `reviewGateEnabled` precedence matrix; config schema parse.
- Engine (`CEZ_DRY_RUN`): the four `settleSuccess` outcomes; recovered autonomous run; group-pick winner.
- API: `/api/config` GET/PUT round-trip. UI: Settings Switch.

## Breaking Changes
- Behavior change (default flip): the review pause is now off by default; users who relied on it re-enable it via the Settings toggle. No protected code contract touched (additive `reviewGate` + `autonomous` keys). Called out for the CHANGELOG.

## Progress
See the Progress section in the tracking plan.
