### PR TITLE
fix(server): stop GitHub nav item flickering — stale-while-revalidate forge probe

### DIFF
--- a/src/server/forge/github.test.ts
+++ b/src/server/forge/github.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `vi.hoisted` so `execFileMock` exists before the (hoisted) vi.mock factory runs. `gh()` builds
+// its subprocess runner from `promisify(execFile)` at module load, so the availability-probe tests
+// below drive `gh repo view` entirely through this mock — no real `gh` on the box. Everything else
+// in this file is pure and never touches child_process, so the default passthrough is harmless.
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  execFileMock.mockImplementation((...args: unknown[]) =>
+    (actual.execFile as (...a: unknown[]) => unknown)(...args),
+  );
+  return { ...actual, execFile: (...args: unknown[]) => execFileMock(...args) };
+});
+
 import {
+  detectGithubCached,
   fetchCommentCounts,
   ghCheckRunSchema,
   mergeThread,
@@ -300,5 +315,54 @@ describe('mergeThread', () => {
     const { comments, truncated } = mergeThread([many], THREAD_ENTRY_CAP);
     expect(comments).toHaveLength(THREAD_ENTRY_CAP);
     expect(truncated).toBe(true);
+  });
+});
+
+/** `detectGithubCached` backs `GET /api/health`'s `forge.available`, which gates the GitHub nav
+ *  item. The sidebar flicker bug was this returning `null` (→ item hidden) for one 5 s health poll
+ *  every time the 60 s probe cache expired; the fix is stale-while-revalidate — keep serving the
+ *  last-known answer while a background probe refreshes it, so the item never blinks out. */
+describe('detectGithubCached', () => {
+  const CACHE_MS = 60_000; // mirrors the constant in github.ts
+  const repoRoot = '/repo/detect-swr'; // distinct root so the module-level cache is isolated
+
+  /** Resolve `gh repo view` as if it succeeded — promisify(execFile) resolves with our value. */
+  const ghOk = () =>
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (e: unknown, r: unknown) => void;
+      cb(null, { stdout: '{"nameWithOwner":"o/r"}', stderr: '' });
+    });
+
+  beforeEach(() => {
+    vi.stubEnv('CEZ_DRY_RUN', ''); // dry-run would short-circuit the cache path we're testing
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('serves the last-known availability instead of null once the cache goes stale', async () => {
+    ghOk();
+
+    // Cold start: nothing cached yet → null (contract-safe "unknown"), and it fires one probe.
+    expect(detectGithubCached(repoRoot)).toBeNull();
+    await vi.advanceTimersByTimeAsync(0); // let the fire-and-forget probe settle
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    // Warm: within the 60 s window the cached result is served with no new probe.
+    expect(detectGithubCached(repoRoot)).toEqual({ available: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    // Cache expires. The bug returned null here (item vanishes); the fix returns the stale value.
+    vi.setSystemTime(CACHE_MS + 1);
+    expect(detectGithubCached(repoRoot)).toEqual({ available: true });
+
+    // …and a background revalidate was kicked off exactly once for the stale read.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -663,19 +663,27 @@ async function detectGithub(repoRoot: string): Promise<ForgeAvailability> {
 }
 
 /**
- * Non-blocking availability for `GET /api/health` (#major-health-latency): returns the cached
- * probe immediately, or `null` while kicking off a background probe to warm it. It NEVER shells
- * out to `gh` on the request that reads it, so health stays under the bookmarklet's 800 ms port
- * budget (a `gh repo view` round-trip is ~500–650 ms on its own). `null` is contract-safe — the
- * whole `forge` field is additive, so "unknown until warm" is a valid answer.
+ * Non-blocking availability for `GET /api/health` (#major-health-latency): serves the last-known
+ * probe immediately (stale-while-revalidate) and only returns `null` on a cold start, before the
+ * first probe has ever warmed the cache. It NEVER shells out to `gh` on the request that reads it,
+ * so health stays under the bookmarklet's 800 ms port budget (a `gh repo view` round-trip is
+ * ~500–650 ms on its own). `null` is contract-safe — the whole `forge` field is additive, so
+ * "unknown until warm" is a valid answer.
+ *
+ * Serving the stale value while revalidating is what keeps the GitHub nav item from flickering:
+ * without it, every time the 60 s cache expired this returned `null` for one 5 s health poll,
+ * dropping `forge.available` and blinking the sidebar item out until the background probe warmed.
  */
 export function detectGithubCached(repoRoot: string): ForgeAvailability | null {
   if (process.env.CEZ_DRY_RUN === '1') return { available: true };
-  if (detectCache && detectCache.repoRoot === repoRoot && Date.now() - detectCache.at < CACHE_MS) {
-    return detectCache.result;
+  const cached =
+    detectCache && detectCache.repoRoot === repoRoot ? detectCache.result : null;
+  const fresh =
+    detectCache && detectCache.repoRoot === repoRoot && Date.now() - detectCache.at < CACHE_MS;
+  if (!fresh) {
+    void detectGithub(repoRoot).catch(() => {}); // revalidate off the request path
   }
-  void detectGithub(repoRoot).catch(() => {}); // warm the cache off the request path
-  return null;
+  return cached; // last-known value while revalidating; null only until the first probe warms
 }
 
 /** owner/repo parsed out of the origin remote — feeds `viewUrl`. */


### PR DESCRIPTION
## Problem

The **GitHub** sidebar nav item disappears for a few seconds and then reappears on its own, with no user action — repeating roughly every 60s.

## Root cause

The GitHub nav item is gated on `/api/health` reporting `forge.available === true`, which the web app polls every 5s. On the server, `detectGithubCached` (`src/server/forge/github.ts`) caches the `gh repo view` availability probe for 60s (`CACHE_MS`).

When that cache expired, it **discarded the last-known-good value and returned `null`** while re-probing `gh` in the background. `null` drops `forge.available`, so the GitHub item blinked out for one 5s poll cycle every ~60s — then reappeared once the ~0.5s probe warmed the cache.

Git was unaffected because it isn't forge-gated (no `forge: true` flag), which is why it stayed put while GitHub vanished.

## Fix

Stale-while-revalidate: keep serving the last-known availability while a background probe refreshes it; return `null` only on a cold start (before the first probe warms). A value up to 60s stale is safe — that's exactly what the existing 60s cache already assumes.

Still non-blocking — it never shells out to `gh` on the health request, so the latency budget is preserved. It just stops throwing away the answer it already had.

## Tests

- New regression test in `github.test.ts` mocks the `gh` subprocess + fake timers past the 60s cache: a stale read now returns `{ available: true }` (not `null`) and kicks exactly one background revalidate.
- `github.test.ts`: 34 passed · `health-forge.test.ts` + `forge/index.test.ts`: 42 passed · `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)