### PR TITLE
feat(github): comment counts + full comment threads with markdown & images (#499)

### DIFF
--- a/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
+++ b/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
@@ -1,0 +1,26 @@
+# Execution plan — GitHub comment counts + threads (#499)
+
+Source doc: `.ai/specs/2026-07-18-github-comment-threads.md`
+Tracking issue: #499
+Branch: `cez/d59e473a`
+
+## Progress
+
+### Phase 1 — counts + icons
+- [ ] 1. `github.ts`: `fetchCommentCounts` (GraphQL, zod, ≤10-page pagination) as 4th `Promise.all` entry in `fetchGithub`; degrade-to-empty on failure; merge into issue/PR mappers (replace `comments: 0`). Unit tests.
+- [ ] 2. `github.tsx`: `MessageSquareIcon` + count in `GithubRow` meta (only when `> 0`) and `GithubDetail` meta. Component tests.
+- [ ] 3. Verify `mockGithub()` counts flow under `CEZ_DRY_RUN=1`.
+
+### Phase 2 — comment threads
+- [ ] 4. `types.ts`: `ForgeComment`/`ForgeCommentsData`. `github.ts`: `fetchGithubComments` (gh calls, zod, review filter, caps, 60s LRU cache, mock). Unit tests.
+- [ ] 5. `server.ts`: `GET /api/github/comments/:kind/:number` (zod params, 400, refresh, degrade). Re-export via `github.ts`. Route test.
+- [ ] 6. `web/app/src/api/`: mirror types, `getGithubComments`, `useGithubComments`.
+- [ ] 7. `github.tsx`: `GithubThread` section (list, skeleton, error, review chips, shortAge). Component tests.
+
+### Phase 3 — polish
+- [ ] 8. `github.tsx`: avatar + letter fallback; review-state chips; truncation row; image-bearing mock comment test.
+- [ ] 9. e2e: extend dry-run smoke (thread badge → entries → image).
+- [ ] 10. Full gate + self-review + PR ready.
+
+## PR
+- PR: (pending)

--- a/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
+++ b/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
@@ -20,7 +20,7 @@ Branch: `cez/d59e473a`
 ### Phase 3 — polish
 - [x] 8. `github.tsx`: avatar + letter fallback; review-state chips; truncation row; image-bearing mock comment test.
 - [x] 9. dry-run coverage: route test serves the mock thread (image + PR review) end-to-end via createApp+CEZ_DRY_RUN; component test asserts image renders `<img>` through Markdown. (Browser `test:e2e` is outside the validation gate + needs a browser provider — the jsdom component + server route tests cover the same path.)
-- [ ] 10. Full gate + self-review + PR ready.
+- [x] 10. Full gate GREEN + adversarial self-review (1 finding fixed: counts pagination bound, d70c539) + PR ready.
 
 ## PR
-- PR: (pending)
+- PR: #505 (https://github.com/open-mercato/cezar/pull/505) — ready, Closes #499

--- a/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
+++ b/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
@@ -12,14 +12,14 @@ Branch: `cez/d59e473a`
 - [x] 3. `mockGithub()` counts flow under `CEZ_DRY_RUN=1` (fixtures already carry counts). — 45c1c05
 
 ### Phase 2 — comment threads
-- [ ] 4. `types.ts`: `ForgeComment`/`ForgeCommentsData`. `github.ts`: `fetchGithubComments` (gh calls, zod, review filter, caps, 60s LRU cache, mock). Unit tests.
-- [ ] 5. `server.ts`: `GET /api/github/comments/:kind/:number` (zod params, 400, refresh, degrade). Re-export via `github.ts`. Route test.
-- [ ] 6. `web/app/src/api/`: mirror types, `getGithubComments`, `useGithubComments`.
-- [ ] 7. `github.tsx`: `GithubThread` section (list, skeleton, error, review chips, shortAge). Component tests.
+- [x] 4. `types.ts`: `ForgeComment`/`ForgeCommentsData`. `github.ts`: `fetchGithubComments` (gh calls, zod, review filter, caps, 60s bounded LRU cache, mock). Unit tests.
+- [x] 5. `server.ts`: `GET /api/github/comments/:kind/:number` (zod params, 400, refresh, degrade). Re-export via `github.ts`. Route test.
+- [x] 6. `web/app/src/api/`: mirror types, `getGithubComments`, `useGithubComments` (staleTime 60s).
+- [x] 7. `github.tsx`: `GithubThread` section (list, skeleton, error, review chips, shortAge). Component tests.
 
 ### Phase 3 — polish
-- [ ] 8. `github.tsx`: avatar + letter fallback; review-state chips; truncation row; image-bearing mock comment test.
-- [ ] 9. e2e: extend dry-run smoke (thread badge → entries → image).
+- [x] 8. `github.tsx`: avatar + letter fallback; review-state chips; truncation row; image-bearing mock comment test.
+- [x] 9. dry-run coverage: route test serves the mock thread (image + PR review) end-to-end via createApp+CEZ_DRY_RUN; component test asserts image renders `<img>` through Markdown. (Browser `test:e2e` is outside the validation gate + needs a browser provider — the jsdom component + server route tests cover the same path.)
 - [ ] 10. Full gate + self-review + PR ready.
 
 ## PR

--- a/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
+++ b/.ai/runs/2026-07-18-issue-499-github-comment-threads.md
@@ -7,9 +7,9 @@ Branch: `cez/d59e473a`
 ## Progress
 
 ### Phase 1 — counts + icons
-- [ ] 1. `github.ts`: `fetchCommentCounts` (GraphQL, zod, ≤10-page pagination) as 4th `Promise.all` entry in `fetchGithub`; degrade-to-empty on failure; merge into issue/PR mappers (replace `comments: 0`). Unit tests.
-- [ ] 2. `github.tsx`: `MessageSquareIcon` + count in `GithubRow` meta (only when `> 0`) and `GithubDetail` meta. Component tests.
-- [ ] 3. Verify `mockGithub()` counts flow under `CEZ_DRY_RUN=1`.
+- [x] 1. `github.ts`: `fetchCommentCounts` (GraphQL, zod, ≤10-page pagination) + merge into mappers. Unit tests. — 45c1c05
+- [x] 2. `github.tsx`: `MessageSquareIcon` + count in `GithubRow`/`GithubDetail` meta. Component tests. — 45c1c05
+- [x] 3. `mockGithub()` counts flow under `CEZ_DRY_RUN=1` (fixtures already carry counts). — 45c1c05
 
 ### Phase 2 — comment threads
 - [ ] 4. `types.ts`: `ForgeComment`/`ForgeCommentsData`. `github.ts`: `fetchGithubComments` (gh calls, zod, review filter, caps, 60s LRU cache, mock). Unit tests.

--- a/src/server/forge/github.test.ts
+++ b/src/server/forge/github.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   fetchCommentCounts,
   ghCheckRunSchema,
+  mergeThread,
+  normalizeComments,
+  normalizeReviews,
   parseCountsPage,
   parseOwnerName,
   rollupToChecks,
+  THREAD_ENTRY_CAP,
 } from './github.js';
