### PR TITLE
fix(worktree): name the autosave trigger in the commit subject + refuse conflicted trees (#471)

### DIFF
--- a/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
+++ b/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
@@ -1,0 +1,98 @@
+# Autosave flush commit clarity + conflict-marker guard
+
+**Issue:** follow-up to #471 / #478
+**Branch:** `fix/autosave-flush-commit-clarity`
+
+## Goal
+
+Make the *kept* autosave flushes distinguishable from the *disabled* periodic
+autosave timer in `git log`, and stop `autosaveCommit` from committing a
+half-resolved merge.
+
+## Background
+
+#471 asked to disable the global task list and autosaves. #478 gated the
+periodic 90 s timer behind `CEZ_AUTOSAVE=1` (off by default) but deliberately
+left three flush call sites ungated, so a task branch still ends holding the
+finished state:
+
+| Call site | Purpose | Gated? |
+|---|---|---|
+| `run.ts:1653` (`armAutosave` timer) | periodic, every 90 s | **yes** — `CEZ_AUTOSAVE=1` |
+| `run.ts:943` | turn-end flush | no, by design |
+| `run.ts:1166` | run-finalize flush | no, by design |
+| `server/forge/github.ts:534` | pre-PR flush | no, by design |
+
+All four commit with the identical message `cezar autosave`
+(`git-worktree.ts:251`). The gate therefore *works*, but is unfalsifiable from
+`git log` alone: a user who opted out still sees `cezar autosave` commits and
+reasonably concludes the opt-out was ignored. That is exactly what happened —
+this run started as a bug report against a correctly-working gate. The only way
+to tell the two apart today is commit *spacing* (85–95 s ⇒ timer; minutes-to-
+hours ⇒ flush), which is not a reasonable thing to ask of a reader.
+
+Separately, the incident that motivated #471 (recorded in
+`.ai/runs/2026-07-17-disable-global-inbox/HANDOFF.md:26-28`) was an autosave
+committing a half-resolved merge carrying conflict markers. `autosaveCommit`
+does a blind `git add -A` with no unmerged-path or marker check
+(`git-worktree.ts:234-254`), so the *ungated* flushes can still do this. #478
+narrowed that hazard; it did not remove it.
+
+## Scope
+
+- Label every autosave commit with the reason that produced it.
+- Refuse to commit a worktree with unmerged paths or leftover conflict markers.
+- Correct docs that describe `cezar autosave` as if it were a CLI subcommand.
+
+## Non-goals
+
+- Changing *which* call sites are gated. The three flushes stay ungated — that
+  is the documented #478 contract and the branch must still end complete.
+- Touching the follow-up inbox / `CEZ_FOLLOWUPS` gate. Verified correct.
+- Anything about `~/HANDOFF.md`, which is written by the user's own
+  `~/.claude/CLAUDE.md`, not by cezar.
+
+## Risks
+
+- The commit message is a de-facto interface (log greps, the run retro docs).
+  Mitigated by keeping the `cezar autosave` prefix and only appending a
+  parenthesised reason, so existing `grep 'cezar autosave'` keeps matching.
+- A conflict-marker guard that is too eager could refuse a legitimate flush and
+  lose the run's recovery point. Mitigated by scanning only *staged, tracked
+  text* files and by logging loudly when the guard trips.
+
+## Implementation Plan
+
+### Phase 1 — label autosave commits by reason
+
+Add an `AutosaveReason` union and thread it through the four call sites so the
+message becomes `cezar autosave (turn end)` etc.
+
+### Phase 2 — conflict-marker guard
+
+Refuse the commit when the worktree has unmerged paths or files containing
+leftover conflict markers; return `false` and log.
+
+### Phase 3 — docs
+
+Fix `README.md:365` (backticks `cezar autosave` like a subcommand that does not
+exist — `src/index.ts:87-118` has no such case) and the stale docstrings.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Label autosave commits by reason
+
+- [ ] 1.1 Add `AutosaveReason` and reason-aware message to `autosaveCommit`
+- [ ] 1.2 Pass the reason at all four call sites
+- [ ] 1.3 Tests for reason-labelled messages
+
+### Phase 2: Conflict-marker guard
+
+- [ ] 2.1 Refuse to autosave unmerged paths / leftover conflict markers
+- [ ] 2.2 Tests for the guard
+
+### Phase 3: Docs
+
+- [ ] 3.1 Correct README and docstrings

--- a/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
+++ b/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
@@ -98,3 +98,17 @@ PR: #533
 ### Phase 3: Docs
 
 - [x] 3.1 Correct README and docstrings — fff538b
+
+### Phase 4: Review follow-ups (#533 review)
+
+The guard made `autosaveCommit` fallible in a new way, and the boolean return
+could not carry that. The pre-PR flush is the one call site where the "next
+flush picks it up" argument does not hold — it is the last one — so a refusal
+there was silently publishing a branch missing the run's final state.
+
+- [x] 4.1 `AutosaveResult` union; surface `refused`/`failed` from `createDraftPr`
+- [x] 4.2 Require `reason` (drop the `'turn end'` default that could mislabel silently)
+- [x] 4.3 Require the full ordered `<<<<<<< / ======= / >>>>>>>` triple, so files
+      that merely document conflict markers keep autosaving
+- [x] 4.4 Cap the marker scan at 2 MB per file; unescape git's octal path quoting
+- [x] 4.5 Tests for the publish-refusal path and the new scan cases

