### PR TITLE
fix(serve): don't crash on headless hosts when the browser opener is missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
       },
       "bin": {
         "cez": "dist/index.js",
-        "cezar": "dist/index.js"
+        "cezar": "dist/index.js",
+        "cezar-cli": "dist/index.js"
       },
       "devDependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,14 @@ function openUrl(url: string): void {
     process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
   const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
   try {
-    spawn(cmd, args, { stdio: 'ignore', detached: true }).unref();
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    // A missing opener (e.g. no `xdg-open` on a headless Linux VPS) surfaces
+    // asynchronously as an 'error' event, NOT a synchronous throw — without a
+    // listener Node promotes it to an unhandled error and hard-crashes the whole
+    // process, even though the cockpit is already serving. Swallow it: the URL is
+    // printed above, so a browser-less host just doesn't auto-open.
+    child.on('error', () => {});
+    child.unref();
   } catch {
     // the printed URL is enough
   }


### PR DESCRIPTION
## What

`cez`/`cezar serve` hard-crashed on a headless Linux VPS (no `xdg-open`) **after** the cockpit had already started serving:

```
Error: spawn xdg-open ENOENT
Emitted 'error' event on ChildProcess instance ...
Node.js v24.15.0   ← whole process dies
```

## Why

`openUrl` (`src/index.ts`) wrapped `spawn` in a `try/catch`, but a missing opener does **not** throw synchronously — it emits an asynchronous `'error'` event on the child process. With no `'error'` listener, Node promotes it to an unhandled error and kills the whole process, taking the already-running server down with it. The `catch` never fires.

## Fix

Attach a no-op `'error'` handler to the spawned child. A browser-less host now simply skips auto-open — the cockpit URL is already printed to the console, so nothing is lost.

```
cockpit → http://localhost:4322     ← server stays up
```

## Verification

- Full validation gate green: `typecheck`, `npm test` (2533 passed), `test:unit`, `build`, `test:package`.
- Smoke-tested on a headless box with `xdg-open` absent: process now stays alive through the auto-open attempt instead of crashing.
- Confirmed two concurrent instances land on distinct ports via `pickPort` auto-increment (4322 / 4323), so this unblocks running multiple cockpits on one VPS.

## Notes on the broader ask (multiple instances / installer)

- **Two cockpits on separate ports** — already works via the plain alias; `pickPort` (`src/index.ts:182`) scans from 4321 upward and each instance takes the next free port. Use `-p <n>` to pin one explicitly, and `--no-open` on headless hosts.
- **`install-as-command` on macOS + Ubuntu** — already correct; shim paths branch only win32 vs posix, and both are posix.
- **`cezar server-install` wizard** — single-instance per host by design (one `~/.cezar/server.json`, one `primaryPort`, one lock). Hosting two *managed* instances via that wizard is out of scope here and would be a separate feature.