### PR TITLE
docs(adr): correct the linting constraint — oxlint, not typescript-eslint

### DIFF
--- a/docs/adr/0001-typescript-7.md
+++ b/docs/adr/0001-typescript-7.md
@@ -3,10 +3,11 @@
 We moved from TypeScript 5.6 to 7.0, the Go-native compiler rewrite. TypeScript 7 ships no
 JavaScript compiler API — `require("typescript")` returns only `{ version, versionMajorMinor }`,
 and `tsserver` is gone — which currently blocks typescript-eslint, ts-jest, and Volar-based
-tooling. Cezar uses `tsc` purely as a compiler and typechecker: it has no eslint setup, no
-programmatic consumer of the compiler API, and vite/vitest/tsx strip types with esbuild and
-never load the `typescript` package. None of the blockers apply to us, so we took 7.0 directly
-rather than parking on the 6.0 bridge release.
+tooling. Cezar uses `tsc` purely as a compiler and typechecker: it has no linter that consumes
+the compiler API (oxlint, our chosen linter, does not — see Consequences), no other programmatic
+API consumer, and vite/vitest/tsx strip types with esbuild and never load the `typescript`
+package. None of the blockers apply to us, so we took 7.0 directly rather than parking on the
+6.0 bridge release.
 
 ## Consequences
 
@@ -21,10 +22,24 @@ Two config changes are not obvious from reading the tsconfigs:
   it is declared explicitly in `web/app/vite.config.ts`, and the tsconfig `paths` entry only
   mirrors it for typechecking.
 
-The binding constraint going forward: **we cannot add typescript-eslint (or any tool that
-imports the compiler API) until TypeScript 7.1 ships the new API.** If we need such a tool
-sooner, the sanctioned escape hatch is a side-by-side install — alias `typescript` to
-`@typescript/typescript6` for API consumers while `tsc` stays on 7.x — rather than reverting.
+**This decision commits us to oxlint over typescript-eslint for linting.** typescript-eslint
+consumes TypeScript as a JS library, so TS 7 breaks it outright — its peer range is
+`>=4.8.4 <6.1.0` and installing it against 7.0.2 fails with `ERESOLVE`. It stays blocked until
+TypeScript 7.1 ships the new API. oxlint is unaffected for the opposite reason: it has no
+dependency on the `typescript` package at all, and its type-aware mode vendors typescript-go
+directly into its own Go binary (`oxlint-tsgolint`) rather than loading yours.
+
+That makes TS 7 a **prerequisite** for our linter rather than a tax on it. oxlint's type-aware
+docs state that TypeScript 7.0+ is required and that `baseUrl` is unsupported — the exact
+option this migration removed, so we satisfy both by construction. Two things to plan around
+when we adopt it: oxlint's type-aware rules are explicitly carved out of its semver guarantee,
+so pin and upgrade `oxlint` and `oxlint-tsgolint` together; and `oxlint --type-aware
+--type-check` can fold in typescript-go's own type diagnostics, which may later let it replace
+the separate `tsc --noEmit` typecheck step.
+
+If we ever do need a compiler-API consumer (ts-jest, a codemod, Volar-based tooling), the
+sanctioned escape hatch is a side-by-side install — alias `typescript` to
+`@typescript/typescript6` for that tool while `tsc` stays on 7.x — rather than reverting.
 
 `tsc` in 7.0 is fully capable for our use: JS + `.d.ts` + source-map emit under `NodeNext`,
 project references, and `--build` all work. The compiler is a platform-specific Go binary


### PR DESCRIPTION
Follow-up to #559, which merged before this correction landed.

The ADR added in #559 named the binding constraint as *"we cannot add typescript-eslint until TypeScript 7.1 ships the new API"*. That framing is wrong for this project, because **oxlint** — not typescript-eslint — is the linter we're adopting, and oxlint is immune to the TS 7 packaging change by design.

## The correction

| | consumes TypeScript as… | effect of TS 7 |
|---|---|---|
| typescript-eslint | a **JS library** (compiler API) | **broken** — peer range `>=4.8.4 <6.1.0`, `ERESOLVE` against 7.0.2 |
| oxlint | **vendored Go source** compiled into its own binary | unaffected — no `typescript` dependency at all |

oxlint's type-aware mode is powered by `oxlint-tsgolint`, which embeds microsoft/typescript-go and explicitly *targets* TypeScript 7. It doesn't read the installed `typescript` package — it works even with `typescript` absent from `node_modules` entirely.

This inverts the ADR's conclusion. oxlint's type-aware docs state that **TypeScript 7.0+ is required** and that **`baseUrl` is unsupported** — the exact option #559 removed. The migration is therefore a **prerequisite** for our linter, not a tax on it.

## Also captured

- oxlint's type-aware rules sit **outside its semver guarantee**, so `oxlint` and `oxlint-tsgolint` should be pinned and upgraded together.
- `oxlint --type-aware --type-check` can fold in typescript-go's own type diagnostics, which may later replace the separate `tsc --noEmit` step.
- The side-by-side escape hatch (alias `typescript` → `@typescript/typescript6`) is retained, but reframed as being for a genuine compiler-API consumer (ts-jest, a codemod, Volar tooling) rather than for linting.

Docs only — no code or config change.