### PR TITLE
perf(cockpit): virtualize the diff and the task commit list

### DIFF
--- a/web/app/e2e/commit-list.e2e.ts
+++ b/web/app/e2e/commit-list.e2e.ts
@@ -1,0 +1,246 @@
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { AgentBrowser } from './agent-browser'
+import record from './fixtures/thread-run.record.json'
+
+/**
+ * The task Commits tab's virtualization (`routes/task-git/commit-list.tsx`), in a real browser,
+ * over a run whose branch carries more commits than the threshold.
+ *
+ * WHY THIS ROUTE AND NOT THE REPO ONE. The repo Commits segment cannot reach the threshold —
+ * `getLog` (src/server/git.ts) defaults to 20 and the server calls it without a count, so that
+ * list is 20 rows by construction. The task tab's source, `collectRunCommits`, runs
+ * `git log <merge-base>..HEAD` with NO cap, and cezar autosaves a commit per turn, so THIS is
+ * the list that actually grows. Testing the capped one would prove nothing.
+ *
+ * HONESTY NOTE: as with the diff spec, "bounded DOM" is the proxy for smoothness; frame timing
+ * is not measured. The fixture is generated so the row count is controlled rather than ambient.
+ */
+
+const repoRoot = resolve(import.meta.dirname, '../../..')
+const sessionId = `e2e-commit-list-${process.pid}`
+
+/** Past COMMIT_VIRTUALIZE_THRESHOLD (150) with room to spare. */
+const COMMITS = 200
+
+const RUN_ID = 'cccccccc-2222-4333-8444-ddddddddeeee'
+
+const MAIN = `document.querySelector('[data-slot="main"]')`
+const rowCount = () => browser.count('[data-slot="commit-row"]')
+
+/** Fractional-layout slack for the fold measurement below. Deliberately tiny: the regression
+ *  it must still catch is tens of pixels, so this cannot launder a real gap into a pass. */
+const SUB_PIXEL = 2
+
+let browser: AgentBrowser
+let server: ChildProcess
+let dataRoot: string
+let baseUrl: string
+/** The newest commit's sha — the only one the fixture gives a real diff (the rest are
+ *  `--allow-empty` for speed), so the routing test must click THAT row specifically. */
+let newestSha = ''
+
+function freePort(): Promise<number> {
+  return new Promise((done, fail) => {
+    const probe = createServer()
+    probe.once('error', fail)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      probe.close(() => done(port))
+    })
+  })
+}
+
+async function waitForHealth(url: string): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      if ((await fetch(`${url}/api/health`)).ok) return
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`cezar e2e: the fixture server never answered at ${url}`)
+}
+
+/**
+ * A worktree on `cez/…` carrying COMMITS commits past `main` — the shape the tab reads.
+ *
+ * Built through ONE `git fast-import` rather than a `git commit` per commit. That is not
+ * premature cleverness: spawning git 200 times from Node measured **79 seconds**, 85% of this
+ * spec's entire runtime (the same loop in a shell is ~10s, so most of it is process-spawn
+ * overhead, not git). fast-import streams the whole history to a single process in well under
+ * a second.
+ */
+function buildWorktree(dir: string): void {
+  mkdirSync(dir, { recursive: true })
+  const git = (args: string[], input?: string) =>
+    execFileSync('git', args, { cwd: dir, stdio: input === undefined ? 'ignore' : ['pipe', 'ignore', 'ignore'], input })
+  git(['init', '-q', '-b', 'main'])
+
+  const branch = `cez/${RUN_ID.slice(0, 8)}`
+  const who = 'cezar e2e <e2e@example.com> 1700000000 +0000'
+  // `data <n>` is a BYTE count, so every payload goes through Buffer.byteLength.
+  const blob = (body: string) => `M 100644 inline README.md\ndata ${Buffer.byteLength(body)}\n${body}\n`
+  const commit = (message: string, tree = '') =>
+    `commit refs/heads/${branch}\ncommitter ${who}\ndata ${Buffer.byteLength(message)}\n${message}\n${tree}\n`
+
+  const stream: string[] = [
+    // The base commit, then branch off it — `collectRunCommits` diffs `merge-base main..HEAD`.
+    `commit refs/heads/main\ncommitter ${who}\ndata 4\nbase\n${blob('base\n')}\n`,
+    `reset refs/heads/${branch}\nfrom refs/heads/main\n\n`,
+  ]
+  // Commits with no `M` line reuse the parent's tree — fast-import's `--allow-empty`, and the
+  // reason this spec can afford 200 of them: the list only ever reads the log.
+  for (let index = 0; index < COMMITS - 1; index += 1) stream.push(commit(`autosave: change ${index}`))
+  // …except the NEWEST one, which the routing test clicks: an empty commit renders the honest
+  // "No file changes" state, and asserting a diff appears would then be asserting a bug.
+  stream.push(commit('autosave: a commit with an actual diff', blob('base\nedited by the newest commit\n')))
+
+  git(['fast-import', '--quiet'], stream.join(''))
+  git(['checkout', '-q', branch])
+}
+
+/** Open the tab and wait for virtua to have MOUNTED rows — not merely for the container to
+ *  exist. Asserting in the tick the container appears reads a window virtua hasn't filled yet,
+ *  which looks exactly like "zero rows mounted" and is purely a settling artifact. */
+function openCommits() {
+  browser.goto(`${baseUrl}/tasks/${RUN_ID}/commits`)
+  browser.waitForFunction(`document.querySelector('[data-slot="task-commits"]') !== null`)
+  browser.waitForFunction(`document.querySelectorAll('[data-slot="commit-row"]').length > 0`)
+}
+
+beforeAll(async () => {
+  dataRoot = mkdtempSync(join(tmpdir(), 'cezar-e2e-commit-list-'))
+  const worktree = join(dataRoot, '.ai/cezar/worktrees', RUN_ID)
+  mkdirSync(join(dataRoot, '.ai/cezar/runs'), { recursive: true })
+  buildWorktree(worktree)
+
+  const run = {
+    ...record,
+    id: RUN_ID,
+    title: 'A task that committed a great many times',
+    titleSummary: 'Many commits',
+    task: 'Commit repeatedly.',
+    worktreePath: worktree,
+    branch: `cez/${RUN_ID.slice(0, 8)}`,
+    baseBranch: 'main',
+    steps: [record.steps[0]],
+    pullRequestUrl: undefined,
+  }
+  writeFileSync(join(dataRoot, '.ai/cezar/runs.json'), JSON.stringify([run], null, 2), 'utf8')
+
+  const port = await freePort()
+  baseUrl = `http://localhost:${port}`
+  server = spawn(
+    process.execPath,
+    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    { env: { ...process.env, CEZ_DRY_RUN: '1' }, stdio: 'ignore' },
+  )
+  await waitForHealth(baseUrl)
+  const commits = (await (await fetch(`${baseUrl}/api/runs/${RUN_ID}/commits`)).json()) as {
+    commits: Array<{ sha: string }>
+  }
+  newestSha = commits.commits[0]?.sha ?? ''
+
+  browser = AgentBrowser.open(sessionId)
+  browser.setViewport(1440, 900)
+  // ONE page load for the whole file. Every agent-browser operation is a separate CLI process
+  // and each SPA load costs seconds, so a goto per test dominated this spec's runtime; the
+  // assertions below are ordered to share a single load instead.
+  openCommits()
+}, 180_000)
+
+afterAll(() => {
+  browser?.close()
+  server?.kill()
+  // Cleanup races the dying server (see thread-scroll.e2e.ts) — litter, not a failure.
+  try {
+    if (dataRoot) rmSync(dataRoot, { recursive: true, force: true })
+  } catch {
+    /* the OS reaps it */
+  }
+})
+
+describe(`the task Commits tab on a ${COMMITS}-commit branch`, () => {
+  it('serves every commit from the API — the list really is unbounded', async () => {
+    const payload = (await (await fetch(`${baseUrl}/api/runs/${RUN_ID}/commits`)).json()) as {
+      commits: unknown[]
+    }
+    // No server-side cap on this route, which is the whole reason the tab needs windowing.
+    expect(payload.commits).toHaveLength(COMMITS)
+  }, 60_000)
+
+  it('virtualizes the list and keeps the DOM bounded', () => {
+    const view = browser.evaluate(`(() => {
+      const list = document.querySelector('[data-slot="task-commits"]')
+      return JSON.stringify({
+        virtualized: list.dataset.virtualized,
+        rows: document.querySelectorAll('[data-slot="commit-row"]').length,
+      })
+    })()`) as string
+    const { virtualized, rows } = JSON.parse(view) as { virtualized: string; rows: number }
+
+    expect(virtualized).toBe('true')
+    expect(rows).toBeGreaterThan(0)
+    // A viewport window plus overscan, not 200 rows.
+    expect(rows).toBeLessThan(COMMITS / 3)
+  }, 60_000)
+
+  it('mounts rows that cover the viewport after scrolling (startMargin is real)', () => {
+    // Park with a real scroll event and let virtua re-window before measuring: a raw scrollTop
+    // write is not a frame, and asserting in the same tick reads the pre-scroll window.
+    browser.waitForFunction(`(() => {
+      const m = ${MAIN}
+      if (Math.abs(m.scrollTop - 1500) > 50) {
+        m.scrollTop = 1500
+        m.dispatchEvent(new Event('scroll', { bubbles: true }))
+        return false
+      }
+      return document.querySelectorAll('[data-slot="commit-row"]').length > 0
+    })()`)
+
+    // The same trap the diff hit: measure `startMargin` before the scroller ref is attached and
+    // virtua windows around the wrong offset, leaving an uncovered band at the top. Rows here
+    // are ~41px — far smaller than the viewport — so any such error is visible.
+    const gap = Number(
+      browser.evaluate(`(() => {
+        const scroller = ${MAIN}
+        const fold = scroller.getBoundingClientRect().top
+        const tops = [...document.querySelectorAll('[data-slot="commit-row"]')]
+          .map((row) => row.getBoundingClientRect().top - fold)
+        return tops.length === 0 ? NaN : Math.round(Math.min(...tops))
+      })()`),
+    )
+
+    expect(Number.isNaN(gap), 'no commit rows mounted at all').toBe(false)
+    // The topmost mounted row reaches the fold — no uncovered band. `SUB_PIXEL` absorbs
+    // fractional layout rounding only; the failure this guards against is an order of
+    // magnitude larger (the diff's equivalent regression measured a 30px band).
+    expect(gap).toBeLessThanOrEqual(SUB_PIXEL)
+  }, 60_000)
+
+  it('still routes a row through to its commit diff', () => {
+    // Back to the top, then wait for the NEWEST row to be mounted before clicking it. Picking
+    // "the first row in the DOM" would race virtua's re-window after the scroll above and can
+    // land on one of the fixture's empty commits, which honestly renders "No file changes".
+    expect(newestSha).not.toBe('')
+    browser.waitForFunction(`(() => {
+      const m = ${MAIN}
+      if (m.scrollTop !== 0) { m.scrollTop = 0; m.dispatchEvent(new Event('scroll', { bubbles: true })); return false }
+      return document.querySelector('[data-sha="${newestSha}"]') !== null
+    })()`)
+    browser.click(`[data-slot="commit-row"][data-sha="${newestSha}"]`)
+
+    // The virtualized row is a real <Link>, not a positioned decoration.
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="task-commit"]') !== null && document.querySelector('[data-slot="diff-file"]') !== null`,
+    )
+  }, 60_000)
+})

--- a/web/app/e2e/diff-scroll.e2e.ts
+++ b/web/app/e2e/diff-scroll.e2e.ts
@@ -100,13 +100,23 @@ function buildFixtureRepo(dir: string): void {
   for (let index = 0; index < FIXTURE_FILES; index += 1) write(index, 'after')
 }
 
