### PR TITLE
feat(ui): project-aware browser page titles (#543)

### DIFF
--- a/.ai/runs/2026-07-21-page-title-selected-project.md
+++ b/.ai/runs/2026-07-21-page-title-selected-project.md
@@ -51,4 +51,4 @@ PR: #592
 ### Phase 2: Live shell integration
 
 - [x] 2.1 Wire active project and task/page data into the single AppShellContainer title writer — 368b0af
-- [ ] 2.2 Extend shell tests for scoped, boot, global, no-repo, navigation, and live updates
+- [x] 2.2 Extend shell tests for scoped, boot, global, no-repo, navigation, and live updates — 901f649

--- a/.ai/runs/2026-07-21-page-title-selected-project.md
+++ b/.ai/runs/2026-07-21-page-title-selected-project.md
@@ -45,7 +45,7 @@ PR: #592
 
 ### Phase 1: Pure title and route contracts
 
-- [ ] 1.1 Add the document-title formatter/effect and its table-driven unit tests
+- [x] 1.1 Add the document-title formatter/effect and its table-driven unit tests — 4a7b5de
 - [ ] 1.2 Add the route title-context resolver beside AppRoutes and cover current route families
 
 ### Phase 2: Live shell integration

--- a/.ai/runs/2026-07-21-page-title-selected-project.md
+++ b/.ai/runs/2026-07-21-page-title-selected-project.md
@@ -1,0 +1,59 @@
+# Execution plan: project-aware browser page titles
+
+Source doc: .ai/specs/2026-07-21-page-title-selected-project.md
+
+## Goal
+
+Make the hydrated cockpit browser title identify the selected project and current page or loaded task, using one live writer and truthful fallbacks.
+
+## Scope
+
+- Add a pure document-title formatter and thin React effect.
+- Add project-relative route metadata and a pure route-context resolver beside `AppRoutes`.
+- Resolve the selected project's registry name and task title in `AppShellContainer` using existing project/query primitives.
+- Add unit and shell-integration regression coverage.
+- Preserve the static pre-hydration title and every server/API/state contract.
+
+## Non-goals
+
+- Favicon or unread-count changes.
+- Changes to `src/server/static-ui.ts` or `web/app/index.html`.
+- New router modes, head-management dependencies, project renaming, or server endpoints.
+- Per-task sub-tab suffixes or raw route identifiers in titles.
+
+## Risks
+
+- A health fallback must never label a non-boot project with the boot repository's basename.
+- The shell sits outside `ProjectScopeProvider`; active project identity must use the existing URL-aware helper.
+- Dynamic task titles must reuse the explicit project run-list cache without creating a competing data source.
+- Route metadata can drift unless every route family is covered by the pure resolver tests.
+
+## Implementation Plan
+
+### Phase 1: Pure title and route contracts
+
+1. Add the pure title formatter and thin effect with table-driven unit coverage.
+2. Add route-label metadata and the pure route-context resolver with route-family coverage.
+
+### Phase 2: Live shell integration
+
+1. Wire active project, safe boot fallback, route context, and task title into the shell's sole title writer.
+2. Add shell integration coverage for scoped, boot, global, no-repo, live-name, task-title, and navigation behavior.
+3. Run the complete configured validation gate, self-review, automated review, and browser-title verification.
+
+## Progress
+
+PR: #592
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Pure title and route contracts
+
+- [ ] 1.1 Add the pure title formatter and thin effect with table-driven unit coverage
+- [ ] 1.2 Add route-label metadata and the pure route-context resolver with route-family coverage
+
+### Phase 2: Live shell integration
+
+- [ ] 2.1 Wire active project, safe boot fallback, route context, and task title into the shell's sole title writer
+- [ ] 2.2 Add shell integration coverage for scoped, boot, global, no-repo, live-name, task-title, and navigation behavior
+- [ ] 2.3 Run the complete configured validation gate, self-review, automated review, and browser-title verification

--- a/.ai/runs/2026-07-21-page-title-selected-project.md
+++ b/.ai/runs/2026-07-21-page-title-selected-project.md
@@ -50,5 +50,5 @@ PR: #592
 
 ### Phase 2: Live shell integration
 
-- [ ] 2.1 Wire active project and task/page data into the single AppShellContainer title writer
+- [x] 2.1 Wire active project and task/page data into the single AppShellContainer title writer — 368b0af
 - [ ] 2.2 Extend shell tests for scoped, boot, global, no-repo, navigation, and live updates

--- a/.ai/runs/2026-07-21-page-title-selected-project.md
+++ b/.ai/runs/2026-07-21-page-title-selected-project.md
@@ -46,7 +46,7 @@ PR: #592
 ### Phase 1: Pure title and route contracts
 
 - [x] 1.1 Add the document-title formatter/effect and its table-driven unit tests — 4a7b5de
-- [ ] 1.2 Add the route title-context resolver beside AppRoutes and cover current route families
+- [x] 1.2 Add the route title-context resolver beside AppRoutes and cover current route families — b7018ad
 
 ### Phase 2: Live shell integration
 

--- a/.ai/runs/2026-07-21-page-title-selected-project.md
+++ b/.ai/runs/2026-07-21-page-title-selected-project.md
@@ -4,56 +4,51 @@ Source doc: .ai/specs/2026-07-21-page-title-selected-project.md
 
 ## Goal
 
-Make the hydrated cockpit browser title identify the selected project and current page or loaded task, using one live writer and truthful fallbacks.
+Make the hydrated cockpit browser title identify the selected project and current page or task, using one truthful, live writer while retaining `cezar` as the pre-hydration and no-context fallback.
 
 ## Scope
 
-- Add a pure document-title formatter and thin React effect.
-- Add project-relative route metadata and a pure route-context resolver beside `AppRoutes`.
-- Resolve the selected project's registry name and task title in `AppShellContainer` using existing project/query primitives.
-- Add unit and shell-integration regression coverage.
-- Preserve the static pre-hydration title and every server/API/state contract.
+- Add a pure title formatter and thin React effect hook.
+- Add a route-adjacent, project-prefix-agnostic page-title context resolver.
+- Resolve authoritative project names and loaded task titles in `AppShellContainer` using existing registry, health, router, and query primitives.
+- Add focused unit and shell-integration coverage for formatting, routing, loading/fallback states, navigation, and live updates.
 
 ## Non-goals
 
-- Favicon or unread-count changes.
-- Changes to `src/server/static-ui.ts` or `web/app/index.html`.
-- New router modes, head-management dependencies, project renaming, or server endpoints.
-- Per-task sub-tab suffixes or raw route identifiers in titles.
+- Changing the static SPA or build-hint HTML titles.
+- Adding title badges, unread counts, favicon changes, new APIs, persisted state, or dependencies.
+- Showing raw project/task ids or task-subtab suffixes.
 
 ## Risks
 
-- A health fallback must never label a non-boot project with the boot repository's basename.
-- The shell sits outside `ProjectScopeProvider`; active project identity must use the existing URL-aware helper.
-- Dynamic task titles must reuse the explicit project run-list cache without creating a competing data source.
-- Route metadata can drift unless every route family is covered by the pure resolver tests.
+- Route metadata can drift from `AppRoutes`; table-driven coverage must enumerate every current route family.
+- The boot repo basename must never label a non-boot project during registry loading.
+- Task title lookup must reuse the correct boot/non-boot run-list cache and avoid a startup cache-key flip.
 
 ## Implementation Plan
 
 ### Phase 1: Pure title and route contracts
 
-1. Add the pure title formatter and thin effect with table-driven unit coverage.
-2. Add route-label metadata and the pure route-context resolver with route-family coverage.
+1. Add the document-title formatter/effect and its table-driven unit tests.
+2. Add the route title-context resolver beside `AppRoutes` and cover scoped, nested, dynamic-task, global, and unknown paths.
 
 ### Phase 2: Live shell integration
 
-1. Wire active project, safe boot fallback, route context, and task title into the shell's sole title writer.
-2. Add shell integration coverage for scoped, boot, global, no-repo, live-name, task-title, and navigation behavior.
-3. Run the complete configured validation gate, self-review, automated review, and browser-title verification.
+1. Wire active project and task/page data into the single `AppShellContainer` title writer.
+2. Extend shell tests for scoped, boot, global, no-repo, navigation, and live project/task title updates.
 
 ## Progress
 
-PR: #592
-
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+PR: #592
 
 ### Phase 1: Pure title and route contracts
 
-- [ ] 1.1 Add the pure title formatter and thin effect with table-driven unit coverage
-- [ ] 1.2 Add route-label metadata and the pure route-context resolver with route-family coverage
+- [ ] 1.1 Add the document-title formatter/effect and its table-driven unit tests
+- [ ] 1.2 Add the route title-context resolver beside AppRoutes and cover current route families
 
 ### Phase 2: Live shell integration
 
-- [ ] 2.1 Wire active project, safe boot fallback, route context, and task title into the shell's sole title writer
-- [ ] 2.2 Add shell integration coverage for scoped, boot, global, no-repo, live-name, task-title, and navigation behavior
-- [ ] 2.3 Run the complete configured validation gate, self-review, automated review, and browser-title verification
+- [ ] 2.1 Wire active project and task/page data into the single AppShellContainer title writer
+- [ ] 2.2 Extend shell tests for scoped, boot, global, no-repo, navigation, and live updates

--- a/.ai/specs/2026-07-21-page-title-selected-project.md
+++ b/.ai/specs/2026-07-21-page-title-selected-project.md
@@ -1,0 +1,150 @@
+# Project-aware browser page titles
+
+## TLDR
+
+Update the cockpit's single browser-document title writer so every hydrated route identifies the active project and page while retaining `cezar` as the product suffix and pre-hydration fallback. Use the workspace registry name as the authoritative project label, derive static page labels from the project-relative route map, and use an already loaded run title for task-detail routes without ever exposing raw ids or loading placeholders.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirm? |
+|---|----------|-----------------|-----------|----------|
+| Q1 | What should a global page with no selected project show? | `${pageLabel} · cezar` | It preserves useful page context while avoiding a guessed project and follows the existing honesty rule. | ok |
+| Q2 | Should task subtabs add `Changes`, `Files`, or `Commits` after the task title? | Use the task title alone for every `/tasks/:id/*` route. | The task is the meaningful tab-strip discriminator; omitting subtab text keeps titles compact and avoids expanding the route-label contract. | ok |
+
+## Problem Statement
+
+The static SPA shell title remains `cezar` after hydration, so multiple tabs for different projects or cockpit pages are indistinguishable. The merged multi-project workspace makes the selected project a URL fact and exposes authoritative registry display names, but no runtime seam currently combines that state with route context.
+
+## Proposed Solution
+
+Add a pure title formatter plus a thin React effect hook, add a pure project-relative route-label resolver beside the route table, and call the hook exactly once from `AppShellContainer`. Resolve the active project from the URL-aware project-router helper and registry, fall back to the health repo basename only when registry truth is unavailable, and derive task-detail labels from the shared run-list cache once it has answered.
+
+The static `<title>cezar</title>` in `web/app/index.html` remains the pre-hydration value. The build-hint document in `src/server/static-ui.ts` is a separate non-SPA surface and does not change.
+
+## Research and Alternatives
+
+- The browser-native `document.title` property is sufficient and broadly supported; adding a head-management dependency would create a second abstraction for one string assignment.
+- Accessible title guidance recommends a concise, unique page purpose followed by site identity. The proposed format keeps the selected project first because distinguishing several cezar project tabs is the primary use case, then adds page context and the stable product suffix.
+- React Router supports route metadata through `handle`/`useMatches` in data-router mode, but this cockpit uses declarative `<BrowserRouter><Routes>` routing. Migrating router modes solely for titles would be disproportionate. A pure ordered pattern table beside `AppRoutes` keeps the metadata adjacent to the route source without changing router architecture.
+- Scattered route-level effects were rejected because navigation could briefly expose stale or competing titles. `AppShellContainer` remains the only writer.
+
+References:
+
+- [MDN: Document title](https://developer.mozilla.org/en-US/docs/Web/API/Document/title)
+- [MDN: title accessibility guidance](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title#accessibility)
+- [React Router: route handles](https://reactrouter.com/how-to/using-handle)
+
+## Architecture
+
+### Title primitive
+
+Add `web/app/src/lib/use-document-title.ts` with:
+
+```ts
+export interface DocumentTitleParts {
+  projectName: string | null
+  pageLabel: string | null
+}
+
+export function documentTitleOf(parts: DocumentTitleParts): string
+export function useDocumentTitle(parts: DocumentTitleParts): void
+```
+
+`documentTitleOf` treats null, undefined-at-the-call-site, and empty/whitespace-only strings as absent and returns:
+
+| Project | Page | Result |
+|---------|------|--------|
+| present | present | `${projectName} — ${pageLabel} · cezar` |
+| present | absent | `${projectName} · cezar` |
+| absent | present | `${pageLabel} · cezar` |
+| absent | absent | `cezar` |
+
+`useDocumentTitle` is a thin `useEffect` that assigns the pure result to `document.title` whenever either input changes. It does not restore an intermediate value in effect cleanup: dependency changes must move directly from the old truthful title to the new truthful title without a transient `cezar` write. The app-lifetime owner is `AppShellContainer`.
+
+### Route metadata
+
+Keep a static ordered route-label table next to `AppRoutes` in `web/app/src/routes.tsx`. Export pure helpers that first call `stripProjectPrefix(pathname)` and then match the project-relative route:
+
+| Pattern | Page label |
+|---------|------------|
+| `/` | `Tasks` |
+| `/new` | `New task` |
+| `/compare/:groupId` | `Compare` |
+| `/git/*` | `Git` |
+| `/github/*` | `GitHub` |
+| `/skills` | `Skills` |
+| `/inbox` | `Inbox` |
+| `/workflows/*` | `Workflows` |
+| `/settings/*` and `/settings/global/*` | `Settings` |
+
+Task routes are the one dynamic exception: `/tasks/:id` and every `/tasks/:id/*` child expose the decoded `id` only as a lookup key and return the loaded task title as the page label. Until that title is available, the page label is null. Unknown/not-found routes also return null. Neither case renders a raw identifier, `undefined`, `loading…`, nor a guessed label.
+
+The route helper returns enough structured context for the shell to know whether it needs a task lookup, rather than making a second ad-hoc pathname parser in `AppShellContainer`.
+
+### Project and task resolution
+
+`AppShellContainer` already owns `useHealth()` and `useProjects()`. It additionally reads the URL-aware active project id through `useActiveProjectId()`; this is required because the shell sits above `ProjectScopeProvider`, and the boot project intentionally mounts an unscoped API context even though its URL still carries `/p/:projectId`.
+
+Project-name precedence is:
+
+1. The `useProjects()` registry entry whose id matches the active URL project id.
+2. The health repo basename from `repoChipOf(health.data)` only when health confirms that the active id is the boot project. This is a safe loading/error fallback for the boot project; it must not label a non-boot project with the boot repo's basename.
+3. Null when the route has no project scope (for example `/settings/global/*`), the selected registry entry is unavailable, or no truthful fallback exists.
+
+For task routes, read the active project's run list through the existing explicit-project query seam (`useProjectRuns`), enabled only when a task id exists and the loaded registry identifies the active project. Waiting for that registry fact avoids choosing the wrong boot/non-boot cache key during startup. Pass the boot-project flag so the query shares the same `default`-scoped cache as the boot route; non-boot projects share their project-scoped list cache. Resolve the display value with the canonical `runTitle(run)` helper. React Query deduplicates this subscription with existing list consumers, and SSE/cache updates make task renames update the document title without introducing a second task-title definition.
+
+Finally, call `useDocumentTitle({ projectName, pageLabel })` once in `AppShellContainer`, before rendering the shell.
+
+## Data Model
+
+No persisted data, migrations, configuration, or API response changes. The implementation reads existing `ProjectsResponse`, `HealthResponse`, and run-list data.
+
+## API Contracts
+
+No new endpoints or changes to existing request/response shapes. The registry remains the authority for project display names. Existing `/api/projects`, `/api/health`, and project-scoped run-list queries retain their current error and caching behavior.
+
+## UI/UX
+
+- Before hydration, the tab reads `cezar` exactly as today.
+- A scoped tasks page reads, for example, `cezar — Tasks · cezar` when the registered project is named `cezar`.
+- A scoped task page reads, for example, `cezar — Implement page titles · cezar` after the run list answers; before that it reads `cezar · cezar` rather than exposing the run id or a loading word.
+- A global settings page reads `Settings · cezar` because no project is selected.
+- A project registry rename updates the title on the next authoritative query result; navigation between projects or pages updates the existing title writer rather than mounting another writer.
+- No visible in-page layout changes are introduced. Static mockups and viewport screenshots are not useful for a browser-tab metadata change; implementation QA should verify the browser-reported title across routes instead.
+
+## Edge Cases and Failure Scenarios
+
+- `/api/projects` pending or failed: show a project name only for the confirmed boot project via the health repo fallback; never show the boot name on a non-boot URL.
+- Health pending, unreachable, or `repo: null`: omit the fallback. Page-only context may still render (for example `Settings · cezar`); otherwise use `cezar`.
+- Unknown project or route: do not guess a project/page label. The existing routed error surface remains responsible for its visible explanation.
+- Legacy flat URL during redirect: retain `cezar` or page-only truth until the boot-project scoped URL is known; the redirect's next render supplies the project label.
+- Empty registry names or labels: normalize them as absent so the title never contains blank separators.
+- Task deleted, missing, or not loaded: omit the page label and never expose the id.
+- Task or project renamed: subscribed query data recomputes the title; no boot-time value is cached locally.
+- React StrictMode/effect replay: assignments are idempotent and have no external cleanup resource.
+
+## Risks and Impact Review
+
+- **Risk: route table drift.** A new route could omit title metadata. Keep the ordered label table adjacent to `AppRoutes` and cover every current route family with pure table tests.
+- **Risk: wrong project during registry loading.** Restrict the repo-basename fallback to the health-confirmed boot project.
+- **Risk: extra task-list traffic or a startup cache-key flip.** Enable the explicit project run-list subscription only on task routes after the registry identifies the project, and reuse its existing query keys so established consumers deduplicate the request.
+- **Risk: title flicker/staleness.** Keep one effect writer, derive values from live queries, and do not reset the title during effect cleanup.
+- **Compatibility:** no protected API, CLI, state, workflow, environment, or packaging surface changes. The static `web/app/index.html` title and `src/server/static-ui.ts` stay unchanged.
+- **Rollback:** remove the hook call and helper modules/tests; the static `cezar` title immediately becomes the only title again. No state rollback is needed.
+
+## Phasing
+
+The feature is one independently deployable UI capability delivered in two small phases: establish the pure title/route contracts, then wire live project/task data into the single shell owner.
+
+## Implementation Plan
+
+### Phase 1: Pure title and route contracts
+
+1. Add `web/app/src/lib/use-document-title.ts` with `documentTitleOf` and the thin `useDocumentTitle` effect. Add table-driven unit coverage for both parts, project-only, page-only, neither, empty strings, and dependency updates.
+2. Add the static route-label metadata and pure route-context resolver beside `AppRoutes`. Cover scoped and unscoped paths, every current route family, dynamic task ids, global settings, and unknown routes without mounting the application.
+
+### Phase 2: Live shell integration
+
+1. In `AppShellContainer`, resolve the active URL project, authoritative registry name, safe boot fallback, and task title from the explicit-project run-list cache; call `useDocumentTitle` once.
+2. Extend `app-shell-container.test.tsx` to verify scoped project, boot project, global/page-only behavior, `repo: null`, registry-name changes with no stale title, task-title loading/rename behavior, and navigation between representative pages. Keep `web/app/index.html` and `src/server/static-ui.ts` unchanged.
+3. Run the repository validation gate in order, then exercise representative boot/non-boot project routes and a task rename in the browser. Record the observed `document.title`; viewport screenshots are optional because browser tab chrome is outside the captured app surface.

--- a/web/app/src/components/app-shell-container.test.tsx
+++ b/web/app/src/components/app-shell-container.test.tsx
@@ -1,16 +1,18 @@
-import { QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClientProvider, type QueryClient } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createQueryClient } from '@/api/query-client'
-import type { HealthResponse } from '@/api/types'
+import { workspaceQueryKeys } from '@/api/queries'
+import type { HealthResponse, RunRecord } from '@/api/types'
 import { AppShellContainer, repoChipOf } from '@/components/app-shell-container'
 import { ThemeProvider } from '@/components/theme-provider'
 
 const fetchMock = vi.fn<typeof fetch>()
 
 beforeEach(() => {
+  document.title = 'cezar'
   vi.stubGlobal('fetch', fetchMock)
   // jsdom ships no matchMedia; the shell's breakpoint effect and the theme toggle need one.
   vi.stubGlobal(
@@ -65,18 +67,37 @@ function serve(routes: Record<string, unknown>): void {
   })
 }
 
-function renderShell() {
-  return render(
-    <QueryClientProvider client={createQueryClient()}>
+function renderShell(entry = '/', client: QueryClient = createQueryClient()) {
+  return {
+    client,
+    ...render(
+    <QueryClientProvider client={client}>
       <ThemeProvider>
-        <MemoryRouter initialEntries={['/']}>
+        <MemoryRouter initialEntries={[entry]}>
           <AppShellContainer>
             <p>route content</p>
           </AppShellContainer>
         </MemoryRouter>
       </ThemeProvider>
     </QueryClientProvider>,
-  )
+    ),
+  }
+}
+
+function run(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: 'run-1',
+    title: 'Raw task prompt',
+    titleSummary: 'Implement page titles',
+    workflow: 'quick-task',
+    task: 'Implement page titles',
+    status: 'running',
+    createdAt: '2026-07-21T12:00:00.000Z',
+    tokensUsed: 0,
+    archived: false,
+    steps: [],
+    ...overrides,
+  }
 }
 
 const repoChip = () => document.querySelector('[data-slot="repo-chip"]')
@@ -235,5 +256,99 @@ describe('sidebar wiring', () => {
     await waitFor(() => expect(versionChip()).not.toBeNull())
     expect(versionChip()?.textContent).toBe('v0.1.3')
     expect(repoChip()).toBeNull()
+  })
+})
+
+describe('document title wiring', () => {
+  const REGISTRY = {
+    projects: [PROJECT],
+    bootProject: 'cezar',
+    projectsDir: '/home/me/cezar/projects',
+  }
+  const HEALTH_WITH_BOOT = { ...HEALTH, bootProject: 'cezar' }
+
+  it('combines the selected project with scoped page context', async () => {
+    serve({
+      '/api/health': HEALTH_WITH_BOOT,
+      '/api/todos': [],
+      '/api/projects': {
+        ...REGISTRY,
+        projects: [{ ...PROJECT, id: 'shop', name: 'Storefront' }],
+      },
+      '/api/runs': [],
+    })
+    renderShell('/p/shop/git')
+
+    await waitFor(() => expect(document.title).toBe('Storefront — Git · cezar'))
+  })
+
+  it('falls back to the boot repository name when the registry is unavailable', async () => {
+    serve({ '/api/health': HEALTH_WITH_BOOT, '/api/todos': [], '/api/runs': [] })
+    renderShell('/p/cezar/')
+
+    await waitFor(() => expect(document.title).toBe('cezar — Tasks · cezar'))
+  })
+
+  it('keeps global settings and a no-repo task route free of invented project context', async () => {
+    serve({
+      '/api/health': { ...HEALTH_WITH_BOOT, repo: null },
+      '/api/todos': [],
+      '/api/projects': REGISTRY,
+      '/api/runs': [],
+    })
+    const global = renderShell('/settings/global/projects')
+
+    await waitFor(() => expect(document.title).toBe('Settings · cezar'))
+    global.unmount()
+
+    renderShell('/tasks/missing')
+    await waitFor(() => expect(document.title).toBe('cezar'))
+  })
+
+  it('updates after in-app navigation without remounting the shell', async () => {
+    serve({
+      '/api/health': HEALTH_WITH_BOOT,
+      '/api/todos': [],
+      '/api/projects': REGISTRY,
+      '/api/runs': [],
+    })
+    renderShell('/p/cezar/')
+
+    await waitFor(() => expect(document.title).toBe('cezar — Tasks · cezar'))
+    fireEvent.click(screen.getByRole('link', { name: 'Git' }))
+    await waitFor(() => expect(document.title).toBe('cezar — Git · cezar'))
+  })
+
+  it('reacts to live project and task title cache updates', async () => {
+    const initialRun = run()
+    serve({
+      '/api/health': HEALTH_WITH_BOOT,
+      '/api/todos': [],
+      '/api/projects': {
+        ...REGISTRY,
+        projects: [{ ...PROJECT, id: 'shop', name: 'Storefront' }],
+      },
+      '/api/runs': [],
+      '/api/p/shop/runs': [initialRun],
+    })
+    const { client } = renderShell('/p/shop/tasks/run-1')
+
+    await waitFor(() =>
+      expect(document.title).toBe('Storefront — Implement page titles · cezar'),
+    )
+
+    act(() => {
+      client.setQueryData(workspaceQueryKeys.projects, {
+        ...REGISTRY,
+        projects: [{ ...PROJECT, id: 'shop', name: 'Renamed storefront' }],
+      })
+      client.setQueryData(['shop', 'runs', 'list'], [
+        { ...initialRun, titleSummary: 'Rename browser titles' },
+      ])
+    })
+
+    await waitFor(() =>
+      expect(document.title).toBe('Renamed storefront — Rename browser titles · cezar'),
+    )
   })
 })

--- a/web/app/src/components/app-shell-container.tsx
+++ b/web/app/src/components/app-shell-container.tsx
@@ -58,10 +58,14 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
   const titleContext = pageTitleContext(pathname)
   const bootProjectId = registry?.bootProject ?? health.data?.bootProject ?? null
   const isBootProject = projectId !== null && projectId === bootProjectId
+  const activeProject = registry?.projects.find((project) => project.id === projectId)
   const titleRuns = useProjectRuns(
     projectId ?? '',
-    projectId !== null && titleContext.taskId !== null,
-    isBootProject,
+    // Wait for the registry to identify the project before choosing the boot/non-boot cache
+    // key. Health can arrive first; fetching then would briefly populate a project-scoped key
+    // for the boot project before switching to the authoritative `default` key.
+    activeProject !== undefined && titleContext.taskId !== null,
+    registry?.bootProject === projectId,
   ).data
 
   // Global settings intentionally has no selected project. Everywhere else the URL id selects
@@ -70,7 +74,7 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
   const globalSettings = pathname === '/settings/global' || pathname.startsWith('/settings/global/')
   const projectName = globalSettings
     ? null
-    : (registry?.projects.find((project) => project.id === projectId)?.name ??
+    : (activeProject?.name ??
       (isBootProject ? (repoChipOf(health.data)?.name ?? null) : null))
   const titleRun = titleContext.taskId
     ? titleRuns?.find((run) => run.id === titleContext.taskId)

--- a/web/app/src/components/app-shell-container.tsx
+++ b/web/app/src/components/app-shell-container.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
+import { useLocation } from 'react-router'
 
-import { useHealth, useProjects, useTodos } from '@/api/queries'
+import { useHealth, useProjectRuns, useProjects, useTodos } from '@/api/queries'
 import type { HealthResponse } from '@/api/types'
 import { AppShell, type RepoChip } from '@/components/app-shell'
 import { CommandPalette } from '@/components/command-palette'
@@ -9,6 +10,10 @@ import { ProjectGroups } from '@/components/project-groups'
 import { SkillsBanner } from '@/components/skills-banner'
 import { TaskQuickListContainer } from '@/components/task-quick-list'
 import { ToolsMenu } from '@/components/tools-menu'
+import { useDocumentTitle } from '@/lib/use-document-title'
+import { useActiveProjectId } from '@/lib/project-router'
+import { runTitle } from '@/lib/task-groups'
+import { pageTitleContext } from '@/routes'
 
 /**
  * Derive the sidebar's repo chip from `/api/health`.
@@ -42,12 +47,37 @@ export function repoChipOf(health: HealthResponse | undefined): RepoChip | null 
  * reconcile — not a change here.
  */
 export function AppShellContainer({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation()
+  const projectId = useActiveProjectId()
   const health = useHealth()
   // The global inbox is opt-in (#471). With the capability off there is no Inbox nav item to
   // badge and the endpoint can only answer [], so the query parks rather than polls.
   const inboxAvailable = health.data?.capabilities.followups === true
   const todos = useTodos(inboxAvailable)
   const registry = useProjects().data
+  const titleContext = pageTitleContext(pathname)
+  const bootProjectId = registry?.bootProject ?? health.data?.bootProject ?? null
+  const isBootProject = projectId !== null && projectId === bootProjectId
+  const titleRuns = useProjectRuns(
+    projectId ?? '',
+    projectId !== null && titleContext.taskId !== null,
+    isBootProject,
+  ).data
+
+  // Global settings intentionally has no selected project. Everywhere else the URL id selects
+  // the authoritative registry entry; health may name only the CONFIRMED boot project while
+  // the registry is unavailable, never a non-boot project whose root health does not describe.
+  const globalSettings = pathname === '/settings/global' || pathname.startsWith('/settings/global/')
+  const projectName = globalSettings
+    ? null
+    : (registry?.projects.find((project) => project.id === projectId)?.name ??
+      (isBootProject ? (repoChipOf(health.data)?.name ?? null) : null))
+  const titleRun = titleContext.taskId
+    ? titleRuns?.find((run) => run.id === titleContext.taskId)
+    : undefined
+  const pageLabel = titleRun ? runTitle(titleRun) : titleContext.pageLabel
+
+  useDocumentTitle({ projectName, pageLabel })
 
   // Multi-project sidebar only from the SECOND project on (multi-project spec, "Sidebar").
   // With one registered project — or with the registry still loading, or unreachable — the

--- a/web/app/src/lib/use-document-title.test.ts
+++ b/web/app/src/lib/use-document-title.test.ts
@@ -1,7 +1,11 @@
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { documentTitleOf, useDocumentTitle } from './use-document-title'
+import {
+  documentTitleOf,
+  type DocumentTitleParts,
+  useDocumentTitle,
+} from './use-document-title'
 
 describe('documentTitleOf', () => {
   it.each([
@@ -37,10 +41,13 @@ describe('useDocumentTitle', () => {
   })
 
   it('updates the existing writer when its truthful inputs change', () => {
+    const initialProps: DocumentTitleParts = {
+      projectName: 'Storefront',
+      pageLabel: 'Tasks',
+    }
     const { rerender } = renderHook(
-      (parts: { projectName: string | null; pageLabel: string | null }) =>
-        useDocumentTitle(parts),
-      { initialProps: { projectName: 'Storefront', pageLabel: 'Tasks' } },
+      (parts: DocumentTitleParts) => useDocumentTitle(parts),
+      { initialProps },
     )
 
     expect(document.title).toBe('Storefront — Tasks · cezar')

--- a/web/app/src/lib/use-document-title.test.ts
+++ b/web/app/src/lib/use-document-title.test.ts
@@ -1,0 +1,60 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { documentTitleOf, useDocumentTitle } from './use-document-title'
+
+afterEach(() => {
+  cleanup()
+  document.title = 'cezar'
+})
+
+describe('documentTitleOf', () => {
+  it.each([
+    {
+      name: 'project and page',
+      projectName: 'storefront',
+      pageLabel: 'Tasks',
+      expected: 'storefront — Tasks · cezar',
+    },
+    {
+      name: 'project only',
+      projectName: 'storefront',
+      pageLabel: null,
+      expected: 'storefront · cezar',
+    },
+    {
+      name: 'page only',
+      projectName: null,
+      pageLabel: 'Settings',
+      expected: 'Settings · cezar',
+    },
+    { name: 'neither', projectName: null, pageLabel: null, expected: 'cezar' },
+    { name: 'empty strings', projectName: '', pageLabel: '', expected: 'cezar' },
+    { name: 'whitespace', projectName: '   ', pageLabel: '\n', expected: 'cezar' },
+  ])('$name', ({ projectName, pageLabel, expected }) => {
+    expect(documentTitleOf({ projectName, pageLabel })).toBe(expected)
+  })
+
+  it('trims the known parts before formatting', () => {
+    expect(documentTitleOf({ projectName: ' storefront ', pageLabel: ' Tasks ' })).toBe(
+      'storefront — Tasks · cezar',
+    )
+  })
+})
+
+describe('useDocumentTitle', () => {
+  it('updates the same document title when its inputs change', () => {
+    const { rerender } = renderHook(
+      ({ projectName, pageLabel }) => useDocumentTitle({ projectName, pageLabel }),
+      { initialProps: { projectName: 'cezar', pageLabel: 'Tasks' as string | null } },
+    )
+
+    expect(document.title).toBe('cezar — Tasks · cezar')
+
+    rerender({ projectName: 'storefront', pageLabel: 'Git' })
+    expect(document.title).toBe('storefront — Git · cezar')
+
+    rerender({ projectName: '', pageLabel: null })
+    expect(document.title).toBe('cezar')
+  })
+})

--- a/web/app/src/lib/use-document-title.test.ts
+++ b/web/app/src/lib/use-document-title.test.ts
@@ -1,26 +1,21 @@
-import { cleanup, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { documentTitleOf, useDocumentTitle } from './use-document-title'
-
-afterEach(() => {
-  cleanup()
-  document.title = 'cezar'
-})
 
 describe('documentTitleOf', () => {
   it.each([
     {
       name: 'project and page',
-      projectName: 'storefront',
+      projectName: 'Storefront',
       pageLabel: 'Tasks',
-      expected: 'storefront — Tasks · cezar',
+      expected: 'Storefront — Tasks · cezar',
     },
     {
       name: 'project only',
-      projectName: 'storefront',
+      projectName: 'Storefront',
       pageLabel: null,
-      expected: 'storefront · cezar',
+      expected: 'Storefront · cezar',
     },
     {
       name: 'page only',
@@ -28,33 +23,28 @@ describe('documentTitleOf', () => {
       pageLabel: 'Settings',
       expected: 'Settings · cezar',
     },
-    { name: 'neither', projectName: null, pageLabel: null, expected: 'cezar' },
-    { name: 'empty strings', projectName: '', pageLabel: '', expected: 'cezar' },
-    { name: 'whitespace', projectName: '   ', pageLabel: '\n', expected: 'cezar' },
-  ])('$name', ({ projectName, pageLabel, expected }) => {
+    { name: 'neither part', projectName: null, pageLabel: null, expected: 'cezar' },
+    { name: 'empty project', projectName: '', pageLabel: 'Tasks', expected: 'Tasks · cezar' },
+    { name: 'blank parts', projectName: '  ', pageLabel: '\t', expected: 'cezar' },
+  ])('formats $name', ({ projectName, pageLabel, expected }) => {
     expect(documentTitleOf({ projectName, pageLabel })).toBe(expected)
-  })
-
-  it('trims the known parts before formatting', () => {
-    expect(documentTitleOf({ projectName: ' storefront ', pageLabel: ' Tasks ' })).toBe(
-      'storefront — Tasks · cezar',
-    )
   })
 })
 
 describe('useDocumentTitle', () => {
-  it('updates the same document title when its inputs change', () => {
+  beforeEach(() => {
+    document.title = 'cezar'
+  })
+
+  it('updates the existing writer when its truthful inputs change', () => {
     const { rerender } = renderHook(
-      ({ projectName, pageLabel }) => useDocumentTitle({ projectName, pageLabel }),
-      { initialProps: { projectName: 'cezar', pageLabel: 'Tasks' as string | null } },
+      (parts: { projectName: string | null; pageLabel: string | null }) =>
+        useDocumentTitle(parts),
+      { initialProps: { projectName: 'Storefront', pageLabel: 'Tasks' } },
     )
 
-    expect(document.title).toBe('cezar — Tasks · cezar')
-
-    rerender({ projectName: 'storefront', pageLabel: 'Git' })
-    expect(document.title).toBe('storefront — Git · cezar')
-
-    rerender({ projectName: '', pageLabel: null })
-    expect(document.title).toBe('cezar')
+    expect(document.title).toBe('Storefront — Tasks · cezar')
+    rerender({ projectName: 'Back office', pageLabel: null })
+    expect(document.title).toBe('Back office · cezar')
   })
 })

--- a/web/app/src/lib/use-document-title.ts
+++ b/web/app/src/lib/use-document-title.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+
+export interface DocumentTitleParts {
+  projectName: string | null
+  pageLabel: string | null
+}
+
+const present = (value: string | null): string | null => value?.trim() || null
+
+/** Pure browser-title grammar: context first, stable product name last. */
+export function documentTitleOf({ projectName, pageLabel }: DocumentTitleParts): string {
+  const project = present(projectName)
+  const page = present(pageLabel)
+
+  if (project && page) return `${project} — ${page} · cezar`
+  if (project) return `${project} · cezar`
+  if (page) return `${page} · cezar`
+  return 'cezar'
+}
+
+/** The cockpit's single hydrated `document.title` writer. */
+export function useDocumentTitle(parts: DocumentTitleParts): void {
+  const title = documentTitleOf(parts)
+
+  useEffect(() => {
+    document.title = title
+  }, [title])
+}

--- a/web/app/src/lib/use-document-title.ts
+++ b/web/app/src/lib/use-document-title.ts
@@ -5,12 +5,15 @@ export interface DocumentTitleParts {
   pageLabel: string | null
 }
 
-const present = (value: string | null): string | null => value?.trim() || null
+function titlePart(value: string | null): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
 
-/** Pure browser-title grammar: context first, stable product name last. */
+/** The browser-tab grammar, kept pure so loading and fallback states are exhaustive in tests. */
 export function documentTitleOf({ projectName, pageLabel }: DocumentTitleParts): string {
-  const project = present(projectName)
-  const page = present(pageLabel)
+  const project = titlePart(projectName)
+  const page = titlePart(pageLabel)
 
   if (project && page) return `${project} — ${page} · cezar`
   if (project) return `${project} · cezar`
@@ -18,10 +21,9 @@ export function documentTitleOf({ projectName, pageLabel }: DocumentTitleParts):
   return 'cezar'
 }
 
-/** The cockpit's single hydrated `document.title` writer. */
+/** The cockpit's single runtime document-title writer. */
 export function useDocumentTitle(parts: DocumentTitleParts): void {
   const title = documentTitleOf(parts)
-
   useEffect(() => {
     document.title = title
   }, [title])

--- a/web/app/src/routes.test.tsx
+++ b/web/app/src/routes.test.tsx
@@ -9,7 +9,7 @@ import type { ProjectsResponse } from './api/types'
 import { AppearanceProvider } from './components/appearance-provider'
 import { ListViewProvider } from './components/list-view'
 import { ThemeProvider } from './components/theme-provider'
-import { AppRoutes } from './routes'
+import { AppRoutes, pageTitleContext } from './routes'
 import { resetDraft } from './routes/new-task-draft'
 
 // The `/` overview fetches `/api/runs` on mount. A never-answering fetch keeps every route
@@ -128,6 +128,37 @@ function currentSearch(): string | null {
 function currentHash(): string | null {
   return screen.getByTestId('location').getAttribute('data-hash')
 }
+
+describe('pageTitleContext', () => {
+  it.each([
+    ['/p/cezar/', 'Tasks'],
+    ['/new', 'New task'],
+    ['/p/cezar/compare/group-1', 'Compare'],
+    ['/p/cezar/git', 'Git'],
+    ['/p/cezar/git/commits/abc123', 'Git'],
+    ['/p/cezar/github/issues/543', 'GitHub'],
+    ['/p/cezar/skills', 'Skills'],
+    ['/p/cezar/inbox', 'Inbox'],
+    ['/p/cezar/workflows/quick-task', 'Workflows'],
+    ['/p/cezar/settings/agents', 'Settings'],
+    ['/settings/global/projects', 'Settings'],
+  ])('labels %s as %s', (pathname, pageLabel) => {
+    expect(pageTitleContext(pathname)).toEqual({ pageLabel, taskId: null })
+  })
+
+  it.each([
+    '/p/cezar/tasks/run-1',
+    '/p/cezar/tasks/run-1/changes',
+    '/p/cezar/tasks/run-1/files',
+    '/p/cezar/tasks/run-1/commits/abc123',
+  ])('returns the task lookup key for %s', (pathname) => {
+    expect(pageTitleContext(pathname)).toEqual({ pageLabel: null, taskId: 'run-1' })
+  })
+
+  it('does not invent a label for an unknown route', () => {
+    expect(pageTitleContext('/p/cezar/not-a-route')).toEqual({ pageLabel: null, taskId: null })
+  })
+})
 
 /** The URL contract from the spec's "Routing — every surface is a URL" section, now under the
  *  `/p/:projectId` prefix (multi-project spec, step 3.2). These paths are pasteable links;

--- a/web/app/src/routes.tsx
+++ b/web/app/src/routes.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from 'react'
 import {
+  matchPath,
   Navigate,
   Outlet,
   Route,
@@ -10,7 +11,7 @@ import {
 
 import { useHealth, useProjects } from './api/queries'
 import { ProjectScopeProvider } from './api/project-scope-context'
-import { Navigate as ScopedNavigate } from './lib/project-router'
+import { Navigate as ScopedNavigate, stripProjectPrefix } from './lib/project-router'
 import { CompareLoading } from './routes/compare-loading'
 import { GithubLoading } from './routes/github/github-loading'
 import { InboxRoute } from './routes/inbox'
@@ -232,6 +233,35 @@ function LegacyPathRedirect() {
       replace
     />
   )
+}
+
+export interface PageTitleContext {
+  pageLabel: string | null
+  taskId: string | null
+}
+
+const PAGE_TITLE_ROUTES = [
+  { pattern: '/', pageLabel: 'Tasks' },
+  { pattern: '/new', pageLabel: 'New task' },
+  { pattern: '/compare/:groupId', pageLabel: 'Compare' },
+  { pattern: '/git/*', pageLabel: 'Git' },
+  { pattern: '/github/*', pageLabel: 'GitHub' },
+  { pattern: '/skills', pageLabel: 'Skills' },
+  { pattern: '/inbox', pageLabel: 'Inbox' },
+  { pattern: '/workflows/*', pageLabel: 'Workflows' },
+  { pattern: '/settings/*', pageLabel: 'Settings' },
+] as const
+
+/** Browser-title context from the project-relative route map; raw ids are lookup keys only. */
+export function pageTitleContext(pathname: string): PageTitleContext {
+  const projectPath = stripProjectPrefix(pathname)
+  const task = matchPath({ path: '/tasks/:id/*', end: true }, projectPath)
+  if (task) return { pageLabel: null, taskId: task.params.id ?? null }
+
+  const route = PAGE_TITLE_ROUTES.find(({ pattern }) =>
+    matchPath({ path: pattern, end: true }, projectPath),
+  )
+  return { pageLabel: route?.pageLabel ?? null, taskId: null }
 }
 
 /** The route map from the spec's "Routing — every surface is a URL" section.


### PR DESCRIPTION
Closes #543
Tracking plan: .ai/runs/2026-07-21-page-title-selected-project.md
Source doc: .ai/specs/2026-07-21-page-title-selected-project.md
Status: in-progress

## 🎯 Goal
- Make the hydrated cockpit browser title identify the selected project and current page or loaded task, without guessed names, raw ids, or competing writers.

## What Changed
- Added the feature specification and progress-tracked implementation plan.
- Runtime implementation and regression tests are in progress on this same PR.

## 🧪 Tests
- Pending the configured validation gate and browser-title verification.

## 💥 Breaking Changes
- None.

## 📋 Progress
See the Progress section in the tracking plan.