### PR TITLE
fix(ui): refresh checkout root after save (#567)

### DIFF
--- a/web/app/src/routes/settings/projects-section.test.tsx
+++ b/web/app/src/routes/settings/projects-section.test.tsx
@@ -171,6 +171,8 @@ describe('Global settings → Projects', () => {
     // The field keeps what the user typed, and the input is flagged for assistive tech.
     expect(rootInput()!.value).toBe('/opt/checkouts')
     expect(rootInput()!.getAttribute('aria-invalid')).toBe('true')
+    // A rejected save changed no authoritative data, so it must not refresh the registry.
+    expect(requests.filter((r) => r.method === 'GET' && r.url === '/api/projects')).toHaveLength(0)
   })
 
   it('clears the inline error as soon as the value changes again', async () => {
@@ -196,6 +198,11 @@ describe('Global settings → Projects', () => {
       expect(requests.filter((r) => r.method === 'PUT' && r.url === '/api/workspace/config')).toEqual([
         { method: 'PUT', url: '/api/workspace/config', body: { projectsDir: '~/code' } },
       ]),
+    )
+    // The clone dialog reads projectsDir from this response, not workspace/config. Refreshing
+    // it here keeps the next Add project opening coherent without a whole-app reload (#567).
+    await waitFor(() =>
+      expect(requests.filter((r) => r.method === 'GET' && r.url === '/api/projects')).toHaveLength(1),
     )
     expect(inlineError()).toBeNull()
   })

--- a/web/app/src/routes/settings/projects-section.tsx
+++ b/web/app/src/routes/settings/projects-section.tsx
@@ -111,11 +111,15 @@ function ProjectsPane({
 /** The `projectsDir` field — edited locally, saved explicitly, and validated by the SERVER. */
 function CheckoutRootField({ projectsDir }: { projectsDir: string }) {
   const queryClient = useQueryClient()
-  // Same shape as the Resources pane's saver: the merged config the PUT answers with lands
-  // straight in the workspace-config query, so nothing refetches on a success.
+  // The merged config the PUT answers with lands straight in the workspace-config query. The
+  // projects response also carries projectsDir for the clone dialog, so invalidate that
+  // authoritative answer too; otherwise reopening Add project keeps the old root until reload.
   const save = useMutation({
     mutationFn: (next: string) => putWorkspaceConfig({ projectsDir: next }),
-    onSuccess: (result) => queryClient.setQueryData(workspaceQueryKeys.config, result),
+    onSuccess: (result) => {
+      queryClient.setQueryData(workspaceQueryKeys.config, result)
+      void queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.projects })
+    },
   })
   const [value, setValue] = useState(projectsDir)
   const trimmed = value.trim()


### PR DESCRIPTION
Closes #567

## 🎯 Goal
- Refresh the Add project clone destination after saving a new checkout root, without requiring a full cockpit reload.

## 🔍 Problem
Global settings saved the new checkout root into the workspace-config query, while the clone dialog reads `projectsDir` from the separate projects query. That query stayed fresh with the previous value.

## 🔍 Root Cause
`CheckoutRootField` updated only `workspaceQueryKeys.config` after `putWorkspaceConfig` succeeded and did not invalidate `workspaceQueryKeys.projects`, even though the projects response is authoritative for the clone preview.

## What Changed
- Keep the successful workspace-config cache update.
- Invalidate the projects query after a successful checkout-root save.
- Prove successful saves refetch the projects response and rejected saves do not.

## 🧪 Tests
- `web/app/src/routes/settings/projects-section.test.tsx`
- `npm run typecheck`
- `npm test` — 205 files, 3,492 tests passed
- `npm run test:unit`
- `npm run build` including `check:pack`
- `npm run test:package`

## 💥 Breaking Changes
- None. API, route, event, config, and persisted-state contracts are unchanged.
