### PR TITLE
fix(runs): adopt the created PR URL, not one referenced earlier (#495)

### DIFF
--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -167,6 +167,27 @@ describe('RunStore — PR auto-link only on real creation (#fake-pr)', () => {
     });
     expect(store.getRun(run.id)?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/9');
   });
+
+  it('adopts the CREATED PR, not one referenced earlier in the same event (#495)', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'Read the linked PR https://github.com/open-mercato/cezar/pull/1 for context, then ' +
+        'opened a draft pull request: https://github.com/open-mercato/cezar/pull/500',
+    } as never);
+    // The first URL in the text is the referenced one — the created URL wins.
+    expect(store.getRun(run.id)?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/500');
+  });
+
+  it('falls back to the URL before the phrase when gh prints it first', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'https://github.com/open-mercato/cezar/pull/321\nDraft pull request created.',
+    } as never);
+    expect(store.getRun(run.id)?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/321');
+  });
 });
 
 describe('RunStore — referenced-PR discovery (#407, spec 2026-07-16-pr-autodiscovery)', () => {

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -193,6 +193,26 @@ function resolveReferencedPr(candidates: string[], task: string): string | undef
 }
 
 /**
+ * The PR URL a creation phrase *introduces*, or undefined. The created URL is
+ * the first one at or after the `CREATED_PR_RE` phrase — a PR the same event
+ * merely referenced *earlier* (e.g. the issue's own linked `…/pull/1`) must not
+ * be mistaken for the one just created (#495). Falls back to the last URL
+ * *before* the phrase for `gh` orderings that print the URL first. Selection
+ * only — the caller decides whether creation phrasing is present.
+ */
+function createdPrUrl(haystack: string): string | undefined {
+  const phrase = CREATED_PR_RE.exec(haystack);
+  if (!phrase) return undefined;
+  const after = PR_URL_RE.exec(haystack.slice(phrase.index));
+  if (after) return after[0];
+  let before: string | undefined;
+  for (const m of haystack.slice(0, phrase.index).matchAll(new RegExp(PR_URL_RE.source, 'g'))) {
+    before = m[0];
+  }
+  return before;
+}
+
+/**
  * File-backed run store: `runs.json` index (atomic tmp+rename writes, the
  * pattern from @cezar/core's IssueStore) plus one append-only NDJSON event
  * file per run. Also the in-process event bus the SSE endpoints subscribe to:
@@ -367,10 +387,10 @@ export class RunStore extends EventEmitter {
     if (!run.pullRequestUrl) {
       const haystack = eventTextFragments(full).join(' ');
       if (haystack.length > 0) {
-        const match = PR_URL_RE.exec(haystack);
-        if (match && CREATED_PR_RE.test(haystack)) {
-          this.updateRun(runId, { pullRequestUrl: match[0] });
-        } else if (match && this.trackReferencedPrs(run, haystack)) {
+        const created = createdPrUrl(haystack);
+        if (created) {
+          this.updateRun(runId, { pullRequestUrl: created });
+        } else if (PR_URL_RE.test(haystack) && this.trackReferencedPrs(run, haystack)) {
           this.touch(run);
         }
       }


### PR DESCRIPTION
Fixes #495

## Problem
When a workflow's agent creates a **new** PR (rather than reviewing an existing one), the run sometimes gets mis-associated with the wrong PR — the "PR#1" chip in the screenshot. Because adoption is guarded by `if (!run.pullRequestUrl)`, the wrong value sticks permanently.

## Root Cause
`RunStore.appendEvent` in `src/runs/store.ts` joined all of an event's text fragments and adopted the **first** GitHub PR URL found *anywhere* as `pullRequestUrl` whenever creation phrasing (`CREATED_PR_RE`) appeared *anywhere* in that same text. There was no correlation between the creation phrase's position and which URL was adopted, so when one event contained both a reference to another PR (earlier — e.g. the issue's linked `…/pull/1`) and the real created-PR URL (after the "opened a draft PR:" / `gh pr create` phrase), the earlier wrong URL won.

## What Changed
- Added a position-anchored `createdPrUrl(haystack)` helper that returns the first PR URL **at or after** the `CREATED_PR_RE` phrase — the URL the creation phrase introduces — falling back to the last URL *before* the phrase for `gh` orderings that print the URL first.
- Rewired `appendEvent`'s adoption block to use it; the referenced-tier fallback (`trackReferencedPrs`) is preserved unchanged. Regexes and the `pullRequestUrl` schema are untouched.

## Tests
- `src/runs/store.test.ts`: regression test — a referenced `…/pull/1` before an "opened a draft pull request: …/pull/500" phrase now adopts `pull/500` (verified: FAILS on `origin/main`, passes with the fix).
- `src/runs/store.test.ts`: fallback test — `gh` printing the URL before a "pull request created" phrase still adopts it.
- Full validation gate passed in order: typecheck (server+web), `npm test` (2428/2428), `test:unit` (9/9), `build` + `check:pack`, `test:package` (1/1).

## Breaking Changes
None. No `RunRecord` schema field added or changed (BACKWARD_COMPATIBILITY.md §3 respected); `pullRequestUrl` semantics unchanged — only which co-occurring URL is selected.

🤖 Generated by autofix.