+import type { ForgeComment } from './types.js';
 
 /** `rollupToChecks` collapses a `gh … --json statusCheckRollup` array — already zod-validated
  *  via `ghCheckRunSchema` at the call site — down to the single enum the GitHub tab renders,
@@ -192,5 +197,108 @@ describe('fetchCommentCounts', () => {
       throw new Error('rate limited');
     });
     expect(await fetchCommentCounts(runGraphql, 'o', 'n')).toEqual({ issues: {}, prs: {} });
+  });
+});
+
+/** Comment threads (#499 Phase 2): the pure normalize/merge seam behind
+ *  `GET /api/github/comments/:kind/:number`. The `gh`-shelling in `fetchGithubComments` isn't
+ *  unit-tested (it degrades on any failure and is covered by the route + component tests); the
+ *  transforms below carry the real logic — review filtering, chronological merge, and caps. */
+
+describe('normalizeComments', () => {
+  it('maps gh issue-comment JSON into ForgeComment, capping the body and defaulting the author', () => {
+    const [c] = normalizeComments([
+      {
+        id: 7,
+        user: { login: 'ada', avatar_url: 'https://a/1.png' },
+        created_at: '2026-07-01T00:00:00Z',
+        body: 'hi',
+        html_url: 'https://gh/1',
+      },
+    ]);
+    expect(c).toEqual({
+      id: 7,
+      author: 'ada',
+      avatarUrl: 'https://a/1.png',
+      createdAt: '2026-07-01T00:00:00Z',
+      body: 'hi',
+      kind: 'comment',
+      url: 'https://gh/1',
+    });
+  });
+
+  it('falls back to "?" when gh omits the user and to "" for a null body', () => {
+    const [c] = normalizeComments([{ id: 1, user: null, created_at: 't', body: null, html_url: 'u' }]);
+    expect(c?.author).toBe('?');
+    expect(c?.body).toBe('');
+    expect(c?.avatarUrl).toBeUndefined();
+  });
+
+  it('slices an over-long body to 8 000 chars', () => {
+    const [c] = normalizeComments([
+      { id: 1, user: { login: 'x' }, created_at: 't', body: 'a'.repeat(9_000), html_url: 'u' },
+    ]);
+    expect(c?.body).toHaveLength(8_000);
+  });
+});
+
+describe('normalizeReviews', () => {
+  const review = (state: string, body: string | null) => ({
+    id: 1,
+    user: { login: 'rev' },
+    body,
+    state,
+    submitted_at: '2026-07-02T00:00:00Z',
+    html_url: 'https://gh/r',
+  });
+
+  it('keeps APPROVED / CHANGES_REQUESTED even with an empty body (the state is the signal)', () => {
+    expect(normalizeReviews([review('APPROVED', '')])).toHaveLength(1);
+    expect(normalizeReviews([review('CHANGES_REQUESTED', null)])).toHaveLength(1);
+    expect(normalizeReviews([review('APPROVED', '')])[0]).toMatchObject({
+      kind: 'review',
+      reviewState: 'approved',
+    });
+  });
+
+  it('drops empty-body COMMENTED and PENDING reviews (no signal in a flat thread)', () => {
+    expect(normalizeReviews([review('COMMENTED', '  ')])).toHaveLength(0);
+    expect(normalizeReviews([review('PENDING', '')])).toHaveLength(0);
+  });
+
+  it('keeps a COMMENTED review that carries a body', () => {
+    const out = normalizeReviews([review('COMMENTED', 'a note')]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ kind: 'review', reviewState: 'commented', body: 'a note' });
+  });
+});
+
+describe('mergeThread', () => {
+  const at = (iso: string, over: Partial<ForgeComment> = {}): ForgeComment => ({
+    id: 1,
+    author: 'a',
+    createdAt: iso,
+    body: '',
+    kind: 'comment',
+    url: 'u',
+    ...over,
+  });
+
+  it('merges lists and sorts oldest-first by createdAt', () => {
+    const { comments, truncated } = mergeThread([
+      [at('2026-07-03T00:00:00Z', { id: 3 })],
+      [at('2026-07-01T00:00:00Z', { id: 1 }), at('2026-07-02T00:00:00Z', { id: 2 })],
+    ]);
+    expect(comments.map((c) => c.id)).toEqual([1, 2, 3]);
+    expect(truncated).toBe(false);
+  });
+
+  it('caps at the entry limit and flags truncation', () => {
+    const many = Array.from({ length: THREAD_ENTRY_CAP + 5 }, (_, i) =>
+      at(`2026-07-01T00:00:${String(i).padStart(2, '0')}Z`, { id: i }),
+    );
+    const { comments, truncated } = mergeThread([many], THREAD_ENTRY_CAP);
+    expect(comments).toHaveLength(THREAD_ENTRY_CAP);
+    expect(truncated).toBe(true);
   });
 });

--- a/src/server/forge/github.test.ts
+++ b/src/server/forge/github.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { ghCheckRunSchema, rollupToChecks } from './github.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchCommentCounts,
+  ghCheckRunSchema,
+  parseCountsPage,
+  parseOwnerName,
+  rollupToChecks,
+} from './github.js';
 
 /** `rollupToChecks` collapses a `gh … --json statusCheckRollup` array — already zod-validated
  *  via `ghCheckRunSchema` at the call site — down to the single enum the GitHub tab renders,
@@ -87,5 +93,104 @@ describe('rollupToChecks', () => {
   it('falls back through conclusion → state → status, then treats a blank as pending', () => {
     expect(rollupToChecks([{ conclusion: null, status: null, state: 'FAILURE' }])).toBe('failing');
     expect(rollupToChecks([{ conclusion: null, status: null, state: null }])).toBe('pending');
+  });
+});
+
+/** Comment counts (#499 Phase 1): the GraphQL seam that replaces the hard-coded `comments: 0`.
+ *  The `gh`-shelling is injected as a `GraphqlRunner`, so pagination, accumulation, the page cap,
+ *  and the degrade-to-empty contract are all unit-testable without a real `gh`. */
+
+const page = (
+  root: 'issues' | 'pullRequests',
+  nodes: Array<{ number: number; count: number }>,
+  next: string | null,
+): string =>
+  JSON.stringify({
+    data: {
+      repository: {
+        [root]: {
+          nodes: nodes.map((n) => ({ number: n.number, comments: { totalCount: n.count } })),
+          pageInfo: { hasNextPage: next !== null, endCursor: next },
+        },
+      },
+    },
+  });
+
+describe('parseOwnerName', () => {
+  it('splits a clean owner/name handle', () => {
+    expect(parseOwnerName('open-mercato/cezar')).toEqual({ owner: 'open-mercato', name: 'cezar' });
+    expect(parseOwnerName('  open-mercato/cezar\n')).toEqual({ owner: 'open-mercato', name: 'cezar' });
+  });
+
+  it('returns null for anything that is not exactly two parts', () => {
+    expect(parseOwnerName('')).toBeNull();
+    expect(parseOwnerName('cezar')).toBeNull();
+    expect(parseOwnerName('a/b/c')).toBeNull();
+  });
+});
+
+describe('parseCountsPage', () => {
+  it('flattens nodes into a number→count map and surfaces the cursor', () => {
+    expect(parseCountsPage(page('issues', [{ number: 7, count: 3 }, { number: 9, count: 0 }], 'CUR'), 'issues')).toEqual({
+      counts: { 7: 3, 9: 0 },
+      hasNextPage: true,
+      endCursor: 'CUR',
+    });
+  });
+
+  it('normalizes a missing endCursor to null', () => {
+    expect(parseCountsPage(page('pullRequests', [{ number: 1, count: 2 }], null), 'pullRequests')).toEqual({
+      counts: { 1: 2 },
+      hasNextPage: false,
+      endCursor: null,
+    });
+  });
+
+  it('throws on a malformed envelope (zod boundary)', () => {
+    expect(() => parseCountsPage('{"data":{"repository":{"issues":{"nodes":"nope"}}}}', 'issues')).toThrow();
+  });
+});
+
+describe('fetchCommentCounts', () => {
+  it('returns per-kind maps for a single page each', async () => {
+    // Distinguish issues vs PRs by the query text (contains `issues(` or `pullRequests(`).
+    const runGraphql = vi.fn(async (q: string) =>
+      q.includes('pullRequests(')
+        ? page('pullRequests', [{ number: 10, count: 4 }], null)
+        : page('issues', [{ number: 1, count: 2 }], null),
+    );
+    const counts = await fetchCommentCounts(runGraphql, 'o', 'n');
+    expect(counts).toEqual({ issues: { 1: 2 }, prs: { 10: 4 } });
+  });
+
+  it('accumulates across pages and passes the endCursor forward', async () => {
+    const issuePages = [page('issues', [{ number: 1, count: 1 }], 'C1'), page('issues', [{ number: 2, count: 2 }], null)];
+    let issueCall = 0;
+    const runGraphql = vi.fn(async (q: string, vars: Record<string, string>) => {
+      if (q.includes('pullRequests(')) return page('pullRequests', [], null);
+      // Page 1 must not carry a cursor; page 2 must forward 'C1'.
+      if (issueCall === 0) expect(vars.endCursor).toBeUndefined();
+      else expect(vars.endCursor).toBe('C1');
+      return issuePages[issueCall++]!;
+    });
+    const counts = await fetchCommentCounts(runGraphql, 'o', 'n');
+    expect(counts.issues).toEqual({ 1: 1, 2: 2 });
+  });
+
+  it('stops at the page cap even when hasNextPage never goes false', async () => {
+    const runGraphql = vi.fn(async (q: string) =>
+      q.includes('pullRequests(') ? page('pullRequests', [], null) : page('issues', [{ number: 1, count: 1 }], 'MORE'),
+    );
+    await fetchCommentCounts(runGraphql, 'o', 'n', 3);
+    // 3 issue pages + 1 PR page (PR stops immediately with no next).
+    const issueCalls = runGraphql.mock.calls.filter(([q]) => !q.includes('pullRequests(')).length;
+    expect(issueCalls).toBe(3);
+  });
+
+  it('degrades to empty maps when the runner throws (never fails the tab)', async () => {
+    const runGraphql = vi.fn(async () => {
+      throw new Error('rate limited');
+    });
+    expect(await fetchCommentCounts(runGraphql, 'o', 'n')).toEqual({ issues: {}, prs: {} });
   });
 });

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -216,13 +216,18 @@ export async function fetchGithub(repoRoot: string, refresh = false, limit = 30)
       for (const [key, value] of Object.entries(variables)) args.push('-f', `${key}=${value}`);
       return gh(repoRoot, args, timeout);
     };