-/** Load /git in a forced mode and wait until the diff has rendered in that mode. */
+/** Which mode is currently loaded, so the virtual-mode tests can share one page load. */
+let loaded: 'flat' | 'virtual' | null = null
+
+/**
+ * Load /git in a forced mode and wait until the diff has rendered in that mode — and skip the
+ * navigation entirely when that mode is already up. Re-loading is the expensive part of this
+ * spec (flat mode paints ~1,900 highlighted rows, which is precisely the cost being measured),
+ * so the three virtual-mode assertions below deliberately share a single load and run in order.
+ */
 function openChanges(mode: 'flat' | 'virtual') {
+  if (loaded === mode) return
   browser.goto(`${baseUrl}/git?diff=${mode}`)
   browser.waitForFunction(
     `document.querySelector('[data-slot="diff-files"]')?.dataset.virtualized === '${mode === 'virtual'}'`,
   )
   browser.waitForFunction(`document.querySelector('[data-slot="diff-file"]') !== null`)
+  loaded = mode
 }
 
 beforeAll(async () => {

--- a/web/app/e2e/diff-scroll.e2e.ts
+++ b/web/app/e2e/diff-scroll.e2e.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { AgentBrowser, readTestEnv } from './agent-browser'
+
+/**
+ * Diff virtualization in a real browser (`components/diff/diff-scroll.ts` §"THE PERFORMANCE
+ * RULE"), against the shared dry-run environment — which serves THIS repository, so the
+ * changeset under test is real git state read at test time, not a fixture.
+ *
+ * The `?diff=flat` / `?diff=virtual` override is the measurement seam: the SAME changeset is
+ * loaded both ways and the DOM is counted each time, which is the only honest way to state
+ * what virtualization bought. That mirrors `thread-scroll.e2e.ts` exactly.
+ *
+ * HONESTY NOTES on what this can and cannot prove:
+ *  - Smoothness is asserted by proxy — a bounded DOM — not measured as frame timing.
+ *  - The suite runs against whatever this checkout's working tree holds. With a clean tree
+ *    there is no diff to measure, so the spec SKIPS loudly rather than asserting on nothing.
+ *  - The sticky-header assertion is the one that earns its keep: virtua absolutely-positions
+ *    every item, which is exactly the layout that could silently break `position: sticky`.
+ *    It is checked in the virtualized mode, at a scroll offset deep inside a file.
+ */
+
+const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
+const sessionId = `e2e-diff-scroll-${process.pid}`
+
+const MAIN = `document.querySelector('[data-slot="main"]')`
+const domSize = () => Number(browser.evaluate(`document.querySelectorAll('*').length`))
+const lineCount = () => browser.count('[data-slot="diff-line"]')
+
+let browser: AgentBrowser
+let baseUrl: string
+/** How many files the working tree has changed — the spec's precondition. */
+let changedFiles = 0
+
+/** Load /git in a forced mode and wait until the diff has rendered in that mode. */
+function openChanges(mode: 'flat' | 'virtual') {
+  browser.goto(`${baseUrl}/git?diff=${mode}`)
+  browser.waitForFunction(
+    `document.querySelector('[data-slot="diff-files"]')?.dataset.virtualized === '${mode === 'virtual'}'`,
+  )
+}
+
+beforeAll(async () => {
+  baseUrl = readTestEnv().baseUrl
+  const res = await fetch(`${baseUrl}/api/repo/changes`)
+  if (res.ok) changedFiles = ((await res.json()) as { files: unknown[] }).files.length
+  browser = AgentBrowser.open(sessionId)
+  browser.setViewport(1440, 900)
+})
+
+afterAll(() => {
+  browser?.close()
+})
+
+describe('diff virtualization on the working tree’s real changeset', () => {
+  let flatLines = 0
+  let flatDom = 0
+
+  it('force-flat renders every file and every line (the before measurement)', () => {
+    if (changedFiles === 0) return // clean tree — nothing to measure; the guard below reports it
+    openChanges('flat')
+
+    expect(browser.count('[data-slot="diff-file"]')).toBe(changedFiles)
+    flatLines = lineCount()
+    flatDom = domSize()
+    expect(flatLines).toBeGreaterThan(0)
+  }, 90_000)
+
+  it('force-virtual holds a viewport window instead of the whole changeset', () => {
+    if (changedFiles === 0) return
+    openChanges('virtual')
+
+    const virtualLines = lineCount()
+    const virtualDom = domSize()
+    // The honest metric, same changeset, same browser: virtua mounts the cards it needs, not
+    // the list. The exact window varies with file sizes — the BOUND is the claim.
+    expect(virtualLines).toBeLessThan(flatLines)
+    expect(virtualDom).toBeLessThan(flatDom)
+    expect(browser.count('[data-slot="diff-file"]')).toBeLessThanOrEqual(changedFiles)
+
+    mkdirSync(artifactsDir, { recursive: true })
+    writeFileSync(
+      join(artifactsDir, 'diff-scroll-metrics.json'),
+      JSON.stringify(
+        { changedFiles, diffLines: { flat: flatLines, virtualized: virtualLines }, domElements: { flat: flatDom, virtualized: virtualDom } },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+    browser.screenshot(`${artifactsDir}/diff-virtualized.png`)
+  }, 90_000)
+
+  it('keeps the per-file header sticky while virtualized — the layout hazard virtua poses', () => {
+    if (changedFiles === 0) return
+    openChanges('virtual')
+
+    // Park deep enough that the first mounted card's body straddles the viewport top, which
+    // is the only position where a sticky header is doing anything at all.
+    browser.waitForFunction(`(() => { ${MAIN}.scrollTop = 600; return true })()`)
+    browser.waitForFunction(`document.querySelector('[data-slot="diff-file"]') !== null`)
+
+    // A header whose card still covers the viewport top must be pinned AT that top edge
+    // (plus the consumer's --diff-sticky-top offset), not scrolled away with its card.
+    const pinned = browser.evaluate(`(() => {
+      const scroller = ${MAIN}
+      const top = scroller.getBoundingClientRect().top
+      for (const card of document.querySelectorAll('[data-slot="diff-file"]')) {
+        const box = card.getBoundingClientRect()
+        const header = card.querySelector('[data-slot="diff-file-header"]')
+        if (!header) continue
+        // The card straddles the viewport top: started above it, still extends below it.
+        if (box.top < top && box.bottom > top + 40) {
+          return { straddling: true, headerTop: Math.round(header.getBoundingClientRect().top - top), cardTop: Math.round(box.top - top) }
+        }
+      }
+      return { straddling: false }
+    })()`) as { straddling: boolean; headerTop?: number; cardTop?: number }
+
+    // A changeset this size MUST put a card across the fold at 600px — if it somehow didn't,
+    // the assertion below never ran, and this spec must say so rather than tick green.
+    expect(pinned.straddling, 'no card straddled the fold — the sticky check did not run').toBe(true)
+    // Sticky means the header sits at/near the scrollport top even though its card began
+    // above it. Without sticky it would be at `cardTop`, which is negative here.
+    expect(pinned.cardTop!).toBeLessThan(0)
+    expect(pinned.headerTop!).toBeGreaterThan(pinned.cardTop!)
+    expect(pinned.headerTop!).toBeGreaterThanOrEqual(0)
+  }, 90_000)
+
+  it('reports loudly when the working tree is clean, rather than passing on nothing', () => {
+    // Not an assertion about the app — an assertion about this SPEC's coverage. A clean tree
+    // means the three measurements above all no-oped, and a green tick would be a lie.
+    if (changedFiles === 0) {
+      console.warn(
+        '\n########\n# diff-scroll.e2e: the working tree is CLEAN — virtualization was NOT measured.\n# Re-run with uncommitted changes present.\n########\n',
+      )
+    }
+    expect(true).toBe(true)
+  })
+})

--- a/web/app/e2e/diff-scroll.e2e.ts
+++ b/web/app/e2e/diff-scroll.e2e.ts
@@ -1,38 +1,104 @@
-import { mkdirSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, readTestEnv } from './agent-browser'
+import { AgentBrowser } from './agent-browser'
 
 /**
  * Diff virtualization in a real browser (`components/diff/diff-scroll.ts` §"THE PERFORMANCE
- * RULE"), against the shared dry-run environment — which serves THIS repository, so the
- * changeset under test is real git state read at test time, not a fixture.
+ * RULE"), over a changeset this spec BUILDS — a throwaway git repo with a deliberately large
+ * uncommitted diff, served by its own cezar instance.
+ *
+ * The fixture is generated rather than read from the checkout on purpose. An earlier version
+ * of this spec measured whatever the working tree happened to hold, which made it silently
+ * worthless the moment the tree was clean or small (cezar's autosave commits as a task runs,
+ * so "small" is the normal state). A regression test for a size threshold has to control the
+ * size.
  *
  * The `?diff=flat` / `?diff=virtual` override is the measurement seam: the SAME changeset is
- * loaded both ways and the DOM is counted each time, which is the only honest way to state
- * what virtualization bought. That mirrors `thread-scroll.e2e.ts` exactly.
+ * loaded both ways and the DOM counted each time, mirroring `thread-scroll.e2e.ts`.
  *
  * HONESTY NOTES on what this can and cannot prove:
  *  - Smoothness is asserted by proxy — a bounded DOM — not measured as frame timing.
- *  - The suite runs against whatever this checkout's working tree holds. With a clean tree
- *    there is no diff to measure, so the spec SKIPS loudly rather than asserting on nothing.
- *  - The sticky-header assertion is the one that earns its keep: virtua absolutely-positions
- *    every item, which is exactly the layout that could silently break `position: sticky`.
- *    It is checked in the virtualized mode, at a scroll offset deep inside a file.
+ *  - Sticky headers and the `startMargin` offset are the two things virtua could plausibly
+ *    break here, and both are checked against real layout, which is why they live in an e2e
+ *    at all: jsdom lays nothing out, so neither is observable in a unit test.
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
+const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-diff-scroll-${process.pid}`
+
+/**
+ * 120 files × ~18 rows ≈ 2,100 rendered rows — past the 1,500 threshold.
+ *
+ * MANY SMALL FILES, deliberately, not a few huge ones. Card height has to stay well under the
+ * viewport for the `startMargin` assertion below to be able to fail: when one card is taller
+ * than the screen, the item covering the fold is the same item the window is centred on, so a
+ * wrong start offset can never expose a gap and the test silently proves nothing. (Verified:
+ * with 8 × 250-line files the assertion passed against known-broken code.)
+ */
+const FIXTURE_FILES = 120
+const LINES_PER_FILE = 8
 
 const MAIN = `document.querySelector('[data-slot="main"]')`
 const domSize = () => Number(browser.evaluate(`document.querySelectorAll('*').length`))
 const lineCount = () => browser.count('[data-slot="diff-line"]')
 
 let browser: AgentBrowser
+let server: ChildProcess
+let repo: string
 let baseUrl: string
-/** How many files the working tree has changed — the spec's precondition. */
+/** The server's own count. NOT `FIXTURE_FILES`: booting cezar against the fixture writes
+ *  `.ai/cezar/.gitignore` into it, which is itself an honest untracked change the view shows. */
 let changedFiles = 0
+
+function freePort(): Promise<number> {
+  return new Promise((done, fail) => {
+    const probe = createServer()
+    probe.once('error', fail)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      probe.close(() => done(port))
+    })
+  })
+}
+
+async function waitForHealth(url: string): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      if ((await fetch(`${url}/api/health`)).ok) return
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`cezar e2e: the fixture server never answered at ${url}`)
+}
+
+/** Commit a baseline, then rewrite every line — a big, honest modified-file diff. */
+function buildFixtureRepo(dir: string): void {
+  const git = (args: string[]) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' })
+  git(['init', '-q', '-b', 'main'])
+  git(['config', 'user.email', 'e2e@example.com'])
+  git(['config', 'user.name', 'cezar e2e'])
+  mkdirSync(join(dir, 'src'), { recursive: true })
+  const write = (index: number, tag: string) =>
+    writeFileSync(
+      join(dir, 'src', `module-${index}.ts`),
+      Array.from({ length: LINES_PER_FILE }, (_, line) => `export const ${tag}_${index}_${line} = ${line}`).join('\n') + '\n',
+      'utf8',
+    )
+  for (let index = 0; index < FIXTURE_FILES; index += 1) write(index, 'before')
+  git(['add', '-A'])
+  git(['commit', '-q', '-m', 'base'])
+  for (let index = 0; index < FIXTURE_FILES; index += 1) write(index, 'after')
+}
 
 /** Load /git in a forced mode and wait until the diff has rendered in that mode. */
 function openChanges(mode: 'flat' | 'virtual') {
@@ -40,70 +106,89 @@ function openChanges(mode: 'flat' | 'virtual') {
   browser.waitForFunction(
     `document.querySelector('[data-slot="diff-files"]')?.dataset.virtualized === '${mode === 'virtual'}'`,
   )
+  browser.waitForFunction(`document.querySelector('[data-slot="diff-file"]') !== null`)
 }
 
 beforeAll(async () => {
-  baseUrl = readTestEnv().baseUrl
-  const res = await fetch(`${baseUrl}/api/repo/changes`)
-  if (res.ok) changedFiles = ((await res.json()) as { files: unknown[] }).files.length
+  repo = mkdtempSync(join(tmpdir(), 'cezar-e2e-diff-scroll-'))
+  buildFixtureRepo(repo)
+
+  const port = await freePort()
+  baseUrl = `http://localhost:${port}`
+  server = spawn(
+    process.execPath,
+    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', repo, '--port', String(port), '--no-open'],
+    { env: { ...process.env, CEZ_DRY_RUN: '1' }, stdio: 'ignore' },
+  )
+  await waitForHealth(baseUrl)
+  changedFiles = ((await (await fetch(`${baseUrl}/api/repo/changes`)).json()) as { files: unknown[] }).files.length
+  expect(changedFiles).toBeGreaterThanOrEqual(FIXTURE_FILES)
+
   browser = AgentBrowser.open(sessionId)
   browser.setViewport(1440, 900)
-})
+}, 120_000)
 
 afterAll(() => {
   browser?.close()
+  server?.kill()
+  // The server may still be flushing its own state into the fixture as it dies; a temp dir
+  // that outlives the run is litter, not a failure, so cleanup never fails the suite.
+  try {
+    if (repo) rmSync(repo, { recursive: true, force: true })
+  } catch {
+    /* the OS reaps it */
+  }
 })
 
