### PR TITLE
fix(web): skill pickers order most-used → project → global (#519)

### DIFF
--- a/web/app/src/components/command-palette.test.tsx
+++ b/web/app/src/components/command-palette.test.tsx
@@ -96,9 +96,16 @@ function renderPalette({
   skills = [] as Skill[],
   theme,
   forge = true,
-}: { runs?: RunRecord[]; skills?: Skill[]; theme?: Theme; forge?: boolean } = {}) {
+  uiState = {} as Record<string, unknown>,
+}: {
+  runs?: RunRecord[]
+  skills?: Skill[]
+  theme?: Theme
+  forge?: boolean
+  uiState?: Record<string, unknown>
+} = {}) {
   if (theme) localStorage.setItem(THEME_STORAGE_KEY, theme)
-  serve({ '/api/runs': runs, '/api/skills': skills, '/api/health': health(forge) })
+  serve({ '/api/runs': runs, '/api/skills': skills, '/api/health': health(forge), '/api/ui-state': uiState })
   render(
     <QueryClientProvider client={createQueryClient()}>
       <ThemeProvider>
@@ -344,6 +351,21 @@ describe('Skills group', () => {
       (item) => item.getAttribute('data-skill'),
     )
     expect(names).toEqual(['project-review', 'project-fix', 'project-plan', 'global-deploy', 'team-release'])
+  })
+
+  it('lists most-used skills first, across localities (#519)', async () => {
+    renderPalette({ skills: MIXED, uiState: { skillUsage: { 'team-release': 5, 'project-fix': 2 } } })
+    openWith({ metaKey: true })
+    await screen.findByText('project-review')
+
+    // Used skills lead frequency-descending regardless of locality; the unused rest keeps
+    // the #377 project-first split.
+    await waitFor(() => {
+      const names = [...document.querySelectorAll('[data-slot="palette-skill"]')].map(
+        (item) => item.getAttribute('data-skill'),
+      )
+      expect(names).toEqual(['team-release', 'project-fix', 'project-review', 'project-plan', 'global-deploy'])
+    })
   })
 
   it('selecting a skill client-navigates to the prefilling /new?skill=…', async () => {

--- a/web/app/src/components/command-palette.tsx
+++ b/web/app/src/components/command-palette.tsx
@@ -2,7 +2,7 @@ import { MoonIcon, PlusIcon } from 'lucide-react'
 import * as React from 'react'
 import { useNavigate } from 'react-router'
 
-import { useHealth, useRuns, useSkills } from '@/api/queries'
+import { useHealth, useRuns, useSkills, useUiState } from '@/api/queries'
 import type { RunRecord } from '@/api/types'
 import { visibleNavItems } from '@/components/nav-items'
 import { StatusDot } from '@/components/status-dot'
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/command'
 import { deriveAttention } from '@/lib/attention'
 import { shortAge } from '@/lib/format'
-import { orderSkills } from '@/lib/skills'
+import { orderSkillsByUsage } from '@/lib/skills'
 import { runTitle } from '@/lib/task-groups'
 import { useCommandShortcut, useKeyShortcut } from '@/lib/use-command-shortcut'
 
@@ -89,13 +89,19 @@ function PaletteContent({ close }: { close: () => void }) {
   // Runs are already cached by the sidebar's quick-list; skills fetch here, on first open.
   const runs = useRuns()
   const skills = useSkills()
+  // Skills list most-used → project → global (#519) — the same order every picker renders.
+  const uiState = useUiState()
   // Health is cached by the shell's chips; here it gates the forge-gated Views row (R6 1.1) —
   // the palette must not offer a GitHub view the sidebar honestly hides.
   const health = useHealth()
   const now = Date.now()
 
   const orderedRuns = React.useMemo(() => orderRuns(runs.data ?? []), [runs.data])
-  const orderedSkills = React.useMemo(() => orderSkills(skills.data ?? []), [skills.data])
+  const skillUsage = uiState.data?.skillUsage
+  const orderedSkills = React.useMemo(
+    () => orderSkillsByUsage(skills.data ?? [], skillUsage),
+    [skills.data, skillUsage],
+  )
 
   const go = (to: string) => {
     close()

--- a/web/app/src/components/composer/composer.test.tsx
+++ b/web/app/src/components/composer/composer.test.tsx
@@ -39,21 +39,35 @@ const SKILLS: Skill[] = [
   { name: 'om-review', body: '', path: '/p/om-review.md', source: 'cezar' },
 ]
 
-/** The composer's only fetch is `/api/skills`, and only once `/` has been typed. */
-function stubSkillsFetch() {
-  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+/** The composer fetches `/api/skills` (only once `/` has been typed) and `/api/ui-state`
+ *  (#519: the autocomplete's usage order + bump). `uiState: null` answers the GET with a 404
+ *  (the "ui-state unavailable" case); PUT bodies are recorded in `uiStatePuts`. */
+function stubSkillsFetch(uiState: Record<string, unknown> | null = {}) {
+  const uiStatePuts: unknown[] = []
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
+    if (url.includes('/api/ui-state')) {
+      if ((init?.method ?? 'GET') === 'PUT') uiStatePuts.push(JSON.parse(String(init?.body)))
+      const status = uiState === null ? 404 : 200
+      const body = uiState === null ? JSON.stringify({ error: 'nope' }) : JSON.stringify(uiState)
+      return Promise.resolve(
+        new Response(body, { status, headers: { 'content-type': 'application/json' } }),
+      )
+    }
     const body = url.includes('/api/skills') ? JSON.stringify(SKILLS) : '[]'
     return Promise.resolve(
       new Response(body, { status: 200, headers: { 'content-type': 'application/json' } }),
     )
   })
   vi.stubGlobal('fetch', fetchMock)
-  return fetchMock
+  return { fetchMock, uiStatePuts }
 }
 
-function renderComposer(props: Partial<ComposerProps> = {}) {
-  const fetchMock = stubSkillsFetch()
+function renderComposer(
+  props: Partial<ComposerProps> = {},
+  uiState: Record<string, unknown> | null = {},
+) {
+  const { fetchMock, uiStatePuts } = stubSkillsFetch(uiState)
   const onSubmit = vi.fn(() => Promise.resolve({}))
   render(
     <QueryClientProvider client={createQueryClient()}>
@@ -61,7 +75,12 @@ function renderComposer(props: Partial<ComposerProps> = {}) {
       <Toaster />
     </QueryClientProvider>,
   )
-  return { onSubmit, fetchMock, textarea: screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement }
+  return {
+    onSubmit,
+    fetchMock,
+    uiStatePuts,
+    textarea: screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement,
+  }
 }
 
 const type = (textarea: HTMLTextAreaElement, value: string) =>
@@ -306,6 +325,57 @@ describe('/ skills autocomplete (#380)', () => {
     const { textarea } = renderComposer({ autocompleteSkills: false })
     type(textarea, '/om')
     expect(document.querySelector('[data-slot="composer-menu"]')).toBeNull()
+  })
+})
+
+describe('/ autocomplete usage order and pick bump (#519)', () => {
+  const menuNames = () =>
+    [...document.querySelectorAll('[data-slot="composer-menu-item"]')].map(
+      (el) => el.querySelector('span')?.textContent,
+    )
+
+  it('orders the list most-used first, across localities', async () => {
+    const { textarea } = renderComposer({}, { skillUsage: { 'global-deploy': 4, 'om-review': 1 } })
+    type(textarea, '/')
+    await screen.findByText('om-fix')
+    // Once ui-state resolves, the used skills lead regardless of locality; unused project
+    // skills follow, per the #519 tier order.
+    await waitFor(() => expect(menuNames()).toEqual(['global-deploy', 'om-review', 'om-fix']))
+  })
+
+  it('picking a skill bumps its skillUsage count (the whole map, shallow-merge safe)', async () => {
+    const { textarea, uiStatePuts } = renderComposer({}, { skillUsage: { 'global-deploy': 4 } })
+    type(textarea, '/')
+    await screen.findByText('om-fix')
+    // The visible reorder proves the ui-state query resolved — the bump guard is now open.
+    await waitFor(() => expect(menuNames()[0]).toBe('global-deploy'))
+    type(textarea, '/omf')
+    await waitFor(() => expect(menuNames()).toEqual(['om-fix']))
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    await waitFor(() => expect(uiStatePuts).toHaveLength(1))
+    // The WHOLE updated map, never one entry — the PUT merge is shallow (#408).
+    expect(uiStatePuts[0]).toEqual({ skillUsage: { 'global-deploy': 4, 'om-fix': 1 } })
+  })
+
+  it('ui-state unavailable → the pick still completes but never PUTs a wiped map', async () => {
+    const { textarea, uiStatePuts } = renderComposer({}, null)
+    type(textarea, 'run /omf')
+    await screen.findByText('om-fix')
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    expect(textarea.value).toBe('run /om-fix ')
+    expect(uiStatePuts).toHaveLength(0)
+  })
+
+  it('an @ mention pick never touches skillUsage', async () => {
+    const { textarea, uiStatePuts } = renderComposer(
+      { getMentionCandidates: () => ['src/app.ts'] },
+      { skillUsage: {} },
+    )
+    type(textarea, 'see @app')
+    await screen.findByText('src/app.ts')
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    expect(textarea.value).toBe('see @src/app.ts ')
+    expect(uiStatePuts).toHaveLength(0)
   })
 })
 

--- a/web/app/src/components/composer/composer.tsx
+++ b/web/app/src/components/composer/composer.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { ArrowUpIcon, CheckIcon, MicIcon, PaperclipIcon, XIcon } from 'lucide-react'
 import {
   useCallback,
@@ -14,14 +15,15 @@ import {
   type Ref,
 } from 'react'
 
-import { useSkills } from '@/api/queries'
+import { putUiState } from '@/api/client'
+import { queryKeys, useSkills, useUiState } from '@/api/queries'
 import type { ImageInput } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import { Command, CommandItem, CommandList } from '@/components/ui/command'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { toast } from '@/components/ui/toaster'
 import { insertTemplate } from '@/lib/prompt-templates'
-import { filterSkills, fuzzyMatch, isProjectSkill } from '@/lib/skills'
+import { bumpSkillUsage, filterSkills, fuzzyMatch, isProjectSkill } from '@/lib/skills'
 import { useNow } from '@/lib/use-now'
 import { isSubmitShortcut } from '@/lib/use-submit-shortcut'
 import { cn } from '@/lib/utils'
@@ -146,6 +148,10 @@ export function Composer({
   const pendingCaretRef = useRef<number | null>(null)
 
   const skills = useSkills(autocompleteSkills && skillsWanted)
+  // The `/` list orders most-used first (#519) and a pick bumps `skillUsage`, so this — the
+  // highest-traffic skill surface — both reads and feeds the same stats as the pickers.
+  const uiState = useUiState()
+  const queryClient = useQueryClient()
   const dictation = useDictation((message) => toast(message, { tone: 'danger' }))
 
   // On-mount only, by design: re-focusing on a later `autoFocus` flip would steal focus mid-visit.
@@ -197,7 +203,7 @@ export function Composer({
   const candidates = useMemo((): MenuCandidate[] => {
     if (trigger === null) return []
     if (trigger.trigger === '/') {
-      return filterSkills(skills.data ?? [], trigger.query).map((skill) => ({
+      return filterSkills(skills.data ?? [], trigger.query, uiState.data?.skillUsage).map((skill) => ({
         // The path suffix keeps values unique when a project skill shadows a global one.
         value: `${skill.name} ${skill.path}`,
         insert: skill.name,
@@ -210,7 +216,7 @@ export function Composer({
     return paths
       .filter((path) => fuzzyMatch(path, trigger.query))
       .map((path) => ({ value: path, insert: path, label: path, emphasized: false }))
-  }, [getMentionCandidates, skills.data, trigger])
+  }, [getMentionCandidates, skills.data, trigger, uiState.data?.skillUsage])
 
   const activeValue = candidates.some((c) => c.value === menuValue)
     ? menuValue
@@ -224,6 +230,15 @@ export function Composer({
     if (!el || trigger === null) return
     const caret = el.selectionStart ?? el.value.length
     const next = applyCompletion(el.value, trigger, caret, candidate.insert)
+    // Frequency sort (#519): a `/` completion is a skill pick, so it counts — same guard as
+    // /new's submit (#408): only bump once the CURRENT map is known. The PUT merge is shallow,
+    // so bumping off an unresolved/errored ui-state query would send a one-entry map and wipe
+    // every accumulated count. Fire-and-forget; a lost bump costs one count, nothing more.
+    if (trigger.trigger === '/' && uiState.data !== undefined) {
+      putUiState({ skillUsage: bumpSkillUsage(uiState.data.skillUsage, candidate.insert) })
+        .then(() => queryClient.invalidateQueries({ queryKey: queryKeys.uiState }))
+        .catch(() => {})
+    }
     setText(next.text)
     pendingCaretRef.current = next.caret
     setTrigger(null)

--- a/web/app/src/lib/skills.test.ts
+++ b/web/app/src/lib/skills.test.ts
@@ -11,6 +11,7 @@ import {
   multiWordFilter,
   orderSkills,
   orderSkillsByUsage,
+  partitionSkillsForDisplay,
   queryScore,
   searchSkills,
   searchWorkflows,
@@ -44,7 +45,7 @@ describe('isProjectSkill / orderSkills (#377)', () => {
   })
 })
 
-describe('orderSkillsByUsage (#408: frequency sort, shared by both composers)', () => {
+describe('partitionSkillsForDisplay / orderSkillsByUsage (#519: most-used → project → global)', () => {
   const skills = [
     skill({ name: 'g1', source: 'global' }),
     skill({ name: 'p1', source: 'agents' }),
@@ -52,24 +53,41 @@ describe('orderSkillsByUsage (#408: frequency sort, shared by both composers)', 
     skill({ name: 'p2', source: 'ai' }),
   ]
 
-  it('#1: sorts most-selected first within each locality half', () => {
+  it('promotes USED skills above locality — a used global outranks an unused project skill', () => {
     const ordered = orderSkillsByUsage(skills, { g2: 5, p2: 9, p1: 1 })
-    // Locality first (project before global), frequency descending within each half.
-    expect(ordered.map((s) => s.name)).toEqual(['p2', 'p1', 'g2', 'g1'])
+    // Most used first (frequency descending, regardless of locality), then the unused
+    // remainder project-first — the #519 contract, replacing the #408 locality-first inversion.
+    expect(ordered.map((s) => s.name)).toEqual(['p2', 'g2', 'p1', 'g1'])
   })
 
-  it('#2: with no usage data, keeps the plain project-first fallback (stable ties)', () => {
-    expect(orderSkillsByUsage(skills, undefined).map((s) => s.name)).toEqual(['p1', 'p2', 'g1', 'g2'])
-    expect(orderSkillsByUsage(skills, {}).map((s) => s.name)).toEqual(['p1', 'p2', 'g1', 'g2'])
+  it('splits into the three tiers without repeating a promoted skill in its locality group', () => {
+    const tiers = partitionSkillsForDisplay(skills, { g2: 5, p1: 1 })
+    expect(tiers.mostUsed.map((s) => s.name)).toEqual(['g2', 'p1'])
+    expect(tiers.project.map((s) => s.name)).toEqual(['p2'])
+    expect(tiers.global.map((s) => s.name)).toEqual(['g1'])
   })
 
-  it('#2: ties (equal counts) also keep locality-then-server order, never flattened', () => {
+  it('caps Most used at the limit; overflow falls back into its locality group', () => {
+    const usage = { g1: 9, p1: 8, g2: 7, p2: 6 }
+    const tiers = partitionSkillsForDisplay(skills, usage, { mostUsedLimit: 2 })
+    expect(tiers.mostUsed.map((s) => s.name)).toEqual(['g1', 'p1'])
+    // The overflow (g2, p2) is NOT dropped — it rejoins its locality tier in server order.
+    expect(tiers.project.map((s) => s.name)).toEqual(['p2'])
+    expect(tiers.global.map((s) => s.name)).toEqual(['g2'])
+  })
+
+  it('zero usage everywhere → empty mostUsed and the plain #377 project-first split', () => {
+    for (const usage of [undefined, {}]) {
+      const tiers = partitionSkillsForDisplay(skills, usage)
+      expect(tiers.mostUsed).toEqual([])
+      expect(tiers.project.map((s) => s.name)).toEqual(['p1', 'p2'])
+      expect(tiers.global.map((s) => s.name)).toEqual(['g1', 'g2'])
+      expect(orderSkillsByUsage(skills, usage).map((s) => s.name)).toEqual(['p1', 'p2', 'g1', 'g2'])
+    }
+  })
+
+  it('equal counts inside Most used break locality-first, then server order', () => {
     const ordered = orderSkillsByUsage(skills, { g1: 3, p1: 3, g2: 3, p2: 3 })
-    expect(ordered.map((s) => s.name)).toEqual(['p1', 'p2', 'g1', 'g2'])
-  })
-
-  it('an unselected skill sorts below any selected one in its half', () => {
-    const ordered = orderSkillsByUsage(skills, { g1: 2 })
     expect(ordered.map((s) => s.name)).toEqual(['p1', 'p2', 'g1', 'g2'])
   })
 
@@ -78,7 +96,7 @@ describe('orderSkillsByUsage (#408: frequency sort, shared by both composers)', 
     // `usage[name]` lookup returns the INHERITED function for these names, `??` does not catch a
     // non-nullish function, and the comparator goes NaN — which silently corrupts the order.
     const usage = JSON.parse('{"p1": 5}') as Record<string, number>
-    const ordered = orderSkillsByUsage(
+    const tiers = partitionSkillsForDisplay(
       [
         skill({ name: 'constructor', source: 'ai' }),
         skill({ name: 'toString', source: 'ai' }),
@@ -86,7 +104,8 @@ describe('orderSkillsByUsage (#408: frequency sort, shared by both composers)', 
       ],
       usage,
     )
-    expect(ordered.map((s) => s.name)).toEqual(['p1', 'constructor', 'toString'])
+    expect(tiers.mostUsed.map((s) => s.name)).toEqual(['p1'])
+    expect(tiers.project.map((s) => s.name)).toEqual(['constructor', 'toString'])
   })
 })
 
@@ -327,5 +346,45 @@ describe('skillUsedBy (the detail pane’s "Used by" breadcrumbs)', () => {
 
   it('an unreferenced skill answers an empty list', () => {
     expect(skillUsedBy(workflows, 'om-unused')).toEqual([])
+  })
+})
+
+describe('#519: usage folds into query ranking and the / autocomplete order', () => {
+  const skills = [
+    skill({ name: 'project-deploy', source: 'ai' }),
+    skill({ name: 'global-deploy', source: 'global', description: 'Deploy from anywhere' }),
+  ]
+
+  it('empty query orders the / autocomplete most-used first, across localities', () => {
+    expect(filterSkills(skills, '', { 'global-deploy': 3 }).map((s) => s.name)).toEqual([
+      'global-deploy',
+      'project-deploy',
+    ])
+    // Without usage, the pre-#519 project-first behavior is unchanged.
+    expect(filterSkills(skills, '').map((s) => s.name)).toEqual(['project-deploy', 'global-deploy'])
+  })
+
+  it('a typed query lets usage break ties between comparably-scoring matches', () => {
+    // Both names hit 'deploy' on a word boundary → equal base score; the usage count decides
+    // (defect 4 of #519: before, a typed query discarded frequency entirely).
+    expect(filterSkills(skills, 'deploy', { 'global-deploy': 3 }).map((s) => s.name)).toEqual([
+      'global-deploy',
+      'project-deploy',
+    ])
+    expect(searchSkills(skills, 'deploy', { 'project-deploy': 2 }).map((s) => s.name)).toEqual([
+      'project-deploy',
+      'global-deploy',
+    ])
+  })
+
+  it('the usage bonus is bounded — heavy usage never outranks a clearly better name match', () => {
+    const s2 = [
+      skill({ name: 'om-fix', source: 'ai' }),
+      skill({ name: 'om-auto-fix-issue', source: 'ai', description: 'runs om-fix internally' }),
+    ]
+    expect(searchSkills(s2, 'om-fix', { 'om-auto-fix-issue': 999 }).map((s) => s.name)).toEqual([
+      'om-fix',
+      'om-auto-fix-issue',
+    ])
   })
 })

--- a/web/app/src/lib/skills.ts
+++ b/web/app/src/lib/skills.ts
@@ -17,30 +17,72 @@ export function isProjectSkill(skill: Pick<Skill, 'source'>): boolean {
   return PROJECT_SKILL_SOURCES.has(skill.source)
 }
 
-/** The sort is stable, so within each half the server's own order (its directory precedence)
- *  is preserved. */
+/** The sort is stable, so within each half the server's own order (alphabetical —
+ *  `src/skills.ts` sorts the merged catalog by name) is preserved. */
 export function orderSkills(skills: readonly Skill[]): Skill[] {
   return [...skills].sort((a, b) => Number(!isProjectSkill(a)) - Number(!isProjectSkill(b)))
 }
 
+/** How many "Most used" skills a picker promotes above the locality groups (#519). */
+const MOST_USED_LIMIT = 5
+
+/** The three display tiers every skill picker renders, in this order (#519). */
+export interface SkillTiers {
+  /** Skills actually picked before (`skillUsage` count > 0), frequency descending, capped. */
+  mostUsed: Skill[]
+  /** Remaining project skills (#377 locality), in the incoming (server-alphabetical) order. */
+  project: Skill[]
+  /** Remaining global/team skills, in the incoming order. */
+  global: Skill[]
+}
+
 /**
- * The composer picker's frequency sort (#408): locality first (project before global, the #377
- * rule), then MOST-SELECTED first within each half. `usage` is the ui-state `skillUsage` map
- * (name → times chosen, counted across BOTH composers — `/new`'s SourcePill and the GitHub tab's
- * follow-up `SkillsPicker`). The sort is stable, so ties — including "never selected", the
- * common case before any stats exist — keep the server's own directory order: the project-first
- * fallback (#2) falls out of stability for free, no separate branch needed. Shared by both
- * pickers so they can never drift into two different orders.
+ * Partition skills into the picker display tiers (#519): **Most used** first — skills with a
+ * `skillUsage` count > 0, frequency descending, ties broken locality-first then by incoming
+ * order, capped at `mostUsedLimit` — then **project**, then **global**, each remainder keeping
+ * the incoming order. A skill promoted into `mostUsed` is NOT repeated in its locality group.
+ * `usage` is the ui-state `skillUsage` map (name → times chosen, counted across every picker
+ * surface). With no usage at all this degrades to the plain #377 project-first split. The one
+ * source of tier truth: grouped pickers render the three tiers, flat surfaces flatten them
+ * through `orderSkillsByUsage`.
+ */
+export function partitionSkillsForDisplay(
+  skills: readonly Skill[],
+  usage: Readonly<Record<string, number>> | undefined,
+  { mostUsedLimit = MOST_USED_LIMIT }: { mostUsedLimit?: number } = {},
+): SkillTiers {
+  const mostUsed = skills
+    .map((skill, index) => ({ skill, index, count: usageCount(usage, skill.name) }))
+    .filter((entry) => entry.count > 0)
+    .sort(
+      (a, b) =>
+        b.count - a.count ||
+        Number(!isProjectSkill(a.skill)) - Number(!isProjectSkill(b.skill)) ||
+        a.index - b.index,
+    )
+    .slice(0, mostUsedLimit)
+    .map((entry) => entry.skill)
+  const promoted = new Set(mostUsed)
+  const rest = skills.filter((skill) => !promoted.has(skill))
+  return {
+    mostUsed,
+    project: rest.filter(isProjectSkill),
+    global: rest.filter((skill) => !isProjectSkill(skill)),
+  }
+}
+
+/**
+ * The flat frequency order (#408, re-tiered by #519): the `partitionSkillsForDisplay` tiers
+ * flattened — most-used first (frequency descending, capped), then project, then global — so
+ * flat surfaces (the workflows palette, the ⌘K palette, the `/` autocomplete's base order)
+ * agree with the grouped pickers. With no usage data this is exactly `orderSkills`.
  */
 export function orderSkillsByUsage(
   skills: readonly Skill[],
   usage: Readonly<Record<string, number>> | undefined,
 ): Skill[] {
-  return [...skills].sort(
-    (a, b) =>
-      Number(!isProjectSkill(a)) - Number(!isProjectSkill(b)) ||
-      usageCount(usage, b.name) - usageCount(usage, a.name),
-  )
+  const tiers = partitionSkillsForDisplay(skills, usage)
+  return [...tiers.mostUsed, ...tiers.project, ...tiers.global]
 }
 
 /** One skill's count out of the `skillUsage` map. `Object.hasOwn`, not a plain lookup: `usage`
@@ -194,30 +236,48 @@ export function queryScore(name: string, description: string | null | undefined,
   return total
 }
 
+/** A heavily-used skill may win among comparably-scoring matches (#519), but never outrank a
+ *  clearly better name match: the bonus is bounded to `MOST_USED_LIMIT * USAGE_BONUS_STEP`,
+ *  well under the `NAME_MATCH_BONUS` gap between match tiers. */
+const USAGE_BONUS_STEP = 0.5
+
 /** Filter a name/description list down to matches and rank them by match quality (#484),
  *  preserving the incoming order for an empty query and for equally-scored ties — so a
- *  caller's project-first or recency order survives. This is the shared ranking engine behind
- *  both the composer `/` autocomplete and the cmdk pickers: the pickers rank in JS through
- *  this rather than trusting cmdk's built-in score-sort, which does not reliably re-order the
- *  list in this app (React re-renders reset cmdk's imperative DOM ordering), so before #484 an
- *  (almost-)exact match could sit below weaker ones. */
+ *  caller's most-used-first or project-first order survives. When `usage` is given (#519), a
+ *  bounded usage bonus is folded into the score and the usage count breaks remaining ties, so
+ *  a typed query no longer discards frequency entirely. This is the shared ranking engine
+ *  behind both the composer `/` autocomplete and the cmdk pickers: the pickers rank in JS
+ *  through this rather than trusting cmdk's built-in score-sort, which does not reliably
+ *  re-order the list in this app (React re-renders reset cmdk's imperative DOM ordering), so
+ *  before #484 an (almost-)exact match could sit below weaker ones. */
 function rankByQuery<T extends { name: string; description?: string | null }>(
   items: readonly T[],
   query: string,
+  usage?: Readonly<Record<string, number>>,
 ): T[] {
   if (query.trim() === '') return [...items]
   return items
-    .map((item, index) => ({ item, index, score: queryScore(item.name, item.description, query) }))
+    .map((item, index) => {
+      const base = queryScore(item.name, item.description, query)
+      const count = usageCount(usage, item.name)
+      const bonus = Math.min(count, MOST_USED_LIMIT) * USAGE_BONUS_STEP
+      return { item, index, count, score: base > 0 ? base + bonus : 0 }
+    })
     .filter((entry) => entry.score > 0)
-    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .sort((a, b) => b.score - a.score || b.count - a.count || a.index - b.index)
     .map((entry) => entry.item)
 }
 
 /** Rank skills for a grouped picker by match quality, keeping the caller's incoming order
- *  (project-first / recency) for ties and the empty query. Callers split the result into their
- *  own Project/Global groups; each group stays match-ranked. */
-export function searchSkills(skills: readonly Skill[], query: string): Skill[] {
-  return rankByQuery(skills, query)
+ *  (most-used-first / project-first) for ties and the empty query — with the #519 usage
+ *  tie-break when `usage` is given. Callers split the result into their own display groups
+ *  (`partitionSkillsForDisplay`); each group stays match-ranked. */
+export function searchSkills(
+  skills: readonly Skill[],
+  query: string,
+  usage?: Readonly<Record<string, number>>,
+): Skill[] {
+  return rankByQuery(skills, query, usage)
 }
 
 /** Rank workflows for a picker by match quality — the workflow counterpart of `searchSkills`. */
@@ -225,12 +285,18 @@ export function searchWorkflows(workflows: readonly WorkflowDef[], query: string
   return rankByQuery(workflows, query)
 }
 
-/** The `/` autocomplete's list for a typed query: ordered project-first, then filtered and
- *  **ranked by match quality** (#484 — an (almost-)exact match must sort to the top, the same
- *  rule the pickers now follow; supersedes the old #380 "filter without re-sorting"). Matches
- *  on the name and, as a fallback, the description ("review" should find `om-code-review` even
- *  when the name says less than the description does). Ties keep the project-first order, so an
- *  empty query and equally-good matches still render project skills before global/team. */
-export function filterSkills(skills: readonly Skill[], query: string): Skill[] {
-  return rankByQuery(orderSkills(skills), query)
+/** The `/` autocomplete's list for a typed query: ordered most-used → project → global (#519,
+ *  via `orderSkillsByUsage`), then filtered and **ranked by match quality** (#484 — an
+ *  (almost-)exact match must sort to the top, the same rule the pickers now follow; supersedes
+ *  the old #380 "filter without re-sorting"). Matches on the name and, as a fallback, the
+ *  description ("review" should find `om-code-review` even when the name says less than the
+ *  description does). Ties keep the usage-then-locality order, so an empty query and
+ *  equally-good matches still render most-used skills first, then project before global/team.
+ *  Without `usage` this is exactly the pre-#519 project-first behavior. */
+export function filterSkills(
+  skills: readonly Skill[],
+  query: string,
+  usage?: Readonly<Record<string, number>>,
+): Skill[] {
+  return rankByQuery(orderSkillsByUsage(skills, usage), query, usage)
 }

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -766,8 +766,8 @@ describe('the hand-to-agent run (legacy three-way body)', () => {
 
 // ---- #408: frequency sort ----------------------------------------------------------------------
 
-describe('the skills dropdown frequency sort (#408 item 1, shared with project-first #2)', () => {
-  it('orders skills by usage count within each locality group', async () => {
+describe('the skills dropdown frequency sort (#408 item 1, re-tiered by #519)', () => {
+  it('promotes used skills into "Most used" ahead of locality, frequency descending', async () => {
     stubFetch({
       'GET /api/ui-state': () => jsonResponse({ skillUsage: { 'team-x': 9, 'g-review': 1 } }),
     })
@@ -778,9 +778,9 @@ describe('the skills dropdown frequency sort (#408 item 1, shared with project-f
       expect(document.querySelectorAll('[data-slot="gh-skill-option"]')).toHaveLength(3),
     )
     const options = [...document.querySelectorAll<HTMLElement>('[data-slot="gh-skill-option"]')]
-    // Project skill still leads (locality wins, #2) — frequency only reorders WITHIN "Global":
-    // team-x (9 picks) now leads g-review (1 pick), reversing the fixture's server order.
-    expect(options.map((option) => option.dataset.skill)).toEqual(['om-fix', 'team-x', 'g-review'])
+    // Most used leads (#519): team-x (9 picks) then g-review (1 pick), BOTH above the unused
+    // project skill om-fix — usage now outranks locality instead of only reordering within it.
+    expect(options.map((option) => option.dataset.skill)).toEqual(['team-x', 'g-review', 'om-fix'])
   })
 
   it('no usage stats at all falls back to the plain project-first order (#2)', async () => {

--- a/web/app/src/routes/github/hand-to-agent.tsx
+++ b/web/app/src/routes/github/hand-to-agent.tsx
@@ -36,7 +36,14 @@ import {
   normalizePromptTemplates,
   resolveAutoApply,
 } from '@/lib/prompt-templates'
-import { bumpSkillUsage, isProjectSkill, searchSkills, searchWorkflows, skillKeywords } from '@/lib/skills'
+import {
+  bumpSkillUsage,
+  isProjectSkill,
+  partitionSkillsForDisplay,
+  searchSkills,
+  searchWorkflows,
+  skillKeywords,
+} from '@/lib/skills'
 import { isSubmitShortcut, submitShortcutHint } from '@/lib/use-submit-shortcut'
 import { cn } from '@/lib/utils'
 
@@ -53,7 +60,7 @@ import { readFollowupPrompt, writeFollowupPrompt } from './hand-to-agent-draft'
  * survives switching between issues — it is a way of working, not a property of one item) —
  * `github.tsx` also persists it to localStorage (#408) so it survives a reload and pre-fills a
  * hand-off you have never touched (`hand-to-agent-draft.ts`). `skills` arrives already ordered
- * project-first-then-frequency (`orderSkillsByUsage`, #408) — this component just renders it.
+ * most-used → project → global (`orderSkillsByUsage`, #519) — this component just renders it.
  *
  * The selected skills render as an always-visible chip row OUTSIDE the dropdown — the legacy
  * invariant "the filter can't hide your selection", carried over: cmdk may filter the list,
@@ -201,7 +208,12 @@ export function HandToAgent({
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
         <WorkflowPicker workflows={workflows} value={workflow} onChange={onWorkflowChange} />
-        <SkillsPicker skills={skills} selected={validSkills} onToggle={toggleSkill} />
+        <SkillsPicker
+          skills={skills}
+          skillUsage={uiState.data?.skillUsage}
+          selected={validSkills}
+          onToggle={toggleSkill}
+        />
         <PromptTemplateMenu templates={templates} onInsert={insertPromptTemplate} />
       </div>
 
@@ -364,16 +376,18 @@ function WorkflowPicker({
 
 /**
  * The skills dropdown: multi-select — toggling keeps it open, because picking a chain is
- * several toggles — grouped Project skills (bold) before Global, per #377. Every row carries
- * a read-only "View skill" eye (spec §Skills): it opens the SAME detail component the
- * Settings catalog renders, as a dialog, without toggling the row.
+ * several toggles — grouped Most used (#519), then Project skills (bold) before Global, per
+ * #377. Every row carries a read-only "View skill" eye (spec §Skills): it opens the SAME
+ * detail component the Settings catalog renders, as a dialog, without toggling the row.
  */
 function SkillsPicker({
   skills,
+  skillUsage,
   selected,
   onToggle,
 }: {
   skills: readonly Skill[]
+  skillUsage: Readonly<Record<string, number>> | undefined
   selected: readonly string[]
   onToggle: (name: string) => void
 }) {
@@ -381,10 +395,9 @@ function SkillsPicker({
   const [search, setSearch] = useState('')
   const [preview, setPreview] = useState<Skill | null>(null)
   const listRef = useRef<HTMLDivElement>(null)
-  // #484: rank matches in JS, then split into Project/Global groups (cmdk's own sort is unreliable here).
-  const matched = searchSkills(skills, search)
-  const project = matched.filter(isProjectSkill)
-  const global = matched.filter((skill) => !isProjectSkill(skill))
+  // #484: rank matches in JS, then split into the #519 tiers (cmdk's own sort is unreliable here).
+  const matched = searchSkills(skills, search, skillUsage)
+  const { mostUsed, project, global } = partitionSkillsForDisplay(matched, skillUsage)
 
   const skillItem = (skill: Skill, emphasized: boolean) => {
     const isSelected = selected.includes(skill.name)
@@ -455,7 +468,14 @@ function SkillsPicker({
               onInput={() => listRef.current?.scrollTo(0, 0)}
             />
             <CommandList ref={listRef} data-slot="gh-skill-menu" className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]">
-              {project.length === 0 && global.length === 0 ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
+              {mostUsed.length === 0 && project.length === 0 && global.length === 0 ? (
+                <CommandEmpty>Nothing matches.</CommandEmpty>
+              ) : null}
+              {mostUsed.length > 0 ? (
+                <CommandGroup heading="Most used">
+                  {mostUsed.map((skill) => skillItem(skill, isProjectSkill(skill)))}
+                </CommandGroup>
+              ) : null}
               {project.length > 0 ? (
                 <CommandGroup heading="Project skills">{project.map((skill) => skillItem(skill, true))}</CommandGroup>
               ) : null}

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -43,6 +43,7 @@ import {
   bumpSkillUsage,
   isProjectSkill,
   orderSkillsByUsage,
+  partitionSkillsForDisplay,
   searchSkills,
   searchWorkflows,
   skillKeywords,
@@ -429,6 +430,7 @@ export function NewTaskRoute() {
                 source={source}
                 ready={sourcesReady}
                 skills={skillList}
+                skillUsage={skillUsage}
                 workflows={workflowList}
                 onPick={(next) => update({ source: next })}
               />
@@ -620,20 +622,22 @@ const chipClass =
 const chevron = <ChevronDownIcon aria-hidden="true" className="size-2.5 shrink-0 text-soft-foreground" />
 
 /**
- * The workflow/skill picker (#385's searchable cmdk dropdown, #377's project-first ordering):
- * ONE pill for both kinds of source. Groups follow the mockup — Project skills (bold), Global,
- * then Workflows.
+ * The workflow/skill picker (#385's searchable cmdk dropdown, #519's tier ordering): ONE pill
+ * for both kinds of source. Groups render Most used (skills picked before, frequency
+ * descending), Project skills (bold), Workflows, then Global.
  */
 function SourcePill({
   source,
   ready,
   skills,
+  skillUsage,
   workflows,
   onPick,
 }: {
   source: TaskSource
   ready: boolean
   skills: readonly Skill[]
+  skillUsage: Readonly<Record<string, number>> | undefined
   workflows: readonly WorkflowDef[]
   onPick: (source: TaskSource) => void
 }) {
@@ -642,12 +646,12 @@ function SourcePill({
   const [preview, setPreview] = useState<Skill | null>(null)
   const listRef = useRef<HTMLDivElement>(null)
   // #484: rank in JS (cmdk's own score-sort does not re-order reliably here), then split the
-  // ranked matches into the Project/Global groups so each group stays match-ordered.
-  const matched = searchSkills(skills, search)
-  const project = matched.filter(isProjectSkill)
-  const global = matched.filter((skill) => !isProjectSkill(skill))
+  // ranked matches into the #519 display tiers so each group stays match-ordered.
+  const matched = searchSkills(skills, search, skillUsage)
+  const { mostUsed, project, global } = partitionSkillsForDisplay(matched, skillUsage)
   const matchedWorkflows = searchWorkflows(workflows, search)
-  const nothingMatches = project.length === 0 && global.length === 0 && matchedWorkflows.length === 0
+  const nothingMatches =
+    mostUsed.length === 0 && project.length === 0 && global.length === 0 && matchedWorkflows.length === 0
   const pick = (next: TaskSource) => {
     onPick(next)
     setOpen(false)
@@ -742,8 +746,13 @@ function SourcePill({
               className="max-h-[min(18rem,calc(var(--radix-popover-content-available-height)-3rem))]"
             >
               {nothingMatches ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
-              {/* Project skills lead, Global trails everything — the closer a skill lives
-                  to the repo, the more likely it's the one being picked. */}
+              {/* Most used leads (#519), then Project skills before Global — the closer a
+                  skill lives to the repo, the more likely it's the one being picked. */}
+              {mostUsed.length > 0 ? (
+                <CommandGroup heading="Most used">
+                  {mostUsed.map((skill) => skillItem(skill, isProjectSkill(skill)))}
+                </CommandGroup>
+              ) : null}
               {project.length > 0 ? (
                 <CommandGroup heading="Project skills">
                   {project.map((skill) => skillItem(skill, true))}

--- a/web/app/src/routes/settings/prompt-templates-section.test.tsx
+++ b/web/app/src/routes/settings/prompt-templates-section.test.tsx
@@ -243,6 +243,20 @@ describe('assigning a template to a skill', () => {
     expect(options[1]?.querySelector('.font-semibold')).toBeNull()
   })
 
+  it('lists most-used skills first, across localities (#519)', async () => {
+    // g-review is global but USED — it now leads the unused project skill om-fix.
+    serve({ skillUsage: { 'g-review': 3 } })
+    renderSection()
+    await waitFor(() => expect(rows()).toHaveLength(DEFAULT_PROMPT_TEMPLATES.length))
+
+    await openPicker(rows()[0]!)
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-slot="prompt-template-skill-option"]')).toHaveLength(2),
+    )
+    const options = [...document.querySelectorAll<HTMLElement>('[data-slot="prompt-template-skill-option"]')]
+    expect(options.map((o) => o.dataset.skill)).toEqual(['g-review', 'om-fix'])
+  })
+
   it('assigning shows a chip and Save PUTs the skills alongside the template', async () => {
     serve()
     renderSection()

--- a/web/app/src/routes/settings/prompt-templates-section.tsx
+++ b/web/app/src/routes/settings/prompt-templates-section.tsx
@@ -25,7 +25,7 @@ import {
   normalizePromptTemplates,
   type PromptTemplate,
 } from '@/lib/prompt-templates'
-import { isProjectSkill, multiWordFilter, skillKeywords } from '@/lib/skills'
+import { isProjectSkill, multiWordFilter, partitionSkillsForDisplay, skillKeywords } from '@/lib/skills'
 import { cn } from '@/lib/utils'
 
 /**
@@ -69,6 +69,8 @@ export function PromptTemplatesSection() {
 function PromptTemplatesForm({ initial }: { initial: PromptTemplate[] }) {
   const queryClient = useQueryClient()
   const skills = useSkills()
+  // Already cached by the section gate above; read again here for the picker's #519 tiers.
+  const uiState = useUiState()
   const [templates, setTemplates] = useState<PromptTemplate[]>(initial)
   const [newLabel, setNewLabel] = useState('')
   const [newText, setNewText] = useState('')
@@ -172,6 +174,7 @@ function PromptTemplatesForm({ initial }: { initial: PromptTemplate[] }) {
                   <TemplateSkillsPicker
                     label={template.label}
                     skills={skills.data ?? []}
+                    skillUsage={uiState.data?.skillUsage}
                     selected={template.skills ?? []}
                     onToggle={(name) => toggleTemplateSkill(template.id, name)}
                   />
@@ -276,18 +279,20 @@ function PromptTemplatesForm({ initial }: { initial: PromptTemplate[] }) {
 function TemplateSkillsPicker({
   label,
   skills,
+  skillUsage,
   selected,
   onToggle,
 }: {
   label: string
   skills: readonly Skill[]
+  skillUsage: Readonly<Record<string, number>> | undefined
   selected: readonly string[]
   onToggle: (name: string) => void
 }) {
   const [open, setOpen] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
-  const project = skills.filter(isProjectSkill)
-  const global = skills.filter((skill) => !isProjectSkill(skill))
+  // The #519 display tiers — the same most-used → project → global order every picker renders.
+  const { mostUsed, project, global } = partitionSkillsForDisplay(skills, skillUsage)
 
   const skillItem = (skill: Skill, emphasized: boolean) => {
     const isSelected = selected.includes(skill.name)
@@ -345,6 +350,11 @@ function TemplateSkillsPicker({
             className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]"
           >
             <CommandEmpty>Nothing matches.</CommandEmpty>
+            {mostUsed.length > 0 ? (
+              <CommandGroup heading="Most used">
+                {mostUsed.map((skill) => skillItem(skill, isProjectSkill(skill)))}
+              </CommandGroup>
+            ) : null}
             {project.length > 0 ? (
               <CommandGroup heading="Project skills">
                 {project.map((skill) => skillItem(skill, true))}

--- a/web/app/src/routes/workflows/workflows.tsx
+++ b/web/app/src/routes/workflows/workflows.tsx
@@ -143,8 +143,8 @@ function WorkflowsBuilder({ routeName }: { routeName: string | undefined }) {
 
   const workflows = workflowsQuery.data?.workflows ?? []
   const skills = skillsQuery.data ?? []
-  // The palette lists skills the way every other picker does (#408/#414): project skills first,
-  // then most-used within each locality — so what you reach for floats to the top.
+  // The palette lists skills the way every other picker does (#519): most-used first, then
+  // project, then global — so what you reach for floats to the top.
   const paletteSkills = orderSkillsByUsage(skills, uiStateQuery.data?.skillUsage)
 
   // First visit seeds the canvas with the deep-linked workflow when the URL names one, else


### PR DESCRIPTION
Fixes #519

## Problem
Skill lists across the cockpit did not honour the intended most-used → project → global order: `orderSkillsByUsage` sorted locality before frequency, the composer `/` autocomplete, ⌘K palette, and Settings → Prompt templates picker never applied usage at all, any typed query discarded usage in ranking, and picks made through the `/` autocomplete were never counted.

## Root Cause
Five distinct defects (detailed in #519): the comparator in `web/app/src/lib/skills.ts` put `isProjectSkill` before usage count; the two-group Project/Global `CommandGroup` split in the `/new` and GitHub hand-to-agent pickers structurally kept used global skills below unused project ones; three surfaces had no usage input; `rankByQuery` re-sorted purely by `queryScore` on any typed query (#484 silently overriding #408); and `bumpSkillUsage` only fired from two of the picker surfaces.

## What Changed
- `lib/skills.ts`: new `partitionSkillsForDisplay(skills, usage, {mostUsedLimit=5})` → `{mostUsed, project, global}` as the single source of tier truth — Most used = usage count > 0, frequency descending, ties locality-first, capped, never repeated in its locality group; `orderSkillsByUsage` reimplemented as the flattened tiers; `rankByQuery` folds a bounded usage bonus (`min(count,5)*0.5`, under the name-match gap) plus a usage tie-break into typed-query ranking; `filterSkills`/`searchSkills` accept an optional `usage` param; stale doc comments fixed (server order is alphabetical, not directory precedence).
- `/new` SourcePill and GitHub hand-to-agent `SkillsPicker`: three `CommandGroup`s — "Most used", "Project skills", "Global" ("Most used" only when non-empty).
- Composer `/` autocomplete: reads `skillUsage` and passes it to `filterSkills`; a skill pick now bumps usage via the same shallow-merge-safe guard as `/new` (whole map PUT, skipped entirely when ui-state is unavailable — never wipes accumulated counts).
- ⌘K palette and workflows palette: flat `orderSkillsByUsage` order.
- Settings → Prompt templates picker: partitioned three-tier groups.
- Out of scope, unchanged: skill discovery precedence (`src/skills.ts`), `/api/skills` payload, `skillUsage` schema, and the browse/catalog surfaces (`routes/skills.tsx`, bookmarklets) which stay on `orderSkills`.

## Tests
- Rewrote the inverted-priority pins (`lib/skills.test.ts`, `routes/github/github.test.tsx`) to the three-tier contract.
- New: partition cases (cap + overflow fallback, no-repeat across tiers, empty mostUsed, prototype-pollution guard), typed-query usage tie-break + bounded-bonus tests, composer autocomplete ordering + pick-bump + no-PUT-on-unavailable-ui-state + no-bump-for-@-mentions, ⌘K palette ordering, prompt-templates picker ordering.
- Validation gate: `npm run typecheck` ✅ · `npm test` 2810/2811 (the 1 failure is `src/server/request-validation.test.ts` open-in 409≠400 — reproduced on clean `main` with this change stashed, pre-existing and unrelated) · `npm run test:unit` ✅ · `npm run build` ✅ · `npm run test:package` ✅

## Breaking Changes
None — `filterSkills`/`searchSkills` gained optional trailing parameters, `orderSkillsByUsage` keeps its signature. Display order changed intentionally per the issue; `BACKWARD_COMPATIBILITY.md` §5 protects discovery precedence, which is untouched.

🤖 Generated by autofix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