+    // Bound the counts pagination to the rows actually being fetched: a page is 100, so
+    // `ceil(capped / 100)` pages (still capped at GH_COUNTS_MAX_PAGES) cover exactly the visible
+    // window and no more — the default 30-item load pays ONE counts round-trip, not ten. Rows
+    // beyond the window keep `comments: 0`, which the UI reads as "no badge" (same as before).
+    const countsMaxPages = Math.min(GH_COUNTS_MAX_PAGES, Math.max(1, Math.ceil(capped / 100)));
     const [issuesOut, prsOut, counts] = await Promise.all([
       gh(repoRoot, ['issue', 'list', '--limit', String(capped), '--json', fields], timeout),
       gh(repoRoot, ['pr', 'list', '--limit', String(capped), '--json', `${fields},isDraft,additions,deletions,statusCheckRollup`], timeout),
       // Real comment counts (#499). Degrades to empty maps on its own — a failure here leaves
       // every count at 0, never fails the tab. Skipped entirely if the handle isn't parseable.
       ownerName
-        ? fetchCommentCounts(runGraphql, ownerName.owner, ownerName.name)
+        ? fetchCommentCounts(runGraphql, ownerName.owner, ownerName.name, countsMaxPages)
         : Promise.resolve<{ issues: Record<number, number>; prs: Record<number, number> }>({ issues: {}, prs: {} }),
     ]);
     // One repo-wide label→color map, filled as we flatten each item's labels.

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -94,6 +94,97 @@ async function gh(repoRoot: string, args: string[], timeout = 15_000): Promise<s
   return stdout;
 }
 
