### PR TITLE
feat(ui): link clone root to project settings (#561)

### DIFF
--- a/.ai/runs/2026-07-21-clone-checkout-root-settings-link.md
+++ b/.ai/runs/2026-07-21-clone-checkout-root-settings-link.md
@@ -1,0 +1,56 @@
+# Execution plan — clone checkout-root settings link
+
+Status: in-progress
+
+Source doc: .ai/specs/2026-07-21-clone-checkout-root-settings-link.md
+Issue: #561
+PR: #571
+
+## Goal
+
+Add an accessible cog link beside the clone destination preview that opens Global
+settings → Projects, without changing clone behavior or the workspace API.
+
+## Scope
+
+- Update only the clone dialog's target-preview affordance and its unit coverage.
+- Use the existing plain global-settings route and shared icon-button primitives.
+- Keep #567 cache refresh, APIs, settings persistence, and clone workflow behavior out
+  of scope.
+
+## Implementation Plan
+
+### Phase 1: Clone-dialog shortcut
+
+1.1 Add the accessible settings icon control and responsive target-preview layout.
+1.2 Add unit coverage for its exact destination, accessible name, and pending state.
+
+### Phase 2: Verification and delivery
+
+2.1 Run targeted validation, remove scope creep, and commit the implementation.
+2.2 Run the complete repository gate and both review passes; normalize the existing PR.
+
+## Risks
+
+- A scope-aware link could incorrectly prefix the global route. Mitigation: use React
+  Router's plain `Link` and assert the exact href.
+- An active link during checkout could abandon a pending operation. Mitigation: render a
+  disabled button instead of a link while the mutation is pending and cover it in tests.
+- Narrow target paths could displace the affordance. Mitigation: make the path flex and
+  truncate while the icon remains fixed-size.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+PR: #571
+
+### Phase 1: Clone-dialog shortcut
+
+- [ ] 1.1 Add the accessible settings icon control and responsive target-preview layout.
+- [ ] 1.2 Add unit coverage for its exact destination, accessible name, and pending state.
+
+### Phase 2: Verification and delivery
+
+- [ ] 2.1 Run targeted validation, remove scope creep, and commit the implementation.
+- [ ] 2.2 Run the complete repository gate and both review passes; normalize the existing PR.

--- a/.ai/runs/2026-07-21-clone-checkout-root-settings-link.md
+++ b/.ai/runs/2026-07-21-clone-checkout-root-settings-link.md
@@ -1,6 +1,6 @@
 # Execution plan — clone checkout-root settings link
 
-Status: in-progress
+Status: complete
 
 Source doc: .ai/specs/2026-07-21-clone-checkout-root-settings-link.md
 Issue: #561
@@ -53,4 +53,4 @@ PR: #571
 ### Phase 2: Verification and delivery
 
 - [x] 2.1 Run targeted validation, remove scope creep, and commit the implementation. — b4e9704
-- [ ] 2.2 Run the complete repository gate and both review passes; normalize the existing PR.
+- [x] 2.2 Run the complete repository gate and both review passes; normalize the existing PR. — 2907cf4

--- a/.ai/runs/2026-07-21-clone-checkout-root-settings-link.md
+++ b/.ai/runs/2026-07-21-clone-checkout-root-settings-link.md
@@ -47,10 +47,10 @@ PR: #571
 
 ### Phase 1: Clone-dialog shortcut
 
-- [ ] 1.1 Add the accessible settings icon control and responsive target-preview layout.
-- [ ] 1.2 Add unit coverage for its exact destination, accessible name, and pending state.
+- [x] 1.1 Add the accessible settings icon control and responsive target-preview layout. — b4e9704
+- [x] 1.2 Add unit coverage for its exact destination, accessible name, and pending state. — b4e9704
 
 ### Phase 2: Verification and delivery
 
-- [ ] 2.1 Run targeted validation, remove scope creep, and commit the implementation.
+- [x] 2.1 Run targeted validation, remove scope creep, and commit the implementation. — b4e9704
 - [ ] 2.2 Run the complete repository gate and both review passes; normalize the existing PR.

--- a/.ai/specs/2026-07-21-clone-checkout-root-settings-link.md
+++ b/.ai/specs/2026-07-21-clone-checkout-root-settings-link.md
@@ -1,6 +1,6 @@
 # Clone dialog checkout-root settings link
 
-Status: draft · Date: 2026-07-21 · Issue: #561 · Extends: spec 2026-07-20-multi-project-workspace
+Status: implemented · Date: 2026-07-21 · Issue: #561 · Extends: spec 2026-07-20-multi-project-workspace
 
 ## Problem
 

--- a/.ai/specs/2026-07-21-clone-checkout-root-settings-link.md
+++ b/.ai/specs/2026-07-21-clone-checkout-root-settings-link.md
@@ -1,0 +1,91 @@
+# Clone dialog checkout-root settings link
+
+Status: draft · Date: 2026-07-21 · Issue: #561 · Extends: spec 2026-07-20-multi-project-workspace
+
+## Problem
+
+The **Add project → Clone from GitHub** dialog previews its destination under the
+configured checkout root, but it does not provide a direct way to edit that root. A
+user who notices the wrong directory must close the dialog, discover Global settings,
+open Projects, and then find the checkout-root field.
+
+Issue #561 originally also reported that a saved root stayed stale in the clone dialog.
+That independently deployable cache defect was split to #567. This specification covers
+only the settings shortcut.
+
+## Goals
+
+- Put a compact settings affordance beside the resolved clone target.
+- Navigate directly to **Global settings → Projects**, where the checkout root is edited.
+- Match the cockpit's existing icon-button language and accessibility behavior.
+- Keep the change additive and local to the clone dialog.
+
+## Non-goals
+
+- Editing or saving the checkout root inside the clone dialog.
+- Changing workspace APIs, query-cache behavior, or checkout validation.
+- Preserving partially entered clone form data after navigating to settings.
+- Adding configuration, environment variables, redirects, or new routes.
+
+## User experience
+
+The target preview row keeps the resolved `<projectsDir>/<name>` path and adds a small
+cog icon at its right edge. The icon is a plain React Router link to
+`/settings/global/projects`, because Global settings are intentionally outside every
+project scope. It uses the existing ghost icon-button styling.
+
+The link has the accessible name and native tooltip **Edit checkout root**. Keyboard
+focus uses the shared button focus treatment. While a checkout is pending, the control
+is disabled so navigation cannot abandon a clone whose dialog currently prevents close.
+
+On narrow viewports the path truncates before the fixed-size icon; the full path remains
+available through the preview's existing `title` attribute.
+
+## Requirements and acceptance criteria
+
+1. The clone target row renders a visible settings/cog icon whenever the dialog is open.
+2. The control links to exactly `/settings/global/projects`; it must not receive a
+   `/p/:projectId` prefix.
+3. The control exposes `aria-label="Edit checkout root"` and
+   `title="Edit checkout root"`.
+4. The target preview remains readable and truncates without pushing the icon out of the
+   dialog.
+5. The control cannot navigate while `useCheckoutProject()` is pending.
+6. Existing clone submission, progress, error, close, and post-clone navigation behavior
+   remains unchanged.
+7. Unit coverage asserts the destination, accessible name, and pending disabled state.
+8. The repository's configured validation gate passes.
+
+## Compatibility, security, and degradation
+
+This is an additive client-side navigation affordance. It changes no protected HTTP,
+route, CLI, event, schema, configuration, persistence, or package surface. It introduces
+no new input or data access and inherits the existing Global settings route's behavior.
+If project data fails to load, the link still reaches the place where the root is managed.
+
+## Implementation Plan
+
+### Phase 1 — Clone-dialog shortcut
+
+1.1 Update `web/app/src/components/clone-project-dialog.tsx`: import the plain router
+    `Link` and the existing Lucide settings icon, make the target preview a flexible row,
+    and add the accessible ghost icon link to `/settings/global/projects`.
+
+1.2 Preserve pending-state semantics by rendering the same icon control disabled while
+    checkout is pending, without creating an active link.
+
+### Phase 2 — Verification
+
+2.1 Extend `web/app/src/components/clone-project-dialog.test.tsx` to assert the shortcut's
+    exact href and accessible name, then hold checkout pending and assert the control is
+    disabled and cannot navigate.
+
+2.2 Run `npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, and
+    `npm run test:package` in order. Manually verify the clone dialog at desktop and
+    mobile widths, keyboard focus, navigation to Global settings → Projects, and target
+    truncation.
+
+## Open Questions
+
+None. The route, component primitives, pending behavior, and scope split are all resolved
+by existing cockpit conventions and the approved #561/#567 issue split.

--- a/web/app/src/components/clone-project-dialog.test.tsx
+++ b/web/app/src/components/clone-project-dialog.test.tsx
@@ -95,6 +95,7 @@ const slot = (name: string) => document.querySelector(`[data-slot="${name}"]`) a
 const urlInput = () => slot('clone-url') as HTMLInputElement
 const nameInput = () => slot('clone-name') as HTMLInputElement
 const cloneButton = () => slot('clone-confirm') as HTMLButtonElement
+const rootSettingsControl = () => slot('clone-root-settings') as HTMLAnchorElement | HTMLButtonElement
 
 describe('CloneProjectDialog', () => {
   it('previews <projectsDir>/<repo> from the typed url and posts the trimmed reference', async () => {
@@ -105,6 +106,10 @@ describe('CloneProjectDialog', () => {
     fireEvent.change(urlInput(), { target: { value: 'https://github.com/open-mercato/cezar.git' } })
     // The name defaults to the repo half — the same rule the server applies.
     await waitFor(() => expect(slot('clone-target')?.textContent).toBe('~/cezar/projects/cezar'))
+    expect(rootSettingsControl().tagName).toBe('A')
+    expect(rootSettingsControl().getAttribute('href')).toBe('/settings/global/projects')
+    expect(rootSettingsControl().getAttribute('aria-label')).toBe('Edit checkout root')
+    expect(rootSettingsControl().getAttribute('title')).toBe('Edit checkout root')
 
     fireEvent.click(cloneButton())
     await waitFor(() => expect(posted).toHaveLength(1))
@@ -138,6 +143,13 @@ describe('CloneProjectDialog', () => {
     await waitFor(() => expect(slot('clone-progress')).toBeTruthy())
     // Pending, before any event: an honest placeholder rather than a blank line.
     expect(slot('clone-progress')?.textContent).toBe('Starting the clone…')
+    // A clone cannot be dismissed while pending; the settings affordance follows the same rule
+    // and becomes a disabled button rather than an active global navigation link (#561).
+    expect(rootSettingsControl().tagName).toBe('BUTTON')
+    expect((rootSettingsControl() as HTMLButtonElement).disabled).toBe(true)
+    expect(rootSettingsControl().getAttribute('aria-label')).toBe('Edit checkout root')
+    fireEvent.click(rootSettingsControl())
+    expect(document.querySelector('[data-testid="location"]')?.textContent).toBe('/p/cezar/')
 
     const checkoutId = String(posted[0]?.checkoutId)
     emitWorkspaceEvent?.('checkout-progress', {

--- a/web/app/src/components/clone-project-dialog.tsx
+++ b/web/app/src/components/clone-project-dialog.tsx
@@ -1,5 +1,6 @@
+import { SettingsIcon } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { Link as RouterLink, useNavigate } from 'react-router'
 
 import { onWorkspaceEvent } from '@/api/global-events'
 import { useCheckoutProject, useProjects } from '@/api/queries'
@@ -135,13 +136,39 @@ export function CloneProjectDialog({
             disabled={checkout.isPending}
             onChange={(event) => setName(event.target.value)}
           />
-          <p
-            data-slot="clone-target"
-            className="truncate font-mono text-[11.5px] text-soft-foreground"
-            title={target}
-          >
-            {target}
-          </p>
+          <div className="flex min-w-0 items-center gap-1">
+            <p
+              data-slot="clone-target"
+              className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-soft-foreground"
+              title={target}
+            >
+              {target}
+            </p>
+            {checkout.isPending ? (
+              <Button
+                data-slot="clone-root-settings"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7"
+                aria-label="Edit checkout root"
+                title="Edit checkout root"
+                disabled
+              >
+                <SettingsIcon className="size-3.5" aria-hidden="true" />
+              </Button>
+            ) : (
+              <Button asChild variant="ghost" size="icon-sm" className="size-7">
+                <RouterLink
+                  to="/settings/global/projects"
+                  data-slot="clone-root-settings"
+                  aria-label="Edit checkout root"
+                  title="Edit checkout root"
+                >
+                  <SettingsIcon className="size-3.5" aria-hidden="true" />
+                </RouterLink>
+              </Button>
+            )}
+          </div>
         </div>
 
         {/* One line, replaced in place: `git clone` emits a counter update every few hundred ms,


### PR DESCRIPTION
## Summary

Adds an accessible cog/settings shortcut beside the Add project → Clone from GitHub destination preview. It links directly to Global settings → Projects and becomes a disabled button while a clone is pending. The stale cache defect remains separate in #567.

Tracking plan: .ai/runs/2026-07-21-clone-checkout-root-settings-link.md
Source doc: .ai/specs/2026-07-21-clone-checkout-root-settings-link.md
Closes #561

Status: complete

## What Changed

- Added a responsive target-preview row with a fixed-size settings affordance.
- Used the plain global React Router link to avoid project-scope prefixing.
- Preserved pending clone semantics with an accessible disabled control.
- Added focused regression coverage for href, accessible name, tooltip, pending state, and non-navigation.

## Tests

- npm run typecheck
- npm test — 214 files, 3,566 tests
- npm run test:unit — 31 tests
- npm run build — includes check:pack
- npm run test:package — 8 tests
- GitHub CI — green at reviewed implementation head

## Breaking Changes

None.