### PR TITLE
fix(runners): isolate cross-backend continuation sessions (#562)

### DIFF
--- a/src/core/__fixtures__/codex/mock-codex-app-server.mjs
+++ b/src/core/__fixtures__/codex/mock-codex-app-server.mjs
@@ -21,6 +21,13 @@ rl.on('line', (line) => {
   } else if (msg.method === 'thread/start') {
     emit({ method: 'thread/started', params: { thread: { id: 'th_mock_1' } } });
     emit({ id: msg.id, result: { thread: { id: 'th_mock_1' } } });
+  } else if (msg.method === 'thread/resume') {
+    if (process.env.MOCK_CODEX_REJECT_RESUME === '1') {
+      emit({ id: msg.id, error: { code: -32603, message: `no rollout found for thread id ${msg.params?.threadId ?? ''}` } });
+      rl.close();
+    } else {
+      emit({ id: msg.id, result: { thread: { id: msg.params?.threadId } } });
+    }
   } else if (msg.method === 'turn/start') {
     emit({ id: msg.id, result: { turn: { id: 'turn_mock_1' } } });
     emit({ method: 'turn/started', params: { turn: { id: 'turn_mock_1', status: 'inProgress', items: [] } } });

--- a/src/core/codex-app-server-runner.ts
+++ b/src/core/codex-app-server-runner.ts
@@ -98,7 +98,7 @@ class CodexSession implements AgentSession {
    *  same item doesn't re-emit the full text on top of the deltas. */
   private readonly streamedItems = new Set<string>();
   private tokensUsed = 0;
-  private ready: Promise<void>;
+  private ready!: Promise<void>;
   private autoEndTimer: NodeJS.Timeout | undefined;
   private eofTermTimer: NodeJS.Timeout | undefined;
   private eofKillTimer: NodeJS.Timeout | undefined;
@@ -163,20 +163,33 @@ class CodexSession implements AgentSession {
     this.ready = this.bootstrap();
 
     this.result = (async (): Promise<AgentRunResult> => {
+      let sessionError: unknown;
       try {
-        for await (const line of readNdjson(this.child.stdout)) {
-          if (this.timedOut) break;
-          let msg: JsonRpcMessage;
-          try {
-            msg = JSON.parse(line) as JsonRpcMessage;
-          } catch {
-            continue; // not JSON-RPC — skip
+        const readLoop = async () => {
+          for await (const line of readNdjson(this.child.stdout)) {
+            if (this.timedOut) break;
+            let msg: JsonRpcMessage;
+            try {
+              msg = JSON.parse(line) as JsonRpcMessage;
+            } catch {
+              continue; // not JSON-RPC — skip
+            }
+            this.emitUi((state) => mapCodexNotification(msg, state));
+            this.dispatch(msg);
           }
-          this.emitUi((state) => mapCodexNotification(msg, state));
-          this.dispatch(msg);
-        }
+        };
+        // Start consuming stdout before awaiting bootstrap: JSON-RPC responses
+        // read here settle the initialize/thread/turn requests. Owning both
+        // promises makes every bootstrap rejection part of session.result.
+        await Promise.all([this.ready, readLoop()]);
       } catch (err) {
-        if (!this.timedOut) throw err;
+        if (!this.timedOut) {
+          sessionError = err;
+          // Bootstrap failed before a usable turn exists. Closing stdin lets
+          // app-server exit normally; end() also owns the TERM/KILL watchdog
+          // if a broken child ignores EOF.
+          this.end();
+        }
       } finally {
         if (deadline) clearTimeout(deadline);
         if (killTimer) clearTimeout(killTimer);
@@ -191,6 +204,7 @@ class CodexSession implements AgentSession {
       this.pending.clear();
 
       if (this.spawnFailed) throw this.spawnFailed;
+      if (sessionError) throw sessionError;
 
       const text = this.textChunks.join('\n').trim();
       const base: AgentRunResult = {

--- a/src/core/codex-ui-mapper.test.ts
+++ b/src/core/codex-ui-mapper.test.ts
@@ -710,6 +710,28 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
     expect(v2).toContainEqual({ type: 'usage.updated', usage: { input: 1200, output: 300, total: 1500 } });
     expect(v2).toContainEqual({ type: 'turn.completed', turnId: 'turn_mock_1', stopReason: 'end_turn' });
   }, 30_000);
+
+  it('rejects a failed resume through session.result without an unhandled rejection', async () => {
+    const runner = new CodexAppServerRunner({ bin: mockBin, timeoutMs: 60_000 });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const session = runner.startSession({
+        userPrompt: 'continue',
+        cwd: process.cwd(),
+        sessionId: 'foreign-session',
+        resume: true,
+        env: { MOCK_CODEX_REJECT_RESUME: '1' },
+      });
+      await expect(session.result).rejects.toThrow('no rollout found for thread id foreign-session');
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(session.open).toBe(false);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  }, 30_000);
 });
 
 /**

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -392,10 +392,11 @@ describe('RunStore — secret redaction before persistence (#427)', () => {
       task: 'task',
       steps: [{ id: 'task', name: 'Do the task', kind: 'agent' }],
     });
-    store.updateStep(run.id, 'task', { status: 'done', sessionId: 'sess-123', tokensUsed: 42 });
+    store.updateStep(run.id, 'task', { status: 'done', sessionId: 'sess-123', backend: 'codex', tokensUsed: 42 });
     const step = store.getRun(run.id)?.steps[0];
     expect(step?.status).toBe('done');
     expect(step?.sessionId).toBe('sess-123');
+    expect(step?.backend).toBe('codex');
     expect(step?.tokensUsed).toBe(42);
   });
 

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -34,8 +34,10 @@ const stepStateSchema = z.object({
   startedAt: z.string().optional(),
   finishedAt: z.string().optional(),
   error: z.string().optional(),
-  /** Latest claude session id — the user can `claude --resume <id>` with it. */
+  /** Latest backend-owned session id, used for same-backend Continue. */
   sessionId: z.string().optional(),
+  /** Backend that owns `sessionId`. Optional so pre-affinity runs.json files still parse. */
+  backend: z.enum(['claude', 'codex', 'opencode']).optional(),
   /** Dollar cost reported by the claude CLI for this step's turns. */
   costUsd: z.number().optional(),
 });

--- a/src/workflows/recover-session-failure.test.ts
+++ b/src/workflows/recover-session-failure.test.ts
@@ -1,0 +1,77 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RunStore } from '../runs/store.js';
+import { RunManager } from './run.js';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MOCK_CODEX = join(HERE, '..', 'core', '__fixtures__', 'codex', 'mock-codex-app-server.mjs');
+
+describe('recover() contains backend session failures (#562)', () => {
+  let repoRoot: string;
+  let store: RunStore;
+  const savedBin = process.env.CEZ_CODEX_BIN;
+  const savedPassthrough = process.env.CEZ_ENV_PASSTHROUGH;
+  const savedReject = process.env.MOCK_CODEX_REJECT_RESUME;
+
+  beforeEach(async () => {
+    process.env.CEZ_CODEX_BIN = MOCK_CODEX;
+    process.env.CEZ_ENV_PASSTHROUGH = 'MOCK_CODEX_REJECT_RESUME';
+    process.env.MOCK_CODEX_REJECT_RESUME = '1';
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-recover-session-'));
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+  });
+
+  afterEach(() => {
+    if (savedBin === undefined) delete process.env.CEZ_CODEX_BIN;
+    else process.env.CEZ_CODEX_BIN = savedBin;
+    if (savedPassthrough === undefined) delete process.env.CEZ_ENV_PASSTHROUGH;
+    else process.env.CEZ_ENV_PASSTHROUGH = savedPassthrough;
+    if (savedReject === undefined) delete process.env.MOCK_CODEX_REJECT_RESUME;
+    else process.env.MOCK_CODEX_REJECT_RESUME = savedReject;
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('marks one recovery continuation failed and does not retry it on the next boot', async () => {
+    const record = store.createRun({
+      title: 't',
+      workflow: 'quick-task',
+      task: 'continue safely',
+      runner: 'codex',
+      steps: [{ id: 'work', name: 'Work', kind: 'agent' }],
+    });
+    store.updateStep(record.id, 'work', {
+      status: 'running',
+      iterations: 1,
+      sessionId: 'missing-thread',
+      backend: 'codex',
+    });
+    store.updateRun(record.id, { status: 'running', currentStepId: 'work' });
+
+    const firstManager = new RunManager(store, repoRoot);
+    await firstManager.recover();
+    await expect
+      .poll(() => store.getRun(record.id)?.error, { timeout: 5_000 })
+      .toContain('no rollout found for thread id missing-thread');
+    expect(store.getRun(record.id)?.status).toBe('failed');
+    expect(store.getRun(record.id)?.error).toContain('no rollout found for thread id missing-thread');
+    expect(store.getRun(record.id)?.steps.filter((step) => step.id.startsWith('continue-'))).toHaveLength(1);
+    firstManager.dispose();
+
+    const secondManager = new RunManager(store, repoRoot);
+    await secondManager.recover();
+    expect(store.getRun(record.id)?.steps.filter((step) => step.id.startsWith('continue-'))).toHaveLength(1);
+    secondManager.dispose();
+  });
+});

--- a/src/workflows/run.test.ts
+++ b/src/workflows/run.test.ts
@@ -192,6 +192,31 @@ describe('RunManager.continueRun override', () => {
     expect(after?.model).toBe('gpt-5.1-codex');
   });
 
+  it('starts fresh when Continue switches to a backend that does not own the session', () => {
+    const id = resumableRun();
+    const calls: unknown[][] = [];
+    (manager as unknown as { runContinuation: (...args: unknown[]) => Promise<void> }).runContinuation = async (...args) => {
+      calls.push(args);
+    };
+
+    expect(manager.continueRun(id, { runner: 'codex' })).toEqual({ ok: true });
+    expect(calls[0]?.[2]).toBeUndefined();
+    expect(calls[0]?.[3]).toBe('codex');
+  });
+
+  it('resumes when Continue stays on the backend that owns the session', () => {
+    const id = resumableRun();
+    store.updateStep(id, 's1', { backend: 'claude' });
+    const calls: unknown[][] = [];
+    (manager as unknown as { runContinuation: (...args: unknown[]) => Promise<void> }).runContinuation = async (...args) => {
+      calls.push(args);
+    };
+
+    expect(manager.continueRun(id, { runner: 'claude' })).toEqual({ ok: true });
+    expect(calls[0]?.[2]).toBe('sess-1');
+    expect(calls[0]?.[3]).toBe('claude');
+  });
+
   it('an omitted override preserves the run current backend/model (backward compat)', () => {
     const id = resumableRun();
     expect(manager.continueRun(id, { text: 'keep going' })).toEqual({ ok: true });

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -801,8 +801,14 @@ export class RunManager {
     if (!['done', 'failed', 'cancelled', 'review'].includes(run.status)) {
       return { ok: false, error: `cannot continue a ${run.status} run` };
     }
-    const sessionId = [...run.steps].reverse().find((s) => s.sessionId)?.sessionId;
-    if (!sessionId) return { ok: false, error: 'no agent session to resume' };
+    const sessionStep = [...run.steps].reverse().find((s) => s.sessionId);
+    if (!sessionStep?.sessionId) return { ok: false, error: 'no agent session to resume' };
+    const targetRunner = opts.runner ?? run.runner ?? 'claude';
+    // Session ids are provider-owned opaque values. New records carry explicit
+    // affinity; for legacy records, the run's current runner is the conservative
+    // owner until a continuation emits a new, attributed session id (#562).
+    const sessionBackend = sessionStep.backend ?? run.runner ?? 'claude';
+    const resume = sessionBackend === targetRunner;
 
     // Follow-up runner/model override (#401): the composer lets the user pick which backend and
     // model handle this continuation. Omitted → the run's current backend/model is kept
@@ -815,7 +821,6 @@ export class RunManager {
       // this continuation will actually use (`opts.runner ?? record.runner ?? 'claude'` — the
       // same resolution `runContinuation` reads off the record). A model that is recognizably
       // another runner's preset would corrupt the run; free-form/custom ids pass untouched.
-      const targetRunner = opts.runner ?? run.runner ?? 'claude';
       if (opts.model && modelConflictsWithRunner(opts.model, targetRunner)) {
         return { ok: false, error: `model '${opts.model}' is not a ${targetRunner} model` };
       }
@@ -842,7 +847,13 @@ export class RunManager {
     const continuations = run.steps.filter((s) => s.id.startsWith('continue-')).length;
     const stepId = `continue-${continuations + 1}`;
     this.store.addStep(runId, { id: stepId, name: 'Continue', kind: 'agent' });
-    void this.runContinuation(runId, stepId, sessionId, opts.text?.trim() || 'Continue.').catch(
+    void this.runContinuation(
+      runId,
+      stepId,
+      resume ? sessionStep.sessionId : undefined,
+      targetRunner,
+      opts.text?.trim() || 'Continue.',
+    ).catch(
       (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         this.store.updateRun(runId, {
@@ -860,7 +871,8 @@ export class RunManager {
   private async runContinuation(
     runId: string,
     stepId: string,
-    sessionId: string,
+    sessionId: string | undefined,
+    backend: RunnerId,
     prompt: string,
   ): Promise<void> {
     // Continuation runs in the task's worktree when it still exists (spec
@@ -913,6 +925,7 @@ export class RunManager {
       iterations: 1,
       startedAt: new Date().toISOString(),
       sessionId,
+      backend,
     });
     this.store.appendEvent(runId, { type: 'step-start', stepId, name: 'Continue', kind: 'agent', iteration: 1 });
     this.store.appendEvent(runId, { type: 'user-message', stepId, text: prompt, imageCount: 0 });
@@ -934,7 +947,7 @@ export class RunManager {
       }
       this.store.appendEvent(runId, { ...event, stepId });
       if (event.type === 'session') {
-        this.store.updateStep(runId, stepId, { sessionId: event.sessionId });
+        this.store.updateStep(runId, stepId, { sessionId: event.sessionId, backend });
       }
       if (event.type === 'token-usage') {
         this.store.updateStep(runId, stepId, { tokensUsed: event.tokensUsed });
@@ -1010,7 +1023,7 @@ export class RunManager {
 
     // Backend + model come off the record: the run's current backend by default, or the
     // follow-up override that `continueRun` persisted before scheduling (#401).
-    const runner = createRunner(record?.runner ?? 'claude');
+    const runner = createRunner(backend);
     const session = runner.startSession(
       {
         // The Continue step is a fresh agent session on the same run — the
@@ -1027,7 +1040,7 @@ export class RunManager {
         env: this.agentEnv(runId, generateFollowups),
         model: record?.model,
         sessionId,
-        resume: true,
+        resume: sessionId !== undefined,
         timeoutMs: 0,
       },
       onEvent,
@@ -1386,7 +1399,8 @@ export class RunManager {
     }
 
     const sessionId = randomUUID();
-    this.store.updateStep(runId, step.id, { sessionId });
+    const backend = step.runner ?? taskBackend;
+    this.store.updateStep(runId, step.id, { sessionId, backend });
 
     const stepRecord = this.store.getRun(runId)?.steps.find((s) => s.id === step.id);
     const startTokens = stepRecord?.tokensUsed ?? 0;
@@ -1408,7 +1422,7 @@ export class RunManager {
       emit({ ...event, stepId: step.id });
       if (event.type === 'session') {
         // Codex/OpenCode mint their own session id — persist it so resume works.
-        this.store.updateStep(runId, step.id, { sessionId: event.sessionId });
+        this.store.updateStep(runId, step.id, { sessionId: event.sessionId, backend });
       }
       if (event.type === 'token-usage') {
         this.store.updateStep(runId, step.id, { tokensUsed: startTokens + event.tokensUsed });


### PR DESCRIPTION
Closes #562

## 🎯 Goal
- Prevent cross-backend Continue and startup recovery failures from crashing the Cezar server.

## 🔍 Problem
Continue reused the latest opaque session ID after persisting a newly selected runner, so a Claude ID could be sent to Codex thread/resume. A rejected Codex bootstrap promise was not owned by session.result and could terminate Node during recovery.

## 🔍 Root Cause
Persisted steps lacked backend affinity, runContinuation always resumed the selected backend with the previous session ID, and Codex bootstrap ran as a separately rejecting promise outside the result lifecycle.

## What Changed
- Added optional per-step backend affinity while keeping old runs.json records readable.
- Resume only same-backend sessions; cross-backend Continue starts a fresh target-backend session in the same worktree with the handoff prompt.
- Made Codex session.result own bootstrap failures and child cleanup.
- Added workflow recovery coverage proving one failed recovery remains terminal across the next manager boot.

## 🧪 Tests
- Added cross/same-backend continuation unit regressions, Codex rejected-resume coverage, persistence coverage, and an end-to-end recovery containment regression.
- PASS: npm run typecheck; targeted changed-area suite (141 tests); npm run test:unit; npm run build; npm run test:package.
- Full npm test under concurrent repository runs: 3430 passed, 28 unrelated 5-second timeouts; every timed-out file reran serially and passed (66/66).

## 💥 Breaking Changes
- None. The StepState backend field is optional and additive; routes, status values, v1 AgentEvent, and v2 UiEvent shapes are unchanged.