### PR TITLE
feat(cockpit): 'monitoring' run activity — stop false Needs attention while agent is still working (#490)

### DIFF
--- a/.ai/runs/2026-07-18-subagent-monitoring-status.md
+++ b/.ai/runs/2026-07-18-subagent-monitoring-status.md
@@ -59,8 +59,8 @@ PR: #497
 
 ### Phase 2: UI surfacing
 
-- [ ] 2.1 Widen `AttentionInput` to include `activity`; add `deriveAttention` monitoring branch + `attention.test.ts`
-- [ ] 2.2 Surface/suppression tests: run-header pill, task-thread no paused-hint, notifications no-notify, stays in Working
+- [x] 2.1 Widen `AttentionInput` to include `activity`; add `deriveAttention` monitoring branch + `attention.test.ts` — 6b286e3
+- [x] 2.2 Surface/suppression tests: run-header pill, task-thread no paused-hint, notifications no-notify, stays in Working — 6b286e3
 
 ### Phase 3: Polish & docs
 

--- a/.ai/runs/2026-07-18-subagent-monitoring-status.md
+++ b/.ai/runs/2026-07-18-subagent-monitoring-status.md
@@ -64,4 +64,4 @@ PR: #497
 
 ### Phase 3: Polish & docs
 
-- [ ] 3.1 Strip `CEZ:MONITORING` from displayed transcript + heartbeat wording; document the marker beside `CEZ:DONE` (AGENTS.md / AGENT_PROTOCOL.md) + test
+- [x] 3.1 Strip `CEZ:MONITORING` from displayed transcript + heartbeat wording; document the marker beside `CEZ:DONE` (AGENTS.md / AGENT_PROTOCOL.md) + test — 1ce1639

--- a/.ai/runs/2026-07-18-subagent-monitoring-status.md
+++ b/.ai/runs/2026-07-18-subagent-monitoring-status.md
@@ -46,16 +46,16 @@ shows as a non-attention "monitoring" label.
 
 ## Progress
 
-PR: (pending)
+PR: #497
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Agent contract + server detection
 
-- [ ] 1.1 Add `MONITORING_MARKER_RE` + `stripMonitoringMarker` in `run.ts` (mirror DONE) + tests
-- [ ] 1.2 Add the `CEZ:MONITORING` rule to `HANDOFF_ONLY_INSTRUCTIONS` (`handoff.ts`) + system-prompt test
-- [ ] 1.3 Add `RunActivity`/`activity?` to `store.ts` (+ zod) and mirror in web `api/types.ts` + schema test
-- [ ] 1.4 Turn-end branch at both sites (runAgentStep, runContinuation); keep waiting-parity lifecycle; clear `activity` on resume/terminal + tests
+- [x] 1.1 Add `MONITORING_MARKER_RE` + `stripMonitoringMarker` in `run.ts` (mirror DONE) + tests — ddaff57
+- [x] 1.2 Add the `CEZ:MONITORING` rule to `HANDOFF_ONLY_INSTRUCTIONS` (`handoff.ts`) + system-prompt test — ddaff57
+- [x] 1.3 Add `RunActivity`/`activity?` to `store.ts` (+ zod) and mirror in web `api/types.ts` + schema test — ddaff57
+- [x] 1.4 Turn-end branch at both sites (runAgentStep, runContinuation); keep waiting-parity lifecycle; clear `activity` on resume/terminal + tests — ddaff57
 
 ### Phase 2: UI surfacing
 

--- a/.ai/runs/2026-07-18-subagent-monitoring-status.md
+++ b/.ai/runs/2026-07-18-subagent-monitoring-status.md
@@ -1,0 +1,67 @@
+# Execution plan: monitoring run activity (FR #490)
+
+Date: 2026-07-18
+Slug: subagent-monitoring-status
+Branch: cez/467bfd0a
+Source doc: .ai/specs/2026-07-18-subagent-monitoring-status.md
+
+> The Progress phases below mirror the spec's Implementation Plan (Phases → Steps).
+
+## Overview
+
+### Goal
+
+Stop the cockpit from raising "Needs attention" / "The agent is paused, waiting for
+your reply" when the agent ended its turn still working on its own downstream work
+(a sub-agent or a monitored command), not on the user. The agent declares that state
+with a new `CEZ:MONITORING` turn-end marker (sibling of `CEZ:DONE`); cezar maps it to
+`status: running` + a new optional `activity: 'monitoring'` sub-state, which the UI
+shows as a non-attention "monitoring" label.
+
+### Scope
+
+- `src/handoff.ts` — one agent-contract line introducing `CEZ:MONITORING`.
+- `src/workflows/run.ts` — marker regex + strip helper; turn-end branch at both sites;
+  `activity` clears on resume/terminal.
+- `src/runs/store.ts` + `web/app/src/api/types.ts` — optional `activity?: 'monitoring'`
+  field.
+- `web/app/src/lib/attention.ts` — widen `AttentionInput`, add the monitoring branch.
+- Tests across server + web; transcript marker-stripping; agent-contract docs.
+
+### Non-goals
+
+- No new `RunStatus` enum value (activity is a sub-state of `running`).
+- No inference from tool events (rejected — see spec "Why detection cannot be inferred").
+- No escalation timer to "needs you" (FR Q3); the existing 15-min idle timer is kept
+  unchanged for liveness/slot reclaim.
+- No new `CEZ_*` env var; `.env.example` untouched.
+
+## Risks
+
+- Marker reliance has the same reliability profile as `CEZ:DONE` (model-followed) with
+  graceful fallback to `waiting` — no regression when absent.
+- `activity` must be clearable via `updateRun` (writing `undefined`); verify the store's
+  merge semantics during Step 3.
+- Widening `AttentionInput` touches every call site that builds it — must pass `activity`.
+
+## Progress
+
+PR: (pending)
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Agent contract + server detection
+
+- [ ] 1.1 Add `MONITORING_MARKER_RE` + `stripMonitoringMarker` in `run.ts` (mirror DONE) + tests
+- [ ] 1.2 Add the `CEZ:MONITORING` rule to `HANDOFF_ONLY_INSTRUCTIONS` (`handoff.ts`) + system-prompt test
+- [ ] 1.3 Add `RunActivity`/`activity?` to `store.ts` (+ zod) and mirror in web `api/types.ts` + schema test
+- [ ] 1.4 Turn-end branch at both sites (runAgentStep, runContinuation); keep waiting-parity lifecycle; clear `activity` on resume/terminal + tests
+
+### Phase 2: UI surfacing
+
+- [ ] 2.1 Widen `AttentionInput` to include `activity`; add `deriveAttention` monitoring branch + `attention.test.ts`
+- [ ] 2.2 Surface/suppression tests: run-header pill, task-thread no paused-hint, notifications no-notify, stays in Working
+
+### Phase 3: Polish & docs
+
+- [ ] 3.1 Strip `CEZ:MONITORING` from displayed transcript + heartbeat wording; document the marker beside `CEZ:DONE` (AGENTS.md / AGENT_PROTOCOL.md) + test

--- a/.ai/specs/2026-07-18-subagent-monitoring-status.md
+++ b/.ai/specs/2026-07-18-subagent-monitoring-status.md
@@ -1,0 +1,311 @@
+# A "monitoring" run activity — stop false "Needs attention" while the agent is still working
+
+> FR: #490 · Slug: `subagent-monitoring-status`
+
+## TLDR
+
+When a task's agent ends a turn while it is **still working on its own downstream
+work** — waiting on a sub-agent or a long-running command it is monitoring, not on
+the user — cezar parks the run at `waiting`, which the cockpit renders as **"Needs
+attention" / "The agent is paused, waiting for your reply."** That is a false
+positive. This spec lets the agent **declare** that state with a new turn-end
+marker, **`CEZ:MONITORING`** (a sibling of the existing `CEZ:DONE`), which cezar maps
+to the existing **`running`** status plus a new optional **`activity: 'monitoring'`**
+sub-state. The cockpit then shows a distinct, non-attention *monitoring* label and
+never fires the attention/notification path. A genuine hand-off to the user (no
+marker) still becomes `waiting` ("needs you"), exactly as today.
+
+## Problem Statement
+
+`src/workflows/run.ts` turn-end has one non-terminal outcome for an open interactive
+session: `status: 'waiting'`, on the assumption *"Turn over, session open: the ball
+is in the user's court"* (`run.ts:1204-1207`, and the sibling continuation site at
+`run.ts:785-791`). Every attention surface is derived from that status:
+
+- `deriveAttention()` (`web/app/src/lib/attention.ts:96`) maps `waiting` → amber
+  pulsing **"needs you"**;
+- `task-thread.tsx:219` shows **"The agent is paused, waiting for your reply"**;
+- `notifications.ts` fires a browser notification via `wantsAttention`.
+
+So whenever an agent ends a turn while its own work is still in flight, the whole
+"needs a human" pipeline lights up with nothing asked of the user (issue #490, *"the
+subagents are progressing ok and actually no user attention is needed but I got [the
+paused banner]"*, confirmed by the author).
+
+### Why detection cannot be inferred from tool events (rejected approach)
+
+An earlier design tried to *infer* the state server-side by watching for an open
+sub-agent (`Task`) tool-use at turn-end. Investigation of the actual runtime
+disproved it, and it is recorded here so it is not re-attempted:
+
+- **cezar models no background/async work at all** — there is zero handling of
+  `run_in_background`, background tasks, or completion-notifications anywhere in
+  `src/`. A turn ends when the backend emits its terminal message; cezar has no
+  signal for "ended but work still pending."
+- **Sub-agents are observed as synchronous.** The claude golden fixture
+  (`src/core/__fixtures__/claude/subagent-task.ndjson`), this feature's own run
+  transcript, and three large production run transcripts all show every `Task`
+  tool-use resolving (its `tool_result` arriving) **before** the turn's `result`
+  event. Across all sampled real runs, **no turn ever ended with an open sub-agent
+  tool-use** — so an "open-tool-at-turn-end" signal would never fire.
+- **`Task`/`Agent` isn't even in the default tool allowlist**
+  (`DEFAULT_ALLOWED_TOOLS`, `types.ts:176`), and codex/opencode expose no
+  comparable background lifecycle.
+
+The information that separates "still working" from "needs you" is **not present in
+the event stream** — but the *agent itself* knows which one it is (it chose to end
+the turn). So the agent should declare it, the same way it already declares
+completion with `CEZ:DONE`.
+
+## Proposed Solution
+
+Mirror cezar's existing agent-contract marker mechanism:
+
+1. **Agent contract** — extend the injected handoff instructions
+   (`HANDOFF_ONLY_INSTRUCTIONS`, `src/handoff.ts:139`, which every backend receives)
+   with one rule: *if you end a turn still working on your own downstream work (a
+   sub-agent or a command you're monitoring) and are NOT waiting on the user, end
+   your final message with a line containing exactly `CEZ:MONITORING`.*
+2. **Server detection** — at both turn-end sites, after the `CEZ:DONE` check, test
+   the accumulated turn text for `CEZ:MONITORING`. When present (and the session is
+   open and the turn wasn't auto-continued), set `status: 'running', activity:
+   'monitoring'` instead of `waiting` — but otherwise treat the run **identically to
+   a waiting run** (same slot release, same idle-liveness timer, same resume path).
+3. **UI** — because the status stays `running` (already outside the attention path),
+   the only additive UI change is `deriveAttention()` returning the label
+   **"monitoring"** when `activity === 'monitoring'`. No notification, no "paused"
+   hint, stays in the *Working* group — all inherited.
+
+**Why a marker (agent-declared) beats inference.** It is **backend-agnostic** (the
+contract is injected for claude, codex, and opencode alike → satisfies FR Q4 "work
+for all agents"), **reliable and observable** (turn text is always present; detection
+runs on the *accumulated* text so delta-streaming backends can't split the marker —
+the same guarantee `CEZ:DONE` relies on), and **idiomatic** (it reuses the existing
+`CEZ:DONE` pattern rather than inventing a parallel mechanism). Agents that don't emit
+the marker degrade gracefully to today's `waiting` behavior.
+
+**Why `activity` and not a new `RunStatus`** (per FR Q1: *"it should be a state of
+running"*). A new top-level status would thread through ~a dozen status-enumeration
+guard sites (`store.ts` recover/interrupt guards, `run.ts` live-run enumerations,
+`task-groups` ordering, the `ALL_STATUSES` exhaustiveness test). Modelling it as an
+optional **sub-state of the existing `running` status** keeps the change to one
+optional field + one `deriveAttention` branch, and inherits correct non-attention
+behavior everywhere.
+
+## Research (how leaders distinguish "working" from "needs you")
+
+Separating *in-progress* from *action-required* is standard in job/agent dashboards
+(GitHub Actions splits "in progress" from manual-approval "waiting"; agent cockpits
+distinguish an actively-working agent from one that asked the operator a question).
+The rule they get right — *an agent blocked on its own downstream work is not blocked
+on you* — is exactly this split. The novel constraint here is that cezar can't
+observe that distinction from the stream, so it adopts the same agent-declared
+sentinel it already uses for completion.
+
+## Architecture
+
+### Agent contract (`src/handoff.ts`)
+
+Add to `HANDOFF_ONLY_INSTRUCTIONS` (inherited by `HANDOFF_INSTRUCTIONS`), alongside
+the existing `CEZ:DONE` sentence, one rule introducing `CEZ:MONITORING`: emit it as
+the final line when ending a turn while still working on downstream work and not
+waiting on the user; never combine it with `CEZ:DONE`; a plain end (no marker) still
+means "genuinely waiting on the user." Because both `HANDOFF_ONLY_INSTRUCTIONS` and
+`HANDOFF_INSTRUCTIONS` are composed into the system prompt for every agent step
+(`composeSystemPrompt`, `run.ts:803` and `:1226`), all three backends receive it.
+
+### Detection (`src/workflows/run.ts`)
+
+Add, next to `DONE_MARKER_RE` (`run.ts:42`):
+
+```ts
+const MONITORING_MARKER_RE = /CEZ:MONITORING\s*$/;   // detected on accumulated turn text
+function stripMonitoringMarker(text: string): string { … }  // mirror stripDoneMarker
+```
+
+At **both** turn-end sites — `runAgentStep` (`~1188-1216`) and `runContinuation`
+(`~752-793`) — after the existing `done` branch and (in the continuation site) inside
+the `if (!autoContinued)` block, decide monitoring vs waiting:
+
+```
+const monitoring = sessionOpen && !done && MONITORING_MARKER_RE.test(turnText.trimEnd());
+if (monitoring) {
+  updateRun(runId, { status: 'running', activity: 'monitoring' });
+  updateStep(runId, step.id, { status: 'running' });
+} else {
+  updateRun(runId, { status: 'waiting' });          // unchanged
+  updateStep(runId, step.id, { status: 'waiting' });
+}
+// SHARED for both branches (unchanged from today's waiting path):
+this.waiting.add(runId);      // frees the concurrency slot (busy() subtracts waiting)
+this.armIdleTimer(runId, state);  // 15-min liveness reclaim — KEPT (see below)
+void this.pump();
+```
+
+`CEZ:DONE` keeps precedence (checked first). The two sites are **not identical** —
+only `runContinuation` has the autonomous-nudge escape hatch — so the branch is
+inserted into each with its local structure; the autonomous nudge still wins over
+monitoring (an autonomous run never parks).
+
+**Lifecycle parity (resolves the slot-leak risk).** A `monitoring` run is treated
+exactly like a `waiting` run for lifecycle: it is added to `this.waiting` (so it
+frees its slot), and it **keeps** `armIdleTimer`. Per FR Q3 there is no escalation
+*to "needs you"* — but the existing 15-minute idle timer still closes a truly-dead
+session and reclaims its slot, identically to a waiting run. Monitoring changes only
+the **surfaced status/attention**, never the liveness/slot accounting, so it can
+never leak a slot that `waiting` wouldn't.
+
+**Clearing `activity`.** `activity: 'monitoring'` is written only at the two turn-end
+sites. It is cleared (`activity: undefined`) wherever a run leaves that state:
+
+- `sendMessage` resume (`run.ts:601`) — already sets `status: 'running'`; also clears
+  `activity` (a user reply means the agent is actively working again);
+- `runContinuation` start (`run.ts:711`) and `recover()` (which resumes via
+  `continueRun`);
+- terminal transitions (`settleSuccess`/`finish`/cancel/fail, `run.ts:~1081`) and the
+  `waiting` branch above.
+
+Because `deriveAttention` gates the label on `status === 'running'`, a stale
+`activity` on a non-running record is visually harmless, but it is cleared for
+correctness so no finished record carries it.
+
+### Cross-backend behavior (FR Q4)
+
+The marker is agent-declared, so it works for **any** backend whose agent follows the
+injected contract — claude, codex, and opencode all receive it. Backends/agents that
+do not emit it fall back to `waiting`, exactly as today. This is strictly better than
+the rejected tool-inference approach, which only ever had a chance on claude. (Same
+reliability profile as `CEZ:DONE`: model-followed, gracefully degrading.)
+
+### Data model
+
+One optional field, additive and backward-compatible (old run files must still parse
+— the `store.ts` convention that new `RunRecord` fields are optional):
+
+```ts
+// src/runs/store.ts
+export type RunActivity = 'monitoring';
+// on RunRecord:  activity?: RunActivity;
+// zod:           activity: z.enum(['monitoring']).optional()
+```
+
+Mirrored in `web/app/src/api/types.ts` (`RunActivity` + `RunRecord.activity?`). No
+`StepStatus` change — steps stay `running`.
+
+### UI/UX
+
+- **`deriveAttention`** (`attention.ts`): widen its input from
+  `Pick<RunRecord,'status'>` to `Pick<RunRecord,'status'|'activity'>` (**required** —
+  the current `AttentionInput` doesn't carry `activity`; call sites that build it must
+  pass the field), and add, **before** the plain `running` branch:
+  `if (run.status === 'running' && run.activity === 'monitoring') return { bucket:
+  'running', tone: 'violet', pulse: true, label: 'monitoring' }`. Bucket `running` ⇒
+  `wantsAttention` is `false`.
+- **Sidebar dot / header pill** render `attention.{tone,pulse,label}` already, so the
+  pill shows **"monitoring"** automatically. Note (honesty): the sidebar *dot* is the
+  same violet-pulse as a running dot — only the label/pill text differs. This matches
+  FR Q1 ("a state of running"); a distinct dot tone is out of scope.
+- **"Paused, waiting for your reply" hint** (`task-thread.tsx:219`) keys on `status
+  === 'waiting'` — a monitoring run is `running`, so the hint and the "reply" composer
+  placeholder are already suppressed. Covered by a test.
+- **Bucketing** (`task-groups.ts`): `running` → *Working* already; unchanged.
+- **Notifications** (`notifications.ts`): gated on `wantsAttention` → a transition into
+  `monitoring` fires **no** notification. Covered by a test.
+- **Transcript hygiene**: strip a trailing `CEZ:MONITORING` from displayed text
+  wherever `stripDoneMarker` is applied, so the marker doesn't show in the thread.
+
+### Edge Cases & Failure Scenarios
+
+- **Agent emits `CEZ:MONITORING`, then the user replies anyway.** `sendMessage`
+  clears `activity` → back to plain `running`. Correct.
+- **Agent emits both markers.** `CEZ:DONE` wins (checked first) → run completes.
+- **Agent never emits the marker** (older agents, a backend ignoring the contract):
+  falls back to `waiting` — status quo, no regression.
+- **Monitoring run that never resumes.** The 15-minute idle timer closes the session
+  and reclaims the slot, exactly as for a waiting run. No escalation to "needs you"
+  (FR Q3), no slot leak.
+- **Cancel / fail while monitoring.** Terminal transitions clear `activity`.
+- **Delta-streaming backends** (codex/opencode) splitting the marker across text
+  events: detection runs on the *accumulated* `turnText`, so the marker is matched
+  whole — same guarantee `CEZ:DONE` documents (`run.ts:39-40`).
+
+### Risks & Impact Review
+
+- **Blast radius:** one optional persisted field, one marker regex + strip helper, one
+  agent-contract sentence, the two turn-end branches, the `activity` clears, and one
+  `deriveAttention` branch (+ widening its input type). No `RunStatus` enum change → no
+  status-guard/exhaustiveness churn.
+- **Backward compatibility:** additive optional field; old `runs.json`/NDJSON parse
+  unchanged (schema test). No public route/config change. No new `CEZ_*` env var (a
+  safe-by-default status refinement, not an exposure/cost-widening feature) →
+  `.env.example` untouched.
+- **Behavioral regression risk:** the only status-behavior change is at turn-end and
+  is *opt-in by the marker* — without the marker, behavior is byte-for-byte today's.
+  Guarded by a test asserting no-marker → `waiting`.
+- **Rollback:** revert the PR; agents stop being told about the marker, `activity`
+  stops being written, old records ignore it.
+
+## Phasing
+
+Each phase leaves the app working and is independently shippable.
+
+- **Phase 1 — contract + server detection:** marker regex/strip, agent-contract line,
+  the `activity` field, and the turn-end branch. After this, an agent that emits
+  `CEZ:MONITORING` parks as `running`/`monitoring` server-side instead of `waiting`.
+- **Phase 2 — UI surfacing:** `deriveAttention` label + tests proving no "paused"
+  hint, no notification, correct pill/bucket.
+- **Phase 3 — polish & docs:** transcript marker-stripping, heartbeat wording, and
+  documenting the new marker beside `CEZ:DONE` in the agent-contract docs.
+
+## Implementation Plan
+
+### Phase 1 — Agent contract + server detection
+
+1. **Marker + strip helpers.** In `src/workflows/run.ts` add `MONITORING_MARKER_RE =
+   /CEZ:MONITORING\s*$/` and `stripMonitoringMarker` (mirror `DONE_MARKER_RE` /
+   `stripDoneMarker`, `run.ts:42-48`).
+   *Test:* the regex matches only at end-of-text (accumulated), tolerant of trailing
+   whitespace; strip removes a trailing marker and leaves other text intact.
+2. **Agent-contract line.** Add the `CEZ:MONITORING` rule to
+   `HANDOFF_ONLY_INSTRUCTIONS` (`src/handoff.ts:139`).
+   *Test:* `system-prompt.test.ts` — the composed prompt contains `CEZ:MONITORING`
+   (both handoff variants).
+3. **`activity` field.** `src/runs/store.ts`: add `RunActivity = 'monitoring'`,
+   `RunRecord.activity?`, zod `activity: z.enum(['monitoring']).optional()`. Mirror in
+   `web/app/src/api/types.ts`. Ensure `updateRun` can clear it (write `undefined`).
+   *Test:* `runRecordSchema` parses a record without `activity` (back-compat) and with
+   `activity:'monitoring'`; rejects an unknown activity value.
+4. **Turn-end branch (both sites).** In `runAgentStep` (`~1204`) and `runContinuation`
+   (`~785`, inside `if (!autoContinued)`), choose `running`+`activity:'monitoring'` vs
+   `waiting` per `MONITORING_MARKER_RE`; keep `this.waiting.add`, `armIdleTimer`,
+   `pump` in both branches. Clear `activity` on `sendMessage` resume (`~601`),
+   continuation start (`~711`), and terminal transitions.
+   *Test:* a fake turn-text ending in `CEZ:MONITORING` → run becomes
+   `running`+`activity:'monitoring'`, is added to `this.waiting`, and arms the idle
+   timer; without the marker → `waiting`; `CEZ:DONE` still wins; a `sendMessage`
+   resume clears `activity`. (Use the existing run-test harness / dry-run mock, adding
+   a `mock:monitoring` trigger analogous to `mock:done`.)
+
+### Phase 2 — UI surfacing
+
+5. **`deriveAttention` branch + input widening.** Widen `AttentionInput` to include
+   `activity`; add the monitoring branch; update any call site that constructs the
+   input to pass `activity`.
+   *Test:* `attention.test.ts` — monitoring → `{bucket:'running', label:'monitoring'}`
+   and `wantsAttention === false`; plain running unchanged; the `ALL_STATUSES`
+   exhaustiveness set still passes (no new status).
+6. **Surface + suppression tests.** `run-header.test.tsx` (pill shows "monitoring"),
+   `task-thread.test.tsx` (a `running`+`monitoring` run shows **no** paused hint and an
+   enabled composer without the "reply" placeholder), `notifications.test.ts` (a
+   `running → monitoring` transition does not notify), a `task-groups`/quick-list test
+   (stays in *Working*).
+
+### Phase 3 — Polish & docs
+
+7. **Transcript hygiene + heartbeat + docs.** Apply `stripMonitoringMarker` wherever
+   `stripDoneMarker` is applied so the marker never shows in the thread; reflect
+   `monitoring` in the turn-end handoff-heartbeat message (`run.ts:793`, `:1215`).
+   Document `CEZ:MONITORING` beside `CEZ:DONE` in the agent-contract docs
+   (`AGENTS.md` and/or `AGENT_PROTOCOL.md` — wherever `CEZ:DONE` is described). No
+   `CEZ_*` env var, so `.env.example` is untouched.
+   *Test:* a text event ending in the marker is stripped in the emitted transcript.

--- a/scripts/mock-claude.mjs
+++ b/scripts/mock-claude.mjs
@@ -80,6 +80,9 @@ async function respond(userText, imageCount) {
   // `mock:done` anywhere in the message → the reply ends with the CEZ:DONE
   // completion marker (#347), so the auto-close path is testable dry.
   const doneMarker = userText.includes('mock:done') ? '\n\nCEZ:DONE' : '';
+  // `mock:monitoring` → the reply ends with CEZ:MONITORING, the "still working
+  // on downstream work" marker (#490), so the monitoring-status path is testable dry.
+  const monitoringMarker = userText.includes('mock:monitoring') ? '\n\nCEZ:MONITORING' : '';
 
   // `mock:slow` → hold the turn for ~25 s so queue states are observable.
   if (userText.includes('mock:slow')) await sleep(25_000);
@@ -250,7 +253,7 @@ async function respond(userText, imageCount) {
       type: 'assistant',
       message: {
         role: 'assistant',
-        content: [{ type: 'text', text: `Done with the first pass — opened a draft PR: https://github.com/open-mercato/demo/pull/123. Anything to adjust? (dry-run mock)${doneMarker}` }],
+        content: [{ type: 'text', text: `Done with the first pass — opened a draft PR: https://github.com/open-mercato/demo/pull/123. Anything to adjust? (dry-run mock)${doneMarker}${monitoringMarker}` }],
         usage: { input_tokens: 300, output_tokens: 90 },
       },
     });
