### PR TITLE
fix(git): scope repointed review changes (#591)

### DIFF
--- a/src/server/git-changes.test.ts
+++ b/src/server/git-changes.test.ts
@@ -136,12 +136,13 @@ describe('collectChanges — structured diff vs base', () => {
     writeFileSync(join(dir, 'reviewed.txt'), 'belongs to the reviewed PR\n');
     g(dir, 'add', '-A');
     g(dir, 'commit', '-m', 'reviewed change');
-    writeFileSync(join(dir, 'local.txt'), 'made by this review task\n');
+    writeFileSync(join(dir, 'reviewed.txt'), 'resolved locally by this review task\n');
+    g(dir, 'add', 'reviewed.txt');
 
     const result = await collectChanges(dir, 'main', { taskBranch: 'cez/task1234' });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.changes.files.map((file) => file.path)).toEqual(['local.txt']);
+    expect(result.changes.files.map((file) => file.path)).toEqual(['reviewed.txt']);
     expect(result.changes.repointedHead).toEqual({
       headBranch: 'review/pr-42',
       taskBranch: 'cez/task1234',
@@ -485,12 +486,12 @@ describe('session git API routes', () => {
     g(worktree, 'add', '-A');
     g(worktree, 'commit', '-m', 'reviewed change');
     g(worktree, 'branch', '-m', 'review/pr-42');
-    writeFileSync(join(worktree, 'local.txt'), 'uncommitted review work\n');
+    writeFileSync(join(worktree, 'reviewed.txt'), 'uncommitted conflict resolution\n');
 
     const res = await apiRequest(app, `/api/runs/${run.id}/changes`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as ChangesPayload;
-    expect(body.files.map((file) => file.path)).toEqual(['local.txt']);
+    expect(body.files.map((file) => file.path)).toEqual(['reviewed.txt']);
     expect(body.repointedHead).toEqual({ headBranch: 'review/pr-42', taskBranch: 'task' });
   });
 

--- a/src/server/git-changes.test.ts
+++ b/src/server/git-changes.test.ts
@@ -128,6 +128,42 @@ describe('collectChanges — structured diff vs base', () => {
     expect(result.changes.stat).toEqual({ adds: 0, dels: 0, files: 0 });
   });
 
+  it('limits a repointed task worktree to uncommitted changes', async () => {
+    writeFileSync(join(dir, 'base.txt'), 'base\n');
+    g(dir, 'add', '-A');
+    g(dir, 'commit', '-m', 'base');
+    g(dir, 'checkout', '-b', 'review/pr-42');
+    writeFileSync(join(dir, 'reviewed.txt'), 'belongs to the reviewed PR\n');
+    g(dir, 'add', '-A');
+    g(dir, 'commit', '-m', 'reviewed change');
+    writeFileSync(join(dir, 'local.txt'), 'made by this review task\n');
+
+    const result = await collectChanges(dir, 'main', { taskBranch: 'cez/task1234' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.changes.files.map((file) => file.path)).toEqual(['local.txt']);
+    expect(result.changes.repointedHead).toEqual({
+      headBranch: 'review/pr-42',
+      taskBranch: 'cez/task1234',
+    });
+  });
+
+  it('keeps committed task changes when HEAD matches the task branch', async () => {
+    writeFileSync(join(dir, 'base.txt'), 'base\n');
+    g(dir, 'add', '-A');
+    g(dir, 'commit', '-m', 'base');
+    g(dir, 'checkout', '-b', 'cez/task1234');
+    writeFileSync(join(dir, 'task.txt'), 'task change\n');
+    g(dir, 'add', '-A');
+    g(dir, 'commit', '-m', 'task change');
+
+    const result = await collectChanges(dir, 'main', { taskBranch: 'cez/task1234' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.changes.files.map((file) => file.path)).toEqual(['task.txt']);
+    expect(result.changes.repointedHead).toBeUndefined();
+  });
+
   it('caps oversized per-file patches with a truncation note', async () => {
     writeFileSync(join(dir, 'a.txt'), 'hello\n');
     g(dir, 'add', '-A');
@@ -442,6 +478,20 @@ describe('session git API routes', () => {
     expect(body.stat).toEqual({ adds: 1, dels: 0, files: 1 });
 
     expect((await apiRequest(app, '/api/runs/nope/changes')).status).toBe(404);
+  });
+
+  it('GET /changes uses the persisted task branch to detect a repointed HEAD', async () => {
+    writeFileSync(join(worktree, 'reviewed.txt'), 'reviewed branch history\n');
+    g(worktree, 'add', '-A');
+    g(worktree, 'commit', '-m', 'reviewed change');
+    g(worktree, 'branch', '-m', 'review/pr-42');
+    writeFileSync(join(worktree, 'local.txt'), 'uncommitted review work\n');
+
+    const res = await apiRequest(app, `/api/runs/${run.id}/changes`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ChangesPayload;
+    expect(body.files.map((file) => file.path)).toEqual(['local.txt']);
+    expect(body.repointedHead).toEqual({ headBranch: 'review/pr-42', taskBranch: 'task' });
   });
 
   it('runs without a worktree get 409 + reason (JSON, never HTML) on every session-git route', async () => {

--- a/src/server/git-changes.ts
+++ b/src/server/git-changes.ts
@@ -72,6 +72,10 @@ export interface ChangedFile {
 export interface ChangesPayload {
   files: ChangedFile[];
   stat: { adds: number; dels: number; files: number };
+  /** Present when a run worktree was repointed away from the task branch (#591). In that case the
+   *  payload is intentionally limited to uncommitted changes instead of attributing the
+   *  checked-out branch's history to this task. */
+  repointedHead?: { headBranch: string; taskBranch: string };
 }
 
 export type ChangesResult = { ok: true; changes: ChangesPayload } | { ok: false; error: string };
@@ -246,7 +250,7 @@ function statusWord(letter: string): ChangedFile['status'] {
 export async function collectChanges(
   dir: string,
   baseBranch: string,
-  opts: { patchCap?: number; intentToAdd?: boolean } = {},
+  opts: { patchCap?: number; intentToAdd?: boolean; taskBranch?: string } = {},
 ): Promise<ChangesResult> {
   if (!isSafeGitRef(baseBranch)) return { ok: false, error: 'refusing option-like base ref' };
   const patchCap = opts.patchCap ?? PATCH_CAP;
@@ -267,7 +271,18 @@ export async function collectChanges(
       await git(dir, ['add', '-N', '.']);
     }
     const mergeBase = await git(dir, ['merge-base', baseBranch, 'HEAD']);
-    const base = mergeBase.ok && mergeBase.stdout.trim() ? mergeBase.stdout.trim() : baseBranch;
+    const headBranchResult = opts.taskBranch
+      ? await git(dir, ['rev-parse', '--abbrev-ref', 'HEAD'])
+      : undefined;
+    const headBranch = headBranchResult?.ok ? headBranchResult.stdout.trim() : '';
+    const repointedHead = opts.taskBranch && headBranch && headBranch !== opts.taskBranch
+      ? { headBranch, taskBranch: opts.taskBranch }
+      : undefined;
+    const base = repointedHead
+      ? 'HEAD'
+      : mergeBase.ok && mergeBase.stdout.trim()
+        ? mergeBase.stdout.trim()
+        : baseBranch;
 
     const nameStatus = await git(dir, ['diff', '--name-status', '-z', '-M', base], env);
     if (!nameStatus.ok) return { ok: false, error: gitReason(nameStatus, 'git diff failed') };
@@ -276,7 +291,13 @@ export async function collectChanges(
     const patchOut = await git(dir, ['diff', '--patch', '-M', '--no-color', base], env);
     if (!patchOut.ok) return { ok: false, error: gitReason(patchOut, 'git diff failed') };
 
-    return { ok: true, changes: assemblePayload(nameStatus.stdout, numstat.stdout, patchOut.stdout, patchCap) };
+    return {
+      ok: true,
+      changes: {
+        ...assemblePayload(nameStatus.stdout, numstat.stdout, patchOut.stdout, patchCap),
+        ...(repointedHead ? { repointedHead } : {}),
+      },
+    };
   } finally {
     if (scratchIndex) rmSync(scratchIndex, { force: true });
   }
@@ -345,9 +366,10 @@ export interface RunCommit {
 export type RunCommitsResult = { ok: true; commits: RunCommit[] } | { ok: false; error: string };
 
 /**
- * The commits a run made on its worktree branch: `<merge-base>..HEAD`, newest first — the same
- * range `collectChanges` diffs, so the commit list and the aggregate Changes tab always agree on
- * what "this task's work" means. Empty (not an error) when the branch has no commits past base.
+ * The commits reachable from the worktree's current HEAD after its base, newest first. A review
+ * task may deliberately repoint HEAD to the reviewed branch, so this list retains that useful
+ * history even though `collectChanges` narrows its payload to uncommitted work in that case.
+ * Empty (not an error) when the branch has no commits past base.
  */
 export async function collectRunCommits(dir: string, baseBranch: string): Promise<RunCommitsResult> {
   if (!isSafeGitRef(baseBranch)) return { ok: false, error: 'refusing option-like base ref' };

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2212,7 +2212,7 @@ export function createApp(deps: ServerDeps): Hono {
     if (!run) return c.json({ error: 'not found' }, 404);
     const worktree = worktreeOf(run);
     if (!worktree) return c.json({ error: NO_WORKTREE }, 409);
-    const result = await collectChanges(worktree, run.baseBranch ?? 'HEAD');
+    const result = await collectChanges(worktree, run.baseBranch ?? 'HEAD', { taskBranch: run.branch });
     if (!result.ok) return c.json({ error: result.error }, 409);
     return c.json(result.changes);
   });

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -422,6 +422,8 @@ export interface ChangedFile {
 export interface ChangesPayload {
   files: ChangedFile[]
   stat: { adds: number; dels: number; files: number }
+  /** Additive context for review tasks whose worktree HEAD no longer matches their own branch. */
+  repointedHead?: { headBranch: string; taskBranch: string }
 }
 
 /** `GET /api/runs/:id/files?path=` — a directory listing or one file (size-capped, binary

--- a/web/app/src/routes/task-git/task-changes.test.tsx
+++ b/web/app/src/routes/task-git/task-changes.test.tsx
@@ -175,6 +175,23 @@ describe('the Changes tab route', () => {
     expect(toolbarAction('commit')?.title).toContain('no changes to commit')
   })
 
+  it('explains when a repointed review worktree shows only uncommitted changes', async () => {
+    stubFetch({
+      'GET /api/runs/r1/changes': () =>
+        jsonResponse({
+          files: [],
+          stat: { adds: 0, dels: 0, files: 0 },
+          repointedHead: { headBranch: 'review/pr-42', taskBranch: 'cez/abc12345' },
+        }),
+    })
+    renderChangesRoute()
+
+    await waitFor(() => expect(document.querySelector('[data-slot="repointed-head-note"]')).not.toBeNull())
+    expect(document.querySelector('[data-slot="repointed-head-note"]')?.textContent).toContain(
+      "HEAD is on review/pr-42, not this task's branch cez/abc12345 — showing uncommitted changes only.",
+    )
+  })
+
   it('a 409 ("no worktree") renders the server reason and disables the git actions', async () => {
     stubFetch({
       'GET /api/runs/r1/changes': () =>

--- a/web/app/src/routes/task-git/task-changes.tsx
+++ b/web/app/src/routes/task-git/task-changes.tsx
@@ -157,6 +157,13 @@ function ChangesView({ run }: { run: ApiRun }) {
         onAction={onAction}
       />
 
+      {changes.data?.repointedHead ? (
+        <p data-slot="repointed-head-note" className="border-b px-4 py-2 text-xs text-soft-foreground md:px-6">
+          HEAD is on <code>{changes.data.repointedHead.headBranch}</code>, not this task&apos;s branch{' '}
+          <code>{changes.data.repointedHead.taskBranch}</code> — showing uncommitted changes only.
+        </p>
+      ) : null}
+
       {changes.isPending ? (
         <p data-slot="changes-loading" className="px-4 py-6 text-center text-xs text-soft-foreground md:px-6">
           Loading changes…


### PR DESCRIPTION
Closes #591

## 🎯 Goal
- Show only work performed by a review task when its worktree HEAD has been repointed to the reviewed PR branch.

## 🔍 Problem
The Changes tab anchored its diff at the merge-base of the configured base branch and the worktree HEAD. Review workflows repoint HEAD to the reviewed PR, causing the tab to attribute that PR’s entire diff to the review task; the added issue evidence also showed real tracked edits missing from the tab.

## 🔍 Root Cause
The run changes route did not pass the persisted task branch to `collectChanges`, so the collector could not distinguish the task’s own branch from a foreign checked-out branch.

## What Changed
- Detect when the actual worktree branch differs from the persisted task branch and anchor Changes at `HEAD`, retaining staged, unstaged, and untracked task edits without including reviewed-PR history.
- Return additive `repointedHead` context and explain the narrowed mode in the Changes UI.
- Keep the Commits tab’s reviewed-branch history intentionally unchanged.
- Cover repointed staged and unstaged tracked edits, normal task commits, route propagation, and UI messaging.

## 🧪 Tests
- `npm run typecheck`
- `npm test` — 3,859 passed
- `npm run test:unit` — 31 passed
- `npm run build` — passed, including `check:pack`
- `npm run test:package` — 8 passed
- Focused follow-up after the latest issue comment — 86 passed

Note: the full local gate was run with ambient `CEZ_REMOTE` unset so tests exercised the repository’s default local-mode contract.

## 💥 Breaking Changes
- None. The response change is additive and existing route fields remain unchanged.