### PR TITLE
fix(ui): keep reasoning text alive across replay and drop empty "Thinking" rows

### DIFF
--- a/src/core/__fixtures__/codex/reasoning-stream.expected.json
+++ b/src/core/__fixtures__/codex/reasoning-stream.expected.json
@@ -1,0 +1,70 @@
+[
+  {
+    "type": "session.started",
+    "sessionId": "th_01J9RSN0001",
+    "backend": "codex"
+  },
+  {
+    "type": "turn.started",
+    "turnId": "turn_01J9RSN01"
+  },
+  {
+    "type": "item.started",
+    "item": {
+      "kind": "reasoning",
+      "id": "item_rsn_1",
+      "text": "Checking the sink"
+    }
+  },
+  {
+    "type": "item.delta",
+    "itemId": "item_rsn_1",
+    "field": "reasoning",
+    "delta": "The deltas never reach disk, "
+  },
+  {
+    "type": "item.delta",
+    "itemId": "item_rsn_1",
+    "field": "reasoning",
+    "delta": "so the completed snapshot has to carry the text."
+  },
+  {
+    "type": "item.completed",
+    "item": {
+      "kind": "reasoning",
+      "id": "item_rsn_1",
+      "text": "The deltas never reach disk, so the completed snapshot has to carry the text."
+    }
+  },
+  {
+    "type": "item.started",
+    "item": {
+      "kind": "message",
+      "id": "item_msg_1",
+      "role": "assistant",
+      "text": "",
+      "phase": "final"
+    }
+  },
+  {
+    "type": "item.delta",
+    "itemId": "item_msg_1",
+    "field": "text",
+    "delta": "Reasoning now survives a reload."
+  },
+  {
+    "type": "item.completed",
+    "item": {
+      "kind": "message",
+      "id": "item_msg_1",
+      "role": "assistant",
+      "text": "Reasoning now survives a reload.",
+      "phase": "final"
+    }
+  },
+  {
+    "type": "turn.completed",
+    "turnId": "turn_01J9RSN01",
+    "stopReason": "end_turn"
+  }
+]

--- a/src/core/__fixtures__/codex/reasoning-stream.ndjson
+++ b/src/core/__fixtures__/codex/reasoning-stream.ndjson
@@ -1,0 +1,11 @@
+{"id":1,"result":{"userAgent":"codex/0.46.0"}}
+{"method":"thread/started","params":{"thread":{"id":"th_01J9RSN0001"}}}
+{"method":"turn/started","params":{"turn":{"id":"turn_01J9RSN01","status":"inProgress","items":[]}}}
+{"method":"item/started","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","item":{"type":"reasoning","id":"item_rsn_1","summary":"Checking the sink"}}}
+{"method":"item/reasoning/textDelta","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","itemId":"item_rsn_1","delta":"The deltas never reach disk, "}}
+{"method":"item/reasoning/textDelta","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","itemId":"item_rsn_1","delta":"so the completed snapshot has to carry the text."}}
+{"method":"item/completed","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","item":{"type":"reasoning","id":"item_rsn_1","summary":"Checking the sink"}}}
+{"method":"item/started","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","item":{"type":"agentMessage","id":"item_msg_1","text":"","phase":"final_answer"}}}
+{"method":"item/agentMessage/delta","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","itemId":"item_msg_1","delta":"Reasoning now survives a reload."}}
+{"method":"item/completed","params":{"threadId":"th_01J9RSN0001","turnId":"turn_01J9RSN01","item":{"type":"agentMessage","id":"item_msg_1","text":"Reasoning now survives a reload.","phase":"final_answer"}}}
+{"method":"turn/completed","params":{"turn":{"id":"turn_01J9RSN01","status":"completed"}}}

--- a/src/core/claude-ui-mapper.test.ts
+++ b/src/core/claude-ui-mapper.test.ts
@@ -607,3 +607,34 @@ describe('ClaudeCliRunner v2 wiring (against the bundled mock CLI)', () => {
     }
   }, 30_000);
 });
+
+/**
+ * #528 — a blank `thinking` block carries no information; minting an item for
+ * it only produces a dead "Thinking —" row in the session view.
+ */
+describe('claude blank thinking blocks (#528)', () => {
+  function reasoningItems(msg: unknown): UiEvent[] {
+    const mapped = mapClaudeMessage(msg, createClaudeUiState());
+    return mapped.events.filter((e) => 'item' in e && e.item.kind === 'reasoning');
+  }
+
+  function assistant(thinking: string): unknown {
+    return {
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'thinking', thinking }] },
+    };
+  }
+
+  it.each([['', 'empty'], ['   ', 'spaces'], ['\n\t ', 'whitespace']])(
+    'mints no reasoning item for a %s thinking block (%s)',
+    (thinking) => {
+      expect(reasoningItems(assistant(thinking))).toEqual([]);
+    },
+  );
+
+  it('still mints an item for real thinking text', () => {
+    const events = reasoningItems(assistant('Checking the auth path.'));
+    expect(events).toHaveLength(2); // started + completed
+    expect(events.every((e) => 'item' in e && e.item.kind === 'reasoning' && e.item.text === 'Checking the auth path.')).toBe(true);
+  });
+});

--- a/src/core/claude-ui-mapper.ts
+++ b/src/core/claude-ui-mapper.ts
@@ -155,7 +155,9 @@ function mapAssistant(msg: Record<string, unknown>, state: ClaudeUiMapperState):
       const item: UiMessageItem = { kind: 'message', id: `item_${++itemSeq}`, role: 'assistant', text: raw.text };
       if (parentItemId !== undefined) item.parentItemId = parentItemId;
       events.push({ type: 'item.started', item }, { type: 'item.completed', item });
