### PR TITLE
fix(skills): exclude nested skill references (#607)

### DIFF
--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { filterImportedTeamSkills, readImportedSkills, type Skill } from './skills.js';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  discoverSkills,
+  filterImportedTeamSkills,
+  readImportedSkills,
+  type Skill,
+} from './skills.js';
 
 /**
  * The opt-out gate's two pure halves (#391 follow-up: the promo banner is gone, replaced by
@@ -9,6 +17,11 @@ import { filterImportedTeamSkills, readImportedSkills, type Skill } from './skil
  */
 
 const OM = 'open-mercato/skills';
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
 
 function teamSkill(name: string, repo: string): Skill {
   return {
@@ -85,5 +98,40 @@ describe('filterImportedTeamSkills', () => {
   it('gates nothing when the gated set is empty (repo configured its own skillsRepos)', () => {
     const skills = [teamSkill('pr-create', OM)];
     expect(filterImportedTeamSkills(skills, new Set(), []).map((s) => s.name)).toEqual(['pr-create']);
+  });
+});
+
+describe('discoverSkills local entrypoints', () => {
+  it('keeps flat and SKILL.md skills while excluding nested reference files', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'cezar-skills-'));
+    tempDirs.push(repoRoot);
+    const skillsDir = join(repoRoot, '.ai/cezar/skills');
+    await mkdir(join(skillsDir, 'om-example/references'), { recursive: true });
+    await mkdir(join(skillsDir, 'legacy/nested'), { recursive: true });
+    await writeFile(join(skillsDir, 'flat.md'), '# Flat skill');
+    await writeFile(join(skillsDir, 'legacy/nested/legacy.md'), '# Legacy skill');
+    await writeFile(join(skillsDir, 'om-example/SKILL.md'), '# Example skill');
+    await writeFile(join(skillsDir, 'om-example/references/agentic-setup.md'), '# Supporting doc');
+
+    const skills = (await discoverSkills(repoRoot)).filter((skill) => skill.source === 'cezar');
+
+    expect(skills.map((skill) => skill.name)).toEqual(['flat', 'legacy', 'om-example']);
+    expect(skills.some((skill) => skill.name === 'agentic-setup')).toBe(false);
+  });
+
+  it('follows npx-skills directory mirrors and deduplicates them by skill name', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'cezar-skills-'));
+    tempDirs.push(repoRoot);
+    const canonicalDir = join(repoRoot, '.agents/skills/om-example');
+    const mirrorRoot = join(repoRoot, '.claude/skills');
+    await mkdir(canonicalDir, { recursive: true });
+    await mkdir(mirrorRoot, { recursive: true });
+    await writeFile(join(canonicalDir, 'SKILL.md'), '# Example skill');
+    await symlink('../../.agents/skills/om-example', join(mirrorRoot, 'om-example'), 'dir');
+
+    const skills = (await discoverSkills(repoRoot)).filter((skill) => skill.name === 'om-example');
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.source).toBe('agents');
   });
 });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -139,12 +139,12 @@ export function filterImportedTeamSkills(
 }
 
 /**
- * Walk a skills dir for `*.md` files, following directory symlinks —
- * `npx skills` mirrors `.claude/skills/<name>` → `.agents/skills/<name>` as
- * symlinks, and `readdir({recursive})` would not descend into them. Depth-
- * capped and cycle-guarded via realpath.
+ * Walk a skills dir for entrypoints, following directory symlinks. Once a
+ * directory contains `SKILL.md`, it is one directory-based skill and its
+ * supporting Markdown (for example `references/*.md`) is not scanned. Other
+ * directories retain the legacy recursive `*.md` discovery behavior.
  */
-async function walkMarkdownFiles(
+async function skillEntryPaths(
   dir: string,
   depth: number,
   visited: Set<string>,
@@ -165,7 +165,17 @@ async function walkMarkdownFiles(
   } catch {
     return [];
   }
-  const files: string[] = [];
+  const skillEntry = entries.find((entry) => entry.name === 'SKILL.md');
+  if (skillEntry) {
+    const skillPath = join(dir, skillEntry.name);
+    try {
+      if ((await stat(skillPath)).isFile()) return [skillPath];
+    } catch {
+      // A dangling or unreadable SKILL.md does not hide other valid entries.
+    }
+  }
+
+  const paths: string[] = [];
   for (const entry of entries) {
     const path = join(dir, entry.name);
     let isDir = entry.isDirectory();
@@ -177,16 +187,16 @@ async function walkMarkdownFiles(
       }
     }
     if (isDir) {
-      files.push(...(await walkMarkdownFiles(path, depth - 1, visited)));
+      paths.push(...(await skillEntryPaths(path, depth - 1, visited)));
     } else if (extname(entry.name).toLowerCase() === '.md') {
-      files.push(path);
+      paths.push(path);
     }
   }
-  return files;
+  return paths;
 }
 
 async function readMarkdownSkills(dir: string, source: Skill['source']): Promise<Skill[]> {
-  const paths = await walkMarkdownFiles(dir, 4, new Set());
+  const paths = await skillEntryPaths(dir, 4, new Set());
   const skills: Skill[] = [];
   for (const absPath of paths) {
     let raw: string;


### PR DESCRIPTION
Closes #607

## 🎯 Goal
- Stop skill support files such as `references/*.md` from appearing as standalone project skills.

## 🔍 Problem
Local skill discovery recursively promoted every Markdown file beneath a configured skill directory, so reference fragments inside installed `om-*` skills appeared in the Project skills list.

## 🔍 Root Cause
`walkMarkdownFiles` had no concept of a directory-based skill boundary: after finding `<name>/SKILL.md`, it continued into that skill package and emitted every nested Markdown file as another skill.

## What Changed
- Treat a directory containing `SKILL.md` as one skill entrypoint and stop descending into its support files.
- Preserve recursive discovery for legacy standalone nested Markdown skills and symlinked `npx skills` mirrors.
- Add filesystem regression coverage for nested references, flat/legacy skills, symlink following, and deduplication.
- Preserve PR #603 import gating and source precedence unchanged.

## 🧪 Tests
- `npx vitest run src/skills.test.ts` — 13 passed.
- `npm run typecheck` — passed.
- `npm test` — 226 files, 3964 tests passed.
- `npm run test:unit` — 34 passed.
- `npm run build` — passed, including `check:pack`.
- `npm run test:package` — 8 passed.

## 💥 Breaking Changes
- None. Legacy recursive Markdown discovery remains available outside canonical `SKILL.md` package boundaries.