--- a/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
+++ b/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
@@ -80,6 +80,8 @@ exist — `src/index.ts:87-118` has no such case) and the stale docstrings.
 
 ## Progress
 
+PR: #533
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Label autosave commits by reason

--- a/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
+++ b/.ai/runs/2026-07-21-autosave-flush-commit-clarity.md
@@ -84,15 +84,15 @@ exist — `src/index.ts:87-118` has no such case) and the stale docstrings.
 
 ### Phase 1: Label autosave commits by reason
 
-- [ ] 1.1 Add `AutosaveReason` and reason-aware message to `autosaveCommit`
-- [ ] 1.2 Pass the reason at all four call sites
-- [ ] 1.3 Tests for reason-labelled messages
+- [x] 1.1 Add `AutosaveReason` and reason-aware message to `autosaveCommit` — 13fb782
+- [x] 1.2 Pass the reason at all four call sites — 13fb782
+- [x] 1.3 Tests for reason-labelled messages — 13fb782
 
 ### Phase 2: Conflict-marker guard
 
-- [ ] 2.1 Refuse to autosave unmerged paths / leftover conflict markers
-- [ ] 2.2 Tests for the guard
+- [x] 2.1 Refuse to autosave unmerged paths / leftover conflict markers — 13fb782
+- [x] 2.2 Tests for the guard — 13fb782
 
 ### Phase 3: Docs
 
-- [ ] 3.1 Correct README and docstrings
+- [x] 3.1 Correct README and docstrings — fff538b

--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,8 @@
 # Off by default. Set to 1 to re-enable the janitor-style "cezar autosave" commit every 90 s
 # in each task worktree (spec 006). Left off, a task branch carries only the agent's own
 # commits — plus the turn-end and pre-PR flushes, which always run so the branch still ends
-# holding the finished state and the diff/review/PR views stay complete.
+# holding the finished state and the diff/review/PR views stay complete. Those flushes commit
+# as `cezar autosave (turn end|run finalize|pre-PR)`; only `(periodic)` is this flag's timer.
 # CEZ_AUTOSAVE=1
 
 # ---- GitHub -----------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Useful environment variables:
 | `CEZ_DRY_RUN=1` | Use the bundled mock instead of the real `claude` CLI — the entire cockpit works offline, for demos and development. |
 | `CEZ_APPROVAL_GATE=1` | Opt into Claude's interactive approval UI; by default, unapproved tools are denied without interrupting the run. |
 | `CEZ_FOLLOWUPS=1` | Turn on the global follow-up **Inbox**: agents are asked to leave follow-ups in `todos.json` when they finish, and the Inbox view appears. Off by default — each task's own **Notes** handoff journal runs either way. |
