### PR TITLE
fix(opencode): scope subtasks by session id (#551)

### DIFF
--- a/src/core/__fixtures__/opencode/subtask-overlapping.expected.json
+++ b/src/core/__fixtures__/opencode/subtask-overlapping.expected.json
@@ -1,0 +1,13 @@
+[
+  {"type":"session.started","sessionId":"ses_01J8ZE00MAIN","backend":"opencode"},
+  {"type":"turn.started","turnId":"turn_1"},
+  {"type":"item.started","item":{"kind":"tool","id":"prt_task_a","name":"subtask","toolKind":"task","title":"Task: Task A","status":"running","input":{"prompt":"Inspect A","description":"Task A","agent":"general"}}},
+  {"type":"item.completed","item":{"kind":"tool","id":"prt_child_a","name":"grep","toolKind":"search","title":"Search A","status":"completed","input":{"pattern":"A"},"output":"a.ts","parentItemId":"prt_task_a"}},
+  {"type":"item.started","item":{"kind":"tool","id":"prt_task_b","name":"subtask","toolKind":"task","title":"Task: Task B","status":"running","input":{"prompt":"Inspect B","description":"Task B","agent":"general"}}},
+  {"type":"item.completed","item":{"kind":"tool","id":"prt_child_b","name":"grep","toolKind":"search","title":"Search B","status":"completed","input":{"pattern":"B"},"output":"b.ts","parentItemId":"prt_task_b"}},
+  {"type":"item.completed","item":{"kind":"tool","id":"prt_child_a_late","name":"read","toolKind":"read","title":"Read a.ts","status":"completed","input":{"filePath":"a.ts"},"output":"A","parentItemId":"prt_task_a"}},
+  {"type":"item.completed","item":{"kind":"tool","id":"prt_task_a","name":"subtask","toolKind":"task","title":"Task: Task A","status":"completed","input":{"prompt":"Inspect A","description":"Task A","agent":"general"}}},
+  {"type":"item.completed","item":{"kind":"tool","id":"prt_child_b_late","name":"read","toolKind":"read","title":"Read b.ts","status":"completed","input":{"filePath":"b.ts"},"output":"B","parentItemId":"prt_task_b"}},
+  {"type":"item.completed","item":{"kind":"tool","id":"prt_task_b","name":"subtask","toolKind":"task","title":"Task: Task B","status":"completed","input":{"prompt":"Inspect B","description":"Task B","agent":"general"}}},
+  {"type":"turn.completed","turnId":"turn_1","stopReason":"end_turn"}
+]

--- a/src/core/__fixtures__/opencode/subtask-overlapping.ndjson
+++ b/src/core/__fixtures__/opencode/subtask-overlapping.ndjson
@@ -1,0 +1,12 @@
+{"type":"message.updated","properties":{"info":{"id":"msg_main","sessionID":"ses_01J8ZE00MAIN","role":"assistant"}}}
+{"type":"message.part.updated","properties":{"part":{"id":"prt_task_a","messageID":"msg_main","sessionID":"ses_01J8ZE00MAIN","type":"subtask","prompt":"Inspect A","description":"Task A","agent":"general"}}}
+{"type":"message.updated","properties":{"info":{"id":"msg_child_a","sessionID":"ses_child_a","role":"assistant","parentID":"ses_01J8ZE00MAIN"}}}
+{"type":"message.part.updated","properties":{"part":{"id":"prt_child_a","messageID":"msg_child_a","sessionID":"ses_child_a","type":"tool","tool":"grep","state":{"status":"completed","input":{"pattern":"A"},"output":"a.ts"}}}}
+{"type":"message.part.updated","properties":{"part":{"id":"prt_task_b","messageID":"msg_main","sessionID":"ses_01J8ZE00MAIN","type":"subtask","prompt":"Inspect B","description":"Task B","agent":"general"}}}
+{"type":"message.updated","properties":{"info":{"id":"msg_child_b","sessionID":"ses_child_b","role":"assistant","parentID":"ses_01J8ZE00MAIN"}}}
+{"type":"message.part.updated","properties":{"part":{"id":"prt_child_b","messageID":"msg_child_b","sessionID":"ses_child_b","type":"tool","tool":"grep","state":{"status":"completed","input":{"pattern":"B"},"output":"b.ts"}}}}
+{"type":"message.part.updated","properties":{"part":{"id":"prt_child_a_late","messageID":"msg_child_a","sessionID":"ses_child_a","type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"a.ts"},"output":"A"}}}}
+{"type":"session.idle","properties":{"sessionID":"ses_child_a"}}
+{"type":"message.part.updated","properties":{"part":{"id":"prt_child_b_late","messageID":"msg_child_b","sessionID":"ses_child_b","type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"b.ts"},"output":"B"}}}}
+{"type":"session.idle","properties":{"sessionID":"ses_child_b"}}
+{"type":"session.idle","properties":{"sessionID":"ses_01J8ZE00MAIN"}}

--- a/src/core/opencode-ui-mapper.test.ts
+++ b/src/core/opencode-ui-mapper.test.ts
@@ -68,6 +68,7 @@ const GOLDEN_FIXTURES = [
   'todowrite-plan',
   'patch-and-step-finish',
   'subtask-nested',
+  'subtask-overlapping',
   'session-error',
 ] as const;
 
@@ -502,6 +503,38 @@ describe('mapOpencodeEvent edge cases', () => {
       mapOpencodeEvent(part({ id: 'prt_f2', messageID: 'msg_child', sessionID: 'ses_child', type: 'text', text: 'late' }), childIdle.state)
         .events,
     ).toEqual([]);
+  });
+
+  it('main-session idle settles and clears child sessions that never went idle', () => {
+    let state = startedState();
+    state = mapOpencodeEvent(
+      part({ id: 'prt_st', type: 'subtask', prompt: 'dig in', description: 'Investigate', agent: 'general' }),
+      state,
+    ).state;
+    state = mapOpencodeEvent(
+      { type: 'message.updated', properties: { info: { id: 'msg_child', sessionID: 'ses_child', role: 'assistant' } } },
+      state,
+    ).state;
+    state = mapOpencodeEvent(
+      part({ id: 'prt_child', messageID: 'msg_child', sessionID: 'ses_child', type: 'text', text: 'working' }),
+      state,
+    ).state;
+
+    const mainIdle = mapOpencodeEvent({ type: 'session.idle', properties: { sessionID: SESSION_ID } }, state);
+    expect(mainIdle.events).toContainEqual({
+      type: 'item.completed',
+      item: {
+        kind: 'tool',
+        id: 'prt_st',
+        name: 'subtask',
+        toolKind: 'task',
+        title: 'Task: Investigate',
+        status: 'completed',
+        input: { prompt: 'dig in', description: 'Investigate', agent: 'general' },
+      },
+    });
+    expect(mainIdle.events.at(-1)).toEqual({ type: 'turn.completed', turnId: 'turn_1', stopReason: 'end_turn' });
+    expect(mapOpencodeEvent({ type: 'session.idle', properties: { sessionID: 'ses_child' } }, mainIdle.state).events).toEqual([]);
   });
 
   it('session.started is emitted once and requires an id', () => {

--- a/src/core/opencode-ui-mapper.ts
+++ b/src/core/opencode-ui-mapper.ts
@@ -56,6 +56,12 @@ interface MessageUsage {
   readonly stepsCost: number | null;
 }
 
+interface SubtaskScope {
+  readonly id: string;
+  readonly title: string;
+  readonly input?: unknown;
+}
+
 export interface OpencodeUiMapperState {
   /** The main session id (from POST /session) — the SSE bus is server-wide,
    *  so this is what separates our events from a subtask's child session. */
@@ -81,9 +87,12 @@ export interface OpencodeUiMapperState {
   /** Serialized last plan — todowrite snapshots are idempotent, so identical
    *  replacements emit no duplicate `plan.updated`. */
   readonly lastPlanJson: string | null;
-  /** Active subtask scope: its id becomes `parentItemId` for child-session
-   *  items; the child's `session.idle` completes it. */
-  readonly subtask: { id: string; title: string; input?: unknown } | null;
+  /** Child session id → subtask scope. Foreign parts are attributed only to
+   *  their own child session; that session's idle completes the scope. */
+  readonly subtasks: ReadonlyMap<string, SubtaskScope>;
+  /** Subtask parts do not carry the child session id. Bind one on the first
+   *  foreign event only while attribution is unambiguous. */
+  readonly unboundSubtasks: readonly SubtaskScope[];
   readonly usageByMessage: ReadonlyMap<string, MessageUsage>;
   /** Last emitted session totals — usage.updated fires only on change. */
   readonly lastUsage: { total: number; cost: number | null } | null;
@@ -107,7 +116,8 @@ export function createOpencodeUiState(): OpencodeUiMapperState {
     endedItems: new Set(),
     tools: new Map(),
     lastPlanJson: null,
-    subtask: null,
+    subtasks: new Map(),
+    unboundSubtasks: [],
     usageByMessage: new Map(),
     lastUsage: null,
   };
@@ -173,6 +183,11 @@ function mapMessageInfo(props: Record<string, unknown>, state: OpencodeUiMapperS
   const id = str(info.id);
   const role = str(info.role);
   let next = state;
+  const messageSession = str(info.sessionID);
+  const foreign = messageSession !== undefined && state.sessionId !== null && messageSession !== state.sessionId;
+  if (foreign && messageSession !== undefined) {
+    next = resolveSubtask(messageSession, next).state;
+  }
   if (id !== undefined && role !== undefined && state.msgRoles.get(id) !== role) {
     const msgRoles = new Map(state.msgRoles);
     msgRoles.set(id, role);
@@ -208,12 +223,15 @@ function mapPart(props: Record<string, unknown>, state: OpencodeUiMapperState): 
   const id = str(part.id) ?? messageID;
   if (type === undefined || id === undefined) return { events: [], state };
 
-  // Foreign-session parts are the active subtask's child session — they nest
-  // under it; without a subtask scope they are another session's traffic.
+  // Foreign-session parts nest only under the subtask bound to that child
+  // session. A newly seen child can claim the sole unbound subtask; with two
+  // candidates attribution is ambiguous, so the event is dropped.
   const partSession = str(part.sessionID);
   const foreign = partSession !== undefined && state.sessionId !== null && partSession !== state.sessionId;
-  if (foreign && state.subtask === null) return { events: [], state };
-  const parentItemId = foreign && state.subtask !== null ? state.subtask.id : undefined;
+  const resolved = foreign && partSession !== undefined ? resolveSubtask(partSession, state) : undefined;
+  if (foreign && resolved?.subtask === undefined) return { events: [], state };
+  state = resolved?.state ?? state;
+  const parentItemId = resolved?.subtask?.id;
 
   // Only assistant parts surface — the user's own prompt streams as parts
   // over the same feed. Role is known early (message.updated precedes its
@@ -503,7 +521,7 @@ function mapSubtask(
     state: {
       ...state,
       startedItems: new Set(state.startedItems).add(id),
-      subtask: { id, title: item.title, input: item.input },
+      unboundSubtasks: [...state.unboundSubtasks, { id, title: item.title, input: item.input }],
     },
   };
 }
@@ -541,29 +559,35 @@ function mapIdle(props: Record<string, unknown>, state: OpencodeUiMapperState): 
   const sid = str(props.sessionID);
   const isMain = sid === undefined || state.sessionId === null || sid === state.sessionId;
   if (!isMain) {
-    if (state.subtask === null) return { events: [], state };
-    const item: UiToolItem = {
-      kind: 'tool',
-      id: state.subtask.id,
-      name: 'subtask',
-      toolKind: 'task',
-      title: state.subtask.title,
-      status: 'completed',
+    if (sid === undefined) return { events: [], state };
+    const resolved = resolveSubtask(sid, state);
+    if (resolved.subtask === undefined) return { events: [], state };
+    const subtasks = new Map(resolved.state.subtasks);
+    subtasks.delete(sid);
+    return {
+      events: [{ type: 'item.completed', item: completedSubtask(resolved.subtask) }],
+      state: { ...resolved.state, subtasks },
     };
-    if (state.subtask.input !== undefined) item.input = state.subtask.input;
-    return { events: [{ type: 'item.completed', item }], state: { ...state, subtask: null } };
   }
   // Idle with no turn in flight (or a repeated idle) closes nothing.
   if (state.currentTurnId === null) return { events: [], state };
+  const openSubtasks = [...state.subtasks.values(), ...state.unboundSubtasks];
   return {
     events: [
+      ...openSubtasks.map((subtask): UiEvent => ({ type: 'item.completed', item: completedSubtask(subtask) })),
       {
         type: 'turn.completed',
         turnId: state.currentTurnId,
         stopReason: state.turnErrored ? 'error' : 'end_turn',
       },
     ],
-    state: { ...state, currentTurnId: null, turnErrored: false },
+    state: {
+      ...state,
+      currentTurnId: null,
+      turnErrored: false,
+      subtasks: new Map(),
+      unboundSubtasks: [],
+    },
   };
 }
 
@@ -572,12 +596,41 @@ function mapIdle(props: Record<string, unknown>, state: OpencodeUiMapperState): 
 function mapSessionError(props: Record<string, unknown>, state: OpencodeUiMapperState): OpencodeUiMapping {
   const sid = str(props.sessionID);
   const foreign = sid !== undefined && state.sessionId !== null && sid !== state.sessionId;
-  if (foreign && state.subtask === null) return { events: [], state };
+  const resolved = foreign && sid !== undefined ? resolveSubtask(sid, state) : undefined;
+  if (foreign && resolved?.subtask === undefined) return { events: [], state };
+  state = resolved?.state ?? state;
   const message = errorText(props.error) ?? 'opencode session error';
   return {
     events: [{ type: 'session.error', message, fatal: false }],
     state: { ...state, turnErrored: state.currentTurnId !== null ? true : state.turnErrored },
   };
+}
+
+function resolveSubtask(
+  sessionId: string,
+  state: OpencodeUiMapperState,
+): { state: OpencodeUiMapperState; subtask?: SubtaskScope } {
+  const existing = state.subtasks.get(sessionId);
+  if (existing !== undefined) return { state, subtask: existing };
+  if (state.unboundSubtasks.length !== 1) return { state };
+  const subtask = state.unboundSubtasks[0];
+  if (subtask === undefined) return { state };
+  const subtasks = new Map(state.subtasks);
+  subtasks.set(sessionId, subtask);
+  return { state: { ...state, subtasks, unboundSubtasks: [] }, subtask };
+}
+
+function completedSubtask(subtask: SubtaskScope): UiToolItem {
+  const item: UiToolItem = {
+    kind: 'tool',
+    id: subtask.id,
+    name: 'subtask',
+    toolKind: 'task',
+    title: subtask.title,
+    status: 'completed',
+  };
+  if (subtask.input !== undefined) item.input = subtask.input;
+  return item;
 }
 
 // ---- telemetry ----------------------------------------------------------------


### PR DESCRIPTION
Closes #551

## 🎯 Goal
- Keep concurrent OpenCode subtasks attributed to their own child sessions and ensure every task settles.

## 🔍 Problem
The OpenCode UI mapper stored one active subtask. A second spawn overwrote it, so child output could attach to the wrong task, idle events could finish the wrong row, and some rows stayed running forever.

## 🔍 Root Cause
Foreign-session parts and idle events read `state.subtask` without matching their own `sessionID`; main-session idle also left that slot untouched.

## What Changed
- Track bound subtasks by child session id and keep new subtask parts unbound until a foreign message or part makes attribution unambiguous.
- Attribute foreign parts and idle events only through the matching child-session entry.
- Settle and clear all remaining subtasks when the main session goes idle.
- Add an exact overlapping-subtask golden fixture and a regression for child sessions that never emit idle.

## 🧪 Tests
- `npm run typecheck`
- `npm test` — 3696 passed (run without inherited `CEZ_REMOTE=1`, which intentionally disables local capability routes)
- `npm run test:unit` — 31 passed
- `npm run build` — passed, including `check:pack`
- `npm run test:package` — 8 passed

## 💥 Breaking Changes
- None. Existing v1/v2 event names and payload shapes are unchanged.