-    } else if (raw.type === 'thinking' && typeof raw.thinking === 'string') {
+    } else if (raw.type === 'thinking' && typeof raw.thinking === 'string' && raw.thinking.trim() !== '') {
+      // Blank `thinking` is skipped: it carries no information and would only
+      // mint a dead "Thinking —" row in the session view (#528).
       const item: UiReasoningItem = { kind: 'reasoning', id: `item_${++itemSeq}`, text: raw.thinking };
       if (parentItemId !== undefined) item.parentItemId = parentItemId;
       events.push({ type: 'item.started', item }, { type: 'item.completed', item });

--- a/src/core/codex-ui-mapper.test.ts
+++ b/src/core/codex-ui-mapper.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import type { AgentEvent } from './agent-runner.js';
-import type { UiEvent } from './ui-events.js';
+import type { UiEvent, UiItem } from './ui-events.js';
 import { codexSessionStarted, createCodexUiState, mapCodexNotification } from './codex-ui-mapper.js';
 import { CodexAppServerRunner } from './codex-app-server-runner.js';
 
@@ -555,4 +555,98 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
     expect(v2).toContainEqual({ type: 'usage.updated', usage: { input: 1200, output: 300, total: 1500 } });
     expect(v2).toContainEqual({ type: 'turn.completed', turnId: 'turn_mock_1', stopReason: 'end_turn' });
   }, 30_000);