@@ -270,7 +273,7 @@ async function respond(userText, imageCount) {
     type: 'assistant',
     message: {
       role: 'assistant',
-      content: [{ type: 'text', text: `Follow-up #${turn - 1} received: "${userText.slice(0, 100)}".${imgNote} Applied (dry run).${doneMarker}` }],
+      content: [{ type: 'text', text: `Follow-up #${turn - 1} received: "${userText.slice(0, 100)}".${imgNote} Applied (dry run).${doneMarker}${monitoringMarker}` }],
       usage: { input_tokens: 200, output_tokens: 60 },
     },
   });

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -143,7 +143,9 @@ CEZ_HANDOFF_FILE (env) is the absolute path to this task's rolling handoff file.
 2. After every meaningful milestone (passing tests, a commit, a PR, a scope decision), append one terse timestamped line under "## Progress log", newest at the top.
 3. Before finishing or pausing, update "## Resume notes" with what's done, what's next and any blockers. Leave it empty only when the task is truly complete.
 
-Task completion marker: when the task's goal is fully achieved and you have no question for the user, end your final message with a line containing exactly CEZ:DONE — cez then closes the session and marks the task finished. If you are waiting on the user (a question, a decision, missing input), just end your message normally; the session stays open for their reply. Never emit CEZ:DONE while anything is unfinished or unverified.`;
+Task completion marker: when the task's goal is fully achieved and you have no question for the user, end your final message with a line containing exactly CEZ:DONE — cez then closes the session and marks the task finished. If you are waiting on the user (a question, a decision, missing input), just end your message normally; the session stays open for their reply. Never emit CEZ:DONE while anything is unfinished or unverified.
+
+Still-working marker: if you end a turn while still working on your OWN downstream work — a sub-agent you dispatched, or a long-running command you're monitoring — and are NOT waiting on the user for anything, end your final message with a line containing exactly CEZ:MONITORING. cez then shows the task as "monitoring" (still working) instead of asking for your attention. Use CEZ:MONITORING only for that in-progress case; use CEZ:DONE when the goal is done; end plainly (no marker) only when you are genuinely waiting on the user. Never combine CEZ:MONITORING with CEZ:DONE.`;
 
 export const FOLLOWUP_INSTRUCTIONS = `## Follow-ups (cezar)
 

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -76,6 +76,40 @@ describe('RunStore — titleSummary + diffStat (#389)', () => {
     expect(RunStore.open(dataDir).getRun(run.id)?.worktreeReclaimedAt).toBeUndefined();
   });
 
+  it("round-trips activity:'monitoring' and lets updateRun clear it (#490)", () => {
+    const store = RunStore.open(dataDir);
+    const run = store.createRun({ title: 't', workflow: 'w', task: 'task', steps: [] });
+    // A fresh record has no activity (additive/optional).
+    expect(run.activity).toBeUndefined();
+    store.updateRun(run.id, { status: 'running', activity: 'monitoring' });
+    store.flush();
+
+    const reopened = RunStore.open(dataDir);
+    expect(reopened.getRun(run.id)?.activity).toBe('monitoring');
+    // Resume/terminal transitions clear it back to a plain running/other state.
+    reopened.updateRun(run.id, { status: 'running', activity: undefined });
+    reopened.flush();
+    expect(RunStore.open(dataDir).getRun(run.id)?.activity).toBeUndefined();
+  });
+
+  it('still loads an old runs.json that predates activity (#490)', () => {
+    writeFileSync(join(dataDir, 'runs.json'), JSON.stringify([LEGACY_RUN]), 'utf8');
+    const store = RunStore.open(dataDir);
+    expect(store.getRun('legacy-1')?.activity).toBeUndefined();
+  });
+
+  it('rejects an unknown activity value at the schema boundary (#490)', () => {
+    writeFileSync(
+      join(dataDir, 'runs.json'),
+      JSON.stringify([{ ...LEGACY_RUN, id: 'bad-activity', status: 'running', activity: 'bogus' }]),
+      'utf8',
+    );
+    // A corrupt/unknown activity must not smuggle a run in with an invalid value:
+    // the schema drops the bad record (degrade-to-fresh), so it does not load.
+    const store = RunStore.open(dataDir);
+    expect(store.getRun('bad-activity')?.activity).not.toBe('bogus');
+  });
+
   it('persists an explicit follow-up opt-out while omission stays compatible', () => {
     const store = RunStore.open(dataDir);
     const disabled = store.createRun({

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -5,6 +5,14 @@ import { join } from 'node:path';
 import { z } from 'zod';
 
 export type RunStatus = 'queued' | 'running' | 'waiting' | 'review' | 'done' | 'failed' | 'cancelled';
+/**
+ * A sub-state of `running` (spec 2026-07-18-subagent-monitoring-status, #490):
+ * the agent ended its turn still working on its own downstream work (a sub-agent
+ * or a monitored command) and declared it with the `CEZ:MONITORING` marker — so
+ * the cockpit shows a non-attention "monitoring" label instead of "needs you".
+ * Only ever set while `status === 'running'`; cleared on resume/terminal.
+ */
+export type RunActivity = 'monitoring';
 export type StepStatus =
   | 'pending'
   | 'running'
@@ -61,6 +69,10 @@ const runRecordSchema = z.object({
    *  means enabled — the historical behavior. */
   generateFollowups: z.boolean().optional(),
   status: z.enum(['queued', 'running', 'waiting', 'review', 'done', 'failed', 'cancelled']),
+  /** Sub-state of `running` (spec 2026-07-18-subagent-monitoring-status, #490):
+   *  `monitoring` while the agent is still working on its own downstream work.
+   *  Optional/absent on old runs; cleared when the run resumes or ends. */
+  activity: z.enum(['monitoring']).optional(),
   createdAt: z.string(),
   startedAt: z.string().optional(),
   finishedAt: z.string().optional(),

--- a/src/workflows/run.test.ts
+++ b/src/workflows/run.test.ts
@@ -336,6 +336,22 @@ describe('CEZ:MONITORING parks as running/monitoring, not waiting (#490)', () =>
     expect(store.getRun(record.id)?.activity).toBeUndefined();
   }, 30_000);
 
+  it('strips the CEZ:MONITORING marker from server-emitted v1 text events', async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: 'mock:monitoring keep going', worktree: false });
+    currentId = record.id;
+    await waitFor(record.id, (r) => r?.activity === 'monitoring');
+    // v1 `text` events are stripped server-side (like CEZ:DONE); v2 message items carry
+    // the raw text and the thread reducer strips it on display (thread-state.test.ts).
+    const ndjson = readFileSync(join(repoRoot, '.ai/cezar/runs', `${record.id}.ndjson`), 'utf8');
+    const v1Text = ndjson
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+      .filter((e) => e.type === 'text');
+    expect(v1Text.length).toBeGreaterThan(0);
+    expect(v1Text.some((e) => String(e.text).includes('CEZ:MONITORING'))).toBe(false);
+  }, 30_000);
+
   it('resuming a monitoring run clears the activity', async () => {
     const record = manager.startRun(SINGLE_STEP, { task: 'mock:monitoring keep going', worktree: false });
     currentId = record.id;

--- a/src/workflows/run.test.ts
+++ b/src/workflows/run.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createWorktree } from '../git-worktree.js';
 import { RunStore, type RunRecord } from '../runs/store.js';
 import { RunManager } from './run.js';
@@ -265,5 +265,85 @@ describe('a single agent step plus a check step gets NO chain note (#410)', () =
     expect(notes[0]).not.toContain('chain of');
     expect(notes[0]).not.toContain('earlier step');
     expect(notes[0]).not.toContain('project-conventions');
+  }, 30_000);
+});
+
+/**
+ * #490 — the `CEZ:MONITORING` marker parks a still-working turn-end as
+ * `running`/`activity:'monitoring'` (a non-attention state) instead of
+ * `waiting`, while a markerless turn-end still parks as `waiting`. Resuming
+ * clears the activity. Driven dry through the mock (`mock:monitoring`).
+ */
+describe('CEZ:MONITORING parks as running/monitoring, not waiting (#490)', () => {
+  // Fresh repo + manager per test: these runs PARK (they never reach a terminal
+  // status), and a `worktree:false` parked run holds the exclusive repo-root
+  // lock — so a shared manager would starve the next test. Isolation avoids that.
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: RunManager;
+  let currentId: string | undefined;
+  const savedEnv: Record<string, string | undefined> = {};
+  const SINGLE_STEP: WorkflowDef = {
+    name: 'quick-task',
+    source: 'built-in',
+    steps: [{ id: 'task', name: 'Task', prompt: '{{task}}' }],
+  };
+
+  beforeEach(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-490-'));
+    savedEnv.CEZ_DRY_RUN = process.env.CEZ_DRY_RUN;
+    process.env.CEZ_DRY_RUN = '1';
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot);
+    currentId = undefined;
+  });
+
+  afterEach(() => {
+    if (currentId) manager.cancel(currentId); // release the session + repo lock
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  const waitFor = async (id: string, pred: (r: RunRecord | undefined) => boolean, ms = 15_000) => {
+    const deadline = Date.now() + ms;
+    while (!pred(store.getRun(id))) {
+      if (Date.now() > deadline) throw new Error('condition not met in time');
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  };
+
+  it('a CEZ:MONITORING turn-end parks the run as running/monitoring', async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: 'mock:monitoring keep going', worktree: false });
+    currentId = record.id;
+    await waitFor(record.id, (r) => r?.activity === 'monitoring');
+    const parked = store.getRun(record.id);
+    expect(parked?.status).toBe('running'); // a sub-state of running, NOT waiting
+    expect(parked?.activity).toBe('monitoring');
+  }, 30_000);
+
+  it('a markerless turn-end still parks as waiting with no activity', async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: 'just do the thing', worktree: false });
+    currentId = record.id;
+    await waitFor(record.id, (r) => r?.status === 'waiting');
+    expect(store.getRun(record.id)?.activity).toBeUndefined();
+  }, 30_000);
+
+  it('resuming a monitoring run clears the activity', async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: 'mock:monitoring keep going', worktree: false });
+    currentId = record.id;
+    await waitFor(record.id, (r) => r?.activity === 'monitoring');
+    // A user reply (no marker) resumes the run: the follow-up turn re-parks as
+    // plain `waiting`, and the monitoring activity is gone.
+    expect(manager.sendMessage(record.id, [{ type: 'text', text: 'thanks, carry on' }])).toBe(true);
+    await waitFor(record.id, (r) => r?.status === 'waiting');
+    expect(store.getRun(record.id)?.activity).toBeUndefined();
   }, 30_000);
 });

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -40,11 +40,27 @@ export const IDLE_TIMEOUT_MS = 15 * 60_000;
  * (codex, opencode) can't split the marker across text events.
  */
 const DONE_MARKER_RE = /CEZ:DONE\s*$/;
+/**
+ * Still-working marker from the agent contract (spec
+ * 2026-07-18-subagent-monitoring-status, #490): a turn whose text ends with
+ * `CEZ:MONITORING` means "I ended this turn but I'm still working on my own
+ * downstream work (a sub-agent / a command I'm monitoring), not waiting on the
+ * user" — cezar parks it as `running`/`activity:'monitoring'` instead of
+ * `waiting`, so the cockpit shows a non-attention state. `CEZ:DONE` wins if both
+ * appear. Detected on accumulated turn text (like `CEZ:DONE`) so delta-streaming
+ * backends can't split the marker across text events.
+ */
+const MONITORING_MARKER_RE = /CEZ:MONITORING\s*$/;
 /** Strip a trailing marker from one text event so transcripts stay free of
  *  protocol noise. Delta backends may split the marker across events — then
  *  it stays visible; detection above is unaffected. */
 function stripDoneMarker(text: string): string {
   return text.replace(/\s*CEZ:DONE\s*$/, '');
+}
+/** Strip a trailing `CEZ:MONITORING` marker from one text event (see
+ *  `stripDoneMarker`; same delta-backend caveat). */
+function stripMonitoringMarker(text: string): string {
+  return text.replace(/\s*CEZ:MONITORING\s*$/, '');
 }
 /** Periodic "cezar autosave" commit in the task worktree (spec 006). */
 export const AUTOSAVE_INTERVAL_MS = 90_000;
@@ -599,7 +615,9 @@ export class RunManager {
     if (delivered) {
       this.clearIdleTimer(state);
       this.waiting.delete(runId); // resumed — the run counts against slots again
-      this.store.updateRun(runId, { status: 'running' });
+      // Clear any `monitoring` activity — the agent is actively working again
+      // (spec 2026-07-18-subagent-monitoring-status, #490).
+      this.store.updateRun(runId, { status: 'running', activity: undefined });
       if (state.currentStepId) {
         this.store.updateStep(runId, state.currentStepId, { status: 'running' });
       }
@@ -713,6 +731,7 @@ export class RunManager {
       error: undefined,
       finishedAt: undefined,
       currentStepId: stepId,
+      activity: undefined, // resuming a monitoring run — it's actively working again (#490)
     });
     this.store.updateStep(runId, stepId, {
       status: 'running',
@@ -757,6 +776,7 @@ export class RunManager {
         void this.recordTurnEnd(runId, turnText); // titleSummary + diffStat (#389)
         const sessionOpen = !state.cancelled && state.session?.open;
         const done = sessionOpen && DONE_MARKER_RE.test(turnText.trimEnd());
+        const monitoring = sessionOpen && !done && MONITORING_MARKER_RE.test(turnText.trimEnd());
         turnText = '';
         if (done) {
           // Goal achieved (agent contract, #347) — same as in runAgentStep.
@@ -783,14 +803,27 @@ export class RunManager {
               return true;
             })();
           if (!autoContinued) {
-            this.store.updateRun(runId, { status: 'waiting' });
-            this.store.updateStep(runId, stepId, { status: 'waiting' });
+            // `CEZ:MONITORING` → non-attention `running`/`activity:'monitoring'`
+            // instead of `waiting` (spec 2026-07-18-subagent-monitoring-status,
+            // #490). Same lifecycle as waiting (frees the slot, keeps the idle
+            // timer). The autonomous nudge above still wins over monitoring.
+            if (monitoring) {
+              this.store.updateRun(runId, { status: 'running', activity: 'monitoring' });
+              this.store.updateStep(runId, stepId, { status: 'running' });
+            } else {
+              this.store.updateRun(runId, { status: 'waiting', activity: undefined });
+              this.store.updateStep(runId, stepId, { status: 'waiting' });
+            }
             this.waiting.add(runId);
             this.armIdleTimer(runId, state);
             void this.pump();
           }
         }
-        appendHandoffHeartbeat(this.dataDir, runId, `turn complete — status=${sessionOpen ? 'waiting' : 'running'}`);
+        appendHandoffHeartbeat(
+          this.dataDir,
+          runId,
+          `turn complete — status=${monitoring ? 'monitoring' : sessionOpen ? 'waiting' : 'running'}`,
+        );
       }
     };
 
@@ -1192,6 +1225,8 @@ export class RunManager {
         void this.recordTurnEnd(runId, turnText); // titleSummary + diffStat (#389)
         const sessionOpen = !state.cancelled && state.session?.open;
         const done = interactive && sessionOpen && DONE_MARKER_RE.test(turnText.trimEnd());
+        const monitoring =
+          interactive && sessionOpen && !done && MONITORING_MARKER_RE.test(turnText.trimEnd());
         turnText = '';
         if (done) {
           // Goal achieved (agent contract, #347): close the session instead
@@ -1203,16 +1238,31 @@ export class RunManager {
         }
         const waiting = interactive && sessionOpen;
         if (waiting) {
-          // Turn over, session open: the ball is in the user's court.
-          this.store.updateRun(runId, { status: 'waiting' });
-          this.store.updateStep(runId, step.id, { status: 'waiting' });
+          // Turn over, session open. Either the ball is in the user's court
+          // (`waiting`), or the agent declared it is still working on its own
+          // downstream work with `CEZ:MONITORING` — then park as
+          // `running`/`activity:'monitoring'`, a non-attention state, instead of
+          // raising "needs you" (spec 2026-07-18-subagent-monitoring-status, #490).
+          // Lifecycle is identical either way: the run frees its slot and keeps
+          // the idle timer, so even a stalled monitoring run is reclaimed.
+          if (monitoring) {
+            this.store.updateRun(runId, { status: 'running', activity: 'monitoring' });
+            this.store.updateStep(runId, step.id, { status: 'running' });
+          } else {
+            this.store.updateRun(runId, { status: 'waiting', activity: undefined });
+            this.store.updateStep(runId, step.id, { status: 'waiting' });
+          }
           this.waiting.add(runId);
           this.armIdleTimer(runId, state);
           void this.pump(); // the freed slot can start a queued run right away
         }
         // Cez's own heartbeat — the handoff stays current even when the
         // agent forgets to write (spec 007).
-        appendHandoffHeartbeat(this.dataDir, runId, `turn complete — status=${waiting ? 'waiting' : 'running'}`);
+        appendHandoffHeartbeat(
+          this.dataDir,
+          runId,
+          `turn complete — status=${monitoring ? 'monitoring' : waiting ? 'waiting' : 'running'}`,
+        );
       }
     };
 

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -753,7 +753,7 @@ export class RunManager {
       }
       if (event.type === 'text') {
         turnText += event.text;
-        const text = stripDoneMarker(event.text);
+        const text = stripMonitoringMarker(stripDoneMarker(event.text));
         if (text) this.store.appendEvent(runId, { type: 'text', text, stepId });
         return;
       }
@@ -1202,7 +1202,7 @@ export class RunManager {
       }
       if (event.type === 'text') {
         turnText += event.text;
-        const text = stripDoneMarker(event.text);
+        const text = stripMonitoringMarker(stripDoneMarker(event.text));
         if (text) emit({ type: 'text', text, stepId: step.id });
         return;
       }

--- a/src/workflows/system-prompt.test.ts
+++ b/src/workflows/system-prompt.test.ts
@@ -478,6 +478,8 @@ describe('the global follow-up gate (dry run)', () => {
     const id = await runToEnd({ task: 'do the thing mock:done' });
     expect(capturedSystemPrompt()).toContain('CEZ_HANDOFF_FILE');
     expect(capturedSystemPrompt()).toContain('CEZ:DONE');
+    // The still-working marker rides in the same handoff contract (#490).
+    expect(capturedSystemPrompt()).toContain('CEZ:MONITORING');
     expect(readFileSync(join(repoRoot, '.ai/cezar/runs', `${id}.handoff.md`), 'utf8')).toContain(
       'mock: implemented the change',
     );

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -20,6 +20,10 @@
 
 export type RunStatus = 'queued' | 'running' | 'waiting' | 'review' | 'done' | 'failed' | 'cancelled'
 
+/** Sub-state of `running` (spec 2026-07-18-subagent-monitoring-status, #490): the agent is
+ *  still working on its own downstream work (a sub-agent / a monitored command), not on you. */
+export type RunActivity = 'monitoring'
+
 export type StepStatus =
   | 'pending'
   | 'running'
@@ -75,6 +79,9 @@ export interface RunRecord {
   /** false when the run deliberately disabled follow-up todo generation. Absent means enabled. */
   generateFollowups?: boolean
   status: RunStatus
+  /** `monitoring` while `status === 'running'` and the agent is working on downstream work
+   *  (spec 2026-07-18-subagent-monitoring-status, #490). Absent on old runs; cleared on resume/end. */
+  activity?: RunActivity
   createdAt: string
   startedAt?: string
   finishedAt?: string

--- a/web/app/src/lib/attention.test.ts
+++ b/web/app/src/lib/attention.test.ts
@@ -148,6 +148,27 @@ describe('wantsAttention', () => {
   })
 })
 
+describe("running activity: 'monitoring' (#490)", () => {
+  it('is a distinct, non-attention sub-state of running', () => {
+    expect(deriveAttention(run({ status: 'running', activity: 'monitoring' }))).toEqual({
+      bucket: 'running',
+      tone: 'violet',
+      pulse: true,
+      label: 'monitoring',
+    })
+  })
+
+  it('does not want attention — no notification, not "Needs you"', () => {
+    expect(wantsAttention(run({ status: 'running', activity: 'monitoring' }))).toBe(false)
+  })
+
+  it('leaves plain running untouched and is inert on non-running statuses', () => {
+    expect(deriveAttention(run({ status: 'running' })).label).toBe('running')
+    // `activity` is only read while running — a stale value on a terminal record is ignored.
+    expect(deriveAttention(run({ status: 'done', activity: 'monitoring' })).label).toBe('done')
+  })
+})
+
 describe('tone vocabulary', () => {
   it('is exactly the StatusDot tones', () => {
     // attention.ts names its tones itself to stay UI-free, so the two lists can drift. These

--- a/web/app/src/lib/attention.ts
+++ b/web/app/src/lib/attention.ts
@@ -70,8 +70,9 @@ function isUnseen(_run: AttentionInput): boolean {
 
 /** What attention derivation actually reads. `Pick`ed rather than the full `RunRecord` so
  *  surfaces that only have a status — the compare view's `GroupVariant` columns — can use the
- *  same canonical function instead of inventing a second status-to-tone mapping. */
-export type AttentionInput = Pick<RunRecord, 'status'>
+ *  same canonical function instead of inventing a second status-to-tone mapping. `activity` is
+ *  optional (#490), so status-only callers keep working unchanged. */
+export type AttentionInput = Pick<RunRecord, 'status' | 'activity'>
 
 /**
  * `RunRecord` → attention.
@@ -98,6 +99,12 @@ export function deriveAttention(run: AttentionInput): Attention {
   }
   if (run.status === 'review') {
     return { bucket: 'waiting', tone: 'violet', pulse: true, label: 'needs review' }
+  }
+  if (run.status === 'running' && run.activity === 'monitoring') {
+    // Still working, but on its OWN downstream work (a sub-agent / a monitored
+    // command), not on you (#490). A sub-state of `running`, so it stays in the
+    // `running` bucket — no notification, no "Needs you" — with its own label.
+    return { bucket: 'running', tone: 'violet', pulse: true, label: 'monitoring' }
   }
   if (run.status === 'running') {
     return { bucket: 'running', tone: 'violet', pulse: true, label: 'running' }

--- a/web/app/src/lib/notifications.test.ts
+++ b/web/app/src/lib/notifications.test.ts
@@ -95,6 +95,13 @@ describe('diffRunTransitions (attention → notify mapping)', () => {
     expect(entering).toEqual([])
   })
 
+  it('entering monitoring never notifies — it is a running sub-state, not attention (#490)', () => {
+    const monitoring = run({ status: 'running', activity: 'monitoring' })
+    // From active running (no status change) and from waiting (leaving attention): neither notifies.
+    expect(diffRunTransitions(seen([['r1', 'running']]), [monitoring]).entering).toEqual([])
+    expect(diffRunTransitions(seen([['r1', 'waiting']]), [monitoring]).entering).toEqual([])
+  })
+
   it('rebuilds the status map each observation, so deleted runs fall out', () => {
     const { statuses } = diffRunTransitions(seen([['gone', 'running'], ['r1', 'running']]), [
       run({ id: 'r1', status: 'running' }),

--- a/web/app/src/lib/task-groups.test.ts
+++ b/web/app/src/lib/task-groups.test.ts
@@ -75,6 +75,10 @@ describe('bucketOf', () => {
   it.each(cases)('%s → Archived in the archived view', (status) => {
     expect(bucketOf(run({ status, archived: true }), 'archived')).toBe('Archived')
   })
+
+  it("a monitoring run stays in Working, not Needs you (#490)", () => {
+    expect(bucketOf(run({ status: 'running', activity: 'monitoring' }), 'active')).toBe('Working')
+  })
 })
 
 describe('sortRuns', () => {

--- a/web/app/src/routes/task-thread/task-thread.test.tsx
+++ b/web/app/src/routes/task-thread/task-thread.test.tsx
@@ -128,6 +128,16 @@ describe('ThreadView', () => {
     expect(textarea.placeholder).toBe('Message the agent — / for skills, @ for files…')
   })
 
+  it('monitoring → no paused hint, "message" placeholder, and a "monitoring" pill (#490)', () => {
+    renderView(<ThreadView run={run('running', { activity: 'monitoring' })} thread={reduceThread(EVENTS)} />)
+    // Still working on downstream work, not on you: never the "paused, waiting for your reply" banner.
+    expect(document.querySelector('[data-slot="paused-hint"]')).toBeNull()
+    expect(document.querySelector('[data-slot="pill"]')?.textContent).toContain('monitoring')
+    const textarea = screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement
+    expect(textarea.disabled).toBe(false)
+    expect(textarea.placeholder).toBe('Message the agent — / for skills, @ for files…')
+  })
+
   it('closed → the composer is disabled with the legacy reason and the Continue way out', () => {
     renderView(
       <ThreadView

--- a/web/app/src/routes/task-thread/thread-state.test.ts
+++ b/web/app/src/routes/task-thread/thread-state.test.ts
@@ -232,6 +232,17 @@ describe('reduceThread — live-stream mechanics', () => {
     expect((turns[0]!.items[0] as UiMessageItem).text).toBe('All done.')
   })
 
+  it('strips a trailing CEZ:MONITORING from assistant messages too (#490)', () => {
+    const events: RunEvent[] = [
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'item.completed', {
+        item: { kind: 'message', id: 'm1', role: 'assistant', text: 'Spawned the reviewer, waiting on it.\n\nCEZ:MONITORING' },
+      }),
+    ]
+    const { turns } = reduceThread(events)
+    expect((turns[0]!.items[0] as UiMessageItem).text).toBe('Spawned the reviewer, waiting on it.')
+  })
+
   it('a malformed line costs itself, not the fold', () => {
     const events: RunEvent[] = [
       line(1, 'item.delta', { itemId: 'ghost', field: 'text', delta: 'x' }), // delta before any item

--- a/web/app/src/routes/task-thread/thread-state.ts
+++ b/web/app/src/routes/task-thread/thread-state.ts
@@ -155,10 +155,11 @@ function str(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
-/** The engine's completion marker (`CEZ:DONE`). v1 `text` lines arrive pre-stripped by the
- *  server; v2 message items carry the raw text, so display strips it here. */
+/** The engine's turn-end markers (`CEZ:DONE`, and `CEZ:MONITORING` from #490). v1 `text` lines
+ *  arrive pre-stripped by the server; v2 message items carry the raw text, so display strips it
+ *  here. Named `stripDoneMarker` for continuity — it now strips either trailing marker. */
 function stripDoneMarker(text: string): string {
-  return text.replace(/\s*CEZ:DONE\s*$/, '')
+  return text.replace(/\s*CEZ:DONE\s*$/, '').replace(/\s*CEZ:MONITORING\s*$/, '')
 }
 
 /** v1 tool results are strings today; anything else is rendered as JSON rather than dropped. */


### PR DESCRIPTION
Closes #490
Tracking plan: .ai/runs/2026-07-18-subagent-monitoring-status.md
Source doc: .ai/specs/2026-07-18-subagent-monitoring-status.md
Status: in-progress

## Goal
- Stop false "Needs attention" when the agent ended its turn still working on its own downstream work (a sub-agent or a monitored command), not on the user.

## Design
- Spec: `.ai/specs/2026-07-18-subagent-monitoring-status.md` — landed as the first commit on this branch.
- The agent declares the state with a new `CEZ:MONITORING` turn-end marker (sibling of `CEZ:DONE`); cezar maps it to `status: running` + a new optional `activity: 'monitoring'` sub-state. Backend-agnostic (the contract is injected for all backends); graceful fallback to `waiting` when absent.
- An earlier tool-event-inference approach was rejected after fresh-context review + transcript forensics: cezar models no background work, sub-agents resolve inline before turn-end, and `Task`/`Agent` isn't in the default allowlist. See the spec's "Why detection cannot be inferred".

## What Changed
- Spec + execution plan only (this commit). Implementation lands phase-by-phase next.

## Tests
- To be added per phase: marker regex/strip, system-prompt contract, `activity` schema back-compat, turn-end branch (marker → monitoring, no marker → waiting, DONE precedence, resume clears), `deriveAttention` label + suppression (no paused hint, no notification), stays in Working.

## Breaking Changes
- None. Additive optional `RunRecord.activity` field (old records parse unchanged); no new `RunStatus`; no route/config/env change.

## Progress
See the Progress section in the tracking plan.