+// ---- comment counts (#499 Phase 1) -----------------------------------------
+// `gh … --json comments` is off the table for the list calls — it ships every
+// comment body for every row (the reason `comments` was hard-coded to 0). Real
+// counts come from one lightweight GraphQL query per kind returning only
+// `number → totalCount`, run in parallel with the list calls. This whole seam
+// degrades to empty maps on any failure, so the tab renders exactly as before
+// when the counts call fails (plan rule: counts never break the tab).
+
+/** Runs a GraphQL query with String variables — injected so pagination is unit-testable
+ *  without shelling to `gh`. */
+export type GraphqlRunner = (query: string, variables: Record<string, string>) => Promise<string>;
+
+/** GraphQL's max page size; pagination is capped at 10 pages/kind (1000 rows — the GUI's full
+ *  background shot). Rows past the window keep `comments: 0`, which the UI reads as "no badge". */
+export const GH_COUNTS_MAX_PAGES = 10;
+
+const countsQuery = (root: 'issues' | 'pullRequests'): string => `
+query ($owner: String!, $name: String!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    ${root}(first: 100, after: $endCursor, states: OPEN,
+           orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes { number comments { totalCount } }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`;
+
+const ghCountsPageSchema = z.object({
+  nodes: z.array(z.object({ number: z.number(), comments: z.object({ totalCount: z.number() }) })),
+  pageInfo: z.object({ hasNextPage: z.boolean(), endCursor: z.string().nullish() }),
+});
+
+/** Validate + flatten one gh GraphQL counts response into a `number → count` map plus the page
+ *  cursor. Exported for unit tests (the zod boundary + shape). Throws on a malformed envelope. */
+export function parseCountsPage(
+  out: string,
+  root: 'issues' | 'pullRequests',
+): { counts: Record<number, number>; hasNextPage: boolean; endCursor: string | null } {
+  const parsed = JSON.parse(out) as { data?: { repository?: Record<string, unknown> | null } };
+  const page = ghCountsPageSchema.parse(parsed?.data?.repository?.[root]);
+  const counts: Record<number, number> = {};
+  for (const node of page.nodes) counts[node.number] = node.comments.totalCount;
+  return { counts, hasNextPage: page.pageInfo.hasNextPage, endCursor: page.pageInfo.endCursor ?? null };
+}
+
+async function paginateCounts(
+  runGraphql: GraphqlRunner,
+  owner: string,
+  name: string,
+  root: 'issues' | 'pullRequests',
+  maxPages: number,
+): Promise<Record<number, number>> {
+  const counts: Record<number, number> = {};
+  let cursor: string | null = null;
+  for (let page = 0; page < maxPages; page++) {
+    const variables: Record<string, string> = { owner, name };
+    if (cursor) variables.endCursor = cursor;
+    const res = parseCountsPage(await runGraphql(countsQuery(root), variables), root);
+    Object.assign(counts, res.counts);
+    if (!res.hasNextPage || !res.endCursor) break;
+    cursor = res.endCursor;
+  }
+  return counts;
+}
+
+/** Comment counts for open issues and PRs as `number → count` maps. Two independent paginated
+ *  queries (issues and PRs need separate cursors) run in parallel; any failure degrades the whole
+ *  thing to empty maps so the tab is never held up by counts. Exported for unit tests. */
+export async function fetchCommentCounts(
+  runGraphql: GraphqlRunner,
+  owner: string,
+  name: string,
+  maxPages = GH_COUNTS_MAX_PAGES,
+): Promise<{ issues: Record<number, number>; prs: Record<number, number> }> {
+  try {
+    const [issues, prs] = await Promise.all([
+      paginateCounts(runGraphql, owner, name, 'issues', maxPages),
+      paginateCounts(runGraphql, owner, name, 'pullRequests', maxPages),
+    ]);
+    return { issues, prs };
+  } catch {
+    return { issues: {}, prs: {} };
+  }
+}
+
+/** `owner/name` → `{ owner, name }`, or null when the handle isn't a clean two-part slug. */
+export function parseOwnerName(nameWithOwner: string): { owner: string; name: string } | null {
+  const [owner, name, ...rest] = nameWithOwner.trim().split('/');
+  return owner && name && rest.length === 0 ? { owner, name } : null;
+}
+
 /* Reads degrade to `available: false` with a hint — never an error (plan rule
    7): no `gh`, no remote, offline all land on the same quiet path. A short
    cache keeps tab switches from hammering the GitHub API; a cached fetch with
@@ -114,10 +205,23 @@ export async function fetchGithub(repoRoot: string, refresh = false, limit = 30)
     // longer wall clock — statusCheckRollup on hundreds of PRs is slow.
     const timeout = capped > 100 ? 60_000 : 15_000;
     const fields = 'number,title,author,createdAt,labels,body,url';
-    const [repoOut, issuesOut, prsOut] = await Promise.all([
-      gh(repoRoot, ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], timeout),
+    // The repo handle first (cheap) so the counts GraphQL query — which needs owner/name —
+    // can run parallel to the two expensive list calls below.
+    const repoOut = await gh(repoRoot, ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], timeout);
+    const ownerName = parseOwnerName(repoOut);
+    const runGraphql: GraphqlRunner = (query, variables) => {
+      const args = ['api', 'graphql', '-f', `query=${query}`];
+      for (const [key, value] of Object.entries(variables)) args.push('-f', `${key}=${value}`);
+      return gh(repoRoot, args, timeout);
+    };
+    const [issuesOut, prsOut, counts] = await Promise.all([
       gh(repoRoot, ['issue', 'list', '--limit', String(capped), '--json', fields], timeout),
       gh(repoRoot, ['pr', 'list', '--limit', String(capped), '--json', `${fields},isDraft,additions,deletions,statusCheckRollup`], timeout),
+      // Real comment counts (#499). Degrades to empty maps on its own — a failure here leaves
+      // every count at 0, never fails the tab. Skipped entirely if the handle isn't parseable.
+      ownerName
+        ? fetchCommentCounts(runGraphql, ownerName.owner, ownerName.name)
+        : Promise.resolve<{ issues: Record<number, number>; prs: Record<number, number> }>({ issues: {}, prs: {} }),
     ]);
     // One repo-wide label→color map, filled as we flatten each item's labels.
     const labelColors: Record<string, string> = {};
@@ -136,7 +240,7 @@ export async function fetchGithub(repoRoot: string, refresh = false, limit = 30)
           labels: i.labels.map((l) => l.name),
           body: (i.body ?? '').slice(0, 8_000),
           url: i.url,
-          comments: 0,
+          comments: counts.issues[i.number] ?? 0,
         };
       },
     );
@@ -152,7 +256,7 @@ export async function fetchGithub(repoRoot: string, refresh = false, limit = 30)
           labels: [...p.labels.map((l) => l.name), ...(p.isDraft ? ['draft'] : [])],
           body: (p.body ?? '').slice(0, 8_000),
           url: p.url,
-          comments: 0,
+          comments: counts.prs[p.number] ?? 0,
           isDraft: p.isDraft,
           additions: p.additions,
           deletions: p.deletions,

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -6,6 +6,8 @@ import type {
   DraftPrInput,
   DraftPrOutcome,
   ForgeAvailability,
+  ForgeComment,
+  ForgeCommentsData,
   ForgeDriver,
   ForgeItem,
   ForgePrStatus,
@@ -321,6 +323,188 @@ function mockGithub(): GithubData {
       draft: '6a737d',
     },
   };
+}
+
+// ---- comment threads (#499 Phase 2) ----------------------------------------
+// A lazy per-thread fetch behind `GET /api/github/comments/:kind/:number`: the
+// conversation comments (issues endpoint — GitHub serves PR conversation
+// comments there too), plus submitted reviews for PRs, normalized into one
+// chronological `ForgeComment[]`. Its own bounded 60 s cache keeps an open
+// detail view from re-fetching on every focus. Degrades to `available: false`
+// exactly like the list fetch — never a 5xx.
+
+const ghCommentUser = z.object({ login: z.string(), avatar_url: z.string().nullish() }).nullish();
+const ghIssueCommentSchema = z.object({
+  id: z.number(),
+  user: ghCommentUser,
+  created_at: z.string(),
+  body: z.string().nullish(),
+  html_url: z.string(),
+});
+const ghReviewSchema = z.object({
+  id: z.number(),
+  user: ghCommentUser,
+  body: z.string().nullish(),
+  state: z.string(),
+  submitted_at: z.string().nullish(),
+  html_url: z.string(),
+});
+
+const REVIEW_STATE: Record<string, ForgeComment['reviewState']> = {
+  APPROVED: 'approved',
+  CHANGES_REQUESTED: 'changes_requested',
+  COMMENTED: 'commented',
+  DISMISSED: 'dismissed',
+};
+
+/** First 200 thread entries, then `truncated`; each body sliced to 8 000 chars (same cap as
+ *  item bodies). */
+export const THREAD_ENTRY_CAP = 200;
+const COMMENT_BODY_CAP = 8_000;
+
+/** `gh api …/issues/{n}/comments` JSON → `ForgeComment[]`. Exported for unit tests. */
+export function normalizeComments(raw: unknown): ForgeComment[] {
+  return z.array(ghIssueCommentSchema).parse(raw).map((c) => ({
+    id: c.id,
+    author: c.user?.login ?? '?',
+    avatarUrl: c.user?.avatar_url ?? undefined,
+    createdAt: c.created_at,
+    body: (c.body ?? '').slice(0, COMMENT_BODY_CAP),
+    kind: 'comment' as const,
+    url: c.html_url,
+  }));
+}
+
+/** `gh api …/pulls/{n}/reviews` JSON → `ForgeComment[]`. Reviews with an empty body AND state
+ *  COMMENTED/PENDING carry no signal in a flat thread and are dropped; the rest map to
+ *  `kind: 'review'` (Q4). Exported for unit tests. */
+export function normalizeReviews(raw: unknown): ForgeComment[] {
+  return z
+    .array(ghReviewSchema)
+    .parse(raw)
+    .filter((r) => {
+      const state = r.state.toUpperCase();
+      const emptyBody = (r.body ?? '').trim().length === 0;
+      return !(emptyBody && (state === 'COMMENTED' || state === 'PENDING'));
+    })
+    .map((r) => ({
+      id: r.id,
+      author: r.user?.login ?? '?',
+      avatarUrl: r.user?.avatar_url ?? undefined,
+      createdAt: r.submitted_at ?? '',
+      body: (r.body ?? '').slice(0, COMMENT_BODY_CAP),
+      kind: 'review' as const,
+      reviewState: REVIEW_STATE[r.state.toUpperCase()],
+      url: r.html_url,
+    }));
+}
+
+/** Merge comment/review lists chronologically (oldest first) and apply the entry cap. Exported
+ *  for unit tests. */
+export function mergeThread(
+  parts: ForgeComment[][],
+  cap = THREAD_ENTRY_CAP,
+): { comments: ForgeComment[]; truncated: boolean } {
+  const all = parts.flat().sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const truncated = all.length > cap;
+  return { comments: truncated ? all.slice(0, cap) : all, truncated };
+}
+
+// Per-thread cache: keyed `kind#number`, same 60 s TTL as the list cache but BOUNDED — a long
+// browsing session can't grow it without limit (Map preserves insertion order → oldest first).
+const commentsCache = new Map<string, { at: number; data: ForgeCommentsData }>();
+const COMMENTS_CACHE_MAX = 50;
+
+function cacheComments(key: string, data: ForgeCommentsData): void {
+  commentsCache.delete(key); // re-insert so this key becomes the newest
+  commentsCache.set(key, { at: Date.now(), data });
+  while (commentsCache.size > COMMENTS_CACHE_MAX) {
+    const oldest = commentsCache.keys().next().value;
+    if (oldest === undefined) break;
+    commentsCache.delete(oldest);
+  }
+}
+
+/** Test-only: drop the per-thread cache so cases don't leak state into each other. */
+export function __clearCommentsCacheForTests(): void {
+  commentsCache.clear();
+}
+
+/**
+ * The conversation thread for one issue/PR, lazily. `{owner}`/`{repo}` in the gh api paths are
+ * filled from the worktree's remote by gh itself, so no extra handle lookup. Everything degrades:
+ * gh missing/offline → `{ available: false, reason }`, a 404 → a "not found" hint — never a throw.
+ */
+export async function fetchGithubComments(
+  repoRoot: string,
+  kind: 'issue' | 'pr',
+  number: number,
+  refresh = false,
+): Promise<ForgeCommentsData> {
+  if (process.env.CEZ_DRY_RUN === '1') return mockGithubComments(kind);
+  const key = `${kind}#${number}`;
+  const hit = commentsCache.get(key);
+  if (!refresh && hit && Date.now() - hit.at < CACHE_MS) return hit.data;
+  try {
+    // PR conversation comments live on the issues endpoint too — always use it for the body thread.
+    const commentsOut = await gh(repoRoot, ['api', `repos/{owner}/{repo}/issues/${number}/comments`, '--paginate']);
+    const parts: ForgeComment[][] = [normalizeComments(JSON.parse(commentsOut))];
+    if (kind === 'pr') {
+      const reviewsOut = await gh(repoRoot, ['api', `repos/{owner}/{repo}/pulls/${number}/reviews`, '--paginate']);
+      parts.push(normalizeReviews(JSON.parse(reviewsOut)));
+    }
+    const { comments, truncated } = mergeThread(parts);
+    const data: ForgeCommentsData = { available: true, comments, truncated: truncated || undefined };
+    cacheComments(key, data);
+    return data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const reason = /ENOENT/.test(message)
+      ? 'gh CLI not found — install it and run `gh auth login`'
+      : /404|not found/i.test(message)
+        ? 'not found on GitHub — it may be closed or deleted'
+        : firstLine(message);
+    return { available: false, reason, comments: [] };
+  }
+}
+
+/** CEZ_DRY_RUN=1 — a small fixed thread (one image-bearing comment, plus a review for PRs) so
+ *  the whole feature is demoable and e2e-testable offline. */
+function mockGithubComments(kind: 'issue' | 'pr'): ForgeCommentsData {
+  const base = Date.now() - 3_600_000;
+  const at = (offset: number) => new Date(base + offset).toISOString();
+  const comments: ForgeComment[] = [
+    {
+      id: 1,
+      author: 'ada',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+      createdAt: at(0),
+      body: 'Thanks for the report — I can reproduce. Which browser were you on?\n\n```\nchrome 126, macOS\n```',
+      kind: 'comment',
+      url: 'https://github.com/mock/repo/issues/1#issuecomment-1',
+    },
+    {
+      id: 2,
+      author: 'lin',
+      createdAt: at(600_000),
+      body: 'Here is the failing screen:\n\n![failure](https://avatars.githubusercontent.com/u/2?v=4)',
+      kind: 'comment',
+      url: 'https://github.com/mock/repo/issues/1#issuecomment-2',
+    },
+  ];
+  if (kind === 'pr') {
+    comments.push({
+      id: 3,
+      author: 'grace',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/3?v=4',
+      createdAt: at(1_200_000),
+      body: 'Looks good overall — please add a regression test before this lands.',
+      kind: 'review',
+      reviewState: 'changes_requested',
+      url: 'https://github.com/mock/repo/pull/1#pullrequestreview-3',
+    });
+  }
+  return { available: true, comments };
 }
 
 // ---- draft-PR creation (review gate, spec 009) ------------------------------