-describe('diff virtualization on the working tree’s real changeset', () => {
+describe(`diff virtualization on a generated ${FIXTURE_FILES}-file changeset`, () => {
   let flatLines = 0
   let flatDom = 0
 
   it('force-flat renders every file and every line (the before measurement)', () => {
-    if (changedFiles === 0) return // clean tree — nothing to measure; the guard below reports it
     openChanges('flat')
 
     expect(browser.count('[data-slot="diff-file"]')).toBe(changedFiles)
     flatLines = lineCount()
     flatDom = domSize()
-    expect(flatLines).toBeGreaterThan(0)
-  }, 90_000)
+    // Every line of every file: ~2 rows per changed line (a del and an add).
+    expect(flatLines).toBeGreaterThan(FIXTURE_FILES * LINES_PER_FILE)
+  }, 120_000)
 
   it('force-virtual holds a viewport window instead of the whole changeset', () => {
-    if (changedFiles === 0) return
     openChanges('virtual')
 
     const virtualLines = lineCount()
     const virtualDom = domSize()
     // The honest metric, same changeset, same browser: virtua mounts the cards it needs, not
     // the list. The exact window varies with file sizes — the BOUND is the claim.
-    expect(virtualLines).toBeLessThan(flatLines)
-    expect(virtualDom).toBeLessThan(flatDom)
-    expect(browser.count('[data-slot="diff-file"]')).toBeLessThanOrEqual(changedFiles)
+    expect(virtualLines).toBeLessThan(flatLines / 5)
+    expect(virtualDom).toBeLessThan(flatDom / 2)
+    expect(browser.count('[data-slot="diff-file"]')).toBeLessThan(changedFiles)
 
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(
       join(artifactsDir, 'diff-scroll-metrics.json'),
       JSON.stringify(
-        { changedFiles, diffLines: { flat: flatLines, virtualized: virtualLines }, domElements: { flat: flatDom, virtualized: virtualDom } },
+        {
+          fixture: { files: changedFiles, linesPerFile: LINES_PER_FILE },
+          diffRows: { flat: flatLines, virtualized: virtualLines },
+          domElements: { flat: flatDom, virtualized: virtualDom },
+        },
         null,
         2,
       ),
       'utf8',
     )
     browser.screenshot(`${artifactsDir}/diff-virtualized.png`)
-  }, 90_000)
+  }, 120_000)
 
   it('keeps the per-file header sticky while virtualized — the layout hazard virtua poses', () => {
-    if (changedFiles === 0) return
     openChanges('virtual')
+    browser.waitForFunction(`(() => { ${MAIN}.scrollTop = 900; return true })()`)
 
-    // Park deep enough that the first mounted card's body straddles the viewport top, which
-    // is the only position where a sticky header is doing anything at all.
-    browser.waitForFunction(`(() => { ${MAIN}.scrollTop = 600; return true })()`)
-    browser.waitForFunction(`document.querySelector('[data-slot="diff-file"]') !== null`)
-
-    // A header whose card still covers the viewport top must be pinned AT that top edge
-    // (plus the consumer's --diff-sticky-top offset), not scrolled away with its card.
+    // A header whose card still covers the viewport top must be pinned AT that top edge, not
+    // scrolled away with its card. virtua absolutely-positions every item, which is exactly
+    // the layout that could silently kill `position: sticky`.
     const pinned = browser.evaluate(`(() => {
       const scroller = ${MAIN}
       const top = scroller.getBoundingClientRect().top
@@ -111,7 +196,6 @@ describe('diff virtualization on the working tree’s real changeset', () => {
         const box = card.getBoundingClientRect()
         const header = card.querySelector('[data-slot="diff-file-header"]')
         if (!header) continue
-        // The card straddles the viewport top: started above it, still extends below it.
         if (box.top < top && box.bottom > top + 40) {
           return { straddling: true, headerTop: Math.round(header.getBoundingClientRect().top - top), cardTop: Math.round(box.top - top) }
         }
@@ -119,24 +203,33 @@ describe('diff virtualization on the working tree’s real changeset', () => {
       return { straddling: false }
     })()`) as { straddling: boolean; headerTop?: number; cardTop?: number }
 
-    // A changeset this size MUST put a card across the fold at 600px — if it somehow didn't,
-    // the assertion below never ran, and this spec must say so rather than tick green.
     expect(pinned.straddling, 'no card straddled the fold — the sticky check did not run').toBe(true)
-    // Sticky means the header sits at/near the scrollport top even though its card began
-    // above it. Without sticky it would be at `cardTop`, which is negative here.
+    // Sticky means the header sits at the scrollport top even though its card began above it.
+    // Without sticky it would ride at `cardTop`, which is negative here.
     expect(pinned.cardTop!).toBeLessThan(0)
     expect(pinned.headerTop!).toBeGreaterThan(pinned.cardTop!)
     expect(pinned.headerTop!).toBeGreaterThanOrEqual(0)
-  }, 90_000)
+  }, 120_000)
 
-  it('reports loudly when the working tree is clean, rather than passing on nothing', () => {
-    // Not an assertion about the app — an assertion about this SPEC's coverage. A clean tree
-    // means the three measurements above all no-oped, and a green tick would be a lie.
-    if (changedFiles === 0) {
-      console.warn(
-        '\n########\n# diff-scroll.e2e: the working tree is CLEAN — virtualization was NOT measured.\n# Re-run with uncommitted changes present.\n########\n',
-      )
-    }
-    expect(true).toBe(true)
-  })
+  it('mounts cards that actually cover the viewport after scrolling (startMargin is real)', () => {
+    openChanges('virtual')
+    browser.waitForFunction(`(() => { ${MAIN}.scrollTop = 1200; return true })()`)
+
+    // virtua positions its window from the scroll offset MINUS the distance down to the list
+    // (`startMargin`). Get that wrong — measuring it before the scroller ref is attached pins
+    // it at 0 — and the window is computed for a point further down the list than the reader
+    // is at, leaving an uncovered band at the top of the viewport once the buffer runs out.
+    const gap = browser.evaluate(`(() => {
+      const scroller = ${MAIN}
+      const fold = scroller.getBoundingClientRect().top
+      const tops = [...document.querySelectorAll('[data-slot="diff-file"]')]
+        .map((card) => card.getBoundingClientRect().top - fold)
+      if (tops.length === 0) return null
+      return Math.round(Math.min(...tops))
+    })()`) as number | null
+
+    expect(gap, 'no diff cards mounted at all').not.toBeNull()
+    // The topmost mounted card starts at or above the fold — no uncovered band.
+    expect(gap!).toBeLessThanOrEqual(0)
+  }, 120_000)
 })

