### PR TITLE
feat(runs): discover PR/issue refs from skill report lines and GitHub links

### DIFF
--- a/.ai/specs/2026-07-21-report-ref-discovery.md
+++ b/.ai/specs/2026-07-21-report-ref-discovery.md
@@ -1,0 +1,87 @@
+# Report-tier reference discovery — skill report lines and issue links
+
+Status: implemented · Date: 2026-07-21 · Relates: spec 2026-07-18-task-ref-markers
+(the CEZ:* tier above this one), spec 2026-07-16-pr-autodiscovery (the fuzzy URL
+tier below it), open-mercato/skills#38 (the emitter-side contract change)
+
+## Problem
+
+The open-mercato pipeline skills changed their chaining hand-off format
+(open-mercato/skills#38): instead of the env-style `PR_URL=` / `PR_NUMBER=` /
+`SPEC_PATH=` markers, every PR-producing skill now ends its report with fixed,
+human-friendly reference lines:
+
+```
+Issue: #433 (link: https://github.com/owner/repo/issues/433)
+PR: #442 (link: https://github.com/owner/repo/pull/442)
+Spec: .ai/specs/2026-07-21-foo.md
+```
+
+cezar discovered PR numbers from those sessions only via the fuzzy URL janitor
+(spec 2026-07-16) or an explicit `CEZ:PR` declaration — the report lines
+themselves were invisible, and **issue** links in conversation were never
+discovered at all (only the task prompt's issue reference seeded
+`issueNumber`).
+
+## The change
+
+### 1. Report-tier marker parsing (`src/runs/task-markers.ts`)
+
+`parseTaskMarkers` now also recognizes, line-anchored and exact-shape, in the
+accumulated turn text (the agent's own words — same trust boundary as `CEZ:*`):
+
+- `PR: #<n> (link: <url>)` and `Issue: #<n> (link: <url>)` — the new skill
+  report lines;
+- `PR_NUMBER=<n>`, `PR_URL=<…/pull/n>`, `ISSUE_NUMBER=<n>` — the legacy
+  markers older skill versions still emit.
+
+Precedence inside one turn: `CEZ:PR`/`CEZ:ISSUE` (explicit declaration) >
+report line > legacy marker; last occurrence wins within each tier, later
+turns win over earlier ones — all through the existing `applyMarkerRefs`
+pipeline, so a recognized report line behaves exactly like a `CEZ:*`
+declaration (owns the display tier, filters the referenced-URL candidates,
+silences the namer for that kind).
+
+`stripTaskMarkers` is unchanged: only `CEZ:*` control lines are stripped from
+display — the report lines are human-readable by design and stay visible.
+
+### 2. Referenced-issue janitor (`src/runs/store.ts`)
+
+A mirror of the referenced-PR tier for `github.com/…/issues/N` links spotted
+in event text (issue links in conversation are unambiguous URLs — "links are
+pretty distinguished"):
+
+- New optional record fields `referencedIssueUrl` + `referencedIssueCandidates`
+  (additive — old `runs.json` files keep parsing).
+- Same resolution rule via the now-shared `resolveReferencedRef`: a declared
+  issue number filters candidates outright; otherwise one distinct URL is the
+  subject; several resolve only when the task prompt names exactly one;
+  ambiguity clears the chip.
+- An unambiguous resolution seeds `issueNumber` when nothing owns that field;
+  ambiguity takes the janitor's own seed back. Marker and namer outrank the
+  janitor and overwrite freely (a namer-written number equal to a revoked
+  seed being cleared alongside it is the documented residual).
+- Issue tracking runs regardless of the created-PR state — a task that opened
+  a PR can still be *about* an issue.
+
+## Degradation & compatibility
+
+- Additive only: no marker/report line → every existing layer behaves as
+  before. The `CEZ:*` vocabulary and the handoff instruction fragment are
+  untouched — `CEZ:PR`/`CEZ:ISSUE` remain the explicit override.
+- Sessions running **older** skill versions keep working via the legacy
+  `PR_URL=`/`PR_NUMBER=` parsing; sessions running the new skills work with
+  **older** cezars through the URL janitor (the report line contains the URL).
+- The cockpit does not yet render `referencedIssueUrl`; surfacing an issue
+  chip in the tasks table is a UI follow-up.
+
+## Test plan
+
+- `task-markers` matrix: report lines parse; CEZ outranks report outranks
+  legacy within a turn; last-wins; line-anchoring (prose mentions, list
+  markers, decorated/suffixed lines, skill-doc placeholders are inert);
+  CRLF tolerance; strip leaves report lines visible.
+- Store: single-link adoption + `issueNumber` seed; independence from the
+  created-PR tier; ambiguity clearing chip and seeded number; task-prompt
+  disambiguation; declared-issue candidate filtering; marker-owned
+  `issueNumber` never overwritten by stray links.

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -142,7 +141,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -293,6 +291,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -341,6 +340,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -364,6 +364,7 @@
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -400,29 +401,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3357,8 +3335,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3729,6 +3706,7 @@
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3739,6 +3717,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3749,6 +3728,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3931,7 +3911,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3942,7 +3921,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3969,7 +3947,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4189,6 +4166,7 @@
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4623,6 +4601,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4840,8 +4819,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.12",
@@ -5260,6 +5238,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
       "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5423,8 +5402,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -5432,6 +5410,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -5812,7 +5791,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6909,6 +6887,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6969,7 +6948,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7084,6 +7062,7 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7094,6 +7073,7 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7106,8 +7086,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -7767,6 +7746,7 @@
       "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -8055,6 +8035,7 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -8315,6 +8296,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,7 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -141,6 +142,7 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -291,7 +293,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -340,7 +341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -364,7 +364,6 @@
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -401,6 +400,29 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3335,7 +3357,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3706,7 +3729,6 @@
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3717,7 +3739,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3728,7 +3749,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3911,6 +3931,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3921,6 +3942,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3947,6 +3969,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4166,7 +4189,6 @@
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4601,7 +4623,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4819,7 +4840,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.12",
@@ -5238,7 +5260,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
       "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5402,7 +5423,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -5410,7 +5432,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -5791,6 +5812,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6887,7 +6909,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6948,6 +6969,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7062,7 +7084,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7073,7 +7094,6 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7086,7 +7106,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -7746,7 +7767,6 @@
       "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -8035,7 +8055,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -8296,7 +8315,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -716,6 +716,97 @@ describe('RunStore — agent-declared marker refs (spec 2026-07-18-task-ref-mark
   });
 });
 