--- a/src/server/forge/types.ts
+++ b/src/server/forge/types.ts
@@ -38,6 +38,38 @@ export interface ForgeItem {
   checks?: 'passing' | 'failing' | 'pending' | null;
 }
 
+/** One comment (or PR review summary) in an issue/PR conversation thread (#499). Served by the
+ *  new `GET /api/github/comments/:kind/:number` endpoint; additive, no impact on `ForgeItem`. */
+export interface ForgeComment {
+  id: number;
+  /** Author login, `'?'` fallback when gh omits the user. */
+  author: string;
+  /** https://avatars.githubusercontent.com/…, when known. */
+  avatarUrl?: string;
+  /** ISO timestamp. */
+  createdAt: string;
+  /** Markdown body, sliced to the same 8 000-char cap as item bodies. */
+  body: string;
+  /** `review` = a submitted PR review summary; `comment` = a conversation comment. */
+  kind: 'comment' | 'review';
+  /** For reviews only — drives the state chip. */
+  reviewState?: 'approved' | 'changes_requested' | 'commented' | 'dismissed';
+  /** html_url deep link back to the comment/review on GitHub. */
+  url: string;
+}
+
+/** The `GET /api/github/comments/:kind/:number` payload — mirrors the tab's quiet-degrade
+ *  contract (`available: false` + a hint, never a 5xx). */
+export interface ForgeCommentsData {
+  available: boolean;
+  /** Human-readable hint when unavailable. */
+  reason?: string;
+  /** Chronological, oldest first. */
+  comments: ForgeComment[];
+  /** True when the thread exceeded the fetch cap and was trimmed. */
+  truncated?: boolean;
+}
+
 export interface ForgeListOptions {
   /** Bypass the driver's short cache. */
   refresh?: boolean;

--- a/src/server/github-comments-api.test.ts
+++ b/src/server/github-comments-api.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Hono } from 'hono';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { RunStore } from '../runs/store.js';
+import type { RunManager } from '../workflows/run.js';
+import type { ForgeCommentsData } from './github.js';
+import { createApp } from './server.js';
+
+/**
+ * `GET /api/github/comments/:kind/:number` (#499 Phase 2). The contract under test: zod-validated
+ * params (400 on garbage, never a throw), and — driven through `CEZ_DRY_RUN=1` so no `gh` is
+ * touched — a `ForgeCommentsData` payload for a valid issue/PR request. The gh-shelling and the
+ * degrade paths live in the driver; here we prove the route wiring and the param gate.
+ */
+describe('the github comments API', () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let app: Hono;
+  const prevDryRun = process.env.CEZ_DRY_RUN;
+
+  beforeAll(() => {
+    process.env.CEZ_DRY_RUN = '1';
+  });
+  afterAll(() => {
+    if (prevDryRun === undefined) delete process.env.CEZ_DRY_RUN;
+    else process.env.CEZ_DRY_RUN = prevDryRun;
+  });
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-ghcomments-'));
+    mkdirSync(join(repoRoot, '.ai/cezar'), { recursive: true });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    app = createApp({ repoRoot, store, manager: {} as RunManager, version: '0.0.0-test' });
+  });
+
+  afterEach(() => {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns a dry-run thread for a valid issue request', async () => {
+    const res = await app.request('/api/github/comments/issue/142');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ForgeCommentsData;
+    expect(body.available).toBe(true);
+    expect(body.comments.length).toBeGreaterThan(0);
+    // Chronological, oldest first.
+    for (let i = 1; i < body.comments.length; i++) {
+      expect(body.comments[i - 1]!.createdAt <= body.comments[i]!.createdAt).toBe(true);
+    }
+  });
+
+  it('includes a PR review summary for a valid pr request', async () => {
+    const res = await app.request('/api/github/comments/pr/137');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ForgeCommentsData;
+    expect(body.comments.some((c) => c.kind === 'review')).toBe(true);
+  });
+
+  it('rejects an unknown kind with 400 and an { error } body, not a throw', async () => {
+    const res = await app.request('/api/github/comments/banana/1');
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toHaveProperty('error');
+  });
+
+  it('rejects a non-numeric / non-positive number with 400', async () => {
+    expect((await app.request('/api/github/comments/issue/abc')).status).toBe(400);
+    expect((await app.request('/api/github/comments/issue/0')).status).toBe(400);
+    expect((await app.request('/api/github/comments/issue/-3')).status).toBe(400);
+  });
+});

--- a/src/server/github.ts
+++ b/src/server/github.ts
@@ -4,5 +4,6 @@
  * seam"). Kept so existing imports and the protected `/api/github` response
  * shape (BACKWARD_COMPATIBILITY.md §2) stay exactly as they were.
  */
-export { fetchGithub, GH_MAX_LIMIT } from './forge/github.js';
+export { fetchGithub, fetchGithubComments, GH_MAX_LIMIT } from './forge/github.js';
 export type { GithubData, GithubItem } from './forge/github.js';
+export type { ForgeComment, ForgeCommentsData } from './forge/types.js';

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -47,7 +47,7 @@ import { reviewGateEnabled } from '../runs/review-gate.js';
 import { readUiState, uiStatePath } from '../ui-state.js';
 import { resolveCapabilities } from './capabilities.js';
 import { resolveForge } from './forge/index.js';
-import { fetchGithub } from './github.js';
+import { fetchGithub, fetchGithubComments } from './github.js';
 import { ensureLaunchKey } from './launch-key.js';
 import { openInTerminal } from './open-in-terminal.js';
 import { agentCliRunner, detectOpenTargets, openInApp } from './open-in-app.js';
@@ -1232,6 +1232,21 @@ export function createApp(deps: ServerDeps): Hono {
     const limit = Number.parseInt(c.req.query('limit') ?? '', 10);
     return c.json(
       await fetchGithub(repoRoot, c.req.query('refresh') === '1', Number.isFinite(limit) ? limit : 30),
+    );
+  });
+
+  // The full comment thread for one issue/PR (#499). Additive sibling of /api/github — lazy
+  // (fetched only while a detail view is open), zod-validated params, 400 on garbage, and the
+  // same in-payload availability degrade (gh missing / offline / 404 all render as a hint).
+  const commentsParams = z.object({
+    kind: z.enum(['issue', 'pr']),
+    number: z.coerce.number().int().positive(),
+  });
+  app.get('/api/github/comments/:kind/:number', async (c) => {
+    const parsed = commentsParams.safeParse({ kind: c.req.param('kind'), number: c.req.param('number') });
+    if (!parsed.success) return c.json({ error: 'invalid kind or number' }, 400);
+    return c.json(
+      await fetchGithubComments(repoRoot, parsed.data.kind, parsed.data.number, c.req.query('refresh') === '1'),
     );
   });
 

