### PR TITLE
fix(web): keyboard-safe popover menus and scroll-to-top on mobile navigation

### DIFF
--- a/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
+++ b/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
@@ -89,6 +89,8 @@ no route resets it on navigation, so a deep scroll on one page carries into the 
 
 ## Progress
 
+PR: #504
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: visual-viewport insets utility
@@ -106,5 +108,5 @@ no route resets it on navigation, so a deep scroll on one page carries into the 
 
 ### Phase 4: validation + PR
 
-- [ ] 4.1 Full validation gate, self-review, draft PR + labels
+- [x] 4.1 Full validation gate, self-review, draft PR + labels — PR #504
 - [ ] 4.2 om-auto-verify-pr-ui QA + om-auto-review-pr autofix loop

--- a/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
+++ b/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
@@ -1,0 +1,110 @@
+# Mobile fixes: keyboard-safe skill menus + scroll-to-top on navigation
+
+- **Date:** 2026-07-18
+- **Branch:** `fix/mobile-keyboard-popovers-scroll-top`
+- **Base:** `main`
+- **Source:** user brief with mobile screenshot (iOS Safari, /new composer)
+
+## Goal
+
+On mobile, the `/` skills autocomplete and the skills/workflow selector must stay visible
+while the virtual keyboard is open, and navigating to list pages (Tasks, GitHub, …) must
+always land at the top of the list.
+
+## Scope
+
+- `web/app/src/lib/keyboard-inset.ts` — add visual-viewport inset math (top + bottom) and a
+  React hook exposing it as state.
+- `web/app/src/components/composer/composer.tsx` — keyboard-aware collision padding + a
+  visible-height clamp for the `/` skills & `@` mention menu.
+- `web/app/src/routes/new-task.tsx` — same treatment for the `SourcePill` skills/workflow
+  picker (its `CommandInput` opens the keyboard itself).
+- `web/app/src/components/app-shell.tsx` — reset the shared `main` scroller to the top on
+  every pathname change.
+- Unit tests beside each change.
+
+### Non-goals
+
+- No redesign of the popovers into bottom sheets; the Radix popover surfaces stay.
+- No changes to the `PickerPill` dropdowns (model/variants/base) — they open no keyboard.
+- No changes to the thread's stick-to-bottom machinery (`thread-scroller.tsx`); the thread
+  route keeps owning its arrival scroll, which runs after the shell's reset.
+- No server-side changes.
+
+## Background
+
+The cockpit's popover menus are portaled Radix popovers positioned against the **layout**
+viewport. iOS Safari does not shrink the layout viewport when the keyboard opens — it pans
+the **visual** viewport instead — so a menu can be laid out under the keyboard or above the
+panned-away top edge. The repo's existing answer is the `--kb` visualViewport watcher
+(`keyboard-inset.ts`, used by the thread's composer dock). This run extends that pattern:
+publish the visual viewport's top/bottom overlap as React state and feed it to Radix as
+`collisionPadding`, so collision avoidance works against the *visible* viewport.
+
+The second bug: the app shell has one persistent scrolling region (`[data-slot="main"]`);
+no route resets it on navigation, so a deep scroll on one page carries into the next.
+
+## Implementation plan
+
+### Phase 1: visual-viewport insets utility
+
+- 1.1 Add `viewportInsets(win): { top, bottom }` to `keyboard-inset.ts` (top = the visual
+  viewport's `offsetTop`, bottom = the existing `keyboardInset` math), plus a
+  `useViewportInsets()` hook that subscribes via `watchKeyboardInset`-style listeners and
+  returns the insets as state (0/0 when `visualViewport` is absent — jsdom, desktop).
+  Unit tests in `keyboard-inset.test.ts`.
+
+### Phase 2: keyboard-safe menus
+
+- 2.1 Composer: pass `collisionPadding` derived from `useViewportInsets()` to the
+  autocomplete `PopoverContent`, and clamp the menu list height to the popper's
+  `--radix-popover-content-available-height` so it shrinks instead of sliding under the
+  keyboard. Test in `composer.test.tsx`.
+- 2.2 `SourcePill` (new-task): same `collisionPadding` + available-height clamp for the
+  skills/workflow picker popover. Test in `new-task.test.tsx`.
+
+### Phase 3: scroll-to-top on navigation
+
+- 3.1 App shell: `useLayoutEffect` on `pathname` scrolls `[data-slot="main"]` to the top,
+  so every route change (Tasks, GitHub tabs, Skills, …) starts at the top. The task-thread
+  route re-positions itself afterwards (its arrival effect runs on a later commit, after
+  its content ref lands), so thread scroll restore keeps working. Test in
+  `app-shell.test.tsx`.
+
+### Phase 4: validation + PR
+
+- 4.1 Full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`,
+  `npm run build`, `npm run test:package`), self-review, open the draft PR with labels.
+- 4.2 QA the change through `om-auto-verify-pr-ui` (mobile viewport: skills selector,
+  `/` autocomplete with keyboard emulation, list-page scroll reset) and post evidence;
+  then `om-auto-review-pr` autofix loop until clean.
+
+## Risks
+
+- iOS keyboard behavior cannot be reproduced exactly in desktop Chrome QA; the insets math
+  is unit-tested against stubbed `visualViewport` values instead, and QA verifies the
+  popovers reposition and clamp on a small mobile viewport.
+- Scroll-to-top runs for every route: the thread route's own arrival scroll must win on
+  revisits — covered by the effect-ordering note in 3.1 and existing thread tests.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: visual-viewport insets utility
+
+- [ ] 1.1 viewportInsets + useViewportInsets hook with tests
+
+### Phase 2: keyboard-safe menus
+
+- [ ] 2.1 Composer autocomplete collision padding + height clamp
+- [ ] 2.2 SourcePill skills picker collision padding + height clamp
+
+### Phase 3: scroll-to-top on navigation
+
+- [ ] 3.1 App shell scrolls main to top on pathname change
+
+### Phase 4: validation + PR
+
+- [ ] 4.1 Full validation gate, self-review, draft PR + labels
+- [ ] 4.2 om-auto-verify-pr-ui QA + om-auto-review-pr autofix loop

--- a/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
+++ b/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
@@ -93,16 +93,16 @@ no route resets it on navigation, so a deep scroll on one page carries into the 
 
 ### Phase 1: visual-viewport insets utility
 
-- [ ] 1.1 viewportInsets + useViewportInsets hook with tests
+- [x] 1.1 viewportInsets + useViewportInsets hook with tests — bde09e9
 
 ### Phase 2: keyboard-safe menus
 
-- [ ] 2.1 Composer autocomplete collision padding + height clamp
-- [ ] 2.2 SourcePill skills picker collision padding + height clamp
+- [x] 2.1 Composer autocomplete collision padding + height clamp — 17537ad
+- [x] 2.2 SourcePill skills picker collision padding + height clamp — 17537ad
 
 ### Phase 3: scroll-to-top on navigation
 
-- [ ] 3.1 App shell scrolls main to top on pathname change
+- [x] 3.1 App shell scrolls main to top on pathname change — 933272d
 
 ### Phase 4: validation + PR
 

--- a/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
+++ b/.ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
@@ -109,4 +109,4 @@ PR: #504
 ### Phase 4: validation + PR
 
 - [x] 4.1 Full validation gate, self-review, draft PR + labels — PR #504
-- [ ] 4.2 om-auto-verify-pr-ui QA + om-auto-review-pr autofix loop
+- [x] 4.2 om-auto-verify-pr-ui QA (PASS 8/8, evidence on PR) + om-auto-review-pr (APPROVED, 0 autofix iterations)

--- a/web/app/src/components/app-shell.test.tsx
+++ b/web/app/src/components/app-shell.test.tsx
@@ -52,6 +52,16 @@ describe('AppShell', () => {
     expect(within(screen.getByRole('main')).getByText('route content')).toBeTruthy()
   })
 
+  it('resets the main scroller to the top on navigation (#mobile-scroll-top)', () => {
+    renderShell('/')
+    const main = screen.getByRole('main')
+    main.scrollTop = 640
+    expect(main.scrollTop).toBe(640) // jsdom kept the write — the reset below is the effect's
+    fireEvent.click(within(nav()).getByRole('link', { name: 'GitHub' }))
+    expect(screen.getByTestId('location').textContent).toBe('/github')
+    expect(main.scrollTop).toBe(0)
+  })
+
   it('renders the whole nav as real router links', () => {
     renderShell()
     const links = within(nav()).getAllByRole('link')

--- a/web/app/src/components/app-shell.tsx
+++ b/web/app/src/components/app-shell.tsx
@@ -90,6 +90,17 @@ export function AppShell({
   const activeTo = activeNavPath(pathname)
   const current = activeNavItem(pathname)
   const [menuOpen, setMenuOpen] = React.useState(false)
+  const mainRef = React.useRef<HTMLElement>(null)
+
+  // The scroller PERSISTS across routes (it is the shell's, not the view's), so without this
+  // a deep scroll on one page carries into the next — most visibly on mobile, where Tasks or
+  // GitHub opened mid-list. Layout effect: the reset lands before the new view paints. Routes
+  // that own their arrival position (the task thread's cached-restore / stick-to-bottom) set
+  // it later, in their own effects once their content ref lands, so they still win.
+  React.useLayoutEffect(() => {
+    const main = mainRef.current
+    if (main) main.scrollTop = 0
+  }, [pathname])
 
   // Close on route change. Without this the drawer survives the navigation it triggered and sits
   // on top of the view the user just asked for — and back/forward and the ⌘K palette (Step 4.3)
@@ -143,7 +154,11 @@ export function AppShell({
             </div>
           ) : null}
 
-          <main data-slot="main" className="row-start-3 min-h-0 overflow-y-auto overscroll-contain">
+          <main
+            ref={mainRef}
+            data-slot="main"
+            className="row-start-3 min-h-0 overflow-y-auto overscroll-contain"
+          >
             {children}
           </main>
 

--- a/web/app/src/components/composer/composer.test.tsx
+++ b/web/app/src/components/composer/composer.test.tsx
@@ -230,6 +230,16 @@ describe('/ skills autocomplete (#380)', () => {
     expect(rendered[2]!.textContent).toContain('global-deploy')
   })
 
+  it('the menu is clamped to the popper available height (mobile keyboard, #mobile-kb)', async () => {
+    const { textarea } = renderComposer()
+    type(textarea, '/')
+    await screen.findByText('om-fix')
+    const menu = document.querySelector('[data-slot="composer-menu"]')!
+    // The clamp keeps the list inside the visual viewport once PopoverContent's
+    // keyboard-aware collisionPadding has shrunk the popper's available space.
+    expect(menu.className).toContain('--radix-popover-content-available-height')
+  })
+
   it('mid-word slashes (URLs) never open the menu', () => {
     const { textarea } = renderComposer()
     type(textarea, 'see https://example.com/x')

--- a/web/app/src/components/composer/composer.tsx
+++ b/web/app/src/components/composer/composer.tsx
@@ -532,7 +532,9 @@ export function Composer({
           <CommandList
             data-slot="composer-menu"
             data-trigger={trigger?.trigger}
-            className="max-h-64 p-1"
+            // Clamped to the popper's reported space so the open keyboard (collisionPadding
+            // via the shared PopoverContent) shrinks the menu instead of hiding its tail.
+            className="max-h-[min(16rem,var(--radix-popover-content-available-height))] p-1"
           >
             {candidates.length === 0 ? (
               <p className="px-3 py-4 text-center text-xs text-muted-foreground">

--- a/web/app/src/components/prompt-template-menu.tsx
+++ b/web/app/src/components/prompt-template-menu.tsx
@@ -93,7 +93,11 @@ export function PromptTemplateMenu({
             placeholder="search templates…"
             onInput={() => listRef.current?.scrollTo(0, 0)}
           />
-          <CommandList ref={listRef} data-slot="prompt-template-list-menu" className="max-h-64">
+          <CommandList
+            ref={listRef}
+            data-slot="prompt-template-list-menu"
+            className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]"
+          >
             <CommandEmpty>Nothing matches.</CommandEmpty>
             <CommandGroup heading="Insert a template">
               {templates.map((template) => (

--- a/web/app/src/components/ui/popover.tsx
+++ b/web/app/src/components/ui/popover.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { Popover as PopoverPrimitive } from "radix-ui"
 
+import { keyboardAwareCollisionPadding, useViewportInsets } from "@/lib/keyboard-inset"
 import { cn } from "@/lib/utils"
 
 function Popover({
@@ -21,14 +22,22 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  collisionPadding,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  // Collision avoidance against the viewport the user can SEE: the mobile virtual keyboard
+  // shrinks only the visual viewport (iOS never resizes the layout one — see keyboard-inset),
+  // so without these insets a popover near the composer positions itself under the keys.
+  // Insets change re-render the content, which re-runs Radix's positioning. Desktop engines
+  // report {0,0} and keep the exact previous behavior.
+  const insets = useViewportInsets()
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={keyboardAwareCollisionPadding(insets, collisionPadding)}
         className={cn(
           "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className

--- a/web/app/src/lib/keyboard-inset.test.ts
+++ b/web/app/src/lib/keyboard-inset.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  keyboardAwareCollisionPadding,
   keyboardInset,
+  viewportInsets,
   watchKeyboardInset,
+  watchViewportInsets,
   type KeyboardViewport,
   type KeyboardWindow,
+  type ViewportInsets,
 } from './keyboard-inset'
 
 /** A drivable visualViewport: tests resize it and fire the listeners, like Safari does. */
@@ -46,6 +50,79 @@ describe('keyboardInset — the --kb math', () => {
 
   it('is 0 without a visualViewport (older engines)', () => {
     expect(keyboardInset(win(null))).toBe(0)
+  })
+})
+
+describe('viewportInsets — the collision-padding math', () => {
+  it.each([
+    // [innerHeight, vv.height, vv.offsetTop, expected top, expected bottom]
+    [800, 800, 0, 0, 0], // keyboard closed
+    [800, 460, 0, 0, 340], // keyboard open, not panned
+    [800, 460, 100, 100, 240], // panned down: top hidden behind the pan, bottom behind the keys
+    [800, 810, 0, 0, 0], // URL-bar collapse — nothing hidden, both clamp at 0
+  ])('inner %d, vv %d @ %d → top %d / bottom %d', (innerHeight, height, offsetTop, top, bottom) => {
+    expect(viewportInsets(win(new StubViewport(height, offsetTop), innerHeight))).toEqual({ top, bottom })
+  })
+
+  it('is {0,0} without a visualViewport (older engines, jsdom)', () => {
+    expect(viewportInsets(win(null))).toEqual({ top: 0, bottom: 0 })
+  })
+})
+
+describe('keyboardAwareCollisionPadding', () => {
+  const insets: ViewportInsets = { top: 100, bottom: 340 }
+
+  it('defaults to the insets alone (Radix default padding is 0)', () => {
+    expect(keyboardAwareCollisionPadding(insets)).toEqual({ top: 100, right: 0, bottom: 340, left: 0 })
+  })
+
+  it('adds a uniform number padding to every side, insets on top/bottom only', () => {
+    expect(keyboardAwareCollisionPadding(insets, 8)).toEqual({ top: 108, right: 8, bottom: 348, left: 8 })
+  })
+
+  it('merges a partial per-side object', () => {
+    expect(keyboardAwareCollisionPadding({ top: 0, bottom: 0 }, { left: 12 })).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 12,
+    })
+  })
+})
+
+describe('watchViewportInsets — the stubbed adapter', () => {
+  it('applies on install and tracks resize and pan events', () => {
+    const viewport = new StubViewport(800)
+    const applied: ViewportInsets[] = []
+    watchViewportInsets(win(viewport), (insets) => applied.push(insets))
+    expect(applied).toEqual([{ top: 0, bottom: 0 }])
+
+    viewport.height = 460
+    viewport.fire('resize')
+    viewport.offsetTop = 120
+    viewport.fire('scroll')
+    expect(applied).toEqual([
+      { top: 0, bottom: 0 },
+      { top: 0, bottom: 340 },
+      { top: 120, bottom: 220 },
+    ])
+  })
+
+  it('cleanup detaches the listeners', () => {
+    const viewport = new StubViewport(800)
+    const applied: ViewportInsets[] = []
+    const stop = watchViewportInsets(win(viewport), (insets) => applied.push(insets))
+    stop()
+    viewport.height = 460
+    viewport.fire('resize')
+    expect(applied).toEqual([{ top: 0, bottom: 0 }])
+  })
+
+  it('degrades to a one-shot {0,0} without a visualViewport', () => {
+    const applied: ViewportInsets[] = []
+    const stop = watchViewportInsets(win(null), (insets) => applied.push(insets))
+    expect(applied).toEqual([{ top: 0, bottom: 0 }])
+    stop() // must not throw
   })
 })
 

--- a/web/app/src/lib/keyboard-inset.test.ts
+++ b/web/app/src/lib/keyboard-inset.test.ts
@@ -1,8 +1,10 @@
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   keyboardAwareCollisionPadding,
   keyboardInset,
+  useViewportInsets,
   viewportInsets,
   watchKeyboardInset,
   watchViewportInsets,
@@ -123,6 +125,40 @@ describe('watchViewportInsets — the stubbed adapter', () => {
     const stop = watchViewportInsets(win(null), (insets) => applied.push(insets))
     expect(applied).toEqual([{ top: 0, bottom: 0 }])
     stop() // must not throw
+  })
+})
+
+describe('useViewportInsets — the React binding', () => {
+  const setViewport = (viewport: KeyboardViewport | null) =>
+    Object.defineProperty(window, 'visualViewport', { value: viewport, configurable: true })
+
+  afterEach(() => setViewport(null))
+
+  it('tracks the real window.visualViewport while mounted', () => {
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true })
+    const viewport = new StubViewport(800)
+    setViewport(viewport)
+    const { result, unmount } = renderHook(() => useViewportInsets())
+    expect(result.current).toEqual({ top: 0, bottom: 0 })
+
+    act(() => {
+      viewport.height = 460
+      viewport.offsetTop = 100
+      viewport.fire('resize')
+    })
+    expect(result.current).toEqual({ top: 100, bottom: 240 })
+
+    unmount()
+    act(() => {
+      viewport.height = 800
+      viewport.fire('resize')
+    })
+    expect(viewport.listeners.get('resize')?.size ?? 0).toBe(0) // unsubscribed
+  })
+
+  it('stays {0,0} without a visualViewport (jsdom, desktop engines)', () => {
+    const { result } = renderHook(() => useViewportInsets())
+    expect(result.current).toEqual({ top: 0, bottom: 0 })
   })
 })
 

--- a/web/app/src/lib/keyboard-inset.ts
+++ b/web/app/src/lib/keyboard-inset.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /**
  * The iOS virtual-keyboard adapter (spec iOS checklist; tech research §7): Safari does NOT
@@ -75,6 +75,76 @@ export function watchKeyboardInset(
     viewport.removeEventListener('scroll', onChange)
     apply(0)
   }
+}
+
+/**
+ * How much of the layout viewport is OUTSIDE the visual viewport, per edge. Floating layers
+ * (Radix popovers) position against the layout viewport, so on iOS an open keyboard (bottom)
+ * or a panned-down visual viewport (top) can hide them while their math says "visible".
+ * Feeding these to Radix as `collisionPadding` makes collision avoidance work against the
+ * viewport the user can actually see.
+ */
+export interface ViewportInsets {
+  top: number
+  bottom: number
+}
+
+export function viewportInsets(win: KeyboardWindow): ViewportInsets {
+  const viewport = win.visualViewport
+  if (!viewport) return { top: 0, bottom: 0 }
+  return { top: Math.max(0, Math.round(viewport.offsetTop)), bottom: keyboardInset(win) }
+}
+
+/**
+ * Merge the visual-viewport insets into a Radix `collisionPadding` value (number or per-side
+ * object, default 0 — Radix's own default), preserving the caller's left/right padding.
+ */
+export function keyboardAwareCollisionPadding(
+  insets: ViewportInsets,
+  padding: number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>> = 0,
+): Record<'top' | 'right' | 'bottom' | 'left', number> {
+  const base = typeof padding === 'number' ? { top: padding, right: padding, bottom: padding, left: padding } : padding
+  return {
+    top: (base.top ?? 0) + insets.top,
+    right: base.right ?? 0,
+    bottom: (base.bottom ?? 0) + insets.bottom,
+    left: base.left ?? 0,
+  }
+}
+
+/** Watch the visual viewport and publish both insets. Same event surface as
+ *  {@link watchKeyboardInset}; no settle debounce — positioning wants every frame. */
+export function watchViewportInsets(
+  win: KeyboardWindow,
+  apply: (insets: ViewportInsets) => void,
+): () => void {
+  const viewport = win.visualViewport
+  if (!viewport) {
+    apply({ top: 0, bottom: 0 })
+    return () => {}
+  }
+  const onChange = () => apply(viewportInsets(win))
+  onChange()
+  viewport.addEventListener('resize', onChange)
+  viewport.addEventListener('scroll', onChange)
+  return () => {
+    viewport.removeEventListener('resize', onChange)
+    viewport.removeEventListener('scroll', onChange)
+  }
+}
+
+/** The React binding: the current visual-viewport insets as state ({0,0} on engines without
+ *  `visualViewport` — desktop and jsdom stay exactly where they were). */
+export function useViewportInsets(): ViewportInsets {
+  const [insets, setInsets] = useState<ViewportInsets>({ top: 0, bottom: 0 })
+  useEffect(() => {
+    return watchViewportInsets(window as unknown as KeyboardWindow, (next) =>
+      setInsets((current) =>
+        current.top === next.top && current.bottom === next.bottom ? current : next,
+      ),
+    )
+  }, [])
+  return insets
 }
 
 /**

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -431,7 +431,7 @@ function LabelFilter({
       <PopoverContent align="end" sideOffset={6} className="w-60 p-0">
         <Command>
           <CommandInput placeholder="Filter labels…" />
-          <CommandList className="max-h-64">
+          <CommandList className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]">
             <CommandEmpty>No labels.</CommandEmpty>
             {selected.length > 0 ? (
               <CommandItem value="__clear__" onSelect={() => onChange([])} className="text-soft-foreground">

--- a/web/app/src/routes/github/hand-to-agent.tsx
+++ b/web/app/src/routes/github/hand-to-agent.tsx
@@ -261,7 +261,7 @@ function WorkflowPicker({
             onValueChange={setSearch}
             onInput={() => listRef.current?.scrollTo(0, 0)}
           />
-          <CommandList ref={listRef} data-slot="gh-workflow-menu" className="max-h-64">
+          <CommandList ref={listRef} data-slot="gh-workflow-menu" className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]">
             {matched.length === 0 ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
             <CommandGroup>
               {matched.map((workflowDef) => {
@@ -390,7 +390,7 @@ function SkillsPicker({
               onValueChange={setSearch}
               onInput={() => listRef.current?.scrollTo(0, 0)}
             />
-            <CommandList ref={listRef} data-slot="gh-skill-menu" className="max-h-64">
+            <CommandList ref={listRef} data-slot="gh-skill-menu" className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]">
               {project.length === 0 && global.length === 0 ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
               {project.length > 0 ? (
                 <CommandGroup heading="Project skills">{project.map((skill) => skillItem(skill, true))}</CommandGroup>

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -705,7 +705,13 @@ function SourcePill({
               onValueChange={setSearch}
               onInput={() => listRef.current?.scrollTo(0, 0)}
             />
-            <CommandList ref={listRef} data-slot="source-menu" className="max-h-72">
+            {/* The 3rem headroom is the CommandInput row: the popper's available-height var
+                covers the whole popover, and the list must leave the search box visible. */}
+            <CommandList
+              ref={listRef}
+              data-slot="source-menu"
+              className="max-h-[min(18rem,calc(var(--radix-popover-content-available-height)-3rem))]"
+            >
               {nothingMatches ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
               {/* Project skills lead, Global trails everything — the closer a skill lives
                   to the repo, the more likely it's the one being picked. */}

--- a/web/app/src/routes/settings/prompt-templates-section.tsx
+++ b/web/app/src/routes/settings/prompt-templates-section.tsx
@@ -339,7 +339,11 @@ function TemplateSkillsPicker({
       <PopoverContent align="start" sideOffset={8} className="w-[336px] max-w-[calc(100vw-2rem)] p-0">
         <Command filter={multiWordFilter}>
           <CommandInput placeholder="search skills…" onInput={() => listRef.current?.scrollTo(0, 0)} />
-          <CommandList ref={listRef} data-slot="prompt-template-skill-menu" className="max-h-64">
+          <CommandList
+            ref={listRef}
+            data-slot="prompt-template-skill-menu"
+            className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]"
+          >
             <CommandEmpty>Nothing matches.</CommandEmpty>
             {project.length > 0 ? (
               <CommandGroup heading="Project skills">


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-18-mobile-keyboard-popovers-scroll-top.md
Status: complete

## Goal
- On mobile, keep the `/` skills autocomplete and the skills/workflow selector visible while the virtual keyboard is open, and always land at the top of list pages (Tasks, GitHub, …) on navigation.

## What Changed
- **Visual-viewport insets utility** (`keyboard-inset.ts`): `viewportInsets()` measures how much of the layout viewport sits outside the visual viewport (top pan / bottom keyboard), `keyboardAwareCollisionPadding()` folds that into a Radix `collisionPadding` value, and `useViewportInsets()` exposes it as React state. Extends the repo's existing `--kb` pattern.
- **Keyboard-safe popover menus**: the shared `PopoverContent` primitive now merges the live insets into its `collisionPadding`, so Radix collision avoidance works against the viewport the user can actually see — iOS never shrinks the layout viewport when the keyboard opens, which let the `/` autocomplete and the skills/workflow pickers position themselves under the keys. Covers the composer autocomplete, the /new source picker, the GitHub hand-to-agent pickers, the prompt-template menus, and the GitHub label filter in one place. Every popover `CommandList` is clamped to the popper's available height (`--radix-popover-content-available-height`) so long lists shrink instead of sliding off-screen.
- **Scroll-to-top on navigation** (`app-shell.tsx`): the shell's single persistent scroller resets to the top on every pathname change (layout effect). Routes that own their arrival position (the task thread's cached restore / stick-to-bottom) still win — their effects run after their content mounts.

## Tests
- `keyboard-inset.test.ts`: insets math (pan, keyboard, URL-bar-collapse clamp), watcher subscribe/detach/degrade, `useViewportInsets` against a stubbed `window.visualViewport`.
- `app-shell.test.tsx`: main scroller resets to top when a nav link navigates (with a jsdom-write guard).
- `composer.test.tsx`: the open `/` menu carries the available-height clamp.
- Full gate green: typecheck, `npm test` (2472), `npm run test:unit`, `npm run build` (check:pack), `npm run test:package`.

## Breaking Changes
- None — web-UI-only; no API routes, state files, CLI flags, or bookmarklet surfaces touched. Desktop popover behavior is unchanged (insets are `{0,0}` without `visualViewport`).

## Progress
See the Progress section in the tracking plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

