### PR TITLE
feat(server-install): host multiple cockpits per box, keyed by domain (ubuntu-vps)

### DIFF
--- a/.ai/specs/2026-07-16-server-installer.md
+++ b/.ai/specs/2026-07-16-server-installer.md
@@ -226,3 +226,28 @@ Numbered steps; each is testable and leaves the app working. Steps map onto `om-
 ### Phase 3 — macosx-ngrok
 
 11. **`platforms/macosx-ngrok.ts`** — preflight (macOS), deps, `ngrok config add-authtoken` + reserved domain + `--basic-auth`, launchd autostart, identity verify; ephemeral-URL fallback recorded in state. Full `undo` per step (reuses the Phase-1 `runUninstall`). *Test:* dry-run walks every step, produces `server.json` with `platform:"macosx-ngrok"`, and `server-uninstall` reverses it; registry now lists both platforms.
+
+---
+
+## Addendum (2026-07-18) — domain-keyed multi-instance (`ubuntu-vps`)
+
+The original design was **install-once per host** (one `~/.cezar/server.json`,
+one port, one lock). Follow-up: one `ubuntu-vps` box can now host **several
+independent cockpits, keyed by domain**, so a second `server-install` for a new
+domain no longer resumes/reinstalls the first.
+
+- **Identity** — `--domain <host>` selects/creates an instance; its slug
+  (`instanceSlug()`) keys everything. No `--domain` = the legacy `default`
+  instance, byte-for-byte unchanged (backward compatible).
+- **State** — `default` keeps `~/.cezar/server.json`; a named instance lives at
+  `~/.cezar/server-instances/<slug>.json` with a per-instance lock. `state.ts`
+  gains `listServerInstances()`, `nextFreeInstancePort()`, `deleteServerState()`.
+- **Artifacts** — the `ubuntu-vps` strategy suffixes per instance: nginx site
+  `cezar-<slug>`, `htpasswd-<slug>`, unit `cezar-<slug>.service`; nginx routes by
+  `Host` header (each instance stamps its domain into `server_name` up front),
+  and the identity probe sends the instance's `Host` so it verifies the right
+  vhost. `/etc/cezar` is shared; `rmdir` on uninstall only removes it when empty.
+- **Port** — a new named instance auto-picks the next free loopback port from
+  4321; `--port` overrides.
+- **Scope** — `ubuntu-vps` only (shared nginx front). `macosx-ngrok` stays
+  single-instance.

--- a/README.md
+++ b/README.md
@@ -419,7 +419,14 @@ and verified, and it ends with a real authenticated end-to-end check.
 npx cezar-cli server-install   --platform ubuntu-vps   # stand it up
 npx cezar-cli server-deploy    --platform ubuntu-vps   # roll out a new version (reload the service)
 npx cezar-cli server-uninstall --platform ubuntu-vps   # reverse it
+
+# host a SECOND cockpit for another domain on the same box (ubuntu-vps):
+npx cezar-cli server-install   --platform ubuntu-vps --domain shop.example.com
 ```
+
+On `ubuntu-vps` a single host can run several independent cockpits — add
+`--domain <host>` and each gets its own port, nginx site, login and service; a
+new domain never resumes or clobbers the first install.
 
 | Provider | `--platform` | Public front | Guide |
 |----------|--------------|--------------|-------|

--- a/docs/server-install/README.md
+++ b/docs/server-install/README.md
@@ -27,6 +27,12 @@ npx cezar-cli server-uninstall --platform <id>   # reverse it
 Same engine, different steps — each strategy is a small registry entry, so new
 platforms slot in without touching the engine.
 
