### PR TITLE
docs(changelog): add 0.9.0 release entry (2026-07-19 → 2026-07-21)

### DIFF
--- a/.ai/runs/2026-07-21-changelog-0.9.0.md
+++ b/.ai/runs/2026-07-21-changelog-0.9.0.md
@@ -32,6 +32,8 @@ Add a `CHANGELOG.md` release entry for 0.9.0 covering the 37 PRs merged into `ma
 
 ## Progress
 
+PR: #589
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Changelog entry

--- a/.ai/runs/2026-07-21-changelog-0.9.0.md
+++ b/.ai/runs/2026-07-21-changelog-0.9.0.md
@@ -1,0 +1,39 @@
+# Execution plan: changelog-0.9.0
+
+Date: 2026-07-21
+Branch: feat/changelog-0.9.0
+Owner: pkarw (via om-auto-update-changelog → om-auto-create-pr)
+
+## Goal
+
+Add a `CHANGELOG.md` release entry for 0.9.0 covering the 37 PRs merged into `main` between 2026-07-19 (tag `0.8.0`) and 2026-07-21.
+
+## Scope
+
+- Create `CHANGELOG.md` at the repo root (the repo has none yet) with the 0.9.0 entry in the default emoji-driven format of `om-auto-update-changelog`: Highlights placeholder, ✨ Features, 🔒 Security, 🐛 Fixes, 📝 Specs & Documentation, 🚀 CI/CD & Infrastructure, 👥 Contributors.
+- Entry content was compiled by `om-auto-update-changelog`: window `2026-07-19 → 2026-07-21`, version `0.9.0` (user-confirmed minor bump over the existing `0.8.0` tag), 37 merged PRs, no supersede detections, contributors @pkarw, @pat-lewczuk, @patzick.
+
+## Non-goals
+
+- No manifest version bump (package.json stays at 0.8.0 — release tooling owns that).
+- No changes to any file other than `CHANGELOG.md`.
+- No Highlights prose — the `<!-- TODO: Highlights -->` marker is left for a human author.
+
+## Implementation Plan
+
+### Phase 1: Changelog entry
+
+- 1.1 Add `CHANGELOG.md` with the compiled 0.9.0 entry.
+
+## Risks
+
+- Repo-wide validation commands (typecheck/tests/build) are code gates; this run is docs-only, so the gate is a manual diff re-read plus verifying every PR number, author, and issue reference against the tracker data.
+- The `0.8.0` heading history is absent (first changelog file) — future runs will use this entry's heading as the `last-release` boundary.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Changelog entry
+
+- [ ] 1.1 Add `CHANGELOG.md` with the compiled 0.9.0 entry.

--- a/.ai/runs/2026-07-21-changelog-0.9.0.md
+++ b/.ai/runs/2026-07-21-changelog-0.9.0.md
@@ -36,4 +36,4 @@ Add a `CHANGELOG.md` release entry for 0.9.0 covering the 37 PRs merged into `ma
 
 ### Phase 1: Changelog entry
 
