### PR TITLE
fix(ui): show queued task references immediately (#554)

### DIFF
--- a/.ai/specs/2026-07-21-report-ref-discovery.md
+++ b/.ai/specs/2026-07-21-report-ref-discovery.md
@@ -72,8 +72,10 @@ pretty distinguished"):
 - Sessions running **older** skill versions keep working via the legacy
   `PR_URL=`/`PR_NUMBER=` parsing; sessions running the new skills work with
   **older** cezars through the URL janitor (the report line contains the URL).
-- The cockpit does not yet render `referencedIssueUrl`; surfacing an issue
-  chip in the tasks table is a UI follow-up.
+- The cockpit renders the strongest known task reference in the tasks table:
+  PR first, otherwise issue. Issue URLs are seeded from the prompt at run
+  creation, so an issue-driven run has its linked issue chip while queued
+  (#554), before the first agent event.
 
 ## Test plan
 

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -743,6 +743,14 @@ describe('RunStore — referenced-issue discovery (spec 2026-07-21-report-ref-di
     expect(loaded?.issueNumber).toBe(433);
   });
 
+  it('seeds an issue link while the run is still queued', () => {
+    const { store, run } = freshRun('Fix https://github.com/open-mercato/cezar/issues/554');
+    const loaded = store.getRun(run.id);
+    expect(loaded?.status).toBe('queued');
+    expect(loaded?.referencedIssueUrl).toBe('https://github.com/open-mercato/cezar/issues/554');
+    expect(loaded?.issueNumber).toBe(554);
+  });
+
   it('tracks issues independently of a created PR', () => {
     const { store, run } = freshRun();
     store.appendEvent(run.id, {

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -366,9 +366,11 @@ export class RunStore extends EventEmitter {
         tokensUsed: 0,
       })),
     };
-    // A prompt that pastes a PR URL is already about that PR — seed the
-    // referenced tier so the chip exists before the first event (#407).
+    // A prompt that pastes a PR or issue URL is already about that item — seed
+    // both referenced tiers so queued runs can expose the reference before the
+    // first agent event (#407, #554).
     this.trackReferencedPrs(run, input.task);
+    this.trackReferencedIssues(run, input.task);
     this.runs.set(run.id, run);
     this.pruneOldRuns();
     this.touch(run);

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -92,6 +92,8 @@ export interface RunRecord {
    *  Display tier only: `pullRequestUrl` (the PR this task CREATED) wins, and the
    *  Draft-PR / Create-PR action gates ignore it. Read via `taskPrUrl()`. */
   referencedPullRequestUrl?: string
+  /** The issue this task is ABOUT — discovered from an issue URL in the prompt or transcript. */
+  referencedIssueUrl?: string
   /** The PR/issue number this task is ABOUT (task auto-naming spec) — display tier only. */
   prNumber?: number
   issueNumber?: number

--- a/web/app/src/lib/tasks-table.test.ts
+++ b/web/app/src/lib/tasks-table.test.ts
@@ -8,6 +8,7 @@ import {
   formatCost,
   formatMem,
   prNumber,
+  taskReference,
   taskPrUrl,
   usageCells,
   workflowLabel,
@@ -167,6 +168,27 @@ describe('taskPrUrl', () => {
 
   it('is undefined when the task has no PR association at all', () => {
     expect(taskPrUrl(run())).toBeUndefined()
+  })
+})
+
+describe('taskReference', () => {
+  it('shows the known issue while an issue-driven task is queued', () => {
+    expect(taskReference(run({ status: 'queued', issueNumber: 554 }))).toEqual({
+      kind: 'Issue',
+      number: 554,
+    })
+  })
+
+  it('prefers a pull request once the task has one', () => {
+    expect(
+      taskReference(
+        run({
+          issueNumber: 554,
+          referencedIssueUrl: 'https://github.com/o/r/issues/554',
+          pullRequestUrl: 'https://github.com/o/r/pull/600',
+        })
+      )
+    ).toEqual({ kind: 'PR', number: 600, url: 'https://github.com/o/r/pull/600' })
   })
 })
 

--- a/web/app/src/lib/tasks-table.ts
+++ b/web/app/src/lib/tasks-table.ts
@@ -82,6 +82,27 @@ export function taskPrUrl(run: RunRecord): string | undefined {
   return run.pullRequestUrl ?? run.referencedPullRequestUrl
 }
 
+export interface TaskReference {
+  kind: 'PR' | 'Issue'
+  number: number
+  url?: string
+}
+
+/** The strongest known tracker reference for a task. PRs win once one exists;
+ * issue-driven queued runs still expose their already-known issue immediately. */
+export function taskReference(run: RunRecord): TaskReference | undefined {
+  const pullRequestUrl = taskPrUrl(run)
+  const pullRequestNumber = pullRequestUrl ? Number(prNumber(pullRequestUrl)) : run.prNumber
+  if (pullRequestNumber && Number.isInteger(pullRequestNumber)) {
+    return { kind: 'PR', number: pullRequestNumber, ...(pullRequestUrl ? { url: pullRequestUrl } : {}) }
+  }
+  const issueNumber = run.issueNumber ?? (run.referencedIssueUrl ? Number(prNumber(run.referencedIssueUrl)) : undefined)
+  if (issueNumber && Number.isInteger(issueNumber)) {
+    return { kind: 'Issue', number: issueNumber, ...(run.referencedIssueUrl ? { url: run.referencedIssueUrl } : {}) }
+  }
+  return undefined
+}
+
 /** The PR chip's `#402`. Null when the URL's last segment is not a number — a forge we don't
  *  recognize still gets a working chip, just without a number we'd be inventing. */
 export function prNumber(url: string): string | null {

--- a/web/app/src/routes/tasks-overview.test.tsx
+++ b/web/app/src/routes/tasks-overview.test.tsx
@@ -109,6 +109,22 @@ describe('TasksOverview — the table', () => {
     expect(pillOf('d')?.querySelector('[data-slot="status-dot"]')?.getAttribute('data-tone')).toBe('success')
   })
 
+  it('shows a queued issue reference before the agent starts', () => {
+    renderOverview({
+      runs: [
+        run({
+          id: 'queued-issue',
+          status: 'queued',
+          issueNumber: 554,
+          referencedIssueUrl: 'https://github.com/open-mercato/cezar/issues/554',
+        }),
+      ],
+    })
+    const chip = tableRow('queued-issue')?.querySelector('[data-slot="issue-chip"]')
+    expect(chip?.textContent).toBe('Issue #554')
+    expect(chip?.getAttribute('href')).toBe('https://github.com/open-mercato/cezar/issues/554')
+  })
+
   it('fills the columns with the run facts, and honest dashes where no fact exists', () => {
     renderOverview({
       runs: [

--- a/web/app/src/routes/tasks-overview.tsx
+++ b/web/app/src/routes/tasks-overview.tsx
@@ -31,8 +31,7 @@ import {
   filterRuns,
   finishedRunCount,
   formatCost,
-  prNumber,
-  taskPrUrl,
+  taskReference,
   usageCells,
   workflowLabel,
   type UsageCell,
@@ -144,7 +143,7 @@ export function TasksOverview({
                     <Th>Workflow</Th>
                     <Th>Branch</Th>
                     <Th>±</Th>
-                    <Th>PR</Th>
+                    <Th>Ref</Th>
                     <Th right>Tokens</Th>
                     <Th right>Cost</Th>
                     <Th right>CPU</Th>
@@ -334,7 +333,7 @@ function TableRow({
   const attention = deriveAttention(run)
   const to = `/tasks/${run.id}`
   const cost = formatCost(run.costUsd)
-  const prUrl = taskPrUrl(run)
+  const reference = taskReference(run)
 
   return (
     <tr
@@ -358,9 +357,7 @@ function TableRow({
       <td className={TD_BASE}>{run.branch ? <BranchChip branch={run.branch} /> : <Dash />}</td>
       {/* ± — refreshed on every turn-end (#389); still an honest dash on records that predate it. */}
       <td className={TD_BASE}>{run.diffStat ? <DiffStatLabel stat={run.diffStat} /> : <Dash />}</td>
-      <td className={TD_BASE}>
-        {prUrl ? <PrChip url={prUrl} taskTitle={runTitle(run)} /> : <Dash />}
-      </td>
+      <td className={TD_BASE}>{reference ? <ReferenceChip reference={reference} taskTitle={runTitle(run)} /> : <Dash />}</td>
       <td className={cn(TD_BASE, 'text-right font-mono text-xs text-muted-foreground tabular-nums')}>
         {compactTokens(run.tokensUsed)}
       </td>
@@ -473,7 +470,7 @@ function TaskCard({
   const navigate = useNavigate()
   const attention = deriveAttention(run)
   const to = `/tasks/${run.id}`
-  const prUrl = taskPrUrl(run)
+  const reference = taskReference(run)
 
   return (
     <div
@@ -526,8 +523,8 @@ function TaskCard({
             ) : null}
           </>
         )}
-        {prUrl ? (
-          <PrChip url={prUrl} taskTitle={runTitle(run)} className="h-5" />
+        {reference ? (
+          <ReferenceChip reference={reference} taskTitle={runTitle(run)} className="h-5" />
         ) : null}
       </div>
     </div>
@@ -557,8 +554,16 @@ function BranchChip({ branch }: { branch: string }) {
 
 /** The out-of-app link. One style for every PR — the record carries no merged/closed state to
  *  honestly split violet-open from green-merged (that is R5's forge driver). */
-function PrChip({ url, taskTitle, className }: { url: string; taskTitle: string; className?: string }) {
-  const num = prNumber(url)
+function ReferenceChip({
+  reference,
+  taskTitle,
+  className,
+}: {
+  reference: NonNullable<ReturnType<typeof taskReference>>
+  taskTitle: string
+  className?: string
+}) {
+  const { kind, number, url } = reference
   const chipClass = cn(
     'inline-flex h-[22px] items-center gap-1 rounded-full border border-violet/35 px-2 font-mono text-[11px] font-semibold text-violet',
     className
@@ -566,24 +571,24 @@ function PrChip({ url, taskTitle, className }: { url: string; taskTitle: string;
   // href protocol guard (#431): render a link only for http(s) URLs; a
   // non-http value (e.g. a `javascript:` PR URL scraped from a transcript)
   // degrades to inert text instead of an executable link.
-  if (!isHttpUrl(url)) {
+  if (!url || !isHttpUrl(url)) {
     return (
-      <span data-slot="pr-chip" className={chipClass} title={url}>
-        {num ? `#${num}` : 'PR'}
+      <span data-slot={kind === 'PR' ? 'pr-chip' : 'issue-chip'} className={chipClass}>
+        {kind === 'Issue' ? 'Issue ' : ''}#{number}
       </span>
     )
   }
   return (
     <a
-      data-slot="pr-chip"
+      data-slot={kind === 'PR' ? 'pr-chip' : 'issue-chip'}
       href={url}
       target="_blank"
       rel="noopener noreferrer"
       title={url}
-      aria-label={`Open the pull request for ${taskTitle}`}
+      aria-label={`Open the ${kind === 'PR' ? 'pull request' : 'issue'} for ${taskTitle}`}
       className={cn(chipClass, 'hover:bg-violet/10')}
     >
-      {num ? `#${num}` : 'PR'}
+      {kind === 'Issue' ? 'Issue ' : ''}#{number}
       <ArrowUpRightIcon className="size-2.5" aria-hidden="true" />
     </a>
   )


### PR DESCRIPTION
Closes #554

## 🎯 Goal
- Show a queued task's known issue or pull-request reference before its agent begins processing.

## 🔍 Problem
Queued issue-driven tasks already had a synchronously extracted issue number, but the Tasks overview's PR-only cell ignored it and displayed an em dash until later agent output supplied a PR URL.

## 🔍 Root Cause
`RunManager.startRun` persisted numeric task references immediately, while `RunStore.createRun` seeded only PR URLs and the Tasks overview rendered only URL-backed PR chips. The known `issueNumber` therefore never reached the queued reference cell.

## What Changed
- Seed referenced issue URLs from the task prompt during run creation.
- Select the strongest known task reference: PR first, otherwise issue.
- Render linked or inert issue references in the desktop table and mobile task cards.
- Update the reference-discovery design record.

## 🧪 Tests
- Added store coverage for issue URL discovery while a run is queued.
- Added reference-selection coverage for queued issues and PR precedence.
- Added Tasks overview coverage for a queued linked issue chip.
- Full gate passed: `npm run typecheck`, `npm test` (3,678), `npm run test:unit` (31), `npm run build`, `npm run test:package` (8). The gate was run with inherited `CEZ_REMOTE` removed to match the repository's default local-mode test environment.

## 💥 Breaking Changes
- None. The web API mirror gains one optional field and persisted state remains additive.