--- a/web/app/src/api/client.ts
+++ b/web/app/src/api/client.ts
@@ -16,6 +16,7 @@ import type {
   FinishResponse,
   GitCommitResponse,
   GitPushResponse,
+  GithubCommentsData,
   GithubData,
   GroupResponse,
   HealthResponse,
@@ -258,6 +259,16 @@ export function getGithub(
   if (params.refresh) query.set('refresh', '1')
   const search = query.toString()
   return get<GithubData>(`/api/github${search ? `?${search}` : ''}`, opts)
+}
+
+/** The full comment thread for one issue/PR (#499). Degrades to `{ available: false, reason }`
+ *  server-side — an unreachable thread is a one-line hint in the detail view, not an ApiError. */
+export function getGithubComments(
+  kind: 'issue' | 'pr',
+  number: number,
+  opts?: ReadOptions,
+): Promise<GithubCommentsData> {
+  return get<GithubCommentsData>(`/api/github/comments/${kind}/${number}`, opts)
 }
 
 /** The run's worktree diff against its base, as unified-diff text. Also the plain-text

--- a/web/app/src/api/queries.ts
+++ b/web/app/src/api/queries.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   getConfig,
   getGithub,
+  getGithubComments,
   getGroup,
   getHealth,
   getLaunchKey,
@@ -68,6 +69,7 @@ export const queryKeys = {
   /** The worktree management panel (`GET /api/worktrees`, #483). */
   worktrees: ['worktrees'] as const,
   github: (params: { limit?: number } = {}) => ['github', params.limit ?? null] as const,
+  githubComments: (kind: 'issue' | 'pr', number: number) => ['github', 'comments', kind, number] as const,
   openTargets: ['open-targets'] as const,
 } as const
 
@@ -330,5 +332,17 @@ export function useGithub(params: { limit?: number } = {}, enabled = true) {
     queryKey: queryKeys.github(params),
     queryFn: ({ signal }) => getGithub({ limit: params.limit }, { signal }),
     enabled,
+  })
+}
+
+/** The comment thread for one issue/PR (`/api/github/comments/…`, #499). Fetched only while a
+ *  detail view is mounted (`enabled`); `staleTime` aligns with the 60 s server cache so switching
+ *  back to an item doesn't re-hit gh. */
+export function useGithubComments(kind: 'issue' | 'pr', number: number, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.githubComments(kind, number),
+    queryFn: ({ signal }) => getGithubComments(kind, number, { signal }),
+    enabled,
+    staleTime: 60_000,
   })
 }

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -492,6 +492,27 @@ export interface GithubData {
   labelColors?: Record<string, string>
 }
 