+describe('RunStore — referenced-issue discovery (spec 2026-07-21-report-ref-discovery)', () => {
+  let dataDir: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'cez-store-'));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  const freshRun = (task = 'task') => {
+    const store = RunStore.open(dataDir);
+    const run = store.createRun({ title: 't', workflow: 'w', task, steps: [] });
+    return { store, run };
+  };
+
+  it('adopts a single issue link and seeds issueNumber', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Fixing https://github.com/open-mercato/cezar/issues/433 now.',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.referencedIssueUrl).toBe('https://github.com/open-mercato/cezar/issues/433');
+    expect(loaded?.issueNumber).toBe(433);
+  });
+
+  it('tracks issues independently of a created PR', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'Opened a draft pull request: https://github.com/open-mercato/cezar/pull/42 closing https://github.com/open-mercato/cezar/issues/7',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/42');
+    expect(loaded?.referencedIssueUrl).toBe('https://github.com/open-mercato/cezar/issues/7');
+    expect(loaded?.issueNumber).toBe(7);
+  });
+
+  it('ambiguity clears the chip and takes back the number the janitor seeded', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/open-mercato/cezar/issues/1',
+    });
+    expect(store.getRun(run.id)?.issueNumber).toBe(1);
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Also https://github.com/open-mercato/cezar/issues/2',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.referencedIssueUrl).toBeUndefined();
+    expect(loaded?.issueNumber).toBeUndefined();
+  });
+
+  it('disambiguates several issue links by the number named in the task prompt', () => {
+    const { store, run } = freshRun('om-auto-fix-issue 433');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'Working https://github.com/open-mercato/cezar/issues/433, related to https://github.com/open-mercato/cezar/issues/12.',
+    });
+    expect(store.getRun(run.id)?.referencedIssueUrl).toBe(
+      'https://github.com/open-mercato/cezar/issues/433',
+    );
+  });
+
+  it('a declared CEZ:ISSUE filters the candidates and owns issueNumber', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'See https://github.com/open-mercato/cezar/issues/1 and https://github.com/open-mercato/cezar/issues/2',
+    });
+    store.applyMarkerRefs(run.id, { issue: 2 });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.referencedIssueUrl).toBe('https://github.com/open-mercato/cezar/issues/2');
+    expect(loaded?.issueNumber).toBe(2);
+  });
+
+  it('never overwrites a marker-owned issueNumber from a stray link', () => {
+    const { store, run } = freshRun();
+    store.applyMarkerRefs(run.id, { issue: 500 });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Mentioned in https://github.com/open-mercato/cezar/issues/9',
+    });
+    expect(store.getRun(run.id)?.issueNumber).toBe(500);
+  });
+});
+
 describe('RunStore — seq survives a restart (#424 symptom class)', () => {
   let dataDir: string;
 

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -112,6 +112,13 @@ const runRecordSchema = z.object({
    *  persisted so a resumed run keeps disambiguating against the full history
    *  instead of re-adopting the next URL as "the only one". Capped. */
   referencedPrCandidates: z.array(z.string()).optional(),
+  /** The issue this task is ABOUT (spec 2026-07-21-report-ref-discovery):
+   *  auto-discovered from `github.com/…/issues/N` links in the conversation,
+   *  mirroring the referenced-PR tier. Display-only; never gates actions. */
+  referencedIssueUrl: z.string().optional(),
+  /** Distinct issue URLs spotted so far — the referenced-issue working set,
+   *  persisted like `referencedPrCandidates`. Capped. */
+  referencedIssueCandidates: z.array(z.string()).optional(),
   /** Task worktree (spec 006) — absent when the run executed in the repo root. */
   worktreePath: z.string().optional(),
   /** The task's own branch (`cez/<id8>`), created off `baseBranch`. */
@@ -160,6 +167,7 @@ const MAX_RUNS_KEPT = 300;
 const MAX_ARCHIVED_KEPT = 500;
 
 const PR_URL_RE = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/;
+const ISSUE_URL_RE = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+/;
 // The transcript auto-link is convenience only (the cockpit's own `gh pr create` path sets the
 // URL authoritatively). Adopt a PR URL ONLY when the agent actually CREATED one — a task that
 // reviews or merely references an existing PR must not get mislabeled with its number (#fake-pr).
@@ -203,15 +211,16 @@ function eventTextFragments(event: Record<string, unknown>): string[] {
 }
 
 /**
- * The referenced tier's resolution rule: a marker-declared PR number (spec
- * 2026-07-18-task-ref-markers) owns the answer outright — only a candidate URL
- * ending in that number resolves, and a contradiction clears the chip.
- * Without a declaration: one distinct URL is the subject; among several, the
- * one whose PR number the task prompt names (and only when exactly one
- * matches); otherwise ambiguous — no chip beats a wrong chip.
+ * The referenced tier's resolution rule, shared by the PR and issue janitors:
+ * a marker-declared number (spec 2026-07-18-task-ref-markers) owns the answer
+ * outright — only a candidate URL ending in that number resolves, and a
+ * contradiction clears the chip. Without a declaration: one distinct URL is
+ * the subject; among several, the one whose number the task prompt names (and
+ * only when exactly one matches); otherwise ambiguous — no chip beats a wrong
+ * chip.
  */
-function resolveReferencedPr(candidates: string[], task: string, markerPr?: number): string | undefined {
-  if (markerPr !== undefined) return candidates.find((url) => url.endsWith(`/${markerPr}`));
+function resolveReferencedRef(candidates: string[], task: string, declared?: number): string | undefined {
+  if (declared !== undefined) return candidates.find((url) => url.endsWith(`/${declared}`));
   if (candidates.length === 1) return candidates[0];
   const named = candidates.filter((url) => {
     const num = url.split('/').pop() ?? '';
@@ -464,16 +473,24 @@ export class RunStore extends EventEmitter {
     // first one spotted in the transcript becomes the run's PR link. Scans v1
     // fields AND nested v2 `item.*` content (#407). A URL without the created
     // phrasing still feeds the referenced tier (the PR the task is about).
-    if (!run.pullRequestUrl) {
-      const haystack = eventTextFragments(full).join(' ');
-      if (haystack.length > 0) {
+    const haystack = eventTextFragments(full).join(' ');
+    if (haystack.length > 0) {
+      let changed = false;
+      if (!run.pullRequestUrl) {
         const created = createdPrUrl(haystack);
         if (created) {
           this.updateRun(runId, { pullRequestUrl: created });
         } else if (PR_URL_RE.test(haystack) && this.trackReferencedPrs(run, haystack)) {
-          this.touch(run);
+          changed = true;
         }
       }
+      // Issue links feed their own referenced tier regardless of PR state —
+      // a task that created a PR can still be ABOUT an issue
+      // (spec 2026-07-21-report-ref-discovery).
+      if (ISSUE_URL_RE.test(haystack) && this.trackReferencedIssues(run, haystack)) {
+        changed = true;
+      }
+      if (changed) this.touch(run);
     }
     return full;
   }
@@ -493,11 +510,47 @@ export class RunStore extends EventEmitter {
     }
     if (seen.size === before) return false;
     run.referencedPrCandidates = [...seen];
-    run.referencedPullRequestUrl = resolveReferencedPr(
+    run.referencedPullRequestUrl = resolveReferencedRef(
       run.referencedPrCandidates,
       run.task,
       run.markerRefs?.pr,
     );
+    return true;
+  }
+
+  /**
+   * The issue-side mirror of `trackReferencedPrs` (spec
+   * 2026-07-21-report-ref-discovery): fold every issue URL in `haystack` into
+   * the working set and re-resolve `referencedIssueUrl`. An unambiguous
+   * resolution also seeds `issueNumber` when nothing owns that field yet —
+   * marker and namer both outrank this janitor and overwrite it freely.
+   */
+  private trackReferencedIssues(run: RunRecord, haystack: string): boolean {
+    const seen = new Set(run.referencedIssueCandidates ?? []);
+    const before = seen.size;
+    for (const match of haystack.matchAll(new RegExp(ISSUE_URL_RE.source, 'g'))) {
+      if (seen.size >= MAX_PR_CANDIDATES) break;
+      seen.add(match[0]);
+    }
+    if (seen.size === before) return false;
+    run.referencedIssueCandidates = [...seen];
+    const prev = run.referencedIssueUrl;
+    run.referencedIssueUrl = resolveReferencedRef(
+      run.referencedIssueCandidates,
+      run.task,
+      run.markerRefs?.issue,
+    );
+    if (run.markerRefs?.issue === undefined) {
+      if (run.referencedIssueUrl && run.issueNumber === undefined) {
+        const n = Number(run.referencedIssueUrl.split('/').pop());
+        if (Number.isInteger(n) && n > 0) run.issueNumber = n;
+      } else if (!run.referencedIssueUrl && prev && run.issueNumber === Number(prev.split('/').pop())) {
+        // Ambiguity revoked the resolution — take back the number this janitor
+        // seeded from it (a namer-written number that happens to match is the
+        // documented residual). No chip beats a wrong chip.
+        delete run.issueNumber;
+      }
+    }
     return true;
   }
 
@@ -520,10 +573,17 @@ export class RunStore extends EventEmitter {
     if (refs.pr !== undefined) run.prNumber = refs.pr;
     if (refs.issue !== undefined) run.issueNumber = refs.issue;
     if (run.markerRefs.pr !== undefined) {
-      run.referencedPullRequestUrl = resolveReferencedPr(
+      run.referencedPullRequestUrl = resolveReferencedRef(
         run.referencedPrCandidates ?? [],
         run.task,
         run.markerRefs.pr,
+      );
+    }
+    if (run.markerRefs.issue !== undefined) {
+      run.referencedIssueUrl = resolveReferencedRef(
+        run.referencedIssueCandidates ?? [],
+        run.task,
+        run.markerRefs.issue,
       );
     }
     this.touch(run);

--- a/src/runs/task-markers.test.ts
+++ b/src/runs/task-markers.test.ts
@@ -42,6 +42,55 @@ describe('parseTaskMarkers', () => {
   });
 });
 
+/** Spec 2026-07-21-report-ref-discovery — the report-tier lines skills end their runs with. */
+describe('parseTaskMarkers — report-tier reference lines', () => {
+  it('reads the human-friendly PR/Issue report lines', () => {
+    const report = [
+      'om-auto-create-pr: add dark mode',
+      'Issue: #433 (link: https://github.com/open-mercato/cezar/issues/433)',
+      'PR: #442 (link: https://github.com/open-mercato/cezar/pull/442)',
+      'Status: complete',
+    ].join('\n');
+    expect(parseTaskMarkers(report)).toEqual({ pr: 442, issue: 433 });
+  });
+
+  it('a CEZ declaration in the same turn outranks a report line', () => {
+    expect(
+      parseTaskMarkers('CEZ:PR=7\nPR: #442 (link: https://github.com/o/r/pull/442)'),
+    ).toEqual({ pr: 7 });
+    expect(
+      parseTaskMarkers('Issue: #9 (link: https://github.com/o/r/issues/9)\nCEZ:ISSUE=3'),
+    ).toEqual({ issue: 3 });
+  });
+
+  it('still accepts the legacy env-style markers from older skill versions', () => {
+    expect(parseTaskMarkers('PR_URL=https://github.com/o/r/pull/442\nPR_NUMBER=442')).toEqual({ pr: 442 });
+    expect(parseTaskMarkers('PR_URL=https://github.com/o/r/pull/442')).toEqual({ pr: 442 });
+    expect(parseTaskMarkers('ISSUE_NUMBER=12')).toEqual({ issue: 12 });
+  });
+
+  it('a report line outranks a legacy marker; the last report line wins', () => {
+    expect(parseTaskMarkers('PR_NUMBER=1\nPR: #2 (link: https://github.com/o/r/pull/2)')).toEqual({ pr: 2 });
+    expect(
+      parseTaskMarkers(
+        'PR: #1 (link: https://github.com/o/r/pull/1)\nPR: #2 (link: https://github.com/o/r/pull/2)',
+      ),
+    ).toEqual({ pr: 2 });
+  });
+
+  it('is line-anchored and exact-shape — prose, placeholders and decorated lines never parse', () => {
+    expect(parseTaskMarkers('the report ends with PR: #442 (link: https://github.com/o/r/pull/442)')).toEqual({});
+    expect(parseTaskMarkers('PR: #<PR number> (link: <full PR URL>)')).toEqual({});
+    expect(parseTaskMarkers('- PR: #442 (link: https://github.com/o/r/pull/442)')).toEqual({});
+    expect(parseTaskMarkers('PR: #442 (link: https://github.com/o/r/pull/442) — merged')).toEqual({});
+    expect(parseTaskMarkers('PR: 442')).toEqual({});
+  });
+
+  it('tolerates trailing whitespace and CRLF', () => {
+    expect(parseTaskMarkers('PR: #7 (link: https://github.com/o/r/pull/7)  \r\n')).toEqual({ pr: 7 });
+  });
+});
+
 describe('stripTaskMarkers', () => {
   it('removes complete marker lines and keeps the surrounding text', () => {
     expect(stripTaskMarkers('Opened the PR.\nCEZ:PR=442\nCEZ:TITLE=fixing plan rendering\nNext: tests.')).toBe(
@@ -56,5 +105,10 @@ describe('stripTaskMarkers', () => {
 
   it('is a no-op on text without any CEZ prefix', () => {
     expect(stripTaskMarkers('plain progress update')).toBe('plain progress update');
+  });
+
+  it('leaves report-tier reference lines visible — they are human-readable by design', () => {
+    const text = 'PR: #442 (link: https://github.com/o/r/pull/442)\nCEZ:PR=442\ndone';
+    expect(stripTaskMarkers(text)).toBe('PR: #442 (link: https://github.com/o/r/pull/442)\ndone');
   });
 });

--- a/src/runs/task-markers.ts
+++ b/src/runs/task-markers.ts
@@ -21,6 +21,19 @@ const PR_MARKER_RE = /^CEZ:PR=(\d+)\s*$/gm;
 const ISSUE_MARKER_RE = /^CEZ:ISSUE=(\d+)\s*$/gm;
 const TITLE_MARKER_RE = /^CEZ:TITLE=(.+)$/gm;
 
+// Report-tier reference lines (spec 2026-07-21-report-ref-discovery): the
+// human-friendly chaining lines pipeline skills end their reports with —
+// `PR: #12 (link: https://…/pull/12)` — plus the legacy env-style markers
+// older skill versions printed. Same trust boundary as CEZ:* (parsed from the
+// agent's own turn text only), one notch below in precedence: an explicit
+// CEZ:PR / CEZ:ISSUE in the same turn wins. The skill docs' own placeholders
+// (`PR: #<PR number> (link: …)`) are non-numeric and inert.
+const REPORT_PR_RE = /^PR: #(\d+) \(link: \S+\)\s*$/gm;
+const REPORT_ISSUE_RE = /^Issue: #(\d+) \(link: \S+\)\s*$/gm;
+const LEGACY_PR_NUMBER_RE = /^PR_NUMBER=(\d+)\s*$/gm;
+const LEGACY_PR_URL_RE = /^PR_URL=\S*\/pull\/(\d+)\s*$/gm;
+const LEGACY_ISSUE_NUMBER_RE = /^ISSUE_NUMBER=(\d+)\s*$/gm;
+
 function lastNumber(text: string, re: RegExp): number | undefined {
   let value: number | undefined;
   for (const match of text.matchAll(re)) {
@@ -31,13 +44,22 @@ function lastNumber(text: string, re: RegExp): number | undefined {
 }
 
 /** The turn's declared references. The last occurrence of each marker wins —
- *  an agent that corrects itself mid-turn is believed, not averaged. */
+ *  an agent that corrects itself mid-turn is believed, not averaged. Within a
+ *  turn, an explicit CEZ:* declaration outranks a report-tier line, which
+ *  outranks the legacy env-style markers. */
 export function parseTaskMarkers(text: string): TaskMarkers {
   const markers: TaskMarkers = {};
   const source = text ?? '';
-  const pr = lastNumber(source, PR_MARKER_RE);
+  const pr =
+    lastNumber(source, PR_MARKER_RE) ??
+    lastNumber(source, REPORT_PR_RE) ??
+    lastNumber(source, LEGACY_PR_NUMBER_RE) ??
+    lastNumber(source, LEGACY_PR_URL_RE);
   if (pr !== undefined) markers.pr = pr;
-  const issue = lastNumber(source, ISSUE_MARKER_RE);
+  const issue =
+    lastNumber(source, ISSUE_MARKER_RE) ??
+    lastNumber(source, REPORT_ISSUE_RE) ??
+    lastNumber(source, LEGACY_ISSUE_NUMBER_RE);
   if (issue !== undefined) markers.issue = issue;
   let title: string | undefined;
   for (const match of source.matchAll(TITLE_MARKER_RE)) {
@@ -52,7 +74,9 @@ const MARKER_LINE = /^CEZ:(?:PR=\d+|ISSUE=\d+|TITLE=.+)\s*$/;
 
 /**
  * Remove complete marker lines from display text — the `stripDoneMarker`
- * precedent. Best-effort by design: a marker split across streamed v1 chunks
+ * precedent. Only `CEZ:*` control lines are stripped: the report-tier
+ * reference lines (`PR: #12 (link: …)`) are human-readable by design and
+ * stay visible. Best-effort by design: a marker split across streamed v1 chunks
  * may transiently render; parsing always runs on the whole turn text, so the
  * record is never affected. Mirrored for v2 display in the cockpit's
  * `thread-state.ts`.


### PR DESCRIPTION
Status: complete

## 🎯 Goal
- Discover a session's subject PR and issue numbers from the new human-friendly skill report lines (`PR: #N (link: …)`, `Issue: #N (link: …)` — open-mercato/skills#38), from the legacy `PR_URL=`/`PR_NUMBER=`/`ISSUE_NUMBER=` markers older skill versions emit, and from plain `github.com/…/issues/N` links in conversation.

## What Changed
- `src/runs/task-markers.ts` — `parseTaskMarkers` gains a report tier: line-anchored, exact-shape parsing of the skill report lines plus the legacy env-style markers. Precedence within a turn: `CEZ:PR`/`CEZ:ISSUE` > report line > legacy marker; recognized values flow through the existing `applyMarkerRefs` pipeline. `stripTaskMarkers` unchanged — report lines stay visible (human-readable by design).
- `src/runs/store.ts` — referenced-**issue** janitor mirroring the referenced-PR tier: new optional `referencedIssueUrl` / `referencedIssueCandidates` record fields (additive; old `runs.json` parses), shared `resolveReferencedRef` resolution (declared number filters; single URL adopts; task-prompt disambiguation; ambiguity clears — and takes back the janitor's own `issueNumber` seed). Issue tracking runs independently of the created-PR state.
- `.ai/specs/2026-07-21-report-ref-discovery.md` — the design record (relates: 2026-07-18-task-ref-markers, 2026-07-16-pr-autodiscovery).

## 🧪 Tests
- `task-markers` matrix: report-line parsing, per-turn precedence, last-wins, line anchoring (prose/placeholders/decorated lines inert), CRLF, strip keeps report lines.
- Store: single-link adoption + seed, created-PR independence, ambiguity clearing, prompt disambiguation, marker filtering, marker-owned number protection.
- Full gate green: `npm run typecheck`, `npm test` (2927 tests / 172 files), `npm run test:unit`, `npm run build`, `npm run test:package`.

## 💥 Breaking Changes
- None — additive-only per the marker-vocabulary compatibility rule; `CEZ:*`, the handoff fragment, and all existing discovery layers are untouched. Cockpit rendering of `referencedIssueUrl` is a noted UI follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