+});
+
+/**
+ * #528 — reasoning text must survive into the persisted `item.completed`
+ * snapshot. `item.delta`s are live-only (`UiEventSink` never writes them), so
+ * a completed reasoning item that carries no `content` would replay empty.
+ */
+describe('codex reasoning text survives replay (#528)', () => {
+  const THREAD = 'th_1';
+  const TURN = 'turn_1';
+
+  function fold(frames: unknown[]): UiEvent[] {
+    let state = createCodexUiState();
+    const events: UiEvent[] = [];
+    for (const frame of frames) {
+      const mapped = mapCodexNotification(frame, state);
+      state = mapped.state;
+      events.push(...mapped.events);
+    }
+    return events;
+  }
+
+  function completedReasoning(events: UiEvent[], id: string): UiItem | undefined {
+    return events.find(
+      (e): e is Extract<UiEvent, { type: 'item.completed' }> =>
+        e.type === 'item.completed' && e.item.kind === 'reasoning' && e.item.id === id,
+    )?.item;
+  }
+
+  const started = {
+    method: 'item/started',
+    params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', summary: 'Tracing it' } },
+  };
+  const textDelta = (delta: string) => ({
+    method: 'item/reasoning/textDelta',
+    params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta },
+  });
+
+  it('falls back to the accumulated deltas when item/completed carries no content', () => {
+    const events = fold([
+      started,
+      textDelta('The session cookie '),
+      textDelta('is dropped on refresh.'),
+      // The real app-server may close a reasoning item with the summary only.
+      {
+        method: 'item/completed',
+        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', summary: 'Tracing it' } },
+      },
+    ]);
+    expect(completedReasoning(events, 'item_rsn_1')).toEqual({
+      kind: 'reasoning',
+      id: 'item_rsn_1',
+      text: 'The session cookie is dropped on refresh.',
+    });
+  });
+
+  it('accumulates summaryDelta and summaryTextDelta on the same item', () => {
+    const events = fold([
+      started,
+      { method: 'item/reasoning/summaryDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta: 'a' } },
+      { method: 'item/reasoning/summaryTextDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta: 'b' } },
+      {
+        method: 'item/completed',
+        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1' } },
+      },
+    ]);
+    expect(completedReasoning(events, 'item_rsn_1')).toMatchObject({ text: 'ab' });
+  });
+
+  it('wire content still wins over the accumulator', () => {
+    const events = fold([
+      started,
+      textDelta('streamed'),
+      {
+        method: 'item/completed',
+        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', content: 'authoritative' } },
+      },
+    ]);
+    expect(completedReasoning(events, 'item_rsn_1')).toMatchObject({ text: 'authoritative' });
+  });
+
+  it('does not leak one item’s reasoning into the next', () => {
+    const events = fold([
+      started,
+      textDelta('first'),
+      { method: 'item/completed', params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1' } } },
+      {
+        method: 'item/started',
+        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_2', summary: 'Next' } },
+      },
+      { method: 'item/completed', params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_2', summary: 'Next' } } },
+    ]);
+    expect(completedReasoning(events, 'item_rsn_2')).toMatchObject({ text: 'Next' });
+  });
 });

--- a/src/core/codex-ui-mapper.test.ts
+++ b/src/core/codex-ui-mapper.test.ts
@@ -51,6 +51,9 @@ function expectedEvents(fixture: string): unknown {
 
 const GOLDEN_FIXTURES = [
   'text-turn',
+  // Reasoning streamed as textDelta and closed with a summary-only
+  // `item/completed` — the wire shape #528 was reported against.
+  'reasoning-stream',
   'command-lifecycle',
   'file-change-and-mcp',
   // NOT app-server wire truth: codex has no `todoList` item and no `item/updated`
@@ -565,6 +568,7 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
 describe('codex reasoning text survives replay (#528)', () => {
   const THREAD = 'th_1';
   const TURN = 'turn_1';
+  const ID = 'item_rsn_1';
 
   function fold(frames: unknown[]): UiEvent[] {
     let state = createCodexUiState();
@@ -577,76 +581,144 @@ describe('codex reasoning text survives replay (#528)', () => {
     return events;
   }
 
-  function completedReasoning(events: UiEvent[], id: string): UiItem | undefined {
+  function reasoningAt(events: UiEvent[], type: 'item.started' | 'item.completed', id = ID): UiItem | undefined {
     return events.find(
-      (e): e is Extract<UiEvent, { type: 'item.completed' }> =>
-        e.type === 'item.completed' && e.item.kind === 'reasoning' && e.item.id === id,
+      (e): e is Extract<UiEvent, { type: 'item.started' | 'item.completed' }> =>
+        e.type === type && 'item' in e && e.item.kind === 'reasoning' && e.item.id === id,
     )?.item;
   }
 
-  const started = {
+  /** The last reasoning text a reload would reconstruct: snapshots only. */
+  function replayedText(events: UiEvent[], id = ID): string | undefined {
+    let text: string | undefined;
+    for (const e of events) {
+      if ((e.type === 'item.started' || e.type === 'item.updated' || e.type === 'item.completed') &&
+          e.item.kind === 'reasoning' && e.item.id === id) {
+        text = e.item.text;
+      }
+    }
+    return text;
+  }
+
+  const turnStarted = { method: 'turn/started', params: { turn: { id: TURN, status: 'inProgress', items: [] } } };
+  const started = (item: Record<string, unknown> = { summary: 'Tracing it' }) => ({
     method: 'item/started',
-    params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', summary: 'Tracing it' } },
-  };
-  const textDelta = (delta: string) => ({
-    method: 'item/reasoning/textDelta',
-    params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta },
+    params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: ID, ...item } },
   });
+  const completed = (item: Record<string, unknown> = {}) => ({
+    method: 'item/completed',
+    params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: ID, ...item } },
+  });
+  const delta = (method: string, d: string, itemId = ID) => ({
+    method: `item/reasoning/${method}`,
+    params: { threadId: THREAD, turnId: TURN, itemId, delta: d },
+  });
+  const textDelta = (d: string) => delta('textDelta', d);
 
   it('falls back to the accumulated deltas when item/completed carries no content', () => {
     const events = fold([
-      started,
+      started(),
       textDelta('The session cookie '),
       textDelta('is dropped on refresh.'),
       // The real app-server may close a reasoning item with the summary only.
-      {
-        method: 'item/completed',
-        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', summary: 'Tracing it' } },
-      },
+      completed({ summary: 'Tracing it' }),
     ]);
-    expect(completedReasoning(events, 'item_rsn_1')).toEqual({
+    expect(reasoningAt(events, 'item.completed')).toEqual({
       kind: 'reasoning',
-      id: 'item_rsn_1',
+      id: ID,
       text: 'The session cookie is dropped on refresh.',
     });
   });
 
-  it('accumulates summaryDelta and summaryTextDelta on the same item', () => {
-    const events = fold([
-      started,
-      { method: 'item/reasoning/summaryDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta: 'a' } },
-      { method: 'item/reasoning/summaryTextDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta: 'b' } },
-      {
-        method: 'item/completed',
-        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1' } },
-      },
-    ]);
-    expect(completedReasoning(events, 'item_rsn_1')).toMatchObject({ text: 'ab' });
-  });
-
   it('wire content still wins over the accumulator', () => {
-    const events = fold([
-      started,
-      textDelta('streamed'),
-      {
-        method: 'item/completed',
-        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', content: 'authoritative' } },
-      },
-    ]);
-    expect(completedReasoning(events, 'item_rsn_1')).toMatchObject({ text: 'authoritative' });
+    const events = fold([started(), textDelta('streamed'), completed({ content: 'authoritative' })]);
+    expect(reasoningAt(events, 'item.completed')).toMatchObject({ text: 'authoritative' });
   });
 
-  it('does not leak one item’s reasoning into the next', () => {
+  it('accumulates both summary delta methods into the summary channel', () => {
     const events = fold([
-      started,
+      started({}),
+      delta('summaryDelta', 'Checking '),
+      delta('summaryTextDelta', 'the auth path.'),
+      completed(),
+    ]);
+    expect(reasoningAt(events, 'item.completed')).toMatchObject({ text: 'Checking the auth path.' });
+  });
+
+  // The two channels are distinct streams — codex emits both when raw reasoning
+  // is on. One shared bucket would persist "<raw CoT><summary>" over the summary.
+  it('never concatenates the raw-thought channel with the summary channel', () => {
+    const events = fold([
+      started({ summary: 'Short summary.' }),
+      textDelta('RAW CHAIN OF THOUGHT.'),
+      delta('summaryDelta', 'Short summary.'),
+      completed({ summary: 'Short summary.' }),
+    ]);
+    // The raw stream is the fuller text and wins outright; the summary is not appended to it.
+    expect(reasoningAt(events, 'item.completed')).toMatchObject({ text: 'RAW CHAIN OF THOUGHT.' });
+  });
+
+  // A dropped frame or a mapper attached mid-turn leaves a partial accumulator.
+  it('a partial streamed summary never overwrites a complete wire summary', () => {
+    const events = fold([
+      started({ summary: 'Full summary of the reasoning' }),
+      delta('summaryDelta', 'Full sum'), // only part of the stream was seen
+      completed({ summary: 'Full summary of the reasoning' }),
+    ]);
+    expect(reasoningAt(events, 'item.completed')).toMatchObject({ text: 'Full summary of the reasoning' });
+  });
+
+  it('the streamed summary wins when it is the fuller of the two', () => {
+    const events = fold([
+      started({ summary: 'Full' }),
+      delta('summaryDelta', 'Full summary of the reasoning'),
+      completed({ summary: 'Full' }),
+    ]);
+    expect(reasoningAt(events, 'item.completed')).toMatchObject({ text: 'Full summary of the reasoning' });
+  });
+
+  // A delta can outrun its item/started; the real started must not blank the row.
+  it('a delta arriving before item/started is not wiped by it', () => {
+    const events = fold([turnStarted, textDelta('streamed first'), started({})]);
+    // The synthesized started is empty by design — the delta appends to it live.
+    // The REAL item/started that follows must not blank what the stream filled.
+    const starts = events.filter((e) => e.type === 'item.started');
+    expect(starts).toHaveLength(2);
+    expect(replayedText(events)).toBe('streamed first');
+  });
+
+  // The leak this guards is id REUSE after an item that never completed.
+  it('an interrupted item’s reasoning does not leak into the next turn that reuses its id', () => {
+    const events = fold([
+      turnStarted,
+      started({}),
+      textDelta('TURN-1 SECRET REASONING'),
+      // turn ends without item/completed — the item was interrupted.
+      { method: 'turn/started', params: { turn: { id: 'turn_2', status: 'inProgress', items: [] } } },
+      started({}),
+      completed(),
+    ]);
+    const second = [...events].reverse().find(
+      (e): e is Extract<UiEvent, { type: 'item.completed' }> =>
+        e.type === 'item.completed' && e.item.kind === 'reasoning',
+    );
+    expect(second?.item.kind === 'reasoning' && second.item.text).toBe('');
+  });
+
+  it('does not leak one item’s reasoning into a different id in the same turn', () => {
+    const events = fold([
+      started(),
       textDelta('first'),
-      { method: 'item/completed', params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1' } } },
+      completed(),
       {
         method: 'item/started',
         params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_2', summary: 'Next' } },
       },
-      { method: 'item/completed', params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_2', summary: 'Next' } } },
+      {
+        method: 'item/completed',
+        params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_2', summary: 'Next' } },
+      },
     ]);
-    expect(completedReasoning(events, 'item_rsn_2')).toMatchObject({ text: 'Next' });
+    expect(reasoningAt(events, 'item.completed', 'item_rsn_2')).toMatchObject({ text: 'Next' });
   });
 });

--- a/src/core/codex-ui-mapper.ts
+++ b/src/core/codex-ui-mapper.ts
@@ -38,6 +38,15 @@ import type {
 } from './ui-events.js';
 import { toolDisplay } from './tool-display.js';
 
+/** The two reasoning delta channels, accumulated separately — see
+ *  `CodexUiMapperState.reasonings`. */
+export interface ReasoningAccumulator {
+  /** `item/reasoning/textDelta` — the raw chain of thought. */
+  readonly text: string;
+  /** `item/reasoning/summaryDelta` + `summaryTextDelta` — the condensed summary. */
+  readonly summary: string;
+}
+
 export interface CodexUiMapperState {
   /** True once `session.started` was emitted (thread/started notification or
    *  the runner's `codexSessionStarted` after the thread/start result —
@@ -52,11 +61,21 @@ export interface CodexUiMapperState {
   /** Accumulated `outputDelta` text per commandExecution item, attached to
    *  the final snapshot when the wire `item/completed` carries no output. */
   readonly outputs: ReadonlyMap<string, string>;
-  /** Accumulated reasoning delta text per reasoning item, attached to the
-   *  final snapshot when the wire `item/completed` carries no `content`.
-   *  Deltas are live-only (never persisted), so without this the reasoning
-   *  text is unrecoverable on replay and the row reads back empty (#528). */
-  readonly reasonings: ReadonlyMap<string, string>;
+  /** Accumulated reasoning deltas per reasoning item, attached to the final
+   *  snapshot when the wire `item/completed` carries no `content`. Deltas are
+   *  live-only (never persisted), so without this the reasoning text is
+   *  unrecoverable on replay and the row reads back empty (#528).
+   *
+   *  Kept PER CHANNEL: `item/reasoning/textDelta` streams the raw chain of
+   *  thought while `summaryDelta`/`summaryTextDelta` stream the condensed
+   *  summary, and codex emits both when raw reasoning is enabled. One shared
+   *  bucket would concatenate the two into `"<raw CoT><summary>"` and persist
+   *  that garble over the clean wire `summary`.
+   *
+   *  Turn-scoped, and reset by `turn/started`: an interrupted item is never
+   *  completed, so without the reset its text would both leak into a later
+   *  turn that reuses the id and pin whole chains of thought in memory. */
+  readonly reasonings: ReadonlyMap<string, ReasoningAccumulator>;
   /** True once `turn/plan/updated` has spoken IN THE CURRENT TURN. Both that
    *  notification and the `plan`/`todoList` item arm write `plan.updated`, so
    *  without a precedence rule the last frame wins and a prose plan item would
@@ -127,9 +146,10 @@ export function mapCodexNotification(frame: unknown, state: CodexUiMapperState):
     case 'item/agentMessage/delta':
       return mapDelta(params, state, 'text');
     case 'item/reasoning/textDelta':
+      return mapDelta(params, state, 'reasoning', 'text');
     case 'item/reasoning/summaryDelta':
     case 'item/reasoning/summaryTextDelta':
-      return mapDelta(params, state, 'reasoning');
+      return mapDelta(params, state, 'reasoning', 'summary');
     case 'item/commandExecution/outputDelta':
       return mapDelta(params, state, 'output');
     case 'thread/tokenUsage/updated':
@@ -148,7 +168,10 @@ function mapTurnStarted(params: Record<string, unknown>, state: CodexUiMapperSta
   return {
     events: [{ type: 'turn.started', turnId }],
     // planFromNotification is turn-scoped — a new turn re-opens the item arm.
-    state: { ...state, turnSeq, currentTurnId: turnId, planFromNotification: false },
+    // So are the reasoning accumulators: an interrupted item never completes,
+    // so its text would otherwise leak into a later turn that reuses the id
+    // and pin whole chains of thought in memory for the session (#528).
+    state: { ...state, turnSeq, currentTurnId: turnId, planFromNotification: false, reasonings: new Map() },
   };
 }
 
@@ -279,7 +302,7 @@ function mapItemLifecycle(
     type === 'agentMessage'
       ? messageItem(raw, id)
       : type === 'reasoning'
-        ? reasoningItem(raw, id, eventType, state)
+        ? reasoningItem(raw, id, state)
         : toolItem(raw, id, type, eventType, state);
   const events: UiEvent[] = [{ type: eventType, item }];
 
@@ -313,19 +336,35 @@ function messageItem(raw: Record<string, unknown>, id: string): UiMessageItem {
   return item;
 }
 
-/** `reasoning` → reasoning item — full `content` when present, else what
- *  `reasoning/*Delta` streamed, else the summary. The accumulator matters on
- *  `item.completed`: deltas never reach disk, so a completed snapshot without
- *  `content` would otherwise persist the short summary (or nothing) and the
- *  row would read back empty after a reload (#528). */
+/** `reasoning` → reasoning item. Precedence, most authoritative first:
+ *  wire `content` → streamed raw chain of thought → the fuller of the wire
+ *  `summary` and the streamed summary.
+ *
+ *  The accumulators matter on `item.completed`: deltas never reach disk, so a
+ *  completed snapshot without `content` would otherwise persist the short
+ *  summary (or nothing) and the row would read back empty after a reload
+ *  (#528). They are consulted on `item.started` too — a delta can outrun its
+ *  `item/started`, and re-emitting an empty snapshot would blank the row the
+ *  synthesized item already filled.
+ *
+ *  Summary picks the LONGER of the two sources rather than preferring the
+ *  stream: a mapper attached mid-turn, or any dropped frame, leaves a partial
+ *  accumulator that must not overwrite a complete `summary` from the wire. */
 function reasoningItem(
   raw: Record<string, unknown>,
   id: string,
-  eventType: ItemEventType,
   state: CodexUiMapperState,
 ): UiReasoningItem {
-  const streamed = eventType === 'item.started' ? undefined : str(state.reasonings.get(id));
-  return { kind: 'reasoning', id, text: str(raw.content) ?? streamed ?? str(raw.summary) ?? '' };
+  const streamed = state.reasonings.get(id);
+  const summary = longer(str(raw.summary), str(streamed?.summary));
+  return { kind: 'reasoning', id, text: str(raw.content) ?? str(streamed?.text) ?? summary ?? '' };
+}
+
+/** The longer of two optional strings — neither present yields undefined. */
+function longer(a: string | undefined, b: string | undefined): string | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return b.length > a.length ? b : a;
 }
 
 /** The §7.1 status map — the wire word wins; an item without one derives its
@@ -486,6 +525,8 @@ function mapDelta(
   params: Record<string, unknown>,
   state: CodexUiMapperState,
   field: 'text' | 'reasoning' | 'output',
+  /** Which reasoning stream fed this delta — see `ReasoningAccumulator`. */
+  reasoningChannel: 'text' | 'summary' = 'text',
 ): CodexUiMapping {
   const itemId = str(params.itemId);
   const delta = typeof params.delta === 'string' ? params.delta : '';
@@ -505,10 +546,16 @@ function mapDelta(
     next.set(itemId, (next.get(itemId) ?? '') + delta);
     outputs = next;
   }
-  let reasonings: ReadonlyMap<string, string> = state.reasonings;
+  let reasonings: ReadonlyMap<string, ReasoningAccumulator> = state.reasonings;
   if (field === 'reasoning') {
     const next = new Map(state.reasonings);
-    next.set(itemId, (next.get(itemId) ?? '') + delta);
+    const prev = next.get(itemId) ?? { text: '', summary: '' };
+    next.set(
+      itemId,
+      reasoningChannel === 'text'
+        ? { ...prev, text: prev.text + delta }
+        : { ...prev, summary: prev.summary + delta },
+    );
     reasonings = next;
   }
   return { events, state: { ...state, knownItems, outputs, reasonings } };

--- a/src/core/codex-ui-mapper.ts
+++ b/src/core/codex-ui-mapper.ts
@@ -52,6 +52,11 @@ export interface CodexUiMapperState {
   /** Accumulated `outputDelta` text per commandExecution item, attached to
    *  the final snapshot when the wire `item/completed` carries no output. */
   readonly outputs: ReadonlyMap<string, string>;
+  /** Accumulated reasoning delta text per reasoning item, attached to the
+   *  final snapshot when the wire `item/completed` carries no `content`.
+   *  Deltas are live-only (never persisted), so without this the reasoning
+   *  text is unrecoverable on replay and the row reads back empty (#528). */
+  readonly reasonings: ReadonlyMap<string, string>;
   /** True once `turn/plan/updated` has spoken IN THE CURRENT TURN. Both that
    *  notification and the `plan`/`todoList` item arm write `plan.updated`, so
    *  without a precedence rule the last frame wins and a prose plan item would
@@ -76,6 +81,7 @@ export function createCodexUiState(): CodexUiMapperState {
     currentTurnId: null,
     knownItems: new Set(),
     outputs: new Map(),
+    reasonings: new Map(),
     planFromNotification: false,
   };
 }
@@ -273,18 +279,22 @@ function mapItemLifecycle(
     type === 'agentMessage'
       ? messageItem(raw, id)
       : type === 'reasoning'
-        ? reasoningItem(raw, id)
+        ? reasoningItem(raw, id, eventType, state)
         : toolItem(raw, id, type, eventType, state);
   const events: UiEvent[] = [{ type: eventType, item }];
 
   // Track live ids (for delta synthesis) and drop bookkeeping on completion.
   if (eventType === 'item.completed') {
-    if (!state.knownItems.has(id) && !state.outputs.has(id)) return { events, state };
+    if (!state.knownItems.has(id) && !state.outputs.has(id) && !state.reasonings.has(id)) {
+      return { events, state };
+    }
     const knownItems = new Set(state.knownItems);
     knownItems.delete(id);
     const outputs = new Map(state.outputs);
     outputs.delete(id);
-    return { events, state: { ...state, knownItems, outputs } };
+    const reasonings = new Map(state.reasonings);
+    reasonings.delete(id);
+    return { events, state: { ...state, knownItems, outputs, reasonings } };
   }
   if (state.knownItems.has(id)) return { events, state };
   return { events, state: { ...state, knownItems: new Set(state.knownItems).add(id) } };
@@ -303,9 +313,19 @@ function messageItem(raw: Record<string, unknown>, id: string): UiMessageItem {
   return item;
 }
 
-/** `reasoning` → reasoning item — full `content` when present, else the summary. */
-function reasoningItem(raw: Record<string, unknown>, id: string): UiReasoningItem {
-  return { kind: 'reasoning', id, text: str(raw.content) ?? str(raw.summary) ?? '' };
+/** `reasoning` → reasoning item — full `content` when present, else what
+ *  `reasoning/*Delta` streamed, else the summary. The accumulator matters on
+ *  `item.completed`: deltas never reach disk, so a completed snapshot without
+ *  `content` would otherwise persist the short summary (or nothing) and the
+ *  row would read back empty after a reload (#528). */
+function reasoningItem(
+  raw: Record<string, unknown>,
+  id: string,
+  eventType: ItemEventType,
+  state: CodexUiMapperState,
+): UiReasoningItem {
+  const streamed = eventType === 'item.started' ? undefined : str(state.reasonings.get(id));
+  return { kind: 'reasoning', id, text: str(raw.content) ?? streamed ?? str(raw.summary) ?? '' };
 }
 
 /** The §7.1 status map — the wire word wins; an item without one derives its
@@ -485,7 +505,13 @@ function mapDelta(
     next.set(itemId, (next.get(itemId) ?? '') + delta);
     outputs = next;
   }
-  return { events, state: { ...state, knownItems, outputs } };
+  let reasonings: ReadonlyMap<string, string> = state.reasonings;
+  if (field === 'reasoning') {
+    const next = new Map(state.reasonings);
+    next.set(itemId, (next.get(itemId) ?? '') + delta);
+    reasonings = next;
+  }
+  return { events, state: { ...state, knownItems, outputs, reasonings } };
 }
 
 // ---- telemetry ---------------------------------------------------------------

--- a/src/core/ui-parity.test.ts
+++ b/src/core/ui-parity.test.ts
@@ -53,7 +53,12 @@ const CAPABILITIES: ReadonlyArray<[name: string, produced: (events: UiEvent[]) =
   ['tool status: running', (events) => hasToolStatus(events, 'running')],
   ['tool status: completed', (events) => hasToolStatus(events, 'completed')],
   ['tool status: failed', (events) => hasToolStatus(events, 'failed')],
-  ['reasoning items (thinking / reasoning items / reasoning parts)', (events) => items(events).some((item) => item.kind === 'reasoning')],
+  // Non-empty is the point: a reasoning item with no text renders as a dead
+  // "Thinking —" row, so presence alone is not parity (#528).
+  [
+    'reasoning items (thinking / reasoning items / reasoning parts)',
+    (events) => items(events).some((item) => item.kind === 'reasoning' && item.text.trim() !== ''),
+  ],
   [
     'structured diffs (Edit input / fileChange.changes / patch parts)',
     (events) => items(events).some((item) => item.kind === 'tool' && (item.diffs?.length ?? 0) > 0),

--- a/src/runs/ui-event-sink.test.ts
+++ b/src/runs/ui-event-sink.test.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { UiEvent, UiItem, UiToolItem } from '../core/ui-events.js';
+import { createCodexUiState, mapCodexNotification } from '../core/codex-ui-mapper.js';
 import { RunStore } from './store.js';
 import { DELTA_FLUSH_MS, UiEventSink, isV2WireEventType } from './ui-event-sink.js';
 
@@ -325,5 +326,59 @@ describe('isV2WireEventType (the SSE event-name router)', () => {
     for (const t of ['text', 'tool-call', 'tool-result', 'image', 'token-usage', 'cost', 'session', 'turn-end', 'note', 'done', 'error', 'lifecycle', 'step-start', 'step-end', 'check-output', 'user-message']) {
       expect(isV2WireEventType(t), t).toBe(false);
     }
+  });
+});
+
+/**
+ * #528 — the regression guard for the whole persistence path: reasoning text
+ * that arrives ONLY as `item/reasoning/textDelta` must still be readable after
+ * a reload, which replays the NDJSON from scratch with no ephemeral deltas.
+ */
+describe('reasoning text survives persist → replay (#528)', () => {
+  const THREAD = 'th_1';
+  const TURN = 'turn_1';
+
+  /** Codex closes the reasoning item with the summary only — the streamed
+   *  prose lives nowhere but the deltas, which are never written to disk. */
+  const FRAMES: unknown[] = [
+    { method: 'thread/started', params: { thread: { id: THREAD } } },
+    { method: 'turn/started', params: { turn: { id: TURN, status: 'inProgress', items: [] } } },
+    {
+      method: 'item/started',
+      params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', summary: 'Tracing it' } },
+    },
+    { method: 'item/reasoning/textDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta: 'The session cookie ' } },
+    { method: 'item/reasoning/textDelta', params: { threadId: THREAD, turnId: TURN, itemId: 'item_rsn_1', delta: 'is dropped on refresh.' } },
+    {
+      method: 'item/completed',
+      params: { threadId: THREAD, turnId: TURN, item: { type: 'reasoning', id: 'item_rsn_1', summary: 'Tracing it' } },
+    },
+  ];
+
+  it('a reload-style replay of the persisted snapshots shows the full reasoning text', () => {
+    const { sink, persisted, live } = recorder();
+    let state = createCodexUiState();
+    for (const frame of FRAMES) {
+      const mapped = mapCodexNotification(frame, state);
+      state = mapped.state;
+      for (const event of mapped.events) sink.handle(event);
+    }
+    sink.flushAll();
+
+    // Deltas stay live-only — the policy this fix must not change.
+    expect(persisted.some((e) => e.type === 'item.delta')).toBe(false);
+    expect(live.some((e) => e.type === 'item.delta')).toBe(true);
+
+    // What a page reload reconstructs: snapshots only, last one wins.
+    const replayed = new Map<string, UiItem>();
+    for (const e of persisted) {
+      if (e.type === 'item.started' || e.type === 'item.updated' || e.type === 'item.completed') {
+        const item = e.item as UiItem;
+        replayed.set(item.id, item);
+      }
+    }
+    const reasoning = replayed.get('item_rsn_1');
+    expect(reasoning?.kind).toBe('reasoning');
+    expect(reasoning?.kind !== 'tool' && reasoning?.text).toBe('The session cookie is dropped on refresh.');
   });
 });

--- a/web/app/src/routes/task-thread/thread-groups.test.ts
+++ b/web/app/src/routes/task-thread/thread-groups.test.ts
@@ -237,3 +237,23 @@ describe('splitToolTitle', () => {
     expect(splitToolTitle(title)).toEqual({ verb: title })
   })
 })
+
+/** #528 — a reasoning item with no text renders as a dead row. It is dropped
+ *  during grouping (like plan tools) so it never reaches the always-rendered
+ *  `thread-row` wrapper, which would otherwise leave a blank gap. */
+describe('groupThreadItems — blank reasoning items (#528)', () => {
+  const reasoning = (id: string, text: string): ThreadEntry => ({ kind: 'reasoning', id, text })
+
+  it.each([['', 'empty'], ['   ', 'spaces'], ['\n\t ', 'whitespace']])(
+    'drops a %s reasoning entry (%s)',
+    (text) => {
+      expect(groupThreadItems([reasoning('r1', text)])).toEqual([])
+    },
+  )
+
+  it('keeps reasoning that has text, and drops only the blank sibling', () => {
+    const blocks = groupThreadItems([reasoning('r1', ''), reasoning('r2', 'Real thinking.')])
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ kind: 'entry', entry: { id: 'r2', text: 'Real thinking.' } })
+  })
+})

--- a/web/app/src/routes/task-thread/thread-groups.ts
+++ b/web/app/src/routes/task-thread/thread-groups.ts
@@ -97,7 +97,15 @@ export function groupThreadItems(allEntries: ThreadEntry[]): ThreadBlock[] {
   // Pass 0 — plan-kind tools (TodoWrite / todoList / todowrite) never render in the thread:
   // the plan dock is their surface (#382); a card here would only duplicate the checklist as
   // raw input JSON. Filtering the flat list drops them from children lists too.
-  const entries = allEntries.filter((entry) => !(entry.kind === 'tool' && entry.toolKind === 'plan'))
+  // Blank reasoning items go with them (#528): an interrupted or delta-only item can carry no
+  // text, and dropping it here — rather than at the leaf — keeps it out of row counts, children
+  // lists, and the always-rendered `thread-row` wrapper, which would otherwise reserve a blank
+  // ~3rem gap. A live item that is still empty simply appears once its first delta lands.
+  const entries = allEntries.filter(
+    (entry) =>
+      !(entry.kind === 'tool' && entry.toolKind === 'plan') &&
+      !(entry.kind === 'reasoning' && entry.text.trim() === ''),
+  )
 
   // Pass 1 — nesting. Children keep stream order; only tool items can be parents.
   const toolIds = new Set(entries.filter(isTool).map((item) => item.id))

--- a/web/app/src/routes/task-thread/thread-items.test.tsx
+++ b/web/app/src/routes/task-thread/thread-items.test.tsx
@@ -186,6 +186,16 @@ describe('ReasoningItem', () => {
     render(<ReasoningItem text={text} />)
     expect(screen.getByRole('button').textContent).toBe(`Thinking — ${text}`)
   })
+
+  // #528 — an empty item must not leave a bare, un-expandable "Thinking —" row.
+  it.each([['', 'empty'], ['   ', 'spaces'], ['\n\t ', 'whitespace']])(
+    'renders nothing for %s text (%s)',
+    (empty) => {
+      const { container } = render(<ReasoningItem text={empty} />)
+      expect(container.innerHTML).toBe('')
+      expect(screen.queryByRole('button')).toBeNull()
+    },
+  )
 })
 
 describe('ContextGroup + ToolStreak', () => {

--- a/web/app/src/routes/task-thread/thread-items.tsx
+++ b/web/app/src/routes/task-thread/thread-items.tsx
@@ -103,6 +103,9 @@ export function NoteLine({ note }: { note: ThreadNote }) {
  * Streams live — the reducer grows `text` in place, so the summary line grows with it.
  */
 export function ReasoningItem({ text }: { text: string }) {
+  // A mapper regression that mints an empty reasoning item should degrade
+  // quietly rather than render a bare, un-expandable "Thinking —" row (#528).
+  if (text.trim() === '') return null
   const firstLine = text.split('\n', 1)[0] ?? ''
   const truncated = firstLine.length < text.length
   return (


### PR DESCRIPTION
## Summary

Reasoning rows in the Session tab rendered as bare `Thinking —` with no text, even when expanded. Both mechanisms named in the issue analysis were real, and both are fixed.

**(a) Reasoning text was lost on replay.** `UiEventSink` coalesces `item.delta` live-only and never writes deltas to disk (`ui-event-sink.ts:8-9`), and `itemShape()` strips `text` before comparing (`ui-event-sink.ts:220-227`), so an `item.updated` carrying only grown text is not persisted either. The reasoning text on disk is therefore only as good as the `item.started` / `item.completed` snapshots.

Codex streams reasoning purely as `item/reasoning/textDelta` and — unlike `commandExecution`, which has an `outputs` accumulator and falls back to it on completion — kept **no reasoning accumulator**. A wire `item/completed` without `content` persisted the short summary, or nothing. After any reload or SSE reconnect the thinking was gone for good.

Fixed by mirroring the existing `outputs` precedent rather than changing the persistence policy (the issue's preferred option): `CodexUiMapperState` gains a `reasonings` map, `mapDelta` accumulates reasoning deltas, and `reasoningItem` falls back to it on non-started snapshots. Wire `content` still wins, and **disk-write frequency is unchanged**.

**(b) Empty reasoning items were minted and rendered.** `claude-ui-mapper.ts:158` guarded only `typeof raw.thinking === 'string'`, so a blank `thinking` block produced a `text: ''` item and a dead row. It is now skipped.

**Belt-and-braces.** `ReasoningItem` renders nothing when the text is blank, so a future mapper regression degrades quietly instead of emitting visual noise. `ui-parity.test.ts`'s reasoning capability now requires **non-empty** text rather than mere presence — previously it would have passed on exactly the bug being fixed.

## Changes

| File | Change |
|---|---|
| `src/core/codex-ui-mapper.ts` | `reasonings` accumulator: state field, init, `mapDelta` accumulation, `reasoningItem` fallback, completion cleanup |
| `src/core/claude-ui-mapper.ts` | Skip blank `thinking` blocks |
| `web/app/src/routes/task-thread/thread-items.tsx` | `ReasoningItem` renders `null` for blank text |
| `src/core/ui-parity.test.ts` | Reasoning parity requires non-empty text |
| `src/core/codex-ui-mapper.test.ts` | 4 cases: delta fallback, summary/summaryText deltas, `content` precedence, no cross-item leakage |
| `src/core/claude-ui-mapper.test.ts` | Blank/whitespace thinking mints nothing; real thinking still does |
| `src/runs/ui-event-sink.test.ts` | End-to-end persist → reload-style replay guard for (a) |
| `web/app/src/routes/task-thread/thread-items.test.tsx` | Blank reasoning renders no DOM |

## Testing

Full configured validation gate green: `npm run typecheck`, `npm test` (**2939 passed**, 174 files), `npm run test:unit` (30), `npm run build` + `check:pack`, `npm run test:package` (8).

The new tests were verified to be genuine regression guards — reverting only the two mapper source files makes **6 of them fail**, and they pass with the fix in place.

## Compatibility

Additive and backward compatible per **BACKWARD_COMPATIBILITY.md §7 (agent event protocol)** and **§3 (`.ai/cezar/` NDJSON)**: no event type added, no field removed. Populating `text` on an already-shipped `item.completed` reasoning snapshot is a pure improvement. Old recordings keep replaying — they simply continue to show no reasoning text, which the parity test tolerates because it unions across fixtures. Reasoning still flows through `secret-redaction.ts` on the way in; the accumulator sits downstream of it in the mapper, so redaction is unaffected.

## Notes for the reviewer

Two adjacent observations found while tracing this, **deliberately left out of scope**:

1. Codex's `item.started` pre-fills `text` with the *summary* while the web reducer *appends* deltas to it (`thread-state.ts:324`), so a live viewer transiently sees `"Tracing the redirect" + streamed prose` concatenated until `item.completed` replaces the item wholesale. Cosmetic, live-only, and fixing it would churn the golden `.expected.json` files.
2. `opencode-ui-mapper.ts` emits `item.started` with empty text and only carries the payload on `item.completed` (gated on `time.end`), so an interrupted reasoning part persists `''`. The renderer guard covers the symptom; a proper fix belongs with interrupt handling.

Happy to split either into a follow-up issue.

Fixes #528