-| `CEZ_AUTOSAVE=1` | Re-enable the periodic (90 s) `cezar autosave` commit in task worktrees. Off by default (#471) — turn-end and pre-PR flushes always run, so branches still end complete. |
+| `CEZ_AUTOSAVE=1` | Re-enable the periodic (90 s) autosave commit in task worktrees. Off by default (#471) — turn-end and pre-PR flushes always run, so branches still end complete. Every autosave names its trigger in the commit subject (`cezar autosave (periodic)` vs `(turn end)` / `(run finalize)` / `(pre-PR)`), so the flushes you keep are distinguishable from the timer you disabled. |
 | `CEZ_CLAUDE_BIN=/path/to/claude` | Override which `claude` binary is used. |
 | `CEZ_CODEX_BIN=/path/to/codex` | Override which `codex` binary is used. |
 | `CEZ_OPENCODE_BIN=/path/to/opencode` | Override which `opencode` binary is used. |

--- a/src/autosave-conflict-guard.test.ts
+++ b/src/autosave-conflict-guard.test.ts
@@ -1,0 +1,91 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { autosaveCommit } from './git-worktree.js';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+
+/**
+ * `autosaveCommit` must never capture a half-resolved merge (#471). The incident
+ * behind that issue was an autosave committing conflict markers, and the flushes
+ * that produce most autosave commits are deliberately ungated — so the guard,
+ * not the `CEZ_AUTOSAVE` gate, is what actually prevents a recurrence.
+ */
+describe('autosave conflict guard (#471 follow-up)', () => {
+  let repo: string;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  const git = (args: string[]) => run('git', args, { cwd: repo });
+  const subject = async () => (await git(['log', '-1', '--format=%s'])).stdout.trim();
+
+  beforeEach(async () => {
+    repo = mkdtempSync(join(tmpdir(), 'cez-autosave-conflict-'));
+    await git(['init', '-q', '-b', 'main']);
+    writeFileSync(join(repo, 'a.txt'), 'base\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', 'base']);
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  /** Leave the repo mid-merge with a genuine conflict in `a.txt`. */
+  async function startConflictingMerge(): Promise<void> {
+    await git([...GIT_ID, 'checkout', '-q', '-b', 'other']);
+    writeFileSync(join(repo, 'a.txt'), 'theirs\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', 'theirs']);
+    await git([...GIT_ID, 'checkout', '-q', 'main']);
+    writeFileSync(join(repo, 'a.txt'), 'ours\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', 'ours']);
+    await git([...GIT_ID, 'merge', 'other']).catch(() => undefined); // expected to conflict
+  }
+
+  it('refuses to commit an unresolved merge', async () => {
+    await startConflictingMerge();
+    const before = await subject();
+    expect(await autosaveCommit(repo, 'turn end')).toBe(false);
+    expect(await subject()).toBe(before); // nothing new landed
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unmerged path'));
+  });
+
+  it('refuses when markers survive a premature `git add`', async () => {
+    await startConflictingMerge();
+    // Staging without editing clears the porcelain `U` code but leaves the
+    // markers in the text — the exact shape of the original incident.
+    await git(['add', 'a.txt']);
+    const before = await subject();
+    expect(await autosaveCommit(repo, 'run finalize')).toBe(false);
+    expect(await subject()).toBe(before);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('leftover conflict markers'));
+  });
+
+  it('commits once the conflict is genuinely resolved', async () => {
+    await startConflictingMerge();
+    writeFileSync(join(repo, 'a.txt'), 'resolved\n');
+    await git(['add', 'a.txt']);
+    expect(await autosaveCommit(repo, 'turn end')).toBe(true);
+    expect(await subject()).toBe('cezar autosave (turn end)');
+  });
+
+  it('does not mistake Markdown setext headings for conflict markers', async () => {
+    // A bare `=======` line is an ordinary heading underline. Matching it would
+    // refuse legitimate autosaves of this repo's own docs.
+    writeFileSync(join(repo, 'doc.md'), 'Title\n=======\n\nbody\n');
+    expect(await autosaveCommit(repo, 'turn end')).toBe(true);
+    expect(await subject()).toBe('cezar autosave (turn end)');
+  });
+
+  it('is a quiet no-op on a clean tree', async () => {
+    expect(await autosaveCommit(repo, 'turn end')).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/autosave-conflict-guard.test.ts
+++ b/src/autosave-conflict-guard.test.ts
@@ -52,7 +52,7 @@ describe('autosave conflict guard (#471 follow-up)', () => {
   it('refuses to commit an unresolved merge', async () => {
     await startConflictingMerge();
     const before = await subject();
-    expect(await autosaveCommit(repo, 'turn end')).toBe(false);
+    expect(await autosaveCommit(repo, 'turn end')).toBe('refused');
     expect(await subject()).toBe(before); // nothing new landed
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('unmerged path'));
   });
@@ -63,7 +63,7 @@ describe('autosave conflict guard (#471 follow-up)', () => {
     // markers in the text — the exact shape of the original incident.
     await git(['add', 'a.txt']);
     const before = await subject();
-    expect(await autosaveCommit(repo, 'run finalize')).toBe(false);
+    expect(await autosaveCommit(repo, 'run finalize')).toBe('refused');
     expect(await subject()).toBe(before);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('leftover conflict markers'));
   });
@@ -72,20 +72,60 @@ describe('autosave conflict guard (#471 follow-up)', () => {
     await startConflictingMerge();
     writeFileSync(join(repo, 'a.txt'), 'resolved\n');
     await git(['add', 'a.txt']);
-    expect(await autosaveCommit(repo, 'turn end')).toBe(true);
+    expect(await autosaveCommit(repo, 'turn end')).toBe('committed');
     expect(await subject()).toBe('cezar autosave (turn end)');
   });
+
+  /**
+   * The guard deliberately skips untracked (`??`) paths, so a test that only
+   * writes a new file exercises nothing. Commit an innocuous version first,
+   * then overwrite it — that is the ` M` state the scan actually looks at.
+   */
+  async function trackThenRewrite(name: string, content: string): Promise<void> {
+    writeFileSync(join(repo, name), 'placeholder\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', `add ${name}`]);
+    writeFileSync(join(repo, name), content);
+  }
+
+  const CONFLICT_HUNK = ['<<<<<<< HEAD', 'ours', '=======', 'theirs', '>>>>>>> other', ''].join('\n');
 
   it('does not mistake Markdown setext headings for conflict markers', async () => {
     // A bare `=======` line is an ordinary heading underline. Matching it would
     // refuse legitimate autosaves of this repo's own docs.
-    writeFileSync(join(repo, 'doc.md'), 'Title\n=======\n\nbody\n');
-    expect(await autosaveCommit(repo, 'turn end')).toBe(true);
+    await trackThenRewrite('doc.md', 'Title\n=======\n\nbody\n');
+    expect(await autosaveCommit(repo, 'turn end')).toBe('committed');
     expect(await subject()).toBe('cezar autosave (turn end)');
   });
 
+  it('does not trip on a file that merely documents conflict markers', async () => {
+    // A checked-in patch fixture, or docs explaining how to resolve a conflict,
+    // carry marker-shaped lines out of order or without the `=======` middle.
+    // Requiring the full ordered triple is what keeps those autosaving.
+    await trackThenRewrite(
+      'doc.md',
+      ['Resolving conflicts', '', '>>>>>>> is the end marker.', '<<<<<<< is the start marker.', ''].join('\n'),
+    );
+    expect(await autosaveCommit(repo, 'turn end')).toBe('committed');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('still catches a real conflict hunk written by hand', async () => {
+    await trackThenRewrite('a.txt', CONFLICT_HUNK);
+    expect(await autosaveCommit(repo, 'pre-PR')).toBe('refused');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('leftover conflict markers'));
+  });
+
+  it('scans paths git reports quoted and octal-escaped', async () => {
+    // `café.txt` reads back from porcelain as `"caf\303\251.txt"`; leaving the
+    // escapes literal would make the file unopenable and hide a real conflict.
+    await trackThenRewrite('café.txt', CONFLICT_HUNK);
+    expect(await autosaveCommit(repo, 'turn end')).toBe('refused');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('café.txt'));
+  });
+
   it('is a quiet no-op on a clean tree', async () => {
-    expect(await autosaveCommit(repo, 'turn end')).toBe(false);
+    expect(await autosaveCommit(repo, 'turn end')).toBe('nothing-to-do');
     expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { existsSync, realpathSync, type Dirent } from 'node:fs';
-import { readdir, readFile, rm } from 'node:fs/promises';
+import { readdir, readFile, rm, stat } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 import { isSafeGitRef } from './git-refs.js';
 
@@ -252,13 +252,51 @@ export async function removeWorktree(
 export type AutosaveReason = 'periodic' | 'turn end' | 'run finalize' | 'pre-PR';
 
 /**
- * Leftover merge-conflict markers, anchored at line start as git writes them.
- * Both ends must be present: a bare `=======` line is ordinary Markdown (a
- * setext heading underline), and matching it alone would refuse legitimate
- * autosaves of this repo's own docs.
+ * What an autosave attempt did. `refused` and `failed` are distinct from
+ * `nothing-to-do` because one call site must act on them: the pre-PR flush is
+ * the *last* one, so anything other than `committed`/`nothing-to-do` there
+ * means the branch leaves the box without the run's final state and the user
+ * has to be told (see createDraftPr). A bare boolean could not carry that.
  */
-const CONFLICT_START = /^<{7}(?:\s|$)/m;
-const CONFLICT_END = /^>{7}(?:\s|$)/m;
+export type AutosaveResult = 'committed' | 'nothing-to-do' | 'refused' | 'failed';
+
+/**
+ * Leftover merge-conflict markers, anchored at line start as git writes them.
+ * All three must appear *in order*: a bare `=======` line is ordinary Markdown
+ * (a setext heading underline), and any of the three alone — or the pair
+ * `<<<<<<<`/`>>>>>>>` in either order — occurs legitimately in checked-in
+ * patch fixtures and in docs that demonstrate conflict markers. Requiring the
+ * full ordered triple is what separates a real conflict from a file that
+ * merely talks about one.
+ */
+const CONFLICT_START = /^<{7}(?:\s|$)/;
+const CONFLICT_MID = /^={7}(?:\s|$)/;
+const CONFLICT_END = /^>{7}(?:\s|$)/;
+
+/**
+ * Largest file the marker scan will read. Autosave runs as often as every 90 s,
+ * and decoding a large tracked file into a JS string each time is a real memory
+ * cost for a check that only ever looks at a few marker lines. Oversized files
+ * are skipped, which fails *open* — consistent with the rest of this guard,
+ * where a false negative costs noise and a false positive costs the recovery
+ * point.
+ */
+const MARKER_SCAN_MAX_BYTES = 2_000_000;
+
+/** Does this file carry a complete, ordered conflict hunk? */
+function hasConflictMarkers(text: string): boolean {
+  let want: 0 | 1 | 2 = 0; // 0: `<<<<<<<`, 1: `=======`, 2: `>>>>>>>`
+  for (const line of text.split('\n')) {
+    if (want === 0) {
+      if (CONFLICT_START.test(line)) want = 1;
+    } else if (want === 1) {
+      if (CONFLICT_MID.test(line)) want = 2;
+    } else if (CONFLICT_END.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Stage and commit everything in the worktree as a "cezar autosave" commit
@@ -273,18 +311,17 @@ const CONFLICT_END = /^>{7}(?:\s|$)/m;
  * markers: the incident behind #471 was an autosave capturing a half-resolved
  * merge, and a blind `git add -A` would do it again.
  */
-export async function autosaveCommit(
-  dir: string,
-  reason: AutosaveReason = 'turn end',
-): Promise<boolean> {
+export async function autosaveCommit(dir: string, reason: AutosaveReason): Promise<AutosaveResult> {
   const status = await git(dir, ['status', '--porcelain']);
-  if (!status.ok || !status.stdout.trim()) return false;
+  if (!status.ok || !status.stdout.trim()) return 'nothing-to-do';
   const unresolved = await unresolvedConflicts(dir, status.stdout);
   if (unresolved) {
     // Losing one recovery point beats poisoning the branch with a commit that
-    // does not build. The next flush picks the work up once the merge resolves.
+    // does not build. For the periodic and turn-end flushes the next one picks
+    // the work up once the merge resolves; the pre-PR flush has no next one,
+    // which is why callers get `refused` rather than a bare `false`.
     console.warn(`[cezar] skipping ${reason} autosave in ${dir}: ${unresolved}`);
-    return false;
+    return 'refused';
   }
   await git(dir, ['add', '-A']);
   // Commit as the CURRENT git user, so the branch's commits (and any PR opened from it) are
@@ -302,7 +339,7 @@ export async function autosaveCommit(
     '-m',
     `cezar autosave (${reason})`,
   ]);
-  return commit.ok;
+  return commit.ok ? 'committed' : 'failed';
 }
 
 /**
@@ -336,8 +373,7 @@ async function unresolvedConflicts(dir: string, porcelain: string): Promise<stri
       // A rename reads `old -> new`; the new path is what gets committed.
       const raw = line.slice(3).trim();
       const path = raw.includes(' -> ') ? (raw.split(' -> ')[1] ?? raw) : raw;
-      // Git quotes paths containing spaces or non-ASCII bytes.
-      return path.startsWith('"') ? path.slice(1, -1) : path;
+      return unquotePath(path);
     });
   for (const path of candidates) {
     // Read the working tree, not the index: this runs before `git add -A`, so
@@ -346,15 +382,51 @@ async function unresolvedConflicts(dir: string, porcelain: string): Promise<stri
     // pattern; unreadable paths (races, symlinks) are skipped, not fatal.
     let text: string;
     try {
-      text = await readFile(join(dir, path), 'utf8');
+      const full = join(dir, path);
+      if ((await stat(full)).size > MARKER_SCAN_MAX_BYTES) continue;
+      text = await readFile(full, 'utf8');
     } catch {
       continue;
     }
-    if (CONFLICT_START.test(text) && CONFLICT_END.test(text)) {
+    if (hasConflictMarkers(text)) {
       return `leftover conflict markers in ${path}`;
     }
   }
   return null;
+}
+
+/**
+ * Undo `git status --porcelain` path quoting. Git quotes a path containing a
+ * space or a non-ASCII byte, escaping the latter as octal — `café.txt` reads
+ * back as `"caf\303\251.txt"`. Stripping the quotes alone leaves those escapes
+ * literal, so the file would not open and a real conflict in it would go
+ * unnoticed. Decoding the octal bytes as UTF-8 restores the actual name.
+ */
+function unquotePath(path: string): string {
+  if (!path.startsWith('"') || !path.endsWith('"')) return path;
+  const inner = path.slice(1, -1);
+  const bytes: number[] = [];
+  for (let i = 0; i < inner.length; i += 1) {
+    if (inner[i] !== '\\') {
+      bytes.push(...Buffer.from(inner[i] as string, 'utf8'));
+      continue;
+    }
+    const next = inner[i + 1] as string | undefined;
+    if (next === undefined) break;
+    const octal = inner.slice(i + 1, i + 4);
+    if (/^[0-7]{3}$/.test(octal)) {
+      bytes.push(parseInt(octal, 8));
+      i += 3;
+      continue;
+    }
+    // C-style single-character escapes git also emits.
+    const simple: Record<string, number> = { n: 10, t: 9, r: 13, '"': 34, '\\': 92 };
+    const escaped = simple[next];
+    if (escaped === undefined) bytes.push(...Buffer.from(next, 'utf8'));
+    else bytes.push(escaped);
+    i += 1;
+  }
+  return Buffer.from(bytes).toString('utf8');
 }
 
 /** Does this repo/worktree resolve a git author identity (name + email)? Ambient config wins so

--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -325,7 +325,11 @@ async function unresolvedConflicts(dir: string, porcelain: string): Promise<stri
   if (firstUnmerged) {
     return `${unmerged.length} unmerged path(s), e.g. ${firstUnmerged.slice(3)}`;
   }
-  // Only tracked, non-deleted paths can carry markers into the commit.
+  // Deleted paths have no content to scan. Untracked (`??`) ones are skipped
+  // even though `git add -A` will commit them: a conflict always lands in a
+  // tracked file, whereas an untracked fixture or doc that legitimately
+  // contains marker-shaped lines would otherwise wedge every autosave. False
+  // negatives here cost noise; false positives would cost the recovery point.
   const candidates = entries
     .filter((line) => !line.startsWith('D ') && !line.startsWith(' D') && !line.startsWith('??'))
     .map((line) => {

--- a/src/git-worktree.ts
+++ b/src/git-worktree.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { existsSync, realpathSync, type Dirent } from 'node:fs';
-import { readdir, rm } from 'node:fs/promises';
+import { readdir, readFile, rm } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 import { isSafeGitRef } from './git-refs.js';
 
@@ -242,13 +242,50 @@ export async function removeWorktree(
 }
 
 /**
+ * Why an autosave commit happened. Only `periodic` is gated (behind
+ * `CEZ_AUTOSAVE=1`, #471) — the three flushes always run so the branch ends
+ * holding the finished state. Before this was recorded, all four wrote the bare
+ * message `cezar autosave`, so a user who had opted out of the periodic timer
+ * still saw `cezar autosave` in `git log` and reasonably concluded the opt-out
+ * was broken. Only commit *spacing* (~90 s ⇒ timer) told them apart.
+ */
+export type AutosaveReason = 'periodic' | 'turn end' | 'run finalize' | 'pre-PR';
+
+/**
+ * Leftover merge-conflict markers, anchored at line start as git writes them.
+ * Both ends must be present: a bare `=======` line is ordinary Markdown (a
+ * setext heading underline), and matching it alone would refuse legitimate
+ * autosaves of this repo's own docs.
+ */
+const CONFLICT_START = /^<{7}(?:\s|$)/m;
+const CONFLICT_END = /^>{7}(?:\s|$)/m;
+
+/**
  * Stage and commit everything in the worktree as a "cezar autosave" commit
  * (janitor pattern) — the agent's progress is always recoverable from the
  * `cez/<id8>` branch history. Quietly a no-op when nothing changed.
+ *
+ * The message carries `reason` so the opt-in periodic timer and the always-on
+ * flushes are distinguishable in `git log`; the `cezar autosave` prefix is kept
+ * so existing log greps still match.
+ *
+ * Refuses to commit a worktree that is mid-merge or still carries conflict
+ * markers: the incident behind #471 was an autosave capturing a half-resolved
+ * merge, and a blind `git add -A` would do it again.
  */
-export async function autosaveCommit(dir: string): Promise<boolean> {
+export async function autosaveCommit(
+  dir: string,
+  reason: AutosaveReason = 'turn end',
+): Promise<boolean> {
   const status = await git(dir, ['status', '--porcelain']);
   if (!status.ok || !status.stdout.trim()) return false;
+  const unresolved = await unresolvedConflicts(dir, status.stdout);
+  if (unresolved) {
+    // Losing one recovery point beats poisoning the branch with a commit that
+    // does not build. The next flush picks the work up once the merge resolves.
+    console.warn(`[cezar] skipping ${reason} autosave in ${dir}: ${unresolved}`);
+    return false;
+  }
   await git(dir, ['add', '-A']);
   // Commit as the CURRENT git user, so the branch's commits (and any PR opened from it) are
   // attributed to the real author and pass CLA / attribution checks. The old hardcoded
@@ -263,9 +300,57 @@ export async function autosaveCommit(dir: string): Promise<boolean> {
     'commit',
     '--no-verify',
     '-m',
-    'cezar autosave',
+    `cezar autosave (${reason})`,
   ]);
   return commit.ok;
+}
+
+/**
+ * Is the worktree mid-merge or still carrying conflict markers? Returns a
+ * human-readable reason, or `null` when it is safe to autosave.
+ *
+ * Two independent checks, because they catch different failures: porcelain `U`
+ * codes catch an *unresolved* merge, while the marker scan catches the worse
+ * case — someone ran `git add` on a file they had not finished resolving, which
+ * clears the `U` code but leaves `<<<<<<<` in the text.
+ */
+async function unresolvedConflicts(dir: string, porcelain: string): Promise<string | null> {
+  const entries = porcelain.split('\n').filter(Boolean);
+  const unmerged = entries.filter((line) => {
+    const xy = line.slice(0, 2);
+    // Unmerged per `git status` docs: any side U, plus the AA / DD collisions.
+    return xy.includes('U') || xy === 'AA' || xy === 'DD';
+  });
+  const firstUnmerged = unmerged[0];
+  if (firstUnmerged) {
+    return `${unmerged.length} unmerged path(s), e.g. ${firstUnmerged.slice(3)}`;
+  }
+  // Only tracked, non-deleted paths can carry markers into the commit.
+  const candidates = entries
+    .filter((line) => !line.startsWith('D ') && !line.startsWith(' D') && !line.startsWith('??'))
+    .map((line) => {
+      // A rename reads `old -> new`; the new path is what gets committed.
+      const raw = line.slice(3).trim();
+      const path = raw.includes(' -> ') ? (raw.split(' -> ')[1] ?? raw) : raw;
+      // Git quotes paths containing spaces or non-ASCII bytes.
+      return path.startsWith('"') ? path.slice(1, -1) : path;
+    });
+  for (const path of candidates) {
+    // Read the working tree, not the index: this runs before `git add -A`, so
+    // the on-disk copy is what would be committed. Binary files decode to
+    // mojibake rather than throwing, but cannot match the anchored marker
+    // pattern; unreadable paths (races, symlinks) are skipped, not fatal.
+    let text: string;
+    try {
+      text = await readFile(join(dir, path), 'utf8');
+    } catch {
+      continue;
+    }
+    if (CONFLICT_START.test(text) && CONFLICT_END.test(text)) {
+      return `leftover conflict markers in ${path}`;
+    }
+  }
+  return null;
 }
 
 /** Does this repo/worktree resolve a git author identity (name + email)? Ambient config wins so

--- a/src/server/forge/draft-pr-autosave.test.ts
+++ b/src/server/forge/draft-pr-autosave.test.ts
@@ -1,0 +1,87 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDraftPr } from './github.js';
+import type { RunRecord } from '../../runs/store.js';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+
+/**
+ * The pre-PR autosave is the LAST flush — unlike the turn-end and run-finalize
+ * ones, no later autosave picks the work up. So when the conflict guard (#471)
+ * refuses it, publishing must stop with a human-readable error rather than
+ * pushing a branch that is missing the run's final state.
+ */
+describe('createDraftPr pre-PR autosave (#471 follow-up)', () => {
+  let repo: string;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  const git = (args: string[]) => run('git', args, { cwd: repo });
+
+  const input = () => ({
+    repoRoot: repo,
+    handoffText: '# Goal\n\nship it\n',
+    run: { worktreePath: repo, branch: 'cez/abc123', task: 'do the thing' } as RunRecord,
+  });
+
+  beforeEach(async () => {
+    repo = mkdtempSync(join(tmpdir(), 'cez-draft-pr-'));
+    await git(['init', '-q', '-b', 'main']);
+    writeFileSync(join(repo, 'a.txt'), 'base\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', 'base']);
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.stubEnv('CEZ_DRY_RUN', '1'); // stop before push/gh; the guard runs earlier
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    vi.unstubAllEnvs();
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('refuses to publish a worktree holding conflict markers', async () => {
+    writeFileSync(
+      join(repo, 'a.txt'),
+      ['<<<<<<< HEAD', 'ours', '=======', 'theirs', '>>>>>>> other', ''].join('\n'),
+    );
+    const outcome = await createDraftPr(input());
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.error).toContain('unresolved merge conflicts');
+  });
+
+  it('refuses to publish an unresolved merge', async () => {
+    await git([...GIT_ID, 'checkout', '-q', '-b', 'other']);
+    writeFileSync(join(repo, 'a.txt'), 'theirs\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', 'theirs']);
+    await git([...GIT_ID, 'checkout', '-q', 'main']);
+    writeFileSync(join(repo, 'a.txt'), 'ours\n');
+    await git(['add', '-A']);
+    await git([...GIT_ID, 'commit', '-q', '-m', 'ours']);
+    await git([...GIT_ID, 'merge', 'other']).catch(() => undefined); // expected to conflict
+
+    const outcome = await createDraftPr(input());
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.error).toContain('unresolved merge conflicts');
+  });
+
+  it('publishes normally when the worktree is clean', async () => {
+    writeFileSync(join(repo, 'a.txt'), 'finished work\n');
+    const outcome = await createDraftPr(input());
+    expect(outcome.ok).toBe(true);
+    // The final state landed on the branch before publishing.
+    const { stdout } = await run('git', ['log', '-1', '--format=%s'], { cwd: repo });
+    expect(stdout.trim()).toBe('cezar autosave (pre-PR)');
+  });
+
+  it('publishes when there was nothing left to flush', async () => {
+    const outcome = await createDraftPr(input());
+    expect(outcome.ok).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -531,7 +531,20 @@ export async function createDraftPr(input: DraftPrInput): Promise<DraftPrOutcome
   }
 
   // Final autosave: the branch must hold everything before it leaves the box.
-  await autosaveCommit(worktree, 'pre-PR');
+  // This is the LAST flush — unlike the turn-end and run-finalize ones there is
+  // no later autosave to pick the work up, so a refusal (conflicted tree) or a
+  // failed commit has to stop the publish instead of silently opening a PR from
+  // a branch that is missing the run's final state.
+  const saved = await autosaveCommit(worktree, 'pre-PR');
+  if (saved === 'refused') {
+    return {
+      ok: false,
+      error: 'worktree has unresolved merge conflicts — resolve them, then publish again',
+    };
+  }
+  if (saved === 'failed') {
+    return { ok: false, error: 'could not commit the final changes — check git status in the worktree' };
+  }
 
   // DRY-RUN (CEZ_DRY_RUN=1): no push, no gh — simulate success with a fake PR
   // URL so the whole review → PR flow is testable without GitHub.

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -531,7 +531,7 @@ export async function createDraftPr(input: DraftPrInput): Promise<DraftPrOutcome
   }
 
   // Final autosave: the branch must hold everything before it leaves the box.
-  await autosaveCommit(worktree);
+  await autosaveCommit(worktree, 'pre-PR');
 
   // DRY-RUN (CEZ_DRY_RUN=1): no push, no gh — simulate success with a fake PR
   // URL so the whole review → PR flow is testable without GitHub.

--- a/src/workflows/autosave-gate.test.ts
+++ b/src/workflows/autosave-gate.test.ts
@@ -98,6 +98,19 @@ describe('periodic autosave gate (#471)', () => {
     writeFileSync(join(worktreePath, 'work.txt'), 'progress\n');
     expect(await autosaveCommit(worktreePath)).toBe(true);
     const { stdout } = await run('git', ['log', '-1', '--format=%s'], { cwd: worktreePath });
-    expect(stdout.trim()).toBe('cezar autosave');
+    // Keeps the `cezar autosave` prefix so existing log greps still match, and
+    // names the reason so an opted-out user can tell this flush apart from the
+    // periodic timer they disabled (#471 follow-up).
+    expect(stdout.trim()).toBe('cezar autosave (turn end)');
+  });
+
+  it('records the reason, so the gated timer is distinguishable in the log', async () => {
+    delete process.env.CEZ_AUTOSAVE;
+    for (const reason of ['periodic', 'turn end', 'run finalize', 'pre-PR'] as const) {
+      writeFileSync(join(worktreePath, 'work.txt'), `progress ${reason}\n`);
+      expect(await autosaveCommit(worktreePath, reason)).toBe(true);
+      const { stdout } = await run('git', ['log', '-1', '--format=%s'], { cwd: worktreePath });
+      expect(stdout.trim()).toBe(`cezar autosave (${reason})`);
+    }
   });
 });

--- a/src/workflows/autosave-gate.test.ts
+++ b/src/workflows/autosave-gate.test.ts
@@ -96,7 +96,7 @@ describe('periodic autosave gate (#471)', () => {
   it('the flush path (autosaveCommit) still commits with the env off', async () => {
     delete process.env.CEZ_AUTOSAVE;
     writeFileSync(join(worktreePath, 'work.txt'), 'progress\n');
-    expect(await autosaveCommit(worktreePath)).toBe(true);
+    expect(await autosaveCommit(worktreePath, 'turn end')).toBe('committed');
     const { stdout } = await run('git', ['log', '-1', '--format=%s'], { cwd: worktreePath });
     // Keeps the `cezar autosave` prefix so existing log greps still match, and
     // names the reason so an opted-out user can tell this flush apart from the
@@ -108,7 +108,7 @@ describe('periodic autosave gate (#471)', () => {
     delete process.env.CEZ_AUTOSAVE;
     for (const reason of ['periodic', 'turn end', 'run finalize', 'pre-PR'] as const) {
       writeFileSync(join(worktreePath, 'work.txt'), `progress ${reason}\n`);
-      expect(await autosaveCommit(worktreePath, reason)).toBe(true);
+      expect(await autosaveCommit(worktreePath, reason)).toBe('committed');
       const { stdout } = await run('git', ['log', '-1', '--format=%s'], { cwd: worktreePath });
       expect(stdout.trim()).toBe(`cezar autosave (${reason})`);
     }

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -219,7 +219,9 @@ const VARIANT_HINTS: Record<string, string | undefined> = {
  * cancel. Runs queue behind `maxParallel` slots and each run executes in its
  * own git worktree on a `cez/<id8>` branch (spec 006), autosave-committed at
  * turn end and before a draft PR — plus every 90 s when opted in via
- * CEZ_AUTOSAVE=1 (#471). The user's working tree is never touched.
+ * CEZ_AUTOSAVE=1 (#471). Each autosave records its trigger in the commit
+ * subject, so the always-on flushes are not mistaken for the opt-in timer.
+ * The user's working tree is never touched.
  */
 export class RunManager {
   private readonly active = new Map<string, ActiveRun>();

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -954,7 +954,7 @@ export class RunManager {
       this.recordUsagePeaks(runId);
       this.clearIdleTimer(state);
       this.clearAutosaveTimer(state);
-      if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd);
+      if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd, 'turn end');
       this.dropActive(runId);
       void this.pump();
     }
@@ -1177,7 +1177,7 @@ export class RunManager {
 
     // Final autosave: the branch always ends holding the finished state.
     this.clearAutosaveTimer(state);
-    if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd);
+    if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd, 'run finalize');
 
     const finishedAt = new Date().toISOString();
     if (state.cancelled) {
@@ -1672,7 +1672,7 @@ export class RunManager {
     if (!periodicAutosaveEnabled()) return;
     if (state.cwd === this.repoRoot || state.autosaveTimer) return;
     state.autosaveTimer = setInterval(() => {
-      void autosaveCommit(state.cwd);
+      void autosaveCommit(state.cwd, 'periodic');
     }, AUTOSAVE_INTERVAL_MS);
     state.autosaveTimer.unref?.();
   }


### PR DESCRIPTION
## Summary

Follow-up to #471 / #478. The `CEZ_AUTOSAVE` gate works correctly, but you cannot
tell that from `git log` — so it keeps getting reported as broken. This makes the
kept flushes distinguishable from the disabled timer, and closes the conflict-marker
hole that motivated #471 in the first place.

**Status:** complete

**Tracking plan:** `.ai/runs/2026-07-21-autosave-flush-commit-clarity.md`

## Why

#478 gated the periodic 90 s autosave behind `CEZ_AUTOSAVE=1` and deliberately left
three flushes ungated, so a task branch still ends holding the finished state:

| Call site | Trigger | Gated? |
|---|---|---|
| `run.ts:1653` | periodic, every 90 s | **yes** — `CEZ_AUTOSAVE=1` |
| `run.ts:943` | turn end | no, by design |
| `run.ts:1166` | run finalize | no, by design |
| `server/forge/github.ts:534` | pre-PR | no, by design |

All four committed the identical subject `cezar autosave`. So a user who opted out
still saw `cezar autosave` in the log and reasonably concluded the opt-out was
ignored — the only way to tell them apart was commit *spacing* (85–95 s ⇒ timer),
which is not a reasonable thing to ask of a reader. This PR started life as exactly
that bug report, filed against a gate that turned out to be working.

Separately, the incident behind #471 was an autosave committing a half-resolved
merge with conflict markers. `autosaveCommit` did a blind `git add -A` with no
unmerged-path or marker check, so the *ungated* flushes could still do it. #478
narrowed that hazard; it did not remove it.

## Changes

- `autosaveCommit(dir, reason)` takes an `AutosaveReason` (`periodic` / `turn end` /
  `run finalize` / `pre-PR`) and commits as `cezar autosave (<reason>)`. The
  `cezar autosave` prefix is kept, so existing log greps still match.
- All four call sites pass their reason.
- `autosaveCommit` refuses a worktree with unmerged paths or leftover conflict
  markers, warns, and returns `false`. Two independent checks: porcelain `U` codes
  catch an unresolved merge; a marker scan catches the worse case where someone ran
  `git add` on a file they had not finished resolving, which clears the `U` code but
  leaves `<<<<<<<` in the text.
- README / `.env.example` / `RunManager` docs corrected. README no longer backticks
  `cezar autosave` as though it were a CLI subcommand — it is a commit message, and
  `src/index.ts:87-118` has no such case.

## Deliberate non-changes

- **Which call sites are gated is unchanged.** The three flushes stay ungated; that
  is the documented #478 contract and the branch must still end complete.
- The `CEZ_FOLLOWUPS` inbox gate was audited during this investigation and is
  correct and complete on every path, including `RunManager.startRun` (not just the
  HTTP routes). No change needed.

## Risk notes

- The commit subject is a de-facto interface. Mitigated by appending rather than
  replacing, so `grep 'cezar autosave'` is unaffected. One test that pinned the exact
  subject was updated.
- An over-eager guard could refuse a legitimate flush and lose a recovery point.
  Mitigated by requiring **both** `<<<<<<<` and `>>>>>>>` — a bare `=======` line is
  an ordinary Markdown setext heading, and matching it alone would have wedged
  autosaves of this repo's own docs. There is a regression test for exactly that.
- Untracked files are not scanned even though `git add -A` commits them. Conflicts
  always land in tracked files; a false positive would cost the recovery point,
  a false negative only costs noise. Documented inline.

## Verification

Full configured gate, all green:

| Command | Result |
|---|---|
| `npm run typecheck` | pass (server + web) |
| `npm test` | 2851 passed, 170 files |
| `npm run test:unit` | 30 passed |
| `npm run build` | pass |
| `npm run test:package` | 8 passed |

The five new guard tests were **mutation-tested**: stubbing `unresolvedConflicts` to
return `null` fails exactly the two guard assertions and leaves the other three
passing, so they are not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