-- [ ] 1.1 Add `CHANGELOG.md` with the compiled 0.9.0 entry.
+- [x] 1.1 Add `CHANGELOG.md` with the compiled 0.9.0 entry. — 230fffd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# 0.9.0 (2026-07-21)
+
+## Highlights
+<!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
+
+## ✨ Features
+- ✨ Edit the coding agents' own config files (global vs local, raw + highlighted). (#418) *(@pkarw)*
+- ✨ Canonical provider/model identity shared across runners (fixes #405). (#466) *(@pat-lewczuk)*
+- ✨ Runner + model selection for the Continue flow (fixes #401). (#468) *(@pat-lewczuk)*
+- ✨ AskUser structured questions across claude, codex & opencode (fixes #473). (#502) *(@pkarw)*
+- ✨ Multi-project workspace — per-user registry, project-scoped cockpit, config migrations (fixes #520). (#521) *(@pkarw)*
+- ✨ Discover PR/issue refs from skill report lines and GitHub links. (#534) *(@pkarw)*
+- ✨ Grouped sub-agent display — Agents dock + drill-down sheet (fixes #474). (#550) *(@pkarw)*
+- ✨ Render full timeline (commits, labels, merges) with per-commit CI markers (fixes #525). (#552) *(@pkarw)*
+- ✨ Stack, edit and remove prompt messages on a queued run (fixes #472). (#553) *(@pkarw)*
+- ✨ Link clone root to project settings (fixes #561). (#571) *(@pkarw)*
+- ✨ Separate browse and checkout roots. (#572) *(@pkarw)*
+
+## 🔒 Security
+- 🔒 Guard the localhost API against CSRF and DNS rebinding (fixes #426). (#467) *(@pat-lewczuk)*
+
+## 🐛 Fixes
+- 📦 Never push a release commit to protected main. (#514) *(@pat-lewczuk)*
+- 🔄 Stop GitHub nav item flickering — stale-while-revalidate forge probe. (#516) *(@pat-lewczuk)*
+- 🔄 Resolve a stale local base ref to `origin/<base>` to stop phantom diffs. (#518) *(@pat-lewczuk)*
+- 🐛 Skill pickers order most-used → project → global (fixes #519). (#523) *(@pkarw)*
+- 🐛 Label Skill and Agent tool rows in the Session tab (fixes #529). (#532) *(@pkarw)*
+- 🐛 Name the autosave trigger in the commit subject + refuse conflicted trees (#471). (#533) *(@pkarw)*
+- 🐛 Keep reasoning text alive across replay and drop empty "Thinking" rows (fixes #528). (#536) *(@pkarw)*
+- 🐛 A custom hand-off prompt extends the item context instead of replacing it (fixes #524). (#541) *(@pkarw)*
+- 🐛 Preserve thinking across resumed steps (fixes #556). (#564) *(@pkarw)*
+- 🐛 Isolate cross-backend continuation sessions (fixes #562). (#566) *(@pkarw)*
+- 🔐 Default to full permissions (fixes #563). (#568) *(@pkarw)*
+- 🔄 Refresh checkout root after save (fixes #567). (#569) *(@pkarw)*
+- 🐛 Make picker tiers deterministic (fixes #555). (#570) *(@pkarw)*
+- 🐛 Render reasoning snapshot arrays. (#573) *(@pkarw)*
+- 🐛 Show queued task references immediately (fixes #554). (#578) *(@pkarw)*
+- 🐛 Bridge subagents and native questions (fixes #565). (#579) *(@pkarw)*
+- 🐛 Scope subtasks by session id (fixes #551). (#587) *(@pkarw)*
+
+## 📝 Specs & Documentation
+- 📝 Multi-project workspace — per-user `~/.cezar` registry, project-scoped cockpit, config migrations. (#517) *(@pkarw)*
+- 📝 Grouped sub-agent display within a single session. (#522) *(@pkarw)*
+- 📝 GitHub tab timeline events (commits, labels, merges) + per-commit CI markers. (#527) *(@pkarw)*
+- 📝 Worktree file editing from the Files tab (#530). (#531) *(@pkarw)*
+- 📝 Stack, edit and remove prompt messages on a queued run. (#537) *(@pkarw)*
+- 📝 Correct the linting constraint — oxlint, not typescript-eslint. (#560) *(@patzick)*
+- 📝 Discover latest Codex models. (#585) *(@pkarw)*
+
+## 🚀 CI/CD & Infrastructure
+- 🚀 Migrate to TypeScript 7 (native compiler). (#559) *(@patzick)*
+
+## 👥 Contributors
+
+- @pkarw
+- @pat-lewczuk
+- @patzick


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-21-changelog-0.9.0.md
Status: complete

## 🎯 Goal
- Add the `CHANGELOG.md` 0.9.0 release entry covering the 37 PRs merged into `main` between 2026-07-19 (tag `0.8.0`) and 2026-07-21.

## What Changed
- New `CHANGELOG.md` at the repo root (first changelog in this repo) with the 0.9.0 entry: Highlights placeholder, ✨ Features (11), 🔒 Security (1), 🐛 Fixes (17), 📝 Specs & Documentation (7), 🚀 CI/CD & Infrastructure (1), 👥 Contributors (3).

## 🧪 Tests
- Docs-only change — no unit tests. Gate: manual diff re-read plus verification of every PR number, author, and closing-issue reference against tracker data.

## 💥 Breaking Changes
- None.

## 📋 Progress
See the Progress section in the tracking plan.

