### PR TITLE
fix(ui): preserve thinking across resumed steps (#556)

### DIFF
--- a/web/app/src/routes/task-thread/thread-state.test.ts
+++ b/web/app/src/routes/task-thread/thread-state.test.ts
@@ -80,6 +80,57 @@ describe('reduceThread — golden v2 fixtures', () => {
   })
 })
 
+describe('reduceThread — item ids across workflow steps', () => {
+  it('keeps earlier reasoning when a resumed step restarts its item ids', () => {
+    const { turns } = reduceThread([
+      line(1, 'turn.started', { turnId: 'turn_1', stepId: 'initial' }),
+      line(2, 'item.started', {
+        item: { kind: 'reasoning', id: 'item_1', text: 'Earlier thinking survives.' },
+        stepId: 'initial',
+      }),
+      line(3, 'item.completed', {
+        item: { kind: 'reasoning', id: 'item_1', text: 'Earlier thinking survives.' },
+        stepId: 'initial',
+      }),
+      line(4, 'turn.completed', { turnId: 'turn_1', stopReason: 'end_turn', stepId: 'initial' }),
+      line(5, 'turn.started', { turnId: 'turn_1', stepId: 'resume' }),
+      line(6, 'item.started', {
+        item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'Resumed response.' },
+        stepId: 'resume',
+      }),
+      line(7, 'item.completed', {
+        item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'Resumed response.' },
+        stepId: 'resume',
+      }),
+    ])
+
+    expect(turns).toHaveLength(2)
+    expect(turns[0]!.items).toEqual([
+      { kind: 'reasoning', id: 'item_1', text: 'Earlier thinking survives.' },
+    ])
+    expect(turns[1]!.items).toEqual([
+      { kind: 'message', id: 'item_1', role: 'assistant', text: 'Resumed response.' },
+    ])
+  })
+
+  it('retains bare-id lifecycle updates for legacy events without stepId', () => {
+    const { turns } = reduceThread([
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'item.started', {
+        item: { kind: 'message', id: 'item_1', role: 'assistant', text: '' },
+      }),
+      line(3, 'item.delta', { itemId: 'item_1', field: 'text', delta: 'Legacy response.' }),
+      line(4, 'item.completed', {
+        item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'Legacy response.' },
+      }),
+    ])
+
+    expect(turns[0]!.items).toEqual([
+      { kind: 'message', id: 'item_1', role: 'assistant', text: 'Legacy response.' },
+    ])
+  })
+})
+
 describe('reduceThread — v1-only fallback (pre-v2 transcripts)', () => {
   // Verbatim shapes from a real pre-R2 transcript (.ai/cezar/runs/2d012907….ndjson), trimmed.
   const v1Only: RunEvent[] = [

--- a/web/app/src/routes/task-thread/thread-state.ts
+++ b/web/app/src/routes/task-thread/thread-state.ts
@@ -236,8 +236,9 @@ function planFromTodos(input: unknown): PlanEntry[] | undefined {
 
 export function reduceThread(events: RunEvent[]): ThreadState {
   const turns: DraftTurn[] = []
-  /** itemId → live item. Rebound on every `item.started`, so per-session id reuse (each step
-   *  restarts `item_1`) always resolves to the newest incarnation. */
+  /** stepId:itemId → live item. Runner sessions restart ids at `item_1`, while every current
+   *  persisted event is stamped with its workflow step. Old recordings without a step id keep
+   *  the historical bare-id lookup semantics. */
   const itemsById = new Map<string, { turn: DraftTurn; entry: DraftEntry }>()
   let sessionEnded: ThreadState['sessionEnded']
   let turnSeq = 0
@@ -254,7 +255,12 @@ export function reduceThread(events: RunEvent[]): ThreadState {
   }
   const currentTurn = (): DraftTurn => turns.at(-1) ?? newTurn()
 
-  const upsertV2 = (turn: DraftTurn, raw: UiItem) => {
+  const itemKey = (event: RunEvent, itemId: string) => {
+    const stepId = str(event.stepId)
+    return stepId === undefined ? itemId : `${stepId}:${itemId}`
+  }
+
+  const upsertV2 = (turn: DraftTurn, raw: UiItem, key: string) => {
     // Clone: deltas append in place, and the event object off the wire must stay untouched.
     const item = { ...raw }
     if (!turn.v2Items) {
@@ -266,15 +272,15 @@ export function reduceThread(events: RunEvent[]): ThreadState {
       }
       turn.entries = turn.entries.filter((e) => !(e.origin === 'v1' && isUiItem(e.entry)))
     }
-    const existing = itemsById.get(item.id)
+    const existing = itemsById.get(key)
     if (existing && existing.turn === turn) {
       existing.entry.entry = item
-      itemsById.set(item.id, existing)
+      itemsById.set(key, existing)
       return
     }
     const draft: DraftEntry = { origin: 'v2', entry: item }
     turn.entries.push(draft)
-    itemsById.set(item.id, { turn, entry: draft })
+    itemsById.set(key, { turn, entry: draft })
   }
 
   for (const event of events) {
@@ -346,12 +352,14 @@ export function reduceThread(events: RunEvent[]): ThreadState {
           break
         }
         const item = event.item as unknown as UiItem
-        const located = itemsById.get(item.id)
-        upsertV2(located?.turn ?? currentTurn(), item)
+        const key = itemKey(event, item.id)
+        const located = itemsById.get(key)
+        upsertV2(located?.turn ?? currentTurn(), item, key)
         break
       }
       case 'item.delta': {
-        const located = itemsById.get(str(event.itemId) ?? '')
+        const itemId = str(event.itemId) ?? ''
+        const located = itemsById.get(itemKey(event, itemId))
         const delta = str(event.delta) ?? ''
         if (!located || delta === '' || !isUiItem(located.entry.entry)) break
         const item = located.entry.entry


### PR DESCRIPTION
Closes #556

## 🎯 Goal
- Keep Thinking rows from earlier task steps visible after a run is continued or resumed.

## 🔍 Problem
Each runner session restarts its item ids at `item_1`, but the thread reducer keyed all persisted v2 items by bare item id across the entire run. A resumed message could therefore replace an earlier reasoning item in place.

## 🔍 Root Cause
`reduceThread` ignored the persisted event `stepId` when locating `item.started`, `item.updated`, `item.completed`, and `item.delta` lifecycle entries. Item ids are session-local, while a run NDJSON file contains events from multiple workflow steps.

## What Changed
- Namespace v2 lifecycle lookup keys by `stepId` when that stamp is present.
- Preserve bare-id lookup semantics for legacy recordings without `stepId`.
- Add regression coverage for cross-step id reuse and legacy no-step lifecycle updates.

## 🧪 Tests
- `npm run typecheck`
- `npm test`
- `npm run test:unit`
- `npm run build`
- `npm run test:package`

## 💥 Breaking Changes
- None. Event files and protocol shapes are unchanged; existing NDJSON remains append-only and legacy recordings continue to replay.