+> **Several domains on one box?** `ubuntu-vps` can host multiple independent
+> cockpits — add `--domain <host>` to install/deploy/uninstall a separate
+> instance (its own port, nginx site, login and service). A new `--domain` never
+> resumes the first install. See
+> [Hosting several cockpits on one box](./ubuntu-vps.md#hosting-several-cockpits-on-one-box-multiple-domains).
+
 ## How it works (all providers)
 
 1. **Dependencies** — detect the agent CLIs (`claude`/`codex`/`opencode`),

--- a/docs/server-install/ubuntu-vps.md
+++ b/docs/server-install/ubuntu-vps.md
@@ -111,6 +111,57 @@ The installer is also **idempotent** if you need to change the setup itself:
 
 ---
 
+## Hosting several cockpits on one box (multiple domains)
+
+One VPS can run **several independent cezar cockpits**, one per domain. Each
+instance gets its **own** loopback port, nginx site, htpasswd, systemd service,
+and state file — they share only nginx and certbot, which route by `Host`
+header. Pass `--domain` to select or create an instance:
+
+```bash
+# first cockpit — the default instance (loopback :4321, ~/.cezar/server.json)
+npx cezar-cli server-install --platform ubuntu-vps
+
+# a SECOND, fully independent cockpit for another domain
+npx cezar-cli server-install --platform ubuntu-vps --domain shop.example.com
+```
+
+Because instances are **keyed by domain**, running `server-install` again with a
+**new** `--domain` never resumes or overwrites an existing install — it stands
+up a fresh instance. Run it again with the **same** `--domain` to resume or
+reconfigure that instance.
+
+What differs per instance:
+
+| Instance | State file | nginx site | htpasswd | systemd unit | Loopback port |
+|----------|-----------|-----------|----------|--------------|---------------|
+| default (no `--domain`) | `~/.cezar/server.json` | `…/sites-available/cezar` | `/etc/cezar/htpasswd` | `cezar.service` | `4321` |
+| `--domain shop.example.com` | `~/.cezar/server-instances/shop-example-com.json` | `…/cezar-shop-example-com` | `/etc/cezar/htpasswd-shop-example-com` | `cezar-shop-example-com.service` | auto (next free, e.g. `4322`) |
+
+- **Port** — a new instance auto-picks the next free loopback port (`4321`,
+  `4322`, …). Override with `--port <n>`. Each cockpit still serves loopback-only;
+  nginx is the single public surface for all of them.
+- **Login** — each instance has its own htpasswd, so every cockpit can have a
+  different username/password.
+- **Deploy / uninstall** — pass the same `--domain` to target that instance:
+
+  ```bash
+  npx cezar-cli server-deploy    --platform ubuntu-vps --domain shop.example.com
+  npx cezar-cli server-uninstall --platform ubuntu-vps --domain shop.example.com
+  ```
+
+  A named-instance uninstall removes only that instance's owned artifacts and
+  deletes its state file; the other cockpits and the shared nginx/certbot are
+  left running. (Uninstalling the **default** instance does not remove a shared
+  nginx that a named instance still needs — it lists it for manual removal.)
+
+> Interactive installs help here too: if a cockpit already exists and you run
+> `server-install` with no `--domain`, the wizard asks whether you want to set up
+> a **second instance for a new domain** or manage the existing one — so the
+> common "it just asks me to reinstall" case now has an obvious path forward.
+
+---
+
 ## Uninstall
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,16 @@ Usage:
   cezar server-uninstall    reverse a server-install
 
 Options:
-  -p, --port <n>              cockpit port (default 4321)
+  -p, --port <n>              cockpit port (default 4321; server-install: this
+                              instance's loopback port — auto-picked per domain)
       --repo <dir>            repo to operate on (default: cwd)
       --workflow <name>       workflow for \`run\` (default: quick-task)
       --model <model>         model override for \`run\`
       --no-open               don't open the browser
       --platform <id>         server-install target (ubuntu-vps | macosx-ngrok)
+      --domain <host>         server-install (ubuntu-vps): host a SECOND, independent
+                              cockpit for this domain (own nginx site + service + port).
+                              A new domain never resumes/clobbers the first install.
       --yes                   server-install: accept safe defaults (never auto-sudo)
       --reconfigure <ids>     server-install: force re-run of step id(s), comma-separated
       --reinstall             server-install: force re-run of every step (full reinstall)
@@ -53,6 +57,7 @@ async function main(): Promise<void> {
       model: { type: 'string' },
       'no-open': { type: 'boolean', default: false },
       platform: { type: 'string' },
+      domain: { type: 'string' },
       yes: { type: 'boolean', default: false },
       reconfigure: { type: 'string' },
       reinstall: { type: 'boolean', default: false },
@@ -60,6 +65,14 @@ async function main(): Promise<void> {
     },
     allowPositionals: true,
   });
+
+  // `port` carries a default, so its presence can't tell an explicit `--port`
+  // from the fallback. server-install needs that distinction (explicit port
+  // wins; otherwise a new named instance auto-picks a free one), so detect the
+  // flag straight from argv.
+  const portExplicit = process.argv
+    .slice(2)
+    .some((a) => a === '-p' || a === '--port' || a.startsWith('--port=') || a.startsWith('-p='));
 
   if (values.help) {
     console.log(HELP);
@@ -86,13 +99,21 @@ async function main(): Promise<void> {
         yes: Boolean(values.yes),
         reconfigure: values.reconfigure,
         reinstall: Boolean(values.reinstall),
+        domain: values.domain,
+        port: portExplicit ? Number(values.port) : undefined,
       });
       return;
     case 'server-deploy':
-      await serverCommand('deploy', repoRoot, values.platform, { yes: Boolean(values.yes) });
+      await serverCommand('deploy', repoRoot, values.platform, {
+        yes: Boolean(values.yes),
+        domain: values.domain,
+      });
       return;
     case 'server-uninstall':
-      await serverCommand('uninstall', repoRoot, values.platform, { yes: Boolean(values.yes) });
+      await serverCommand('uninstall', repoRoot, values.platform, {
+        yes: Boolean(values.yes),
+        domain: values.domain,
+      });
       return;
     default:
       console.error(`unknown command: ${command}\n`);
@@ -308,7 +329,7 @@ async function serverCommand(
   mode: 'install' | 'uninstall' | 'deploy',
   repoRoot: string,
   platform: string | undefined,
-  flags: { yes: boolean; reconfigure?: string; reinstall?: boolean },
+  flags: { yes: boolean; reconfigure?: string; reinstall?: boolean; domain?: string; port?: number },
 ): Promise<void> {
   // Detection (claude/gh/codex) and tool installs resolve executables off the
   // process PATH. When the installer is launched from a non-login shell (an
@@ -319,13 +340,35 @@ async function serverCommand(
 
   const { getStrategy, availablePlatformIds } = await import('./server-install/strategies.js');
   const { runInstall, runUninstall, runDeploy } = await import('./server-install/engine.js');
+  const { loadServerState, listServerInstances, nextFreeInstancePort } = await import('./server-install/state.js');
+  const { instanceSlug, DEFAULT_SERVER_INSTANCE } = await import('./paths.js');
 
   const ids = availablePlatformIds();
-  // Uninstall and deploy can read the platform from the recorded state when omitted.
+
+  // Resolve the instance from --domain (domain-keyed multi-instance). An
+  // interactive install with an existing cockpit and no --domain also offers to
+  // stand up a second instance — the exact "it asks me to reinstall" case.
+  let domain = (flags.domain ?? '').trim() || undefined;
+  if (mode === 'install' && !domain && !flags.yes && process.stdin.isTTY && loadServerState(DEFAULT_SERVER_INSTANCE).installed) {
+    try {
+      const { createClackUi } = await import('./server-install/ui.js');
+      const answer = await createClackUi().text({
+        message:
+          'This host already runs a cezar cockpit. Enter a NEW domain to host a second, independent instance — ' +
+          'or leave blank to manage/redeploy the existing one.',
+        placeholder: 'shop.example.com',
+      });
+      if (typeof answer === 'string' && answer.trim()) domain = answer.trim();
+    } catch {
+      // any prompt failure → fall back to managing the default instance
+    }
+  }
+  const instance = domain ? instanceSlug(domain) : DEFAULT_SERVER_INSTANCE;
+
+  // Uninstall and deploy can read the platform from THIS instance's record when omitted.
   let chosen = platform;
   if ((mode === 'uninstall' || mode === 'deploy') && !chosen) {
-    const { loadServerState } = await import('./server-install/state.js');
-    chosen = loadServerState().platform;
+    chosen = loadServerState(instance).platform;
   }
   if (!chosen) {
     console.error(`--platform is required. Valid platforms: ${ids.join(', ')}`);
@@ -338,6 +381,23 @@ async function serverCommand(
     process.exitCode = 1;
     return;
   }
+  // Domain-keyed multi-instance is an ubuntu-vps feature (shared nginx front).
+  if (instance !== DEFAULT_SERVER_INSTANCE && chosen !== 'ubuntu-vps') {
+    console.error(`--domain (multi-instance) is only supported on ubuntu-vps, not ${chosen}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Port: an explicit --port always wins; a brand-new named instance otherwise
+  // auto-picks the next free loopback port so it can't collide with the first.
+  let port = flags.port;
+  if (mode === 'install' && instance !== DEFAULT_SERVER_INSTANCE && port === undefined) {
+    const known = listServerInstances().some((i) => i.instance === instance);
+    if (!known) {
+      port = nextFreeInstancePort();
+      console.log(`\n  New instance "${instance}" (${domain}) → loopback port ${port} (override with --port).`);
+    }
+  }
 
   const runOpts = {
     dryRun: process.env.CEZ_DRY_RUN === '1',
@@ -346,7 +406,14 @@ async function serverCommand(
     reinstall: Boolean(flags.reinstall),
     repoRoot,
     now: new Date().toISOString(),
+    instance,
+    domain,
+    port,
   };
+
+  // e.g. "ubuntu-vps" or "ubuntu-vps, shop.example.com" for a named instance.
+  const label = instance === DEFAULT_SERVER_INSTANCE ? chosen : `${chosen}, ${domain}`;
+  const domainFlag = instance === DEFAULT_SERVER_INSTANCE ? '' : ` --domain ${domain}`;
 
   try {
     const result =
@@ -356,12 +423,12 @@ async function serverCommand(
           ? await runDeploy(strategy, runOpts)
           : await runUninstall(strategy, runOpts);
     if (mode === 'install' && result.status === 'complete') {
-      console.log(`\n  cezar server-install (${chosen}) complete.`);
-      console.log(`  Redeploy a new version any time with: cezar server-deploy --platform ${chosen}\n`);
+      console.log(`\n  cezar server-install (${label}) complete.`);
+      console.log(`  Redeploy a new version any time with: cezar server-deploy --platform ${chosen}${domainFlag}\n`);
     } else if (mode === 'deploy' && result.status === 'complete') {
-      console.log(`\n  cezar server-deploy (${chosen}) complete — the service was reloaded and verified.\n`);
+      console.log(`\n  cezar server-deploy (${label}) complete — the service was reloaded and verified.\n`);
     } else if (mode === 'uninstall' && result.status === 'complete') {
-      console.log(`\n  cezar server-uninstall (${chosen}) complete — the changes it made were reversed.\n`);
+      console.log(`\n  cezar server-uninstall (${label}) complete — the changes it made were reversed.\n`);
     }
     // complete + cancelled (resumable) exit 0; failed exits 1.
     process.exitCode = result.status === 'failed' ? 1 : 0;

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { cezarHomeDir, serverLockPath, serverStatePath } from './paths.js';
+import {
+  DEFAULT_SERVER_INSTANCE,
+  cezarHomeDir,
+  instanceSlug,
+  serverInstancesDir,
+  serverLockPath,
+  serverStatePath,
+} from './paths.js';
 
 describe('paths', () => {
   const original = process.env.CEZ_HOME;
@@ -20,6 +27,35 @@ describe('paths', () => {
     expect(cezarHomeDir()).toBe('/tmp/cez-home-test');
     expect(serverStatePath()).toBe('/tmp/cez-home-test/server.json');
     expect(serverLockPath()).toBe('/tmp/cez-home-test/server.install.lock');
+  });
+
+  it('the default instance keeps the legacy un-suffixed paths', () => {
+    process.env.CEZ_HOME = '/tmp/cez-home-test';
+    expect(serverStatePath(DEFAULT_SERVER_INSTANCE)).toBe('/tmp/cez-home-test/server.json');
+    expect(serverLockPath(DEFAULT_SERVER_INSTANCE)).toBe('/tmp/cez-home-test/server.install.lock');
+  });
+
+  it('a named instance lives under server-instances/, keyed by slug', () => {
+    process.env.CEZ_HOME = '/tmp/cez-home-test';
+    expect(serverInstancesDir()).toBe('/tmp/cez-home-test/server-instances');
+    expect(serverStatePath('shop-example-com')).toBe('/tmp/cez-home-test/server-instances/shop-example-com.json');
+    expect(serverLockPath('shop-example-com')).toBe(
+      '/tmp/cez-home-test/server-instances/shop-example-com.install.lock',
+    );
+  });
+});
+
+describe('instanceSlug', () => {
+  it('lowercases and turns every non-alnum run (incl. dots) into a single dash', () => {
+    expect(instanceSlug('Shop.Example.COM')).toBe('shop-example-com');
+    expect(instanceSlug('a__b--c')).toBe('a-b-c');
+    expect(instanceSlug('  lead.trail.  ')).toBe('lead-trail');
+  });
+
+  it('degenerate/empty input can never escape the instance namespace', () => {
+    expect(instanceSlug('')).toBe(DEFAULT_SERVER_INSTANCE);
+    expect(instanceSlug(undefined)).toBe(DEFAULT_SERVER_INSTANCE);
+    expect(instanceSlug('.-.-')).toBe(DEFAULT_SERVER_INSTANCE);
   });
 });
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -19,18 +19,55 @@ export function cezarHomeDir(): string {
 }
 
 /**
- * Host-level, install-once record written by `server-install` (spec
- * 2026-07-16-server-installer). Distinct from the per-instance registry the
- * multi-project switcher keeps under `~/.cezar/instances/` — they coexist.
+ * The default server-install instance id. An install with no `--domain` (the
+ * original single-cockpit-per-host flow) is this instance, and it keeps the
+ * legacy `~/.cezar/server.json` path so existing hosts upgrade in place.
  */
-export function serverStatePath(): string {
-  return join(cezarHomeDir(), 'server.json');
+export const DEFAULT_SERVER_INSTANCE = 'default';
+
+/**
+ * Turn a public domain into a stable, filesystem- and systemd-safe instance
+ * slug — the key that lets one host run several independent cockpits, each for
+ * a different domain (nginx site `cezar-<slug>`, unit `cezar-<slug>.service`,
+ * state file `server-instances/<slug>.json`). Lowercased; every run of
+ * non-`[a-z0-9]` becomes a single `-`; leading/trailing `-` trimmed. A `.` in a
+ * systemd unit name is a type separator, so dots collapse to `-` too. Returns
+ * `default` for empty/degenerate input so a bad value can never escape the
+ * instance namespace.
+ */
+export function instanceSlug(domain: string | undefined | null): string {
+  const slug = String(domain ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || DEFAULT_SERVER_INSTANCE;
+}
+
+/** The directory holding per-domain (named) server-install state files. */
+export function serverInstancesDir(): string {
+  return join(cezarHomeDir(), 'server-instances');
 }
 
 /**
- * Single-writer lock the installer/uninstaller hold for a whole run. The
- * host-level installer is not concurrency-safe with itself.
+ * Host-level record written by `server-install` (spec 2026-07-16-server-installer).
+ * The `default` instance keeps the original `~/.cezar/server.json`; a named
+ * (domain-keyed) instance lives at `~/.cezar/server-instances/<slug>.json`, so
+ * a second install for a different domain never resumes or clobbers the first.
+ * Distinct from the per-project registry the multi-project switcher keeps under
+ * `~/.cezar/instances/` — they coexist.
  */
-export function serverLockPath(): string {
-  return join(cezarHomeDir(), 'server.install.lock');
+export function serverStatePath(instance: string = DEFAULT_SERVER_INSTANCE): string {
+  if (instance === DEFAULT_SERVER_INSTANCE) return join(cezarHomeDir(), 'server.json');
+  return join(serverInstancesDir(), `${instance}.json`);
+}
+
+/**
+ * Single-writer lock the installer/uninstaller hold for a whole run. Per
+ * instance, so installing/uninstalling one cockpit never blocks work on another
+ * on the same host. The host-level installer is not concurrency-safe with
+ * itself *for the same instance*.
+ */
+export function serverLockPath(instance: string = DEFAULT_SERVER_INSTANCE): string {
+  if (instance === DEFAULT_SERVER_INSTANCE) return join(cezarHomeDir(), 'server.install.lock');
+  return join(serverInstancesDir(), `${instance}.install.lock`);
 }

--- a/src/server-install/engine.test.ts
+++ b/src/server-install/engine.test.ts
@@ -168,6 +168,36 @@ describe('engine', () => {
     expect(res.state.installed).toBe(true); // optional skip doesn't block
   });
 
+  it('two instances install to separate records that do not resume each other', async () => {
+    // default install
+    await runInstall(strategyOf([fakeStep('a')]), opts());
+    // a second install for a different domain, keyed by its slug + its own port
+    const b = fakeStep('a');
+    const res = await runInstall(
+      strategyOf([b]),
+      opts({ instance: 'shop-example-com', domain: 'shop.example.com', port: 4322 }),
+    );
+    expect(res.status).toBe('complete');
+    // the second run actually RAN its step — it did NOT report "already done"
+    // from the default record (the "asks me to reinstall" bug being fixed)
+    expect(b.run).toHaveBeenCalledOnce();
+    expect(loadServerState('shop-example-com').domain).toBe('shop.example.com');
+    expect(loadServerState('shop-example-com').primaryPort).toBe(4322);
+    expect(loadServerState('shop-example-com').instance).toBe('shop-example-com');
+    // the default record is untouched (still port 4321, no domain)
+    expect(loadServerState().primaryPort).toBe(4321);
+    expect(loadServerState().domain).toBeUndefined();
+  });
+
+  it('a named instance uninstall removes its record; a default uninstall keeps the file', async () => {
+    await runInstall(strategyOf([fakeStep('a')]), opts({ instance: 'shop-example-com', domain: 'shop.example.com', port: 4322 }));
+    const res = await runUninstall(strategyOf([fakeStep('a')]), opts({ instance: 'shop-example-com' }));
+    expect(res.status).toBe('complete');
+    // the named record file is gone → it no longer reserves a port or lists
+    const { listServerInstances } = await import('./state.js');
+    expect(listServerInstances().some((i) => i.instance === 'shop-example-com')).toBe(false);
+  });
+
   it('--yes skips optional steps rather than running them non-interactively', async () => {
     const a = fakeStep('a');
     const opt = fakeStep('opt', { optional: true });

--- a/src/server-install/engine.ts
+++ b/src/server-install/engine.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { cezarHomeDir } from '../paths.js';
-import { acquireLock, isResolved, loadServerState, saveServerState } from './state.js';
+import { acquireLock, deleteServerState, isResolved, loadServerState, saveServerState } from './state.js';
 import { StepAborted, StepCancelled, StepSkipped, defaultRunner } from './steps.js';
 import { createAutoUi, createClackUi } from './ui.js';
 import {
@@ -34,6 +34,18 @@ export interface RunOptions {
   now: string;
   ui?: Ui;
   runner?: Runner;
+  /**
+   * Instance id (slug) to act on. Omit / `default` for the original
+   * single-cockpit host (legacy `~/.cezar/server.json`); a domain-derived slug
+   * targets a named instance under `~/.cezar/server-instances/`.
+   */
+  instance?: string;
+  /** Public domain for this instance — recorded up front so instance selection
+   * and the SSL step share one source of truth. */
+  domain?: string;
+  /** Loopback port for this instance. For a NEW named instance the caller
+   * passes an auto-picked free port; a resume keeps the recorded one. */
+  port?: number;
 }
 
 export type RunStatus = 'complete' | 'cancelled' | 'failed';
@@ -99,11 +111,13 @@ function buildContext(state: ServerState, opts: RunOptions): InstallContext {
     (opts.dryRun || opts.assumeYes
       ? createAutoUi({}, (m) => console.log(m), { strictValidate: !opts.dryRun })
       : createClackUi());
+  const instance = opts.instance ?? 'default';
   const ctx: InstallContext = {
     state,
     ui,
+    instance,
     runner: opts.runner ?? defaultRunner,
-    save: async () => saveServerState(state),
+    save: async () => saveServerState(state, instance),
     dryRun: opts.dryRun,
     assumeYes: opts.assumeYes,
     reconfigure: opts.reconfigure,
@@ -117,9 +131,9 @@ function buildContext(state: ServerState, opts: RunOptions): InstallContext {
 }
 
 export async function runInstall(strategy: PlatformStrategy, opts: RunOptions): Promise<RunResult> {
-  const release = acquireLock();
+  const release = acquireLock(opts.instance);
   try {
-    const state = loadServerState();
+    const state = loadServerState(opts.instance);
     // buildContext reconciles dry-run records first, so a preview of platform A
     // never blocks a real install of platform B (the reset clears `platform`).
     const ctx = buildContext(state, opts);
@@ -129,6 +143,13 @@ export async function runInstall(strategy: PlatformStrategy, opts: RunOptions): 
       );
     }
     state.platform = strategy.id;
+    // Record instance identity so the file is self-describing and later
+    // uninstall/deploy runs (and `server-instances/` listings) agree on it.
+    state.instance = opts.instance ?? state.instance ?? 'default';
+    if (opts.domain) state.domain = opts.domain;
+    // A caller-supplied port wins (a new named instance auto-picks a free one);
+    // otherwise keep whatever the resumed record already carries.
+    if (opts.port) state.primaryPort = opts.port;
     state.createdAt ??= opts.now;
     state.updatedAt = opts.now;
 
@@ -235,9 +256,9 @@ export async function runInstall(strategy: PlatformStrategy, opts: RunOptions): 
 }
 
 export async function runUninstall(strategy: PlatformStrategy, opts: RunOptions): Promise<RunResult> {
-  const release = acquireLock();
+  const release = acquireLock(opts.instance);
   try {
-    const state = loadServerState();
+    const state = loadServerState(opts.instance);
     const ctx = buildContext(state, opts);
     // Same guard as install/deploy: undoing with the wrong strategy would skip
     // the real artifacts and (before this guard existed) destroy their ledger.
@@ -301,7 +322,12 @@ export async function runUninstall(strategy: PlatformStrategy, opts: RunOptions)
     state.platform = undefined;
     state.publicUrl = undefined;
     state.ephemeral = undefined;
+    state.domain = undefined;
     await ctx.save();
+    // A named instance is fully gone now — drop its (empty) record so it no
+    // longer reserves a port or shows up as an install. The default record is
+    // kept, matching the legacy single-host behavior.
+    if (ctx.instance !== 'default') deleteServerState(ctx.instance);
     return { status: 'complete', state };
   } finally {
     release();
@@ -314,9 +340,9 @@ export async function runUninstall(strategy: PlatformStrategy, opts: RunOptions)
  * + re-verify); holds the single-writer lock for the whole run.
  */
 export async function runDeploy(strategy: PlatformStrategy, opts: RunOptions): Promise<RunResult> {
-  const release = acquireLock();
+  const release = acquireLock(opts.instance);
   try {
-    const state = loadServerState();
+    const state = loadServerState(opts.instance);
     const ctx = buildContext(state, opts);
     if (state.platform && state.platform !== strategy.id) {
       throw new PreflightError(

--- a/src/server-install/platforms/ubuntu-vps.test.ts
+++ b/src/server-install/platforms/ubuntu-vps.test.ts
@@ -13,6 +13,7 @@ function ctxWith(over: { ui?: Ui; runner?: Runner; dryRun?: boolean }): InstallC
   return {
     state: { schema: 1, installed: false, primaryPort: 4321, steps: {} },
     ui: over.ui ?? createAutoUi(),
+    instance: 'default',
     runner: over.runner ?? okRunner,
     save: async () => {},
     dryRun: over.dryRun ?? false,
@@ -103,6 +104,51 @@ describe('nginxVhost', () => {
     expect(nginxVhost(4321)).toContain('server_name _;');
     // The SSL step rewrites server_name to the domain so certbot --nginx can find it.
     expect(nginxVhost(4321, 'cezar.example.com')).toContain('server_name cezar.example.com;');
+  });
+
+  it('defaults to the legacy htpasswd path but accepts an instance-scoped one', () => {
+    expect(nginxVhost(4321)).toContain('auth_basic_user_file /etc/cezar/htpasswd;');
+    expect(nginxVhost(4322, 'shop.example.com', '/etc/cezar/htpasswd-shop-example-com')).toContain(
+      'auth_basic_user_file /etc/cezar/htpasswd-shop-example-com;',
+    );
+  });
+});
+
+describe('ubuntu-vps multi-instance artifact paths', () => {
+  /** ctx for a named instance whose domain is known up front. */
+  function namedCtx(): InstallContext {
+    const c = ctxWith({ dryRun: true });
+    c.instance = 'shop-example-com';
+    c.state.domain = 'shop.example.com';
+    c.state.primaryPort = 4322;
+    return c;
+  }
+
+  it('the default instance records the legacy un-suffixed nginx/htpasswd paths', async () => {
+    const ui = { ...createAutoUi(), text: async () => 'ops', password: async () => 'longenough' } as Ui;
+    const ctx = { ...ctxWith({ ui, dryRun: true }), assumeYes: true } as InstallContext;
+    const created = await stepById('nginx-proxy').run(ctx);
+    const paths = (created?.artifacts ?? []).map((a) => a.path).filter(Boolean);
+    expect(paths).toContain('/etc/nginx/sites-available/cezar');
+    expect(paths).toContain('/etc/nginx/sites-enabled/cezar');
+    expect(paths).toContain('/etc/cezar/htpasswd');
+  });
+
+  it('a named instance suffixes the nginx site + htpasswd with its slug', async () => {
+    const ctx = namedCtx();
+    (ctx as { assumeYes: boolean }).assumeYes = true;
+    ctx.ui = { ...createAutoUi(), text: async () => 'ops', password: async () => 'longenough' } as Ui;
+    const created = await stepById('nginx-proxy').run(ctx);
+    const paths = (created?.artifacts ?? []).map((a) => a.path).filter(Boolean);
+    expect(paths).toContain('/etc/nginx/sites-available/cezar-shop-example-com');
+    expect(paths).toContain('/etc/nginx/sites-enabled/cezar-shop-example-com');
+    expect(paths).toContain('/etc/cezar/htpasswd-shop-example-com');
+  });
+
+  it("a named instance's systemd unit is cezar-<slug>.service", async () => {
+    const created = await stepById('autostart').run(namedCtx());
+    const svc = created?.artifacts.find((a) => a.type === 'service');
+    expect(svc?.name).toBe('cezar-shop-example-com.service');
   });
 });
 

--- a/src/server-install/platforms/ubuntu-vps.ts
+++ b/src/server-install/platforms/ubuntu-vps.ts
@@ -14,9 +14,33 @@ import { depCheckStep, generatePassword, owned, shared, shquote, StepAborted, St
  * Phase 2 appends the optional SSL and autostart steps to `steps()`.
  */
 
-const VHOST_AVAILABLE = '/etc/nginx/sites-available/cezar';
-const VHOST_ENABLED = '/etc/nginx/sites-enabled/cezar';
-const HTPASSWD = '/etc/cezar/htpasswd';
+/**
+ * Instance-scoped artifact paths. The `default` instance (a host with no
+ * `--domain`, i.e. every pre-multi-instance install) keeps the original,
+ * un-suffixed names so it upgrades in place; a named (domain-keyed) instance
+ * suffixes the nginx site, htpasswd, and systemd unit with its slug so several
+ * cockpits coexist on one host without colliding. `undefined`/`'default'` both
+ * resolve to the legacy names.
+ */
+function inst(ctx: InstallContext): string {
+  return ctx.instance && ctx.instance !== 'default' ? ctx.instance : 'default';
+}
+function vhostAvailable(ctx: InstallContext): string {
+  const i = inst(ctx);
+  return i === 'default' ? '/etc/nginx/sites-available/cezar' : `/etc/nginx/sites-available/cezar-${i}`;
+}
+function vhostEnabled(ctx: InstallContext): string {
+  const i = inst(ctx);
+  return i === 'default' ? '/etc/nginx/sites-enabled/cezar' : `/etc/nginx/sites-enabled/cezar-${i}`;
+}
+function htpasswdPath(ctx: InstallContext): string {
+  const i = inst(ctx);
+  return i === 'default' ? '/etc/cezar/htpasswd' : `/etc/cezar/htpasswd-${i}`;
+}
+function unitName(ctx: InstallContext): string {
+  const i = inst(ctx);
+  return i === 'default' ? 'cezar.service' : `cezar-${i}.service`;
+}
 
 /** Best-effort current OS username, suggested as the default cockpit login. */
 function currentUsername(): string {
@@ -92,7 +116,7 @@ async function confirmCezarRunning(ctx: InstallContext, statusCmd: string, logsC
  * `serverName` defaults to the catch-all `_`; the SSL step rewrites it to the
  * real domain so the `certbot --nginx` plugin can find this vhost to edit.
  */
-export function nginxVhost(port: number, serverName = '_'): string {
+export function nginxVhost(port: number, serverName = '_', htpasswd = '/etc/cezar/htpasswd'): string {
   return `# Managed by cezar server-install — do not edit by hand.
 server {
     listen 80;
@@ -100,7 +124,7 @@ server {
     server_name ${serverName};
 
     auth_basic "cezar";
-    auth_basic_user_file ${HTPASSWD};
+    auth_basic_user_file ${htpasswd};
 
     location / {
         proxy_pass http://127.0.0.1:${port};
@@ -158,7 +182,7 @@ const nginxProxyStep: InstallStep = {
   async check(ctx) {
     if (ctx.dryRun) return false;
     const nginxOk = await verifyCommand(ctx, 'nginx', ['-v']);
-    const vhostOk = await verifyCommand(ctx, 'test', ['-f', VHOST_ENABLED]);
+    const vhostOk = await verifyCommand(ctx, 'test', ['-f', vhostEnabled(ctx)]);
     return nginxOk && vhostOk;
   },
   async run(ctx): Promise<{ artifacts: StepArtifact[] }> {
@@ -253,27 +277,33 @@ const nginxProxyStep: InstallStep = {
     // every request 500. 0640 root:www-data: readable by nginx, not by others.
     // The credential line travels on STDIN (`cat > file`), never in argv — the
     // apr1 hash is offline-crackable, and argv is world-readable via `ps`.
+    const htpasswd = htpasswdPath(ctx);
     await sudoStep(ctx, {
       description: 'Write the htpasswd identity file that nginx checks on every request.',
-      note: `${HTPASSWD}\n\n${user}:<apr1 hash of your password>`,
-      command: `install -d -m 0755 /etc/cezar && cat > ${HTPASSWD} && chown root:www-data ${HTPASSWD} && chmod 0640 ${HTPASSWD}`,
+      note: `${htpasswd}\n\n${user}:<apr1 hash of your password>`,
+      command: `install -d -m 0755 /etc/cezar && cat > ${htpasswd} && chown root:www-data ${htpasswd} && chmod 0640 ${htpasswd}`,
       input: `${user}:${hash}\n`,
       inputLabel: 'credential line (username:hash)',
-      verify: (c) => verifyCommand(c, 'test', ['-f', HTPASSWD]),
+      verify: (c) => verifyCommand(c, 'test', ['-f', htpasswd]),
     });
 
     // Record whether the distro's default site was enabled *before* we disable
     // it, so undo only re-enables it if we were the one who removed it.
     const defaultWasEnabled = await verifyCommand(ctx, 'test', ['-L', '/etc/nginx/sites-enabled/default']);
 
-    // 4) vhost + enable + reload
-    const vhost = nginxVhost(ctx.state.primaryPort);
+    // 4) vhost + enable + reload. A named instance already knows its domain, so
+    //    stamp it into server_name from the start (Host-based routing works
+    //    immediately and certbot --nginx can find the vhost later). The default
+    //    instance keeps the catch-all `_` until the SSL step sets a domain.
+    const vhostAvail = vhostAvailable(ctx);
+    const vhostEnbl = vhostEnabled(ctx);
+    const vhost = nginxVhost(ctx.state.primaryPort, ctx.state.domain ?? '_', htpasswd);
     await writeFileStep(ctx, {
       description: 'Write the cezar nginx site, enable it, and reload nginx.',
-      path: VHOST_AVAILABLE,
+      path: vhostAvail,
       content: vhost,
-      extra: `ln -sf ${VHOST_AVAILABLE} ${VHOST_ENABLED} && rm -f /etc/nginx/sites-enabled/default && nginx -t && systemctl reload nginx`,
-      verify: (c) => verifyCommand(c, 'test', ['-f', VHOST_ENABLED]),
+      extra: `ln -sf ${vhostAvail} ${vhostEnbl} && rm -f /etc/nginx/sites-enabled/default && nginx -t && systemctl reload nginx`,
+      verify: (c) => verifyCommand(c, 'test', ['-f', vhostEnbl]),
     });
 
     // 5) firewall: if ufw is active, the cockpit is unreachable until 80/443 are
@@ -317,9 +347,9 @@ const nginxProxyStep: InstallStep = {
     }
 
     const artifacts: StepArtifact[] = [
-      owned('file', { path: VHOST_AVAILABLE }),
-      owned('symlink', { path: VHOST_ENABLED }),
-      owned('htpasswd', { path: HTPASSWD, name: user }),
+      owned('file', { path: vhostAvail }),
+      owned('symlink', { path: vhostEnbl }),
+      owned('htpasswd', { path: htpasswd, name: user }),
     ];
     if (defaultWasEnabled) artifacts.push(owned('nginx-default', { path: '/etc/nginx/sites-enabled/default' }));
     if (!nginxWasPresent) {
@@ -344,14 +374,17 @@ const nginxProxyStep: InstallStep = {
         'Installed for cezar but possibly used elsewhere — remove manually if unwanted',
       );
     }
+    // rmdir /etc/cezar only succeeds when empty, so removing one instance's
+    // htpasswd never nukes another instance's credentials in the same dir.
+    const vhostEnbl = vhostEnabled(ctx);
     await sudoStep(ctx, {
       description: 'Remove the cezar nginx site + htpasswd, reload nginx.',
       command:
-        `rm -f ${VHOST_ENABLED} ${VHOST_AVAILABLE} ${HTPASSWD}` +
+        `rm -f ${vhostEnbl} ${vhostAvailable(ctx)} ${htpasswdPath(ctx)}` +
         restoreClause +
         ` && { rmdir /etc/cezar 2>/dev/null || true; }` +
         ` && { nginx -t && systemctl reload nginx || true; }`,
-      verify: (c) => verifyCommand(c, 'sh', ['-c', `! test -f ${VHOST_ENABLED}`]),
+      verify: (c) => verifyCommand(c, 'sh', ['-c', `! test -f ${vhostEnbl}`]),
     });
   },
 };
@@ -367,11 +400,16 @@ const sslStep: InstallStep = {
     return false; // optional — the engine gates it with a confirm; certbot is idempotent
   },
   async run(ctx): Promise<{ artifacts: StepArtifact[] }> {
-    const domain = await ctx.ui.text({
-      message: 'Domain pointing at this server (an A/AAAA record must resolve here)',
-      placeholder: 'cezar.example.com',
-      validate: (v) => (HOSTNAME_RE.test(v.trim()) ? undefined : 'enter a valid domain'),
-    });
+    // A named instance already captured its domain up front (it is the instance
+    // key) — reuse it instead of asking again. The default instance still
+    // prompts here, since it may be HTTP-only until this step runs.
+    const domain = ctx.state.domain
+      ? ctx.state.domain
+      : await ctx.ui.text({
+          message: 'Domain pointing at this server (an A/AAAA record must resolve here)',
+          placeholder: 'cezar.example.com',
+          validate: (v) => (HOSTNAME_RE.test(v.trim()) ? undefined : 'enter a valid domain'),
+        });
     if (domain === CANCEL) throw new StepCancelled();
     const email = await ctx.ui.text({
       message: 'Email for Let’s Encrypt renewal notices',
@@ -401,23 +439,29 @@ const sslStep: InstallStep = {
     // when TLS config is present, only the `server_name` lines are updated
     // in place; the hostname regex bars every sed/shell metacharacter.
     const trimmedDomain = String(domain).trim();
-    const vhostHasTls = await verifyCommand(ctx, 'sh', ['-c', `grep -qs ssl_certificate ${VHOST_AVAILABLE}`]);
+    // Record the domain on the instance record so a resume / redeploy / verify
+    // (and the nginx server_name) all agree on it, even for the default instance
+    // that entered its domain here rather than up front.
+    ctx.state.domain = trimmedDomain;
+    const vhostAvail = vhostAvailable(ctx);
+    const vhostEnbl = vhostEnabled(ctx);
+    const vhostHasTls = await verifyCommand(ctx, 'sh', ['-c', `grep -qs ssl_certificate ${vhostAvail}`]);
     if (vhostHasTls) {
       await sudoStep(ctx, {
         description: `Update server_name to ${trimmedDomain} in the existing TLS-enabled nginx site (certbot config preserved).`,
-        command: `sed -i 's/^\\([[:space:]]*\\)server_name .*;/\\1server_name ${trimmedDomain};/' ${VHOST_AVAILABLE} && nginx -t && systemctl reload nginx`,
+        command: `sed -i 's/^\\([[:space:]]*\\)server_name .*;/\\1server_name ${trimmedDomain};/' ${vhostAvail} && nginx -t && systemctl reload nginx`,
         verify: (c) =>
-          verifyCommand(c, 'sh', ['-c', `grep -qF ${shquote(`server_name ${trimmedDomain}`)} ${VHOST_AVAILABLE}`]),
+          verifyCommand(c, 'sh', ['-c', `grep -qF ${shquote(`server_name ${trimmedDomain}`)} ${vhostAvail}`]),
       });
     } else {
-      const domainVhost = nginxVhost(ctx.state.primaryPort, trimmedDomain);
+      const domainVhost = nginxVhost(ctx.state.primaryPort, trimmedDomain, htpasswdPath(ctx));
       await writeFileStep(ctx, {
         description: `Point the nginx site at ${trimmedDomain} so certbot can configure TLS for it.`,
-        path: VHOST_AVAILABLE,
+        path: vhostAvail,
         content: domainVhost,
-        extra: `ln -sf ${VHOST_AVAILABLE} ${VHOST_ENABLED} && nginx -t && systemctl reload nginx`,
+        extra: `ln -sf ${vhostAvail} ${vhostEnbl} && nginx -t && systemctl reload nginx`,
         verify: (c) =>
-          verifyCommand(c, 'sh', ['-c', `grep -qF ${shquote(`server_name ${trimmedDomain}`)} ${VHOST_AVAILABLE}`]),
+          verifyCommand(c, 'sh', ['-c', `grep -qF ${shquote(`server_name ${trimmedDomain}`)} ${vhostAvail}`]),
       });
     }
 
@@ -435,7 +479,7 @@ const sslStep: InstallStep = {
       // with permission-denied and reports a false failure even when the cert was
       // issued. certbot --nginx writes `ssl_certificate …` into the vhost, which
       // is world-readable, so grepping it works without root.
-      verify: (c) => verifyCommand(c, 'sh', ['-c', `grep -qs ssl_certificate ${VHOST_AVAILABLE} ${VHOST_ENABLED}`]),
+      verify: (c) => verifyCommand(c, 'sh', ['-c', `grep -qs ssl_certificate ${vhostAvail} ${vhostEnbl}`]),
     });
 
     ctx.state.publicUrl = `https://${trimmedDomain}`;
@@ -473,8 +517,6 @@ const sslStep: InstallStep = {
     // The vhost (with certbot’s edits) is removed by the nginx-proxy step’s undo.
   },
 };
-
-const UNIT_NAME = 'cezar.service';
 
 /**
  * systemd unit that runs cezar loopback-bound with CEZ_REMOTE=1.
@@ -585,6 +627,7 @@ const autostartStep: InstallStep = {
     return false; // always (re)assert the service is installed and running
   },
   async run(ctx): Promise<{ artifacts: StepArtifact[] }> {
+    const UNIT_NAME = unitName(ctx);
     const execStart = await resolveExecStart(ctx);
     // Prefer a rootless `systemd --user` service + linger; fall back to a system
     // unit (via sudoStep) when the user bus is not reachable. `show-environment`
@@ -639,6 +682,7 @@ const autostartStep: InstallStep = {
     return { artifacts: [owned('service', { name: UNIT_NAME, scope: 'system', path: `/etc/systemd/system/${UNIT_NAME}` })] };
   },
   async undo(ctx, created) {
+    const UNIT_NAME = unitName(ctx);
     const svc = (created?.artifacts ?? []).find((a) => a.type === 'service');
     // Reverse linger only when install recorded that it enabled it.
     const linger = (created?.artifacts ?? []).find((a) => a.type === 'linger');
@@ -685,6 +729,10 @@ const identityStep: InstallStep = {
     const https = ctx.state.publicUrl?.startsWith('https://') ?? false;
     const base = https ? 'https://127.0.0.1/' : 'http://127.0.0.1/';
     const tls = https ? ['-k'] : [];
+    // When several instances share nginx, a bare 127.0.0.1 request hits whatever
+    // vhost nginx treats as default. Send this instance's own Host header so the
+    // probe verifies THIS cockpit's vhost, not a sibling's.
+    const host = ctx.state.domain ? ['-H', `Host: ${ctx.state.domain}`] : [];
 
     // 1) Is cezar actually listening on the loopback upstream? nginx challenges
     //    auth *before* proxying, so an anonymous 401 alone does NOT prove the
@@ -692,7 +740,7 @@ const identityStep: InstallStep = {
     const upstreamUp = await isCezarUp(ctx, port);
 
     // 2) An anonymous request through nginx must be challenged (auth is active).
-    const anonCode = await curlCode(ctx, [...tls, base]);
+    const anonCode = await curlCode(ctx, [...tls, ...host, base]);
     const authEnforced = anonCode === '401';
 
     // 3) The real proof: an AUTHENTICATED request reaches cezar (2xx/3xx — not
@@ -706,7 +754,7 @@ const identityStep: InstallStep = {
       // value — both are legal password characters; unescaped they break the
       // config parse and fail a WORKING install with "bad credentials".
       const curlCfgQuote = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const code = await curlCode(ctx, [...tls, '-K', '-', base], {
+      const code = await curlCode(ctx, [...tls, ...host, '-K', '-', base], {
         input: `user = "${curlCfgQuote(cred.user)}:${curlCfgQuote(cred.password)}"\n`,
       });
       authedOk = /^[23]\d\d$/.test(code);
@@ -775,6 +823,7 @@ export const ubuntuVps: PlatformStrategy = {
     return [depCheckStep(), nginxProxyStep, sslStep, autostartStep, identityStep];
   },
   async redeploy(ctx: InstallContext) {
+    const UNIT_NAME = unitName(ctx);
     // Restart the systemd service so it picks up the new cezar (a fresh local
     // build the unit runs from, or a newly published cezar-cli via npx), then
     // re-run the same end-to-end verify install uses.

--- a/src/server-install/state.test.ts
+++ b/src/server-install/state.test.ts
@@ -5,10 +5,13 @@ import { join } from 'node:path';
 import { serverStatePath } from '../paths.js';
 import {
   acquireLock,
+  deleteServerState,
   firstIncompleteStep,
   isResolved,
+  listServerInstances,
   loadServerState,
   LockHeldError,
+  nextFreeInstancePort,
   saveServerState,
 } from './state.js';
 import { freshServerState } from './types.js';
@@ -76,6 +79,69 @@ describe('server state', () => {
     // Simulate the race loser: the file appears (live pid) before our write.
     writeFileSync(join(home, 'server.install.lock'), `${process.pid === 1 ? 2 : 1}\n`, { flag: 'wx' });
     expect(() => acquireLock()).toThrow(LockHeldError);
+  });
+
+  it('named instances persist to their own file and never clobber the default', () => {
+    const def = freshServerState();
+    def.platform = 'ubuntu-vps';
+    def.primaryPort = 4321;
+    saveServerState(def); // default → server.json
+
+    const shop = freshServerState();
+    shop.platform = 'ubuntu-vps';
+    shop.instance = 'shop-example-com';
+    shop.domain = 'shop.example.com';
+    shop.primaryPort = 4322;
+    saveServerState(shop, 'shop-example-com'); // named → server-instances/…
+
+    // Each loads back independently — the second install did not touch the first.
+    expect(loadServerState().primaryPort).toBe(4321);
+    expect(loadServerState('shop-example-com').primaryPort).toBe(4322);
+    expect(loadServerState('shop-example-com').domain).toBe('shop.example.com');
+    // A brand-new (unknown) instance still degrades to a fresh record.
+    expect(loadServerState('nope').installed).toBe(false);
+  });
+
+  it('listServerInstances enumerates default + named; nextFreeInstancePort skips used ports', () => {
+    expect(listServerInstances()).toHaveLength(0);
+    expect(nextFreeInstancePort()).toBe(4321); // nothing recorded yet
+
+    const def = freshServerState();
+    def.primaryPort = 4321;
+    saveServerState(def);
+    const a = freshServerState();
+    a.primaryPort = 4322;
+    saveServerState(a, 'a-example-com');
+
+    const names = listServerInstances().map((i) => i.instance).sort();
+    expect(names).toEqual(['a-example-com', 'default']);
+    expect(nextFreeInstancePort()).toBe(4323); // 4321 + 4322 both taken
+  });
+
+  it('deleteServerState drops a named record but leaves the default in place', () => {
+    saveServerState(freshServerState()); // default
+    const a = freshServerState();
+    a.primaryPort = 4322;
+    saveServerState(a, 'a-example-com');
+    deleteServerState('a-example-com');
+    expect(listServerInstances().map((i) => i.instance)).toEqual(['default']);
+    // deleting the default is a no-op (legacy single-host record is kept)
+    deleteServerState('default');
+    expect(listServerInstances().map((i) => i.instance)).toEqual(['default']);
+  });
+
+  it('the install lock is per-instance — one instance never blocks another', () => {
+    const release = acquireLock('shop-example-com');
+    // a DIFFERENT instance acquires freely (independent lock file)
+    const releaseOther = acquireLock('blog-example-com');
+    releaseOther();
+    // but the SAME instance is exclusive against a live foreign pid
+    writeFileSync(
+      join(home, 'server-instances', 'shop-example-com.install.lock'),
+      `${process.pid === 1 ? 2 : 1}\n`,
+    );
+    expect(() => acquireLock('shop-example-com')).toThrow(LockHeldError);
+    release();
   });
 
   it('a newer-version server.json degrades per-field, never to a fresh record', () => {

--- a/src/server-install/state.ts
+++ b/src/server-install/state.ts
@@ -2,13 +2,19 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
-import { cezarHomeDir, serverLockPath, serverStatePath } from '../paths.js';
+import { basename, dirname } from 'node:path';
+import {
+  DEFAULT_SERVER_INSTANCE,
+  serverInstancesDir,
+  serverLockPath,
+  serverStatePath,
+} from '../paths.js';
 import { freshServerState, serverStateSchema, type ServerState, type StepOutcome } from './types.js';
 
 /**
@@ -18,9 +24,9 @@ import { freshServerState, serverStateSchema, type ServerState, type StepOutcome
  * uninstall's "reverse exactly what was created" logic.
  */
 
-/** Load the host-level state, degrading to a fresh record on any error. */
-export function loadServerState(): ServerState {
-  const path = serverStatePath();
+/** Load a host-level instance record, degrading to a fresh record on any error. */
+export function loadServerState(instance: string = DEFAULT_SERVER_INSTANCE): ServerState {
+  const path = serverStatePath(instance);
   let raw: string;
   try {
     raw = readFileSync(path, 'utf8');
@@ -36,9 +42,48 @@ export function loadServerState(): ServerState {
   return freshServerState();
 }
 
-/** Atomically persist state as `0600`, creating `~/.cezar` (`0700`) if needed. */
-export function saveServerState(state: ServerState): void {
-  const path = serverStatePath();
+/**
+ * Every instance recorded on this host, newest schema first: the `default`
+ * record (`server.json`) plus each named record under `server-instances/`.
+ * Used to auto-pick a free loopback port for a new instance and to let
+ * uninstall/deploy resolve which instance to act on. Never throws — an
+ * unreadable dir or a corrupt file is simply skipped.
+ */
+export function listServerInstances(): Array<{ instance: string; state: ServerState }> {
+  const out: Array<{ instance: string; state: ServerState }> = [];
+  if (existsSync(serverStatePath(DEFAULT_SERVER_INSTANCE))) {
+    out.push({ instance: DEFAULT_SERVER_INSTANCE, state: loadServerState(DEFAULT_SERVER_INSTANCE) });
+  }
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(serverInstancesDir());
+  } catch {
+    entries = [];
+  }
+  for (const file of entries) {
+    if (!file.endsWith('.json')) continue;
+    const instance = basename(file, '.json');
+    out.push({ instance, state: loadServerState(instance) });
+  }
+  return out;
+}
+
+/**
+ * The next free loopback port for a NEW instance, scanning from `startAt`
+ * (4321, the default cockpit port) upward past every port already recorded by
+ * another instance. Deterministic (recorded-state only, no network probe) so it
+ * stays unit-testable; the operator can always override it with `--port`.
+ */
+export function nextFreeInstancePort(startAt = 4321): number {
+  const used = new Set(listServerInstances().map((i) => i.state.primaryPort));
+  let port = startAt;
+  while (used.has(port)) port++;
+  return port;
+}
+
+/** Atomically persist state as `0600`, creating its dir (`0700`) if needed. */
+export function saveServerState(state: ServerState, instance: string = DEFAULT_SERVER_INSTANCE): void {
+  const path = serverStatePath(instance);
   const dir = dirname(path);
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   const tmp = `${path}.tmp`;
@@ -48,6 +93,22 @@ export function saveServerState(state: ServerState): void {
     chmodSync(path, 0o600); // best-effort — ignored on some filesystems
   } catch {
     // non-fatal
+  }
+}
+
+/**
+ * Delete a named instance's state file (used after a complete uninstall so it
+ * stops reserving its port and drops out of `listServerInstances`). The
+ * `default` record is left in place — that is the legacy single-host file, and
+ * its absence vs. an empty-but-present record has historically meant the same
+ * thing, so we don't change that behavior. Best-effort; never throws.
+ */
+export function deleteServerState(instance: string): void {
+  if (instance === DEFAULT_SERVER_INSTANCE) return;
+  try {
+    rmSync(serverStatePath(instance), { force: true });
+  } catch {
+    // non-fatal — an empty record left behind is harmless
   }
 }
 
@@ -71,9 +132,9 @@ export class LockHeldError extends Error {}
  * process already holds it; a stale lock (dead pid) is reclaimed. Returns a
  * release function.
  */
-export function acquireLock(): () => void {
-  const path = serverLockPath();
-  mkdirSync(cezarHomeDir(), { recursive: true, mode: 0o700 });
+export function acquireLock(instance: string = DEFAULT_SERVER_INSTANCE): () => void {
+  const path = serverLockPath(instance);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
 
   // `wx` makes creation atomic — a plain exists-then-write check would let two
   // concurrent wizards both "acquire". One reclaim retry handles a stale lock;

--- a/src/server-install/steps.test.ts
+++ b/src/server-install/steps.test.ts
@@ -17,6 +17,7 @@ function makeCtx(over: {
   return {
     state: { schema: 1, installed: false, primaryPort: 4321, steps: {} },
     ui: over.ui ?? createAutoUi(),
+    instance: 'default',
     runner,
     save: async () => {},
     dryRun: over.dryRun ?? false,

--- a/src/server-install/types.ts
+++ b/src/server-install/types.ts
@@ -70,6 +70,16 @@ export const serverStateSchema = z
      * is where "unknown platform" is decided, with the ledger intact.
      */
     platform: z.string().min(1).optional().catch(undefined),
+    /**
+     * Instance id (slug) this record belongs to — `default` for the original
+     * single-cockpit host, or a domain-derived slug for a named instance under
+     * `~/.cezar/server-instances/`. Self-describing so tooling can list what a
+     * host runs without re-deriving it from the filename.
+     */
+    instance: z.string().min(1).optional().catch(undefined),
+    /** Public domain this instance answers on (drives nginx `server_name` +
+     * the SSL cert). Absent for a plain HTTP / default install. */
+    domain: z.string().optional().catch(undefined),
     /** Flips true only when every required step is `done`. */
     installed: z.boolean().default(false).catch(false),
     /** True when this record was written by a CEZ_DRY_RUN preview — a real
@@ -187,7 +197,14 @@ export interface InstallContext {
   state: ServerState;
   ui: Ui;
   runner: Runner;
-  /** Atomically persist `state` to `~/.cezar/server.json`. */
+  /**
+   * Instance id (slug) this run targets. `default` (the original single-cockpit
+   * flow) keeps every legacy path unchanged; a domain-derived slug suffixes the
+   * nginx site, htpasswd, and systemd unit so instances never collide on one
+   * host. Steps read this to build their instance-scoped paths.
+   */
+  instance: string;
+  /** Atomically persist `state` to this instance's `~/.cezar` record. */
   save(): Promise<void>;
   /** CEZ_DRY_RUN — no real sudo, package installs, or network. */
   dryRun: boolean;


### PR DESCRIPTION
## Problem

Running `cezar server-install --platform ubuntu-vps` a **second time for a
different domain** just resumes / asks to reinstall the first install. The whole
installer was **single-instance-per-host**: one `~/.cezar/server.json`, one lock,
one `primaryPort` (4321), and hardcoded artifact paths (one nginx vhost
`/etc/nginx/sites-available/cezar`, one `/etc/cezar/htpasswd`, one
`cezar.service`). There was no way to stand up a second, independent cockpit for
another domain on the same box.

## What this adds

Domain-keyed **multi-instance** support for `ubuntu-vps`:

```bash
# first cockpit — the default instance (loopback :4321, ~/.cezar/server.json)
npx cezar-cli server-install --platform ubuntu-vps

# a second, fully independent cockpit for another domain
npx cezar-cli server-install --platform ubuntu-vps --domain shop.example.com
```

- **`--domain <host>`** selects/creates an instance (slug via `instanceSlug()`).
  A **new** domain never resumes or clobbers an existing install; the **same**
  domain resumes/reconfigures it. **No `--domain` = the legacy `default`
  instance, byte-for-byte unchanged** (backward compatible).
- **Per-instance state + lock**: `default` keeps `~/.cezar/server.json`; a named
  instance lives at `~/.cezar/server-instances/<slug>.json` with its own lock, so
  installing one cockpit never blocks another. New helpers:
  `listServerInstances()`, `nextFreeInstancePort()`, `deleteServerState()`.
- **Per-instance artifacts** (ubuntu-vps): nginx site `cezar-<slug>`,
  `htpasswd-<slug>`, unit `cezar-<slug>.service`. The domain is stamped into
  nginx `server_name` up front so Host-based routing works immediately, and the
  end-to-end identity probe sends the instance's `Host` header so it verifies the
  correct vhost. `/etc/cezar` is shared; uninstall's `rmdir` only removes it when
  empty, so one instance's teardown never deletes another's credentials.
- **Port**: a new named instance auto-picks the next free loopback port (4321,
  4322, …); `--port` overrides.
- **Interactive nicety**: if a cockpit already exists and you run
  `server-install` with no `--domain`, the wizard asks whether to set up a second
  instance for a new domain or manage the existing one — the exact "it just asks
  me to reinstall" case.
- **`server-deploy` / `server-uninstall`** accept `--domain` to target an
  instance; a named-instance uninstall deletes its state file and leaves siblings
  (and shared nginx/certbot) running.

| Instance | State file | nginx site | htpasswd | unit | Port |
|---|---|---|---|---|---|
| default | `~/.cezar/server.json` | `cezar` | `/etc/cezar/htpasswd` | `cezar.service` | 4321 |
| `--domain shop.example.com` | `server-instances/shop-example-com.json` | `cezar-shop-example-com` | `htpasswd-shop-example-com` | `cezar-shop-example-com.service` | auto (4322…) |

**Scope:** `ubuntu-vps` only (shared nginx front); `macosx-ngrok` stays
single-instance. State-schema additions (`instance`, `domain`) are additive-safe
(optional + `.catch` + `.passthrough`).

## Testing

- Full gate green: **typecheck** / **2547 vitest** (154 files) / **test:unit** (9) /
  **build + check:pack** / **test:package** (tarball e2e).
- **+14 new tests**: `instanceSlug`, instance-scoped paths, per-instance state
  isolation, `listServerInstances` / `nextFreeInstancePort` / `deleteServerState`,
  per-instance lock, two-instance install isolation, named-instance uninstall
  cleanup, suffixed nginx/htpasswd/unit paths.
- Smoke-tested the built CLI (`CEZ_DRY_RUN=1`): default install → `server.json`
  @ 4321; `--domain shop.example.com` → `server-instances/shop-example-com.json`
  @ auto-picked 4322, with no reinstall prompt.

## Docs

- README + `docs/server-install/README.md` + `docs/server-install/ubuntu-vps.md`
  ("Hosting several cockpits on one box").
- Addendum in `.ai/specs/2026-07-16-server-installer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)