+/** One comment or PR review summary in an issue/PR thread (`GET /api/github/comments/…`, #499). */
+export interface GithubComment {
+  id: number
+  author: string
+  avatarUrl?: string
+  createdAt: string
+  body: string
+  kind: 'comment' | 'review'
+  reviewState?: 'approved' | 'changes_requested' | 'commented' | 'dismissed'
+  url: string
+}
+
+/** `GET /api/github/comments/:kind/:number` — degrades to `{ available: false, reason }` like the
+ *  list fetch, never an error. */
+export interface GithubCommentsData {
+  available: boolean
+  reason?: string
+  comments: GithubComment[]
+  truncated?: boolean
+}
+
 // ---- GUI prefs (`PUT /api/ui-state`) -----------------------------------------------------------
 
 /** The keys the server's schema names. It is a passthrough schema, so unknown keys round-trip

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createQueryClient } from '@/api/query-client'
-import type { GithubData, GithubItem, Skill, WorkflowsResponse } from '@/api/types'
+import type { GithubComment, GithubCommentsData, GithubData, GithubItem, Skill, WorkflowsResponse } from '@/api/types'
 import { Toaster, resetToasts } from '@/components/ui/toaster'
 
 import { GithubIndexRoute, GithubRoute } from './github'
@@ -81,6 +81,38 @@ const GITHUB: GithubData = {
   prs: [PR_137],
 }
 
+const COMMENT_TEXT: GithubComment = {
+  id: 1,
+  author: 'maya',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+  createdAt: '2026-07-12T08:00:00.000Z',
+  body: 'Confirmed on my end too — nice catch.',
+  kind: 'comment',
+  url: 'https://github.com/acme/demo/issues/142#issuecomment-1',
+}
+
+const COMMENT_IMAGE: GithubComment = {
+  id: 2,
+  author: 'noAvatar',
+  createdAt: '2026-07-12T09:00:00.000Z',
+  body: 'Screenshot:\n\n![shot](https://example.com/shot.png)',
+  kind: 'comment',
+  url: 'https://github.com/acme/demo/issues/142#issuecomment-2',
+}
+
+const REVIEW_CHANGES: GithubComment = {
+  id: 3,
+  author: 'rev',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/3?v=4',
+  createdAt: '2026-07-12T10:00:00.000Z',
+  body: 'Please add a test.',
+  kind: 'review',
+  reviewState: 'changes_requested',
+  url: 'https://github.com/acme/demo/pull/137#pullrequestreview-3',
+}
+
+const THREAD: GithubCommentsData = { available: true, comments: [COMMENT_TEXT, COMMENT_IMAGE] }
+
 const WORKFLOWS: WorkflowsResponse = {
   workflows: [
     { name: 'quick-task', description: 'one step', steps: [], source: 'built-in' },
@@ -117,6 +149,9 @@ function stubFetch(overrides: Record<string, () => Response> = {}): SentRequest[
       sent.push({ path, method, body: typeof init.body === 'string' ? JSON.parse(init.body) : undefined })
       const override = overrides[`${method} ${path}`]
       if (override) return override()
+      // Any comment-thread request defaults to the two-comment THREAD fixture; a test overrides a
+      // specific `GET /api/github/comments/<kind>/<n>` key to serve a different thread.
+      if (method === 'GET' && path.startsWith('/api/github/comments/')) return jsonResponse(THREAD)
       if (method === 'GET' && path === '/api/github') return jsonResponse(GITHUB)
       if (method === 'GET' && path === '/api/github?limit=1000') return jsonResponse(GITHUB)
       if (method === 'GET' && path === '/api/workflows') return jsonResponse(WORKFLOWS)
@@ -387,6 +422,93 @@ describe('the GitHub detail pane', () => {
         'Repro: log in, hit reload',
       ),
     )
+  })
+})
+
+// ---- comment thread (#499) --------------------------------------------------------------------
+
+describe('the comment thread', () => {
+  const thread = (kind: 'issue' | 'pr', n: number, data: GithubCommentsData) => ({
+    [`GET /api/github/comments/${kind}/${n}`]: () => jsonResponse(data),
+  })
+  const threadSection = () => document.querySelector('[data-slot="gh-thread"]')
+  const entries = () => [...document.querySelectorAll<HTMLElement>('[data-slot="gh-thread-entry"]')]
+
+  it('renders a "Comments · N" section with each body through the markdown pipeline', async () => {
+    stubFetch(thread('issue', 142, { available: true, comments: [COMMENT_TEXT, COMMENT_IMAGE] }))
+    renderAt('/github/issues/142')
+
+    await waitFor(() => expect(threadSection()).not.toBeNull())
+    expect(document.querySelector('[data-slot="gh-thread-header"]')?.textContent).toBe('Comments · 2')
+    expect(entries()).toHaveLength(2)
+    expect(entries()[0]?.textContent).toContain('maya')
+    expect(entries()[0]?.querySelector('[data-slot="gh-thread-body"]')?.textContent).toContain(
+      'Confirmed on my end too',
+    )
+  })
+
+  it('renders an image comment as an <img> through the shared Markdown component', async () => {
+    stubFetch(thread('issue', 142, { available: true, comments: [COMMENT_IMAGE] }))
+    renderAt('/github/issues/142')
+
+    await waitFor(() => expect(threadSection()).not.toBeNull())
+    const img = document.querySelector<HTMLImageElement>('[data-slot="gh-thread-body"] img')
+    expect(img?.getAttribute('src')).toBe('https://example.com/shot.png')
+  })
+
+  it('renders nothing for an empty thread — the count badge already said there were none', async () => {
+    stubFetch(thread('issue', 139, { available: true, comments: [] }))
+    renderAt('/github/issues/139')
+
+    await waitFor(() => expect(detail()?.textContent).toContain('Add --json flag'))
+    expect(threadSection()).toBeNull()
+    expect(document.querySelector('[data-slot="gh-thread-error"]')).toBeNull()
+  })
+
+  it('shows a one-line reason + open-on-GitHub link when the thread is unavailable', async () => {
+    stubFetch(thread('issue', 142, { available: false, reason: 'gh not installed', comments: [] }))
+    renderAt('/github/issues/142')
+
+    await waitFor(() => expect(document.querySelector('[data-slot="gh-thread-error"]')).not.toBeNull())
+    const error = document.querySelector('[data-slot="gh-thread-error"]')!
+    expect(error.textContent).toContain('gh not installed')
+    expect(error.querySelector('a')?.getAttribute('href')).toBe(ISSUE_142.url)
+  })
+
+  it('renders a review entry with a state chip (green/red tone tables)', async () => {
+    stubFetch(thread('pr', 137, { available: true, comments: [COMMENT_TEXT, REVIEW_CHANGES] }))
+    renderAt('/github/prs/137')
+
+    await waitFor(() => expect(entries()).toHaveLength(2))
+    const review = document.querySelector('[data-slot="gh-thread-entry"][data-kind="review"]')
+    const chip = review?.querySelector('[data-slot="gh-review-chip"]')
+    expect(chip?.getAttribute('data-review-state')).toBe('changes_requested')
+    expect(chip?.textContent).toBe('changes requested')
+    expect(chip?.className).toContain('text-danger')
+  })
+
+  it('uses the real avatar when present and a letter fallback when absent', async () => {
+    stubFetch(thread('issue', 142, { available: true, comments: [COMMENT_TEXT, COMMENT_IMAGE] }))
+    renderAt('/github/issues/142')
+
+    await waitFor(() => expect(entries()).toHaveLength(2))
+    // COMMENT_TEXT has an avatarUrl → an <img>; COMMENT_IMAGE has none → a letter block.
+    expect(entries()[0]?.querySelector('[data-slot="gh-avatar"]')?.getAttribute('src')).toBe(
+      COMMENT_TEXT.avatarUrl,
+    )
+    const fallback = entries()[1]?.querySelector('[data-slot="gh-avatar-fallback"]')
+    expect(fallback).not.toBeNull()
+    expect(fallback?.textContent).toBe('n') // first letter of "noAvatar"
+  })
+
+  it('shows a truncation row linking to GitHub when the thread was trimmed', async () => {
+    stubFetch(thread('issue', 142, { available: true, comments: [COMMENT_TEXT], truncated: true }))
+    renderAt('/github/issues/142')
+
+    await waitFor(() => expect(threadSection()).not.toBeNull())
+    const trunc = document.querySelector('[data-slot="gh-thread-truncated"]')
+    expect(trunc?.textContent).toContain('thread truncated')
+    expect(trunc?.getAttribute('href')).toBe(ISSUE_142.url)
   })
 })
 

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -230,6 +230,21 @@ describe('the GitHub tab lists', () => {
     expect(document.querySelector('[data-slot="gh-row-checks"]')).toBeNull()
   })
 
+  it('shows a comment-count badge only on rows with comments (#499)', async () => {
+    stubFetch()
+    renderAt('/github')
+
+    await waitFor(() => expect(rows()).toHaveLength(2))
+    const badge = (number: string) =>
+      document.querySelector(`[data-slot="gh-row"][data-number="${number}"] [data-slot="gh-comment-count"]`)
+
+    // #142 has 3 comments → a labelled badge; #139 has 0 → none, so quiet rows look untouched.
+    expect(badge('142')?.getAttribute('data-count')).toBe('3')
+    expect(badge('142')?.getAttribute('aria-label')).toBe('3 comments')
+    expect(badge('142')?.textContent).toContain('3')
+    expect(badge('139')).toBeNull()
+  })
+
   it('counts at the fast-batch cap render as 30+ until the full fetch lands', async () => {
     const many: GithubData = {
       ...GITHUB,
@@ -338,7 +353,10 @@ describe('the GitHub detail pane', () => {
     expect(meta).toContain('#137')
     expect(meta).toContain('pull request')
     expect(meta).toContain('opened by grace')
-    expect(meta).toContain('1 comments')
+    // The comment count renders as an icon+count badge (#499), labelled for screen readers.
+    const detailCount = document.querySelector('[data-slot="gh-meta"] [data-slot="gh-comment-count"]')
+    expect(detailCount?.getAttribute('data-count')).toBe('1')
+    expect(detailCount?.getAttribute('aria-label')).toBe('1 comment')
     expect(document.querySelector('[data-slot="gh-diffstat"]')?.textContent).toBe('+120 −30')
     expect(document.querySelector('[data-slot="gh-open-link"]')?.getAttribute('href')).toBe(PR_137.url)
 

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -5,6 +5,7 @@ import {
   CircleDotIcon,
   ExternalLinkIcon,
   GitPullRequestIcon,
+  MessageSquareIcon,
   RefreshCwIcon,
   SearchIcon,
   TagIcon,
@@ -377,6 +378,7 @@ function GithubRow({
           <span>#{item.number}</span>
           <span className="min-w-0 truncate">{item.author}</span>
           <span>{shortAge(item.createdAt)}</span>
+          <CommentCount count={item.comments} />
           {item.checks ? <ChecksGlyph checks={item.checks} /> : null}
           {queued ? (
             <span data-slot="gh-queued-flag" className="font-sans font-medium text-violet">
@@ -502,7 +504,7 @@ function GithubDetail({
         <span>{shortAge(item.createdAt)} ago</span>
         {item.comments ? (
           <>
-            ·<span>{item.comments} comments</span>
+            ·<CommentCount count={item.comments} />
           </>
         ) : null}
         {hasDiffStat ? (
@@ -559,6 +561,24 @@ const CHECKS_TONE: Record<Checks, string> = {
   passing: 'text-success',
   failing: 'text-danger',
   pending: 'text-muted-foreground',
+}
+
+/** The comment-count badge (#499): a muted speech-bubble glyph + count, shown on issue/PR rows
+ *  and in the detail meta line. Renders nothing for a zero (or absent) count, so quiet items look
+ *  exactly as they did before real counts arrived. Shared so the row and detail can't drift. */
+function CommentCount({ count }: { count: number }) {
+  if (!count) return null
+  return (
+    <span
+      data-slot="gh-comment-count"
+      data-count={count}
+      aria-label={`${count} comment${count === 1 ? '' : 's'}`}
+      className="inline-flex shrink-0 items-center gap-0.5"
+    >
+      <MessageSquareIcon aria-hidden="true" className="size-3" />
+      {count}
+    </span>
+  )
 }
 
 /** The checks badge — the legacy tab's three phrases, tinted by outcome. Links out

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -15,14 +15,15 @@ import { useState, type DragEvent, type ReactNode } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
 
 import { getGithub, putUiState } from '@/api/client'
-import { queryKeys, useGithub, useSkills, useUiState, useWorkflows } from '@/api/queries'
-import type { GithubItem, UiState } from '@/api/types'
+import { queryKeys, useGithub, useGithubComments, useSkills, useUiState, useWorkflows } from '@/api/queries'
+import type { GithubComment, GithubItem, UiState } from '@/api/types'
 import { CenteredState } from '@/components/centered-state'
 import { GithubIcon } from '@/components/icons'
 import { TabLink } from '@/components/tab-link'
 import { Button } from '@/components/ui/button'
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Skeleton } from '@/components/ui/skeleton'
 import { toast } from '@/components/ui/toaster'
 import { shortAge } from '@/lib/format'
 import { githubTaskPrompt } from '@/lib/github-task'
@@ -548,8 +549,156 @@ function GithubDetail({
         )}
       </div>
 
+      <GithubThread item={item} />
+
       {children}
     </article>
+  )
+}
+
+/** The conversation thread (#499): comments (+ PR review summaries) rendered under the body, each
+ *  body through the shared `Markdown` component so images and code fences render exactly as the
+ *  issue body does. Lazy — only fetched while this detail view is mounted. Everything degrades:
+ *  loading → skeleton, unreachable → one-line reason + "open on GitHub", empty → nothing (the
+ *  count badge already said there were none). */
+function GithubThread({ item }: { item: GithubItem }) {
+  const thread = useGithubComments(item.kind, item.number)
+  const data = thread.data
+
+  if (thread.isPending) {
+    return (
+      <section data-slot="gh-thread-loading" className="mt-6 border-t border-border pt-5">
+        <Skeleton className="mb-3 h-3 w-24" />
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      </section>
+    )
+  }
+
+  if (!data || !data.available) {
+    const reason = data?.reason ?? (thread.error instanceof Error ? thread.error.message : 'could not load comments')
+    return (
+      <section data-slot="gh-thread-error" className="mt-6 border-t border-border pt-5 text-xs text-soft-foreground">
+        <span>Couldn’t load comments — {reason}. </span>
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-0.5 text-muted-foreground hover:text-foreground hover:underline"
+        >
+          open on GitHub
+          <ExternalLinkIcon aria-hidden="true" className="size-2.5" />
+        </a>
+      </section>
+    )
+  }
+
+  // An empty thread renders nothing: the count badge already communicated "no discussion", and an
+  // empty "Comments · 0" section would be noise on the many quiet issues/PRs.
+  if (data.comments.length === 0) return null
+
+  return (
+    <section data-slot="gh-thread" className="mt-6 border-t border-border pt-5">
+      <h3
+        data-slot="gh-thread-header"
+        className="mb-4 text-[11px] font-semibold tracking-wide text-soft-foreground uppercase"
+      >
+        Comments · {data.comments.length}
+      </h3>
+      <ul className="flex flex-col gap-5">
+        {data.comments.map((comment) => (
+          <ThreadEntry key={`${comment.kind}-${comment.id}`} comment={comment} />
+        ))}
+      </ul>
+      {data.truncated ? (
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-slot="gh-thread-truncated"
+          className="mt-4 inline-flex items-center gap-0.5 text-xs text-soft-foreground hover:text-foreground hover:underline"
+        >
+          thread truncated — open on GitHub
+          <ExternalLinkIcon aria-hidden="true" className="size-2.5" />
+        </a>
+      ) : null}
+    </section>
+  )
+}
+
+/** Review-state chip tones — the same success/danger/muted vocabulary the checks badge uses, so
+ *  approved reads green and changes-requested reads red without a new color system. */
+const REVIEW_CHIP: Record<NonNullable<GithubComment['reviewState']>, { label: string; tone: string }> = {
+  approved: { label: 'approved', tone: 'border-success/40 text-success' },
+  changes_requested: { label: 'changes requested', tone: 'border-danger/40 text-danger' },
+  commented: { label: 'commented', tone: 'border-border text-muted-foreground' },
+  dismissed: { label: 'dismissed', tone: 'border-border text-muted-foreground' },
+}
+
+/** One thread entry: avatar (letter fallback), author, age, an optional review-state chip, and the
+ *  body via the shared `Markdown` component (images/code fences render as in the issue body). */
+function ThreadEntry({ comment }: { comment: GithubComment }) {
+  const chip = comment.reviewState ? REVIEW_CHIP[comment.reviewState] : null
+  return (
+    <li data-slot="gh-thread-entry" data-kind={comment.kind} className="min-w-0">
+      <div className="mb-1.5 flex items-center gap-1.5 font-mono text-[11px] text-soft-foreground">
+        <Avatar url={comment.avatarUrl} login={comment.author} />
+        <span className="font-sans font-medium text-foreground">{comment.author}</span>
+        <span>{shortAge(comment.createdAt)}</span>
+        {chip ? (
+          <span
+            data-slot="gh-review-chip"
+            data-review-state={comment.reviewState}
+            className={cn('rounded-full border px-1.5 py-px font-sans text-[10px] font-medium', chip.tone)}
+          >
+            {chip.label}
+          </span>
+        ) : null}
+        <a
+          href={comment.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="open comment on GitHub"
+          className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          <ExternalLinkIcon aria-hidden="true" className="size-2.5" />
+        </a>
+      </div>
+      <div data-slot="gh-thread-body" className="text-sm">
+        {comment.body ? <Markdown>{comment.body}</Markdown> : <p className="text-soft-foreground">(no body)</p>}
+      </div>
+    </li>
+  )
+}
+
+/** A 16 px comment avatar. Falls back to a letter block when no URL is known or the image fails to
+ *  load (private-repo attachments, deleted avatars) — never a broken-image glyph. */
+function Avatar({ url, login }: { url?: string; login: string }) {
+  const [failed, setFailed] = useState(false)
+  if (url && !failed) {
+    return (
+      <img
+        src={url}
+        alt=""
+        width={16}
+        height={16}
+        loading="lazy"
+        onError={() => setFailed(true)}
+        data-slot="gh-avatar"
+        className="size-4 shrink-0 rounded-full"
+      />
+    )
+  }
+  return (
+    <span
+      data-slot="gh-avatar-fallback"
+      aria-hidden="true"
+      className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground uppercase"
+    >
+      {login.slice(0, 1) || '?'}
+    </span>
   )
 }
 


### PR DESCRIPTION
## Summary

Implements the GitHub-tab comment feature specced in #500 (design merged) for FR #499:

1. **Real comment counts + icon badge** on issue/PR rows and in the detail meta line — replacing the hard-coded `comments: 0`.
2. **Full comment thread** (markdown & images, PR review summaries) in the issue/PR detail view, rendered through the app's existing Streamdown `Markdown` component.

Source doc: `.ai/specs/2026-07-18-github-comment-threads.md`
Tracking plan: `.ai/runs/2026-07-18-issue-499-github-comment-threads.md`

Closes #499

## What changed

**Server** (`src/server/forge/github.ts`, `types.ts`, `server.ts`)
- `fetchCommentCounts` — one lightweight GraphQL query per kind (`number → totalCount`), paginated (≤10 pages), run parallel to the list calls, degrading to empty maps on any failure so counts never break the tab. Real counts replace the two `comments: 0` literals.
- `fetchGithubComments` + `GET /api/github/comments/:kind/:number` — lazy per-thread fetch: conversation comments (+ submitted PR reviews), zod-validated, review-filtered (drop empty-body COMMENTED/PENDING), merged chronologically, 200-entry / 8000-char caps, behind a bounded 60 s per-thread cache. zod param validation (400 on garbage); availability degrades in-payload (never a 5xx). `CEZ_DRY_RUN` returns a mock thread (image + PR review) for offline demo/tests.

**Web** (`web/app/src/api/*`, `routes/github/github.tsx`)
- `MessageSquareIcon` + count badge on rows and detail meta (only when `> 0`).
- `GithubThread` under the body — avatar (letter fallback), author, age, review-state chip, body via the shared `Markdown` component; loading → skeleton, unreachable → one-line reason + open-on-GitHub, empty → nothing, truncated → trailing link.

## Phases

- [x] **Phase 1 — counts + icons**
- [x] **Phase 2 — comment threads**
- [x] **Phase 3 — polish** (avatars + letter fallback, review-state chips, truncation row, image render)

## Tests & validation

Full gate green: `typecheck`, `test` (2486), `test:unit`, `build`+`check:pack`, `test:package`. New coverage: counts pagination/cap/degrade, thread normalize/review-filter/merge/cap (unit); route param gate + dry-run thread (server); count badge, thread render, image `<img>`, review chip, avatar fallback, truncation, error/empty states (component).

## Compatibility

`GET /api/github` and `ForgeItem` are protected surfaces (`BACKWARD_COMPATIBILITY.md` §2). All changes are additive — real data in the existing `comments` field plus one net-new endpoint; no removals or renames.

---

🤖 made with cezar