--- a/web/app/e2e/thread-scroll.e2e.ts
+++ b/web/app/e2e/thread-scroll.e2e.ts
@@ -138,7 +138,14 @@ beforeAll(async () => {
 afterAll(() => {
   browser?.close()
   server?.kill()
-  if (dataRoot) rmSync(dataRoot, { recursive: true, force: true })
+  // The killed server may still be flushing its NDJSON into dataRoot, which races rmSync and
+  // throws ENOTEMPTY — a suite-level failure on a run whose every test passed. A temp dir that
+  // outlives the run is litter, not a failure; the OS reaps it.
+  try {
+    if (dataRoot) rmSync(dataRoot, { recursive: true, force: true })
+  } catch {
+    /* the OS reaps it */
+  }
 })
 
 describe('thread virtualization on a 1,000-row transcript', () => {

--- a/web/app/src/components/diff/diff-scroll.test.ts
+++ b/web/app/src/components/diff/diff-scroll.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DIFF_VIRTUALIZE_THRESHOLD,
+  diffRenderMode,
+  diffRowCount,
+  estimateFileHeight,
+  estimateFileRows,
+  fileKey,
+  widestLineChars,
+} from './diff-scroll'
+import type { DiffFileChange } from './types'
+
+/** A file whose patch renders `rows` rows, behind git's 4-line preamble. */
+function file(path: string, rows: number, overrides: Partial<DiffFileChange> = {}): DiffFileChange {
+  const body = ['@@ -1,1 +1,1 @@', ...Array.from({ length: rows - 1 }, (_, index) => ` line ${index}`)]
+  return {
+    path,
+    status: 'modified',
+    adds: 0,
+    dels: 0,
+    patch: [`diff --git a/${path} b/${path}`, 'index 111..222 100644', `--- a/${path}`, `+++ b/${path}`, ...body].join('\n'),
+    ...overrides,
+  }
+}
+
+describe('estimateFileRows', () => {
+  it('counts the rendered rows, discarding git\'s pre-@@ preamble', () => {
+    expect(estimateFileRows(file('a.ts', 10))).toBe(10)
+  })
+
+  it('counts one row for the note a binary or metadata-only file renders instead', () => {
+    expect(estimateFileRows({ ...file('logo.png', 5), binary: true })).toBe(1)
+    expect(estimateFileRows({ ...file('moved.ts', 5), patch: '' })).toBe(1)
+  })
+
+  it('falls back to the whole patch when there is no hunk header to anchor on', () => {
+    // Not a shape git emits, but the estimate must never go negative on a surprise.
+    expect(estimateFileRows({ ...file('a.ts', 3), patch: 'one\ntwo\nthree' })).toBe(3)
+  })
+})
+
+describe('diffRowCount', () => {
+  it('sums the rows across the changeset', () => {
+    expect(diffRowCount([file('a.ts', 10), file('b.ts', 25)])).toBe(35)
+  })
+
+  it('is zero for an empty changeset', () => {
+    expect(diffRowCount([])).toBe(0)
+  })
+})
+
+describe('estimateFileHeight', () => {
+  it('scales with the row count and always leaves room for the card chrome', () => {
+    const small = estimateFileHeight(file('a.ts', 5))
+    const large = estimateFileHeight(file('a.ts', 500))
+    expect(small).toBeGreaterThan(0)
+    expect(large).toBeGreaterThan(small)
+    // A one-row file still needs its sticky header — the placeholder can't be a bare 20px.
+    expect(estimateFileHeight({ ...file('logo.png', 1), binary: true })).toBeGreaterThan(20)
+  })
+})
+
+describe('diffRenderMode', () => {
+  it('renders flat up to the threshold and virtualizes past it', () => {
+    expect(diffRenderMode('', 0)).toBe('flat')
+    expect(diffRenderMode('', DIFF_VIRTUALIZE_THRESHOLD)).toBe('flat')
+    expect(diffRenderMode('', DIFF_VIRTUALIZE_THRESHOLD + 1)).toBe('virtual')
+  })
+
+  it('honors the ?diff= override in both directions — the measurement seam', () => {
+    expect(diffRenderMode('?diff=virtual', 1)).toBe('virtual')
+    expect(diffRenderMode('?diff=flat', 99_999)).toBe('flat')
+  })
+
+  it('ignores an unknown ?diff= value rather than guessing', () => {
+    expect(diffRenderMode('?diff=yes', 1)).toBe('flat')
+    expect(diffRenderMode('?other=flat', 99_999)).toBe('virtual')
+  })
+})
+
+describe('fileKey', () => {
+  it('separates a rename from a same-path edit', () => {
+    expect(fileKey({ ...file('new.ts', 1), oldPath: 'old.ts' })).not.toBe(fileKey(file('new.ts', 1)))
+  })
+
+  it('is stable across refetches of the same file', () => {
+    expect(fileKey(file('a.ts', 1))).toBe(fileKey(file('a.ts', 9)))
+  })
+})
+
+describe('widestLineChars', () => {
+  it('measures the longest line, which is what the horizontal scroll floor needs', () => {
+    expect(widestLineChars('ab\nabcdef\nabc')).toBe(6)
+  })
+
+  it('is zero for an empty patch', () => {
+    expect(widestLineChars('')).toBe(0)
+  })
+})

--- a/web/app/src/components/diff/diff-scroll.ts
+++ b/web/app/src/components/diff/diff-scroll.ts
@@ -1,0 +1,96 @@
+import type { DiffFileChange } from './types'
+
+/**
+ * The diff's rendering-cost rules — pure data, no DOM (the wiring lives in `diff-view.tsx`,
+ * so these stay table-testable). The sibling of `routes/task-thread/thread-scroll.ts`, and
+ * deliberately the SAME doctrine, because the failure mode is the same one: a list whose
+ * total size is unbounded by anything the user controls.
+ *
+ * THE PERFORMANCE RULE (mirrors thread-scroll.ts §"THE PERFORMANCE RULE"): up to
+ * {@link DIFF_VIRTUALIZE_THRESHOLD} rendered rows the diff renders every file card flat, each
+ * carrying `content-visibility: auto` — the browser skips style/layout/paint for off-screen
+ * cards with zero behavior risk. Past the threshold the same cards go through virtua's
+ * `<Virtualizer>`, which bounds the DOM itself.
+ *
+ * WHY THE FILE CARD IS THE VIRTUALIZED UNIT, not the line. Three properties of this view make
+ * the card the honest granularity:
+ *  - Sticky file headers survive. virtua absolutely-positions each item; a sticky header stays
+ *    sticky because its containing block is still its own card box, exactly as in flat mode.
+ *    Virtualizing individual LINES would put each header in its own item box, leaving it a
+ *    zero-height sticky range — the header would stop tracking the file under the reader.
+ *  - Syntax highlighting becomes lazy for free. Shiki tokenizes per file inside the card body
+ *    (`useFileTokens`); an unmounted off-screen card tokenizes nothing. Tokenizing every file
+ *    of a large changeset up front is the single biggest CPU cost this view had.
+ *  - Per-file state (collapse, expanded context gaps) is the thing a reader actually mutates,
+ *    so lifting it out of the card — which unmount now requires — is a small, closed change.
+ * The remaining case the card granularity does NOT bound is ONE enormous file, whose rows are
+ * a single item. That is what the per-row `content-visibility` in the card body covers.
+ */
+
+/** Rendered rows across all files, past which the file list goes through virtua. */
+export const DIFF_VIRTUALIZE_THRESHOLD = 1500
+
+/**
+ * One diff row's height at `text-xs`/`leading-[1.7]` (12px × 1.7 ≈ 20.4px), rounded down.
+ * Only ever a PLACEHOLDER: it seeds `contain-intrinsic-block-size` for never-yet-rendered
+ * content and virtua's first estimate, and both correct themselves on real measurement. It
+ * exists so the scrollbar starts at a sane length, not so it is exact.
+ */
+export const DIFF_ROW_ESTIMATE_PX = 20
+
+/** The card chrome above/below a body (sticky header + padding), for the same estimate. */
+const DIFF_CARD_CHROME_PX = 44
+
+/**
+ * How many rows a file will render, WITHOUT parsing it: the patch's line count, minus the
+ * `diff --git`/`---`/`+++` preamble git puts before the first `@@`. An over-estimate on
+ * files whose patch carries extra metadata lines, which is the safe direction — it only ever
+ * makes a placeholder slightly too tall.
+ */
+export function estimateFileRows(file: DiffFileChange): number {
+  if (file.binary === true || file.patch === '') return 1 // the one-line "no text diff" note
+  const lines = file.patch.split('\n')
+  const firstHunk = lines.findIndex((line) => line.startsWith('@@'))
+  return firstHunk === -1 ? lines.length : lines.length - firstHunk
+}
+
+/** A card's placeholder height for `contain-intrinsic-block-size` / virtua's estimate. */
+export function estimateFileHeight(file: DiffFileChange): number {
+  return estimateFileRows(file) * DIFF_ROW_ESTIMATE_PX + DIFF_CARD_CHROME_PX
+}
+
+/** Total rendered rows across the changeset — the number the threshold rule is about. */
+export function diffRowCount(files: readonly DiffFileChange[]): number {
+  return files.reduce((sum, file) => sum + estimateFileRows(file), 0)
+}
+
+/**
+ * Which renderer the diff uses. `search` is the location's query string: `?diff=flat` and
+ * `?diff=virtual` force a mode — the honest measurement seam (the e2e perf comparison loads
+ * the same changeset both ways, exactly as `?thread=` does for the transcript) and a
+ * debugging escape hatch; anything else is `auto`, the threshold rule above.
+ */
+export function diffRenderMode(search: string, rowCount: number): 'flat' | 'virtual' {
+  const forced = new URLSearchParams(search).get('diff')
+  if (forced === 'flat' || forced === 'virtual') return forced
+  return rowCount > DIFF_VIRTUALIZE_THRESHOLD ? 'virtual' : 'flat'
+}
+
+/** Stable identity for a file across refetches — the renderer's key and its state map's key. */
+export function fileKey(file: DiffFileChange): string {
+  return `${file.oldPath ?? ''}→${file.path}`
+}
+
+/**
+ * The widest line in a patch, in characters. In no-wrap mode the card body scrolls
+ * horizontally, and `content-visibility` size-contains off-screen rows — so without a floor
+ * the body's scrollWidth would be whatever the CURRENTLY VISIBLE rows happen to be, and the
+ * horizontal scrollbar would resize under a reader who had scrolled right. The body pins a
+ * `min-inline-size` of this many `ch` instead, which is exact for the monospace ASCII that
+ * dominates diffs and merely a floor everywhere else (a wider real row still widens the box).
+ */
+export function widestLineChars(patch: string): number {
+  let widest = 0
+  for (const line of patch.split('\n')) if (line.length > widest) widest = line.length
+  return widest
+}

--- a/web/app/src/components/diff/diff-view.tsx
+++ b/web/app/src/components/diff/diff-view.tsx
@@ -223,6 +223,11 @@ function VirtualFiles({
   // run header, toolbar and totals line above it). Measured, not assumed — header height
   // varies by breakpoint and content. A stale value only shifts the overscan window
   // (buffered), so re-measuring on viewport resize is enough.
+  //
+  // The scroller is resolved from THIS component's own element, not handed down from the
+  // parent's ref callback: React attaches refs child-first, so a parent element's callback
+  // runs AFTER this layout effect: the ref would still be null here, `measure()` would bail,
+  // and with stable deps it would never run again — pinning startMargin at 0 forever.
   const [startMargin, setStartMargin] = useState(0)
   useLayoutEffect(() => {
     const measure = () => {
@@ -244,7 +249,14 @@ function VirtualFiles({
   }, [scrollElRef])
 
   return (
-    <div ref={containerRef} data-slot="diff-files" data-virtualized="true">
+    <div
+      ref={(el) => {
+        containerRef.current = el
+        if (el) scrollElRef.current = el.closest<HTMLElement>('[data-slot="main"]')
+      }}
+      data-slot="diff-files"
+      data-virtualized="true"
+    >
       <Virtualizer ref={handleRef} scrollRef={scrollElRef} startMargin={startMargin}>
         {files.map((file) => (
           <div key={fileKey(file)} data-slot="diff-file-slot" className="pb-3">

--- a/web/app/src/components/diff/diff-view.tsx
+++ b/web/app/src/components/diff/diff-view.tsx
@@ -1,11 +1,19 @@
 import { ChevronRightIcon } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { Virtualizer, type VirtualizerHandle } from 'virtua'
 
 import type { DiffStat } from '@/api/types'
 import { DiffStatLabel } from '@/components/diff-stat'
 import { highlight, highlightSync, langForPath, type SynToken } from '@/lib/highlighter'
 import { cn } from '@/lib/utils'
 
+import {
+  diffRenderMode,
+  diffRowCount,
+  estimateFileHeight,
+  fileKey,
+  widestLineChars,
+} from './diff-scroll'
 import { ImagePreview, shouldPreviewImage } from './image-preview'
 
 import {
@@ -39,6 +47,23 @@ import { overlaySegments } from './word-diff'
 /** Past this many patch lines a file skips syntax highlighting — plaintext beats jank. */
 const HIGHLIGHT_MAX_LINES = 1500
 
+/** Stable empty map, so a file with no expanded gaps keeps prop identity across renders. */
+const NO_GAPS: ExpandedGaps = new Map()
+
+/**
+ * The card element for a path, matched on `dataset` rather than an attribute selector: a
+ * repository path may contain any of `"`, `[`, `]` or a backslash, and `CSS.escape` — the
+ * only correct way to embed one in a selector — is absent in some DOM implementations.
+ * Comparing the property sidesteps both problems.
+ */
+export function findFileElement(root: ParentNode | null, path: string): HTMLElement | undefined {
+  if (!root) return undefined
+  for (const element of root.querySelectorAll<HTMLElement>('[data-slot="diff-file"]')) {
+    if (element.dataset.path === path) return element
+  }
+  return undefined
+}
+
 export function DiffView({
   files,
   mode = 'unified',
@@ -46,6 +71,7 @@ export function DiffView({
   loadFileText,
   imageSrc,
   onOpenInApp,
+  viewRef,
   className,
 }: DiffProps) {
   const stat: DiffStat = useMemo(
@@ -56,25 +82,176 @@ export function DiffView({
     }),
     [files],
   )
+
+  // PER-FILE STATE LIVES HERE, not in the card. Virtualization unmounts off-screen cards, and
+  // a collapsed file or an expanded context gap must survive scrolling away and back — state
+  // inside the card would silently reset. Keyed by `fileKey`, so a refetch that returns the
+  // same files (the Changes tab polls every 4s while a run is active) keeps both.
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set())
+  const [expandedByFile, setExpandedByFile] = useState<ReadonlyMap<string, ExpandedGaps>>(() => new Map())
+
+  const toggleFile = useCallback((key: string) => {
+    setCollapsed((previous) => {
+      const next = new Set(previous)
+      if (!next.delete(key)) next.add(key)
+      return next
+    })
+  }, [])
+
+  const expandGap = useCallback(
+    async (file: DiffFileChange, gap: ContextGap) => {
+      if (!loadFileText) return
+      const text = await loadFileText(file.path)
+      if (text === null) return // unavailable (binary/too large/deleted) — the gap stays honest
+      const lines = contextLinesForGap(gap, text.split('\n'))
+      setExpandedByFile((previous) => {
+        const key = fileKey(file)
+        const next = new Map(previous)
+        return next.set(key, new Map(previous.get(key) ?? NO_GAPS).set(gap.beforeHunk, lines))
+      })
+    },
+    [loadFileText],
+  )
+
+  const rowCount = useMemo(() => diffRowCount(files), [files])
+  // The `?diff=` override is a measurement/debugging seam, not reactive state — read once so
+  // this module stays router-free (it renders in tests and in the repo view alike).
+  const [search] = useState(() => (typeof window === 'undefined' ? '' : window.location.search))
+  const renderMode = diffRenderMode(search, rowCount)
+
+  const scrollElRef = useRef<HTMLElement | null>(null)
+  const virtualizerRef = useRef<VirtualizerHandle | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  useImperativeHandle(
+    viewRef,
+    () => ({
+      scrollToPath: (path: string) => {
+        const index = files.findIndex((file) => file.path === path)
+        if (index === -1) return
+        const handle = virtualizerRef.current
+        // Virtualized: the target may not be mounted, so the scroll goes through the index.
+        // Flat: the element is always there, and scrollIntoView keeps the smooth behavior.
+        if (handle) handle.scrollToIndex(index, { align: 'start' })
+        else findFileElement(rootRef.current, path)?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      },
+    }),
+    [files],
+  )
+
+  const card = (file: DiffFileChange) => {
+    const key = fileKey(file)
+    return (
+      <DiffFileCard
+        file={file}
+        open={!collapsed.has(key)}
+        onToggle={() => toggleFile(key)}
+        expanded={expandedByFile.get(key) ?? NO_GAPS}
+        onExpand={(gap) => void expandGap(file, gap)}
+        mode={mode}
+        wrap={wrap}
+        canExpand={loadFileText !== undefined}
+        imageSrc={imageSrc}
+        onOpenInApp={onOpenInApp}
+      />
+    )
+  }
+
   return (
-    <div data-slot="diff" data-mode={mode} className={cn('flex min-w-0 flex-col gap-3', className)}>
-      <p data-slot="diff-totals" className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+    <div
+      ref={(el) => {
+        rootRef.current = el
+        if (el) scrollElRef.current = el.closest<HTMLElement>('[data-slot="main"]')
+      }}
+      data-slot="diff"
+      data-mode={mode}
+      className={cn('flex min-w-0 flex-col', className)}
+    >
+      <p data-slot="diff-totals" className="flex items-center gap-2 px-1 pb-3 text-xs text-muted-foreground">
         <span>
           {stat.files} {stat.files === 1 ? 'file' : 'files'} changed
         </span>
         <DiffStatLabel stat={stat} />
       </p>
-      {files.map((file) => (
-        <DiffFileCard
-          key={`${file.oldPath ?? ''}→${file.path}`}
-          file={file}
-          mode={mode}
-          wrap={wrap}
-          loadFileText={loadFileText}
-          imageSrc={imageSrc}
-          onOpenInApp={onOpenInApp}
-        />
-      ))}
+      {renderMode === 'virtual' ? (
+        <VirtualFiles files={files} handleRef={virtualizerRef} scrollElRef={scrollElRef} card={card} />
+      ) : (
+        <div data-slot="diff-files" data-virtualized="false">
+          {files.map((file) => (
+            // content-visibility skips style/layout/paint for off-screen cards; the
+            // intrinsic-size hint keeps the scrollbar stable before a skipped card is first
+            // measured. The card spacing that used to be the column's `gap` is this wrapper's
+            // bottom padding, so flat and virtualized modes measure identically.
+            <div
+              key={fileKey(file)}
+              data-slot="diff-file-slot"
+              style={{ containIntrinsicBlockSize: `auto ${estimateFileHeight(file)}px` }}
+              className="pb-3 [content-visibility:auto]"
+            >
+              {card(file)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The file cards through virtua, on the app shell's scroller (`[data-slot="main"]`) — the one
+ * scroll owner, exactly as the thread does it. No `shift`: a diff only ever changes in place,
+ * so start-anchored offsets stay correct.
+ *
+ * No measurement cache (the thread's `CacheSnapshot` trick): virtua's snapshot is only valid
+ * at the item count it was taken at, and a diff's file list changes under an active run's
+ * 4s poll. Re-estimating a few dozen cards costs nothing next to mis-applying a stale one.
+ */
+function VirtualFiles({
+  files,
+  handleRef,
+  scrollElRef,
+  card,
+}: {
+  files: DiffFileChange[]
+  handleRef: React.RefObject<VirtualizerHandle | null>
+  scrollElRef: React.RefObject<HTMLElement | null>
+  card: (file: DiffFileChange) => React.ReactNode
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // virtua needs the distance between the scroller's content start and the virtualizer (the
+  // run header, toolbar and totals line above it). Measured, not assumed — header height
+  // varies by breakpoint and content. A stale value only shifts the overscan window
+  // (buffered), so re-measuring on viewport resize is enough.
+  const [startMargin, setStartMargin] = useState(0)
+  useLayoutEffect(() => {
+    const measure = () => {
+      const container = containerRef.current
+      const scroller = scrollElRef.current
+      if (!container || !scroller) return
+      setStartMargin(
+        Math.max(
+          0,
+          Math.round(
+            container.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop,
+          ),
+        ),
+      )
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [scrollElRef])
+
+  return (
+    <div ref={containerRef} data-slot="diff-files" data-virtualized="true">
+      <Virtualizer ref={handleRef} scrollRef={scrollElRef} startMargin={startMargin}>
+        {files.map((file) => (
+          <div key={fileKey(file)} data-slot="diff-file-slot" className="pb-3">
+            {card(file)}
+          </div>
+        ))}
+      </Virtualizer>
     </div>
   )
 }
@@ -86,23 +263,35 @@ const STATUS_BADGE: Partial<Record<DiffFileChange['status'], string>> = {
   copied: 'copied',
 }
 
-/** One file: sticky header (path, status, ±, collapse) over the row grid. */
+/**
+ * One file: sticky header (path, status, ±, collapse) over the row grid.
+ *
+ * Fully controlled — `open` and `expanded` live in {@link DiffView} so they survive the
+ * unmount virtualization performs when this card scrolls off screen.
+ */
 function DiffFileCard({
   file,
+  open,
+  onToggle,
+  expanded,
+  onExpand,
   mode,
   wrap,
-  loadFileText,
+  canExpand,
   imageSrc,
   onOpenInApp,
 }: {
   file: DiffFileChange
+  open: boolean
+  onToggle: () => void
+  expanded: ExpandedGaps
+  onExpand: (gap: ContextGap) => void
   mode: 'unified' | 'split'
   wrap: boolean
-  loadFileText?: (path: string) => Promise<string | null>
+  canExpand: boolean
   imageSrc?: (path: string) => string
   onOpenInApp?: (path: string) => void
 }) {
-  const [open, setOpen] = useState(true)
   const badge = STATUS_BADGE[file.status]
   return (
     <section
@@ -119,7 +308,7 @@ function DiffFileCard({
           type="button"
           data-slot="diff-file-header"
           aria-expanded={open}
-          onClick={() => setOpen((value) => !value)}
+          onClick={onToggle}
           className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/50"
         >
           <ChevronRightIcon
@@ -158,9 +347,11 @@ function DiffFileCard({
       {open ? (
         <DiffFileBody
           file={file}
+          expanded={expanded}
+          onExpand={onExpand}
           mode={mode}
           wrap={wrap}
-          loadFileText={loadFileText}
+          canExpand={canExpand}
           imageSrc={imageSrc}
           onOpenInApp={onOpenInApp}
         />
@@ -171,33 +362,28 @@ function DiffFileCard({
 
 function DiffFileBody({
   file,
+  expanded,
+  onExpand,
   mode,
   wrap,
-  loadFileText,
+  canExpand,
   imageSrc,
   onOpenInApp,
 }: {
   file: DiffFileChange
+  expanded: ExpandedGaps
+  onExpand: (gap: ContextGap) => void
   mode: 'unified' | 'split'
   wrap: boolean
-  loadFileText?: (path: string) => Promise<string | null>
+  canExpand: boolean
   imageSrc?: (path: string) => string
   onOpenInApp?: (path: string) => void
 }) {
   const parsed = useMemo(() => parsePatch(file.patch), [file.patch])
   // The trailing (after-last-hunk) region has an unknown length — only offer it when a
   // loader can actually materialize it, and never for fully-new or deleted files.
-  const expandable = loadFileText !== undefined && file.status !== 'added' && file.status !== 'deleted'
+  const expandable = canExpand && file.status !== 'added' && file.status !== 'deleted'
   const gaps = useMemo(() => contextGaps(parsed.hunks, expandable), [parsed.hunks, expandable])
-  const [expanded, setExpanded] = useState<ExpandedGaps>(new Map())
-
-  const expandGap = async (gap: ContextGap) => {
-    if (!loadFileText) return
-    const text = await loadFileText(file.path)
-    if (text === null) return // unavailable (binary/too large/deleted) — the gap stays honest
-    const lines = contextLinesForGap(gap, text.split('\n'))
-    setExpanded((previous) => new Map(previous).set(gap.beforeHunk, lines))
-  }
 
   // One ordered list of every displayed line (hunks + expanded context) — the highlighting
   // unit. Both layouts reference the same HunkLine objects, so tokens map by identity.
@@ -224,6 +410,19 @@ function DiffFileBody({
     [mode, parsed.hunks, gaps, expanded],
   )
 
+  // The horizontal-scroll floor for `content-visibility` (see `widestLineChars`). Unified
+  // no-wrap only: that is the one layout where the body scrolls horizontally on the widest
+  // LINE. Wrapped rows never exceed the box, and split mode's two columns are a grid sized by
+  // the container, so neither can have its scrollWidth pulled in by a size-contained row.
+  // `7rem` is the gutters (old/new line numbers + marker + the content's right padding).
+  const widthFloor = useMemo(
+    () =>
+      mode === 'unified' && !wrap
+        ? { minInlineSize: `calc(${widestLineChars(file.patch)}ch + 7rem)` }
+        : undefined,
+    [mode, wrap, file.patch],
+  )
+
   // Only images with no text diff to lose take the preview branch — see `shouldPreviewImage`.
   // An SVG git reports as text keeps its rows below, exactly as `DiffFallback` renders it.
   if (shouldPreviewImage(file)) {
@@ -241,7 +440,6 @@ function DiffFileBody({
     const index = lineIndex.get(line)
     return index === undefined ? null : (tokens[index] ?? null)
   }
-  const canExpand = loadFileText !== undefined && file.status !== 'added' && file.status !== 'deleted'
 
   return (
     <div
@@ -249,16 +447,28 @@ function DiffFileBody({
       data-wrap={wrap || undefined}
       className={cn('py-1 font-mono text-xs leading-[1.7]', !wrap && 'overflow-x-auto')}
     >
-      {rows
-        ? rows.map((row, index) => (
-            <UnifiedRowView key={index} row={row} wrap={wrap} tokensFor={tokensFor} onExpand={canExpand ? expandGap : undefined} />
-          ))
-        : null}
-      {splitRows
-        ? splitRows.map((row, index) => (
-            <SplitRowView key={index} row={row} wrap={wrap} tokensFor={tokensFor} onExpand={canExpand ? expandGap : undefined} />
-          ))
-        : null}
+      {/* Every row gets `content-visibility: auto` — the tier that bounds the cost of ONE
+          enormous file, which card-level virtualization cannot (its rows are a single item).
+          Applied through a child selector rather than a wrapper element per row: an extra
+          node per line is the very cost this is here to remove. The intrinsic-size hint is
+          DIFF_ROW_ESTIMATE_PX; `auto` lets a once-rendered row remember its real height.
+          `min-inline-size` is the horizontal-scroll floor — see `widestLineChars`. */}
+      <div
+        data-slot="diff-rows"
+        style={widthFloor}
+        className="[&>*]:[contain-intrinsic-block-size:auto_20px] [&>*]:[content-visibility:auto]"
+      >
+        {rows
+          ? rows.map((row, index) => (
+              <UnifiedRowView key={index} row={row} wrap={wrap} tokensFor={tokensFor} onExpand={expandable ? onExpand : undefined} />
+            ))
+          : null}
+        {splitRows
+          ? splitRows.map((row, index) => (
+              <SplitRowView key={index} row={row} wrap={wrap} tokensFor={tokensFor} onExpand={expandable ? onExpand : undefined} />
+            ))
+          : null}
+      </div>
       {parsed.truncated ? <Note>Patch truncated by the server — counts above remain exact.</Note> : null}
     </div>
   )

--- a/web/app/src/components/diff/diff-virtualize.test.tsx
+++ b/web/app/src/components/diff/diff-virtualize.test.tsx
@@ -1,0 +1,164 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Diff } from './diff'
+import type { DiffFileChange, DiffHandle } from './types'
+
+/**
+ * What each rendering tier actually puts in the DOM (the threshold rule itself is pinned in
+ * diff-scroll.test.ts). The real-browser half of "the DOM stays bounded" — measured element
+ * counts against the same changeset forced both ways — is `web/app/e2e/diff-scroll.e2e.ts`;
+ * jsdom lays nothing out, so virtua can only be observed mounting, not windowing.
+ */
+
+beforeEach(() => {
+  // virtua measures with a ResizeObserver; jsdom has none and never lays anything out.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  )
+  // jsdom implements no scrolling at all — the flat tier's reveal path calls this.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  window.history.replaceState({}, '', '/')
+})
+
+/** A file rendering `rows` diff rows. */
+function file(path: string, rows: number): DiffFileChange {
+  return {
+    path,
+    status: 'modified',
+    adds: rows,
+    dels: 0,
+    patch: [
+      `diff --git a/${path} b/${path}`,
+      'index 1111111..2222222 100644',
+      `--- a/${path}`,
+      `+++ b/${path}`,
+      `@@ -1,${rows} +1,${rows} @@`,
+      ...Array.from({ length: rows - 1 }, (_, index) => `+const value${index} = ${index}`),
+    ].join('\n'),
+  }
+}
+
+/** The engine chunk loads lazily — settle on a rendered file header before asserting. */
+async function renderDiff(ui: React.ReactElement, settleText: string) {
+  const view = render(ui)
+  await screen.findByText(settleText)
+  return view
+}
+
+/**
+ * The virtualized tier's settle: virtua mounts NO items under jsdom (a zero-height viewport
+ * windows down to nothing), so there is no file header to wait for — the engine chunk having
+ * landed is the honest signal.
+ */
+async function renderVirtualDiff(ui: React.ReactElement) {
+  const view = render(ui)
+  await waitFor(() => expect(document.querySelector('[data-slot="diff-files"]')).not.toBeNull())
+  return view
+}
+
+describe('the flat tier (small changesets)', () => {
+  it('renders every file, each hinted for content-visibility skipping', async () => {
+    await renderDiff(<Diff files={[file('a.ts', 3), file('b.ts', 3)]} />, 'a.ts')
+
+    const region = document.querySelector('[data-slot="diff-files"]')!
+    expect(region.getAttribute('data-virtualized')).toBe('false')
+    expect(document.querySelectorAll('[data-slot="diff-file"]')).toHaveLength(2)
+
+    const slot = document.querySelector<HTMLElement>('[data-slot="diff-file-slot"]')!
+    expect(slot.className).toContain('[content-visibility:auto]')
+    // The placeholder keeps the scrollbar honest before a skipped card is ever measured.
+    expect(slot.style.containIntrinsicBlockSize).toMatch(/^auto \d+px$/)
+  })
+
+  it('gives no-wrap unified rows a width floor, so a size-contained row cannot shrink the horizontal scroll', async () => {
+    await renderDiff(<Diff files={[file('a.ts', 3)]} />, 'a.ts')
+
+    const rows = document.querySelector<HTMLElement>('[data-slot="diff-rows"]')!
+    expect(rows.style.minInlineSize).toMatch(/^calc\(\d+ch \+ 7rem\)$/)
+    expect(rows.className).toContain('[content-visibility:auto]')
+  })
+
+  it('drops the width floor when wrapping, where rows never exceed the box', async () => {
+    await renderDiff(<Diff files={[file('a.ts', 3)]} wrap />, 'a.ts')
+
+    expect(document.querySelector<HTMLElement>('[data-slot="diff-rows"]')!.style.minInlineSize).toBe('')
+  })
+})
+
+describe('the virtualized tier (large changesets)', () => {
+  it('switches to virtua past the row threshold', async () => {
+    // 2 × 900 rows = 1,800 > DIFF_VIRTUALIZE_THRESHOLD, without forcing the override.
+    await renderVirtualDiff(<Diff files={[file('a.ts', 900), file('b.ts', 900)]} />)
+
+    expect(document.querySelector('[data-slot="diff-files"]')!.getAttribute('data-virtualized')).toBe('true')
+    // The point of the tier: 1,800 rows of patch, and not one of them in the DOM off-screen.
+    expect(document.querySelectorAll('[data-slot="diff-line"]')).toHaveLength(0)
+  })
+
+  it('honors ?diff=virtual on a changeset that would otherwise render flat', async () => {
+    window.history.replaceState({}, '', '/?diff=virtual')
+    await renderVirtualDiff(<Diff files={[file('a.ts', 3), file('b.ts', 3)]} />)
+
+    expect(document.querySelector('[data-slot="diff-files"]')!.getAttribute('data-virtualized')).toBe('true')
+  })
+})
+
+describe('per-file state survives the unmount virtualization performs', () => {
+  it('collapses one file without touching its neighbours', async () => {
+    await renderDiff(<Diff files={[file('a.ts', 3), file('b.ts', 3)]} />, 'a.ts')
+
+    const headers = document.querySelectorAll<HTMLButtonElement>('[data-slot="diff-file-header"]')
+    expect(headers[0]!.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(headers[0]!)
+
+    expect(headers[0]!.getAttribute('aria-expanded')).toBe('false')
+    expect(headers[1]!.getAttribute('aria-expanded')).toBe('true')
+    // The collapsed file's rows are gone; the untouched one still has its body.
+    expect(document.querySelectorAll('[data-slot="diff-file-body"]')).toHaveLength(1)
+  })
+
+  it('keeps that collapse across a re-render with a fresh files array (the 4s poll)', async () => {
+    const files = [file('a.ts', 3), file('b.ts', 3)]
+    const { rerender } = await renderDiff(<Diff files={files} />, 'a.ts')
+
+    fireEvent.click(document.querySelectorAll<HTMLButtonElement>('[data-slot="diff-file-header"]')[0]!)
+    // A refetch returns equal-but-not-identical file objects — state is keyed by path, so the
+    // reader's collapse must not silently spring back open.
+    rerender(<Diff files={[file('a.ts', 3), file('b.ts', 3)]} />)
+
+    expect(
+      document.querySelectorAll('[data-slot="diff-file-header"]')[0]!.getAttribute('aria-expanded'),
+    ).toBe('false')
+  })
+})
+
+describe('the reveal handle (the Changes tab file tree)', () => {
+  it('scrolls to the file element while flat', async () => {
+    const ref: { current: DiffHandle | null } = { current: null }
+    await renderDiff(<Diff files={[file('a.ts', 3), file('b.ts', 3)]} viewRef={ref} />, 'a.ts')
+
+    ref.current!.scrollToPath('b.ts')
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' })
+  })
+
+  it('is a no-op for a path the changeset no longer carries', async () => {
+    const ref: { current: DiffHandle | null } = { current: null }
+    await renderDiff(<Diff files={[file('a.ts', 3)]} viewRef={ref} />, 'a.ts')
+
+    expect(() => ref.current!.scrollToPath('gone.ts')).not.toThrow()
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/src/components/diff/diff.tsx
+++ b/web/app/src/components/diff/diff.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ComponentType } from 'react'
+import { useEffect, useImperativeHandle, useRef, useState, type ComponentType } from 'react'
 
 import type { DiffStat } from '@/api/types'
 import { DiffStatLabel } from '@/components/diff-stat'
@@ -68,14 +68,31 @@ export function Diff(props: DiffProps) {
  * the engine chunk can. Split mode degrades to unified; that is documented degradation, not
  * a bug.
  */
-export function DiffFallback({ files, wrap = false, imageSrc, onOpenInApp, className }: DiffProps) {
+export function DiffFallback({ files, wrap = false, imageSrc, onOpenInApp, viewRef, className }: DiffProps) {
   const stat: DiffStat = {
     adds: files.reduce((sum, file) => sum + file.adds, 0),
     dels: files.reduce((sum, file) => sum + file.dels, 0),
     files: files.length,
   }
+  // The fallback never virtualizes, so every file IS in the DOM — the handle a consumer's
+  // file tree calls resolves straight to the element. Without this the tree would silently
+  // stop scrolling whenever the engine chunk failed to load. Matched on `dataset` rather than
+  // an attribute selector, for the reasons `diff-view.tsx`'s `findFileElement` spells out
+  // (this stays inline rather than importing that helper: it lives in the lazy engine chunk,
+  // and the fallback exists precisely for when that chunk is unreachable).
+  const root = useRef<HTMLDivElement | null>(null)
+  useImperativeHandle(viewRef, () => ({
+    scrollToPath: (path: string) => {
+      for (const element of root.current?.querySelectorAll<HTMLElement>('[data-slot="diff-file"]') ?? []) {
+        if (element.dataset.path === path) {
+          element.scrollIntoView({ block: 'start', behavior: 'smooth' })
+          return
+        }
+      }
+    },
+  }))
   return (
-    <div data-slot="diff" data-fallback="true" className={cn('flex min-w-0 flex-col gap-3', className)}>
+    <div ref={root} data-slot="diff" data-fallback="true" className={cn('flex min-w-0 flex-col gap-3', className)}>
       <p data-slot="diff-totals" className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
         <span>
           {stat.files} {stat.files === 1 ? 'file' : 'files'} changed

--- a/web/app/src/components/diff/index.ts
+++ b/web/app/src/components/diff/index.ts
@@ -4,4 +4,4 @@
  * modules are internal; they are exported nowhere on purpose.
  */
 export { Diff } from './diff'
-export type { DiffFileChange, DiffMode, DiffProps } from './types'
+export type { DiffFileChange, DiffHandle, DiffMode, DiffProps } from './types'

--- a/web/app/src/components/diff/types.ts
+++ b/web/app/src/components/diff/types.ts
@@ -31,6 +31,18 @@ export interface DiffFileChange {
 
 export type DiffMode = 'unified' | 'split'
 
+/**
+ * The imperative seam for "reveal this file" (the Changes tab's file tree). It exists because
+ * virtualization takes the DOM away: past the threshold in `diff-scroll.ts` an off-screen
+ * file has no element to `scrollIntoView`, so the scroll must go through the virtualizer's
+ * index instead. The handle hides which of the two is in play.
+ */
+export interface DiffHandle {
+  /** Scroll the file at `path` to the top of the scroll container. A no-op if it isn't in
+   *  `files` — a tree selection can race a refetch that dropped the file. */
+  scrollToPath: (path: string) => void
+}
+
 export interface DiffProps {
   files: DiffFileChange[]
   /** Layout: one interleaved column, or old|new side by side. Default `unified`. */
@@ -57,5 +69,12 @@ export interface DiffProps {
    * other local-machine affordance in the cockpit follows (`git-actions.ts`).
    */
   onOpenInApp?: (path: string) => void
+  /**
+   * Receives the {@link DiffHandle}. A plain ref-shaped prop rather than the component's own
+   * `ref`, because `<Diff>` lazy-loads its renderer: the handle only exists once that chunk
+   * lands, and the fallback renderer has none at all (it never virtualizes, so consumers keep
+   * their DOM-based scroll there).
+   */
+  viewRef?: { current: DiffHandle | null }
   className?: string
 }

--- a/web/app/src/routes/repo-git/repo-changes.tsx
+++ b/web/app/src/routes/repo-git/repo-changes.tsx
@@ -1,10 +1,10 @@
 import { FileDiffIcon, TriangleAlertIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 
 import { ApiError } from '@/api/client'
 import { useRepoChanges } from '@/api/queries'
 import { CenteredState } from '@/components/centered-state'
-import { Diff, type DiffMode } from '@/components/diff'
+import { Diff, type DiffHandle, type DiffMode } from '@/components/diff'
 import { useIsDesktop } from '@/lib/use-desktop'
 
 import { ChangesTree } from '../task-git/changes-tree'
@@ -29,6 +29,7 @@ export function RepoChangesSection() {
   const [mode, setMode] = useState<DiffMode>('unified')
   const [wrap, setWrap] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
+  const diffRef = useRef<DiffHandle | null>(null)
 
   // A 409 is the server's answer ("not a git repository"), not an outage.
   const refused = changes.isError && changes.error instanceof ApiError && changes.error.status === 409
@@ -39,11 +40,10 @@ export function RepoChangesSection() {
   const effectiveMode: DiffMode = desktop ? mode : 'unified'
   const effectiveWrap = desktop ? wrap : true
 
+  // Through the facade's handle, not the DOM — see the task Changes tab's note.
   const selectFile = (path: string) => {
     setSelected(path)
-    document
-      .querySelector(`[data-slot="diff-file"][data-path="${CSS.escape(path)}"]`)
-      ?.scrollIntoView?.({ block: 'start', behavior: 'smooth' })
+    diffRef.current?.scrollToPath(path)
   }
 
   return (
@@ -85,7 +85,7 @@ export function RepoChangesSection() {
           <aside className="sticky top-28 hidden w-60 shrink-0 md:block lg:w-72">
             <ChangesTree root={tree} selected={selected} onSelect={selectFile} />
           </aside>
-          <Diff files={files} mode={effectiveMode} wrap={effectiveWrap} className="min-w-0 flex-1" />
+          <Diff files={files} viewRef={diffRef} mode={effectiveMode} wrap={effectiveWrap} className="min-w-0 flex-1" />
         </div>
       )}
     </section>

--- a/web/app/src/routes/repo-git/repo-commits.tsx
+++ b/web/app/src/routes/repo-git/repo-commits.tsx
@@ -11,6 +11,7 @@ import { DiffStatLabel } from '@/components/diff-stat'
 import { Button } from '@/components/ui/button'
 import { useIsDesktop } from '@/lib/use-desktop'
 
+import { CommitList } from '../task-git/commit-list'
 import { DiffViewToggles } from '../task-git/diff-controls'
 
 /**
@@ -35,24 +36,17 @@ export function RepoCommitsSection({ log }: { log: LogEntry[] }) {
     )
   }
   return (
-    <ul data-slot="repo-commits" className="flex flex-col divide-y divide-border px-2 py-1 md:px-4">
-      {log.map((commit) => (
-        <li key={commit.hash}>
-          <Link
-            data-slot="commit-row"
-            data-sha={commit.hash}
-            to={`/git/commits/${commit.hash}`}
-            className="flex min-w-0 items-baseline gap-3 rounded-sm px-2 py-2.5 hover:bg-muted"
-          >
-            <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{commit.hash}</span>
-            <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{commit.subject}</span>
-            <span className="hidden shrink-0 text-[11px] text-soft-foreground sm:inline">
-              {commit.author} · {commit.when}
-            </span>
-          </Link>
-        </li>
-      ))}
-    </ul>
+    <CommitList
+      slot="repo-commits"
+      commits={log.map((commit) => ({
+        sha: commit.hash,
+        shaLabel: commit.hash,
+        subject: commit.subject,
+        author: commit.author,
+        when: commit.when,
+        href: `/git/commits/${commit.hash}`,
+      }))}
+    />
   )
 }
 

--- a/web/app/src/routes/task-git/commit-list.test.tsx
+++ b/web/app/src/routes/task-git/commit-list.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router'
+
+import { COMMIT_VIRTUALIZE_THRESHOLD, CommitList, type CommitListItem } from './commit-list'
+
+/**
+ * The commit log's two rendering tiers. Same shape as the diff's tests: jsdom lays nothing
+ * out, so virtua can be observed mounting but not windowing — what is pinned here is the
+ * threshold switch and that the flat tier keeps every row skippable.
+ */
+
+beforeEach(() => {
+  // virtua measures with a ResizeObserver; jsdom has none and never lays anything out.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const commits = (count: number): CommitListItem[] =>
+  Array.from({ length: count }, (_, index) => ({
+    sha: `sha${index}`,
+    shaLabel: `sha${index}`.slice(0, 8),
+    subject: `commit ${index}`,
+    author: 'ada',
+    when: '2h ago',
+    href: `/git/commits/sha${index}`,
+  }))
+
+function renderList(count: number) {
+  return render(
+    <MemoryRouter>
+      <CommitList slot="repo-commits" commits={commits(count)} />
+    </MemoryRouter>,
+  )
+}
+
+describe('CommitList', () => {
+  it('renders every row flat below the threshold, each content-visibility hinted', () => {
+    renderList(5)
+
+    const list = document.querySelector('[data-slot="repo-commits"]')!
+    expect(list.getAttribute('data-virtualized')).toBe('false')
+    expect(document.querySelectorAll('[data-slot="commit-row"]')).toHaveLength(5)
+    expect(list.firstElementChild!.className).toContain('[content-visibility:auto]')
+  })
+
+  it('links each row to its commit diff, labelled by sha and subject', () => {
+    renderList(2)
+
+    const first = document.querySelector<HTMLAnchorElement>('[data-slot="commit-row"]')!
+    expect(first.getAttribute('href')).toBe('/git/commits/sha0')
+    expect(first.dataset.sha).toBe('sha0')
+    expect(first.textContent).toContain('commit 0')
+    expect(first.textContent).toContain('ada')
+  })
+
+  it('switches to virtua past the threshold, bounding the DOM', () => {
+    renderList(COMMIT_VIRTUALIZE_THRESHOLD + 1)
+
+    expect(document.querySelector('[data-slot="repo-commits"]')!.getAttribute('data-virtualized')).toBe('true')
+    // The whole point: hundreds of commits, and virtua mounts only its window (none, under
+    // jsdom's zero-height viewport) rather than every row.
+    expect(document.querySelectorAll('[data-slot="commit-row"]').length).toBeLessThan(
+      COMMIT_VIRTUALIZE_THRESHOLD,
+    )
+  })
+
+  it('stays flat exactly at the threshold', () => {
+    renderList(COMMIT_VIRTUALIZE_THRESHOLD)
+
+    expect(document.querySelector('[data-slot="repo-commits"]')!.getAttribute('data-virtualized')).toBe('false')
+  })
+})

--- a/web/app/src/routes/task-git/commit-list.tsx
+++ b/web/app/src/routes/task-git/commit-list.tsx
@@ -8,15 +8,22 @@ import { cn } from '@/lib/utils'
  * The commit log list, shared by the task Commits tab and the repo Commits segment — one
  * `sha · subject · author·when` row per commit, deep-linking to that commit's structured diff.
  *
- * Both lists are unbounded in the only direction that matters: a long-lived task's branch and
- * a repository's log both grow without a ceiling the reader controls. So they follow the SAME
- * two-tier rule as the transcript and the diff (`components/diff/diff-scroll.ts` §"THE
+ * Same two-tier rule as the transcript and the diff (`components/diff/diff-scroll.ts` §"THE
  * PERFORMANCE RULE"): flat with `content-visibility: auto` up to
- * {@link COMMIT_VIRTUALIZE_THRESHOLD} rows, virtua past it.
+ * {@link COMMIT_VIRTUALIZE_THRESHOLD} rows, virtua past it. Rows are a fixed single line, which
+ * makes this the easy case — `ROW_HEIGHT_PX` is exact rather than an estimate, so the flat
+ * tier's placeholders and virtua's initial guesses are right the first time.
  *
- * Rows here are a fixed single line, which makes this the easy case of that rule —
- * `ROW_HEIGHT_PX` is exact rather than an estimate, so the flat tier's placeholders and
- * virtua's initial guesses are both right the first time.
+ * WHICH CONSUMER ACTUALLY NEEDS THE VIRTUAL TIER — they are not symmetric, and it would be easy
+ * to assume they are:
+ *  - The TASK Commits tab is why this exists. `collectRunCommits` (src/server/git-changes.ts)
+ *    runs `git log <merge-base>..HEAD` with NO cap, and cezar autosaves a commit per turn, so a
+ *    long-running task genuinely reaches hundreds of rows.
+ *  - The REPO Commits segment cannot reach the threshold today: `getLog` (src/server/git.ts)
+ *    defaults to 20 and `server.ts` calls it without a count, so that list is 20 rows, full
+ *    stop. It shares this component for one renderer rather than two, and for the flat tier's
+ *    `content-visibility` — not because 20 rows need windowing. If that cap is ever lifted,
+ *    this is already correct; until then, don't read the virtual branch as protecting it.
  */
 
 /** Commit rows past which the list goes through virtua. */

--- a/web/app/src/routes/task-git/commit-list.tsx
+++ b/web/app/src/routes/task-git/commit-list.tsx
@@ -1,0 +1,112 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+import { Link } from 'react-router'
+import { Virtualizer } from 'virtua'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * The commit log list, shared by the task Commits tab and the repo Commits segment — one
+ * `sha · subject · author·when` row per commit, deep-linking to that commit's structured diff.
+ *
+ * Both lists are unbounded in the only direction that matters: a long-lived task's branch and
+ * a repository's log both grow without a ceiling the reader controls. So they follow the SAME
+ * two-tier rule as the transcript and the diff (`components/diff/diff-scroll.ts` §"THE
+ * PERFORMANCE RULE"): flat with `content-visibility: auto` up to
+ * {@link COMMIT_VIRTUALIZE_THRESHOLD} rows, virtua past it.
+ *
+ * Rows here are a fixed single line, which makes this the easy case of that rule —
+ * `ROW_HEIGHT_PX` is exact rather than an estimate, so the flat tier's placeholders and
+ * virtua's initial guesses are both right the first time.
+ */
+
+/** Commit rows past which the list goes through virtua. */
+export const COMMIT_VIRTUALIZE_THRESHOLD = 150
+
+/** One row: `py-2.5` (20px) + a `text-[13px]`/`leading-normal` line ≈ 40px, plus the divider. */
+const ROW_HEIGHT_PX = 41
+
+export interface CommitListItem {
+  sha: string
+  subject: string
+  author: string
+  when: string
+  /** Where the row links to — the two consumers have different route prefixes. */
+  href: string
+  /** The sha as displayed; the task list abbreviates, the repo log is already short. */
+  shaLabel: string
+}
+
+export function CommitList({ slot, commits, className }: { slot: string; commits: CommitListItem[]; className?: string }) {
+  const virtual = commits.length > COMMIT_VIRTUALIZE_THRESHOLD
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const scrollElRef = useRef<HTMLElement | null>(null)
+
+  // Same measured `startMargin` as the thread and the diff: the distance from the shell
+  // scroller's content start down to this list (headers, toolbars). See diff-view.tsx.
+  const [startMargin, setStartMargin] = useState(0)
+  useLayoutEffect(() => {
+    if (!virtual) return
+    const measure = () => {
+      const container = containerRef.current
+      const scroller = scrollElRef.current
+      if (!container || !scroller) return
+      setStartMargin(
+        Math.max(
+          0,
+          Math.round(
+            container.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop,
+          ),
+        ),
+      )
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [virtual])
+
+  const rows = commits.map((commit) => <CommitRow key={commit.sha} commit={commit} />)
+
+  return (
+    <div
+      ref={(el) => {
+        containerRef.current = el
+        if (el) scrollElRef.current = el.closest<HTMLElement>('[data-slot="main"]')
+      }}
+      data-slot={slot}
+      data-virtualized={virtual}
+      className={cn('flex flex-col divide-y divide-border px-2 py-1 md:px-4', className)}
+    >
+      {virtual ? (
+        // No `shift`: commit logs are newest-first and only ever grow at the start on a
+        // refetch that REPLACES the list, so there is no prepend to anchor against.
+        <Virtualizer scrollRef={scrollElRef} startMargin={startMargin} itemSize={ROW_HEIGHT_PX}>
+          {rows}
+        </Virtualizer>
+      ) : (
+        rows
+      )}
+    </div>
+  )
+}
+
+function CommitRow({ commit }: { commit: CommitListItem }) {
+  return (
+    // Not a <ul>/<li>: virtua inserts its own positioned wrapper between the list and the
+    // items, which would break that parent/child contract. A plain list of links reads the
+    // same to a screen reader here — each row's accessible name is its own link text.
+    <div className="[contain-intrinsic-block-size:auto_41px] [content-visibility:auto]">
+      <Link
+        data-slot="commit-row"
+        data-sha={commit.sha}
+        to={commit.href}
+        className="flex min-w-0 items-baseline gap-3 rounded-sm px-2 py-2.5 hover:bg-muted"
+      >
+        <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{commit.shaLabel}</span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{commit.subject}</span>
+        <span className="hidden shrink-0 text-[11px] text-soft-foreground sm:inline">
+          {commit.author} · {commit.when}
+        </span>
+      </Link>
+    </div>
+  )
+}

--- a/web/app/src/routes/task-git/task-changes.tsx
+++ b/web/app/src/routes/task-git/task-changes.tsx
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { FileDiffIcon, GitCommitHorizontalIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 
 import { ApiError, createRunPr, getRunFile, openRunFileInApp, openRunInCli, pushRun, runFileRawUrl } from '@/api/client'
 import { queryKeys, useHealth, useRun, useRunChanges } from '@/api/queries'
 import type { ApiRun } from '@/api/types'
 import { CenteredState } from '@/components/centered-state'
-import { Diff, type DiffMode } from '@/components/diff'
+import { Diff, type DiffHandle, type DiffMode } from '@/components/diff'
 import { toast } from '@/components/ui/toaster'
 import { gitActionPolicy, type GitActionId } from '@/lib/git-actions'
 import { useIsDesktop } from '@/lib/use-desktop'
@@ -49,6 +49,7 @@ function ChangesView({ run }: { run: ApiRun }) {
   const [wrap, setWrap] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
   const [commitOpen, setCommitOpen] = useState(false)
+  const diffRef = useRef<DiffHandle | null>(null)
 
   const queryClient = useQueryClient()
   const invalidateRuns = () => queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
@@ -135,11 +136,11 @@ function ChangesView({ run }: { run: ApiRun }) {
   const effectiveMode: DiffMode = desktop ? mode : 'unified'
   const effectiveWrap = desktop ? wrap : true
 
+  // Through the facade's handle, not the DOM: past `diff-scroll.ts`'s threshold the diff is
+  // virtualized and the picked file may not be mounted to scroll to.
   const selectFile = (path: string) => {
     setSelected(path)
-    document
-      .querySelector(`[data-slot="diff-file"][data-path="${CSS.escape(path)}"]`)
-      ?.scrollIntoView?.({ block: 'start', behavior: 'smooth' })
+    diffRef.current?.scrollToPath(path)
   }
 
   return (
@@ -185,6 +186,7 @@ function ChangesView({ run }: { run: ApiRun }) {
           </aside>
           <Diff
             files={files}
+            viewRef={diffRef}
             mode={effectiveMode}
             wrap={effectiveWrap}
             loadFileText={(path) => loadWorktreeText(run.id, path)}

--- a/web/app/src/routes/task-git/task-commits.tsx
+++ b/web/app/src/routes/task-git/task-commits.tsx
@@ -13,6 +13,7 @@ import { useIsDesktop } from '@/lib/use-desktop'
 
 import { isRunActive } from '../task-thread/run-actions'
 import { RunHeader } from '../task-thread/run-header'
+import { CommitList } from './commit-list'
 import { GitTabLoadError, GitTabLoading } from './git-tab-loading'
 import { DiffViewToggles } from './diff-controls'
 
@@ -64,26 +65,15 @@ function CommitsView({ run }: { run: ApiRun }) {
           subtitle="This task hasn't committed anything on its branch. Autosave commits and any the agent makes appear here."
         />
       ) : (
-        <ul data-slot="task-commits" className="mx-auto flex w-full max-w-[820px] flex-col divide-y divide-border px-2 py-1 md:px-4">
-          {commits.data.commits.map((commit: RunCommit) => (
-            <li key={commit.sha}>
-              <Link
-                data-slot="commit-row"
-                data-sha={commit.sha}
-                to={`/tasks/${run.id}/commits/${commit.sha}`}
-                className="flex min-w-0 items-baseline gap-3 rounded-sm px-2 py-2.5 hover:bg-muted"
-              >
-                <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
-                  {commit.sha.slice(0, 8)}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{commit.subject}</span>
-                <span className="hidden shrink-0 text-[11px] text-soft-foreground sm:inline">
-                  {commit.author} · {commit.when}
-                </span>
-              </Link>
-            </li>
-          ))}
-        </ul>
+        <CommitList
+          slot="task-commits"
+          className="mx-auto w-full max-w-[820px]"
+          commits={commits.data.commits.map((commit: RunCommit) => ({
+            ...commit,
+            shaLabel: commit.sha.slice(0, 8),
+            href: `/tasks/${run.id}/commits/${commit.sha}`,
+          }))}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Why

Large changesets and long commit logs put **every** row in the DOM, so the Changes and Commits pages got slower in proportion to the size of the work being reviewed — exactly when you most need them responsive.

## Approach

This follows the doctrine the thread already established (`routes/task-thread/thread-scroll.ts` §"THE PERFORMANCE RULE") rather than inventing one: render flat with `content-visibility: auto` up to a threshold, hand the same rows to `virtua` past it. `virtua` was already a dependency.

**The virtualized unit is the file _card_, not the line.** Line-level virtualization is the obvious move but breaks this view: virtua absolutely-positions each item, which would leave every sticky file header with a zero-height sticky range. Card-level keeps sticky headers working *and* makes Shiki highlighting lazy for free — an off-screen card unmounts and tokenizes nothing, which was the single biggest CPU cost here. Per-row `content-visibility` covers the one case cards can't bound: a single enormous file.

## Measured

Real Chrome, same changeset forced both ways via the `?diff=flat|virtual` seam (the same measurement seam `?thread=` provides):

| | flat | virtualized |
|---|---|---|
| diff — DOM elements (121 files, ~1,900 rows) | 29,903 | **1,823** |
| diff — rows mounted | 1,927 | **39** |
| task commits — rows mounted (200 commits) | 200 | **~27** |

## Worth a reviewer's attention

- **Per-file state moved up** into `DiffView` (collapse, expanded context gaps) — virtualization unmounts the card that used to own it, so card-local state would silently reset on scroll.
- **The file tree now scrolls through a `DiffHandle`**, not the DOM: a virtualized target may not be mounted. Matching is on `dataset.path` rather than an attribute selector, because repo paths may contain `"`/`[`/`]` and `CSS.escape` isn't universally available (this was a real bug the tests caught).
- **No-wrap unified mode pins a `min-inline-size` floor.** `content-visibility` size-contains off-screen rows, so without it the body's `scrollWidth` would be whatever rows happen to be visible and the horizontal scrollbar would resize under a reader who had scrolled right.
- **A `startMargin` ordering bug, found in self-review and fixed here.** `VirtualFiles` measured virtua's start offset from a ref set by its *parent* element's callback, but React attaches refs child-first — the ref was still null, the measurement bailed, and with stable deps it never re-ran, pinning `startMargin` at 0. Symptom: a ~30px uncovered band at the top of the viewport when scrolling. The scroller is now resolved from the component's own element (what `thread-scroller.tsx` already did).
- **The repo Commits segment shares the list component but cannot reach the threshold** — `getLog` caps it at 20 server-side. It's there for one renderer and the flat tier, not because 20 rows need windowing. The task Commits tab is the one that genuinely grows (`collectRunCommits` has no cap, and cezar autosaves per turn).

## Tests

- `diff-scroll.test.ts` (13), `diff-virtualize.test.tsx` (9), `commit-list.test.tsx` (4) — unit.
- `web/app/e2e/diff-scroll.e2e.ts`, `web/app/e2e/commit-list.e2e.ts` — real Chrome, each building its own fixture repo so the row count is controlled rather than ambient (an earlier version measured the working tree, which autosave keeps near-empty — it had quietly stopped measuring anything).
- The `startMargin` assertions are verified to **fail** without the fix. Note the fixture *shape* matters: with a few huge files one card spans the viewport and always covers the fold, so the assertion passes against known-broken code. Many small files is what gives it teeth.

`npm run typecheck`, `npm run build`, `check:pack` green; 98 files / 1,862 web unit tests pass.

## Drive-by

`thread-scroll.e2e.ts` had an intermittent `ENOTEMPTY` in `afterAll` (cleanup racing the dying server) that failed the suite on runs where every test passed. Same guard applied. Happy to split this out if you'd rather.