### PR TITLE
fix: keep agent prose that has no protocol-v2 twin from vanishing

### DIFF
--- a/src/core/claude-ui-mapper.test.ts
+++ b/src/core/claude-ui-mapper.test.ts
@@ -186,6 +186,46 @@ describe('mapClaudeMessage edge cases', () => {
     expect(mapped.events.map((e) => e.type)).toEqual(['turn.completed']);
   });
 
+  // The runner emits a v1 `text` from `msg.result` when a session streamed no assistant text
+  // block (claude-cli-runner.ts, `textChunks.length === 0`). Without the v2 twin, that prose
+  // reached the cockpit only in v1 — where the thread reducer's per-turn "v2 wins" rule deleted
+  // it as soon as any tool item landed, so the message appeared and then vanished.
+  it('mints a message item from msg.result when the session streamed no text block', () => {
+    const mapped = mapClaudeMessage({ type: 'result', subtype: 'success', result: 'The whole reply.' }, state);
+    expect(mapped.events).toEqual([
+      { type: 'item.started', item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'The whole reply.' } },
+      { type: 'item.completed', item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'The whole reply.' } },
+      { type: 'turn.completed', turnId: 'turn_1', stopReason: 'end_turn' },
+    ]);
+  });
+
+  it('does NOT mint a result message once a text block already streamed — no duplicate prose', () => {
+    const streamed = mapClaudeMessage(
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Streamed.' }] } },
+      state,
+    );
+    const mapped = mapClaudeMessage({ type: 'result', subtype: 'success', result: 'Streamed.' }, streamed.state);
+    expect(mapped.events.map((e) => e.type)).toEqual(['turn.completed']);
+  });
+
+  it('the no-text-block guard is session-scoped, mirroring the runner s textChunks', () => {
+    // textChunks is allocated once per runAgent and never cleared, so a later turn that streams
+    // nothing gets NO v1 result fallback — and must get no v2 twin either.
+    const streamed = mapClaudeMessage(
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'Turn one.' }] } },
+      state,
+    );
+    const firstResult = mapClaudeMessage({ type: 'result', subtype: 'success', result: 'Turn one.' }, streamed.state);
+    const nextTurn = claudeTurnStarted(firstResult.state);
+    const mapped = mapClaudeMessage({ type: 'result', subtype: 'success', result: 'Turn two.' }, nextTurn.state);
+    expect(mapped.events.map((e) => e.type)).toEqual(['turn.completed']);
+  });
+
+  it('an empty result string mints nothing', () => {
+    const mapped = mapClaudeMessage({ type: 'result', subtype: 'success', result: '' }, state);
+    expect(mapped.events.map((e) => e.type)).toEqual(['turn.completed']);
+  });
+
   it('TodoWrite with malformed todos filters bad entries; non-array todos emit no plan', () => {
     const good = mapClaudeMessage(
       {

--- a/src/core/claude-ui-mapper.ts
+++ b/src/core/claude-ui-mapper.ts
@@ -52,6 +52,15 @@ export interface ClaudeUiMapperState {
   readonly turnSeq: number;
   readonly currentTurnId: string | null;
   readonly itemSeq: number;
+  /** True once any assistant `text` block minted a message item. SESSION-scoped,
+   *  never reset per turn — it mirrors `ctx.textChunks` in claude-cli-runner.ts,
+   *  which is allocated once per `runAgent` and accumulates across turns. When a
+   *  session streams no text block at all, the runner falls back to emitting the
+   *  v1 `text` from `msg.result` (`textChunks.length === 0`), and `mapResult`
+   *  must mint the v2 twin under the SAME guard — otherwise that prose exists
+   *  only in v1 and the cockpit's "v2 wins per turn" dedup drops it with no
+   *  replacement, which is exactly the vanishing-message bug. */
+  readonly sawAssistantText: boolean;
   /** `tool_use` items awaiting their `tool_result`, keyed by tool_use id. */
   readonly openTools: ReadonlyMap<string, UiToolItem>;
   /** The running plan built incrementally by Claude's task tools, keyed by the
@@ -76,6 +85,7 @@ export function createClaudeUiState(opts: { fallbackSessionId?: string } = {}): 
     turnSeq: 0,
     currentTurnId: null,
     itemSeq: 0,
+    sawAssistantText: false,
     openTools: new Map(),
     tasks: new Map(),
     pendingTaskCreates: new Map(),
@@ -146,12 +156,17 @@ function mapAssistant(msg: Record<string, unknown>, state: ClaudeUiMapperState):
   let openTools: Map<string, UiToolItem> | null = null;
   let tasks = state.tasks;
   let pendingTaskCreates = state.pendingTaskCreates;
+  let sawAssistantText = state.sawAssistantText;
 
   for (const raw of content) {
     if (!isRecord(raw)) continue;
     if (raw.type === 'text' && typeof raw.text === 'string') {
       // Whole blocks per API round-trip — claude sends no deltas in this
       // mode, so we never fake `item.delta`s: started + completed.
+      // Counted against the result fallback exactly as the runner counts it:
+      // every text block, sub-agent ones included (`ctx.textChunks.push` runs
+      // regardless of `parent_tool_use_id`).
+      sawAssistantText = true;
       const item: UiMessageItem = { kind: 'message', id: `item_${++itemSeq}`, role: 'assistant', text: raw.text };
       if (parentItemId !== undefined) item.parentItemId = parentItemId;
       events.push({ type: 'item.started', item }, { type: 'item.completed', item });
@@ -213,7 +228,7 @@ function mapAssistant(msg: Record<string, unknown>, state: ClaudeUiMapperState):
   if (events.length === 0) return { events, state };
   return {
     events,
-    state: { ...state, itemSeq, openTools: openTools ?? state.openTools, tasks, pendingTaskCreates },
+    state: { ...state, itemSeq, openTools: openTools ?? state.openTools, tasks, pendingTaskCreates, sawAssistantText },
   };
 }
 
@@ -499,6 +514,23 @@ function mapResult(msg: Record<string, unknown>, state: ClaudeUiMapperState): Cl
     }
   }
 
+  // The result fallback, mirroring claude-cli-runner.ts's `textChunks.length === 0`
+  // branch: a session that streamed no assistant text block carries its whole
+  // reply on `msg.result`. The runner emits a v1 `text` for it; without the v2
+  // twin below, the cockpit's per-turn "v2 wins" dedup drops that line and the
+  // turn renders tool cards with no prose at all.
+  let sawAssistantText = state.sawAssistantText;
+  if (!sawAssistantText && typeof msg.result === 'string' && msg.result !== '') {
+    sawAssistantText = true;
+    const item: UiMessageItem = {
+      kind: 'message',
+      id: `item_${++itemSeq}`,
+      role: 'assistant',
+      text: msg.result,
+    };
+    events.push({ type: 'item.started', item }, { type: 'item.completed', item });
+  }
+
   const turnId = state.currentTurnId ?? `turn_${++turnSeq}`;
   const usage = rawTokenUsage(msg.usage);
   const costUsd =
@@ -517,7 +549,14 @@ function mapResult(msg: Record<string, unknown>, state: ClaudeUiMapperState): Cl
 
   return {
     events,
-    state: { ...state, itemSeq, turnSeq, currentTurnId: null, openTools: openTools ?? state.openTools },
+    state: {
+      ...state,
+      itemSeq,
+      turnSeq,
+      currentTurnId: null,
+      openTools: openTools ?? state.openTools,
+      sawAssistantText,
+    },
   };
 }
 

--- a/web/app/src/routes/task-thread/thread-state.test.ts
+++ b/web/app/src/routes/task-thread/thread-state.test.ts
@@ -247,6 +247,44 @@ describe('reduceThread — mixed v1+v2 files (the dedup rule)', () => {
     expect(kinds(turns[0]!.items)).toEqual(['tool'])
     expect((turns[0]!.items[0] as UiToolItem).status).toBe('completed')
   })
+
+  // The vanishing-message regression: a turn can be v2-covered for TOOLS while its prose exists
+  // only as a v1 `text` line (claude's `msg.result` fallback — see claude-ui-mapper's mapResult).
+  // The old blanket "drop every v1 item once the latch flips" deleted that message a moment
+  // after it rendered, leaving tool cards with no prose. Membership in v2 is now decided by
+  // text, so an untwinned line survives.
+  it('keeps a v1 text that has NO v2 message twin, even in a v2-covered turn', () => {
+    const resultFallback: RunEvent[] = [
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'text', { text: 'Prose that only v1 ever described.' }),
+      line(3, 'item.started', {
+        item: { kind: 'tool', id: 'toolu_A', name: 'Bash', toolKind: 'execute', title: 'Ran npm test', status: 'running' },
+      }),
+      line(4, 'item.completed', {
+        item: { kind: 'tool', id: 'toolu_A', name: 'Bash', toolKind: 'execute', title: 'Ran npm test', status: 'completed' },
+      }),
+    ]
+    const { turns } = reduceThread(resultFallback)
+    expect(kinds(turns[0]!.items)).toEqual(['message', 'tool'])
+    expect((turns[0]!.items[0] as UiMessageItem).text).toBe('Prose that only v1 ever described.')
+  })
+
+  // The two vocabularies normalize markers differently — the server strips `CEZ:` from v1 `text`
+  // before persisting, v2 items carry it raw — so the twin match has to strip both sides or
+  // every final message in a run would render twice.
+  it('matches a v1 twin against a v2 message whose text still carries its CEZ marker', () => {
+    const finalTurn: RunEvent[] = [
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'item.started', {
+        item: { kind: 'tool', id: 'toolu_A', name: 'Bash', toolKind: 'execute', title: 'Ran x', status: 'completed' },
+      }),
+      line(3, 'item.completed', { item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'All done.\n\nCEZ:DONE' } }),
+      line(4, 'text', { text: 'All done.' }), // the server-stripped v1 twin
+    ]
+    const { turns } = reduceThread(finalTurn)
+    expect(kinds(turns[0]!.items)).toEqual(['tool', 'message'])
+    expect((turns[0]!.items[1] as UiMessageItem).text).toBe('All done.')
+  })
 })
 
 describe('reduceThread — live-stream mechanics', () => {

--- a/web/app/src/routes/task-thread/thread-state.ts
+++ b/web/app/src/routes/task-thread/thread-state.ts
@@ -264,13 +264,21 @@ export function reduceThread(events: RunEvent[]): ThreadState {
     // Clone: deltas append in place, and the event object off the wire must stay untouched.
     const item = { ...raw }
     if (!turn.v2Items) {
-      // The dedup latch flips: this turn is v2-covered, so every v1-synthesized item in it is
-      // a duplicate of something v2 already describes (or is about to).
+      // The dedup latch flips: this turn is v2-covered, so every v1-synthesized TOOL in it is
+      // a duplicate of something v2 already describes (or is about to). Tools can be dropped
+      // sight-unseen because v2 tool coverage is total across backends and ids are shared —
+      // `tool-call`'s own `turn.v2Items` guard already suppresses the rest.
+      //
+      // v1 MESSAGES are deliberately NOT dropped here (#agent-log-vanishing-text): a turn being
+      // v2-covered for tools does NOT prove its prose has a v2 twin. Claude's result fallback
+      // (claude-cli-runner.ts emits a v1 `text` from `msg.result`) had no v2 counterpart, so
+      // this blanket drop deleted the agent's only message a moment after it rendered. The
+      // twinned ones are removed by text at the end of the fold, where the evidence exists.
       turn.v2Items = true
       for (const dropped of turn.entries) {
-        if (dropped.origin === 'v1' && isUiItem(dropped.entry)) itemsById.delete(dropped.entry.id)
+        if (dropped.origin === 'v1' && dropped.entry.kind === 'tool') itemsById.delete(dropped.entry.id)
       }
-      turn.entries = turn.entries.filter((e) => !(e.origin === 'v1' && isUiItem(e.entry)))
+      turn.entries = turn.entries.filter((e) => !(e.origin === 'v1' && e.entry.kind === 'tool'))
     }
     const existing = itemsById.get(key)
     if (existing && existing.turn === turn) {
@@ -373,8 +381,10 @@ export function reduceThread(events: RunEvent[]): ThreadState {
 
       // ---- v1 fallback items (skipped once the turn is v2-covered) -----------------------
       case 'text': {
+        // No `v2Items` guard, unlike `tool-call` below: whether this line has a v2 twin is
+        // decided by TEXT at the end of the fold, not by the latch. Suppressing it here would
+        // lose any prose v2 never described (claude's `msg.result` fallback).
         const turn = currentTurn()
-        if (turn.v2Items) break
         const text = str(event.text) ?? ''
         if (text === '') break
         turn.entries.push({
@@ -545,6 +555,26 @@ export function reduceThread(events: RunEvent[]): ThreadState {
       default:
         break
     }
+  }
+
+  // The message half of the mixed-file dedup, resolved once the whole turn is known: a v1
+  // `text` line is a duplicate exactly when some v2 message item in the same turn carries the
+  // same prose — which is the normal claude/codex/opencode path, where the v2 item lands first
+  // and its v1 twin one line later. Comparison is on marker-stripped, trimmed text because the
+  // two arrive differently normalized: the server strips `CEZ:` markers from v1 `text` before
+  // persisting, while v2 items carry the raw text and are stripped below at render time.
+  // Anything left unmatched is prose that exists ONLY in v1 — it renders rather than vanishing.
+  for (const draft of turns) {
+    if (!draft.v2Items) continue
+    const v2Texts = new Set<string>()
+    for (const { origin, entry } of draft.entries) {
+      if (origin === 'v2' && entry.kind === 'message') v2Texts.add(stripDoneMarker(entry.text).trim())
+    }
+    if (v2Texts.size === 0) continue
+    draft.entries = draft.entries.filter(
+      (e) =>
+        !(e.origin === 'v1' && e.entry.kind === 'message' && v2Texts.has(stripDoneMarker(e.entry.text).trim())),
+    )
   }
 
   return {


### PR DESCRIPTION
Agent text showed up in the session thread and then disappeared a moment later. Two defects stacked; neither alone explains it.

## The reducer deleted it

`web/app/src/routes/task-thread/thread-state.ts` — the first protocol-v2 `item.*` event in a turn flipped the `v2Items` latch, which retroactively removed **every** v1-derived entry already rendered in that turn, messages included. That rule is sound only if every v1 `text` line has a v2 message twin.

## Sometimes it doesn't

`src/core/claude-cli-runner.ts` emits a v1 `text` from `msg.result` when a session streams no assistant text block (`textChunks.length === 0`). Its v2 counterpart, `mapResult`, minted tool items, `turn.completed` and `usage.updated` — but never a `kind:'message'` item. So that prose existed **only** in v1, and the latch deleted it with no replacement: the turn rendered tool cards with no text at all.

Codex has the same v1 fallback but is safe — its mapper handles `item/completed` `agentMessage` generically. Nothing guarded the claude hole: `ui-parity.test.ts` has no message-item row and `claude-ui-mapper.test.ts` had no `msg.result` text case.

## The fix

- **`claude-ui-mapper.ts`** — `mapResult` mints the missing v2 message twin from `msg.result`, guarded by a new `sawAssistantText` flag. It is **session**-scoped, not per-turn, because `ctx.textChunks` in the runner is allocated once per `runAgent` and accumulates across turns; a per-turn flag would make the two paths disagree and emit duplicate prose on later turns.
- **`thread-state.ts`** — the latch now drops only v1 **tools** on flip. v1 messages are resolved by **text** at the end of the fold, where the evidence exists. Comparison strips `CEZ:` markers and trims on both sides: the server strips markers from v1 before persisting while v2 items carry them raw, so a naive compare would double-render every final message.

Net effect: twinned prose still renders exactly once; untwinned prose survives instead of being deleted.

## Tests

Regression tests in both files. Each was **verified to fail against the pre-fix code and pass after** — not just green-on-green.

- `mints a message item from msg.result when the session streamed no text block`
- `does NOT mint a result message once a text block already streamed` (no duplicate prose)
- `the no-text-block guard is session-scoped, mirroring the runner's textChunks`
- `keeps a v1 text that has NO v2 message twin, even in a v2-covered turn`
- `matches a v1 twin against a v2 message whose text still carries its CEZ marker`

127 tests pass across `claude-ui-mapper`, `ui-parity` and `thread-state`; 910 across `src/core`, `src/runs`, `web/app/src/protocol` and `web/app/src/routes/task-thread`.

## Notes for the reviewer

A full-suite baseline was not achievable locally: the dev worktree had stale `node_modules` (`smol-toml` missing), so `typecheck:server` and several server test files fail at import level on `HEAD` too. Separately, `src/workflows/run.test.ts` and `src/runs/retention-*.test.ts` fail non-deterministically (real subprocesses, real git, tight `waitFor` deadlines) — baseline 7 failures vs 9 with this change, varying run to run. A `console.error` probe confirmed the new `mapResult` branch never executes in those tests, and they pass on byte-identical code once the machine is idle.

Scope: this fixes the data loss only. A separate always-visible "latest activity" line (latest text in white, older greyed) was discussed and deliberately left out.