### PR TITLE
fix(server-install): enable HTTP/2 on the cezar nginx vhost

### DIFF
--- a/src/server-install/platforms/ubuntu-vps.test.ts
+++ b/src/server-install/platforms/ubuntu-vps.test.ts
@@ -106,6 +106,10 @@ describe('nginxVhost', () => {
     expect(nginxVhost(4321, 'cezar.example.com')).toContain('server_name cezar.example.com;');
   });
 
+  it('enables HTTP/2 so long-lived SSE streams do not exhaust the browser connection pool', () => {
+    expect(nginxVhost(4321)).toContain('http2 on;');
+  });
+
   it('defaults to the legacy htpasswd path but accepts an instance-scoped one', () => {
     expect(nginxVhost(4321)).toContain('auth_basic_user_file /etc/cezar/htpasswd;');
     expect(nginxVhost(4322, 'shop.example.com', '/etc/cezar/htpasswd-shop-example-com')).toContain(

--- a/src/server-install/platforms/ubuntu-vps.ts
+++ b/src/server-install/platforms/ubuntu-vps.ts
@@ -123,6 +123,13 @@ server {
     listen [::]:80;
     server_name ${serverName};
 
+    # HTTP/2 multiplexes every request over ONE TCP connection. Without it the
+    # browser's ~6-connections-per-origin HTTP/1.1 cap is exhausted by cezar's
+    # long-lived SSE run streams, and further requests block until tabs close.
+    # Valid on the plain :80 block too; it only takes effect once the SSL step
+    # adds a 443 ssl listener (certbot preserves this directive).
+    http2 on;
+
     auth_basic "cezar";
     auth_basic_user_file ${htpasswd};
 

--- a/src/server-install/strategies.test.ts
+++ b/src/server-install/strategies.test.ts
@@ -25,6 +25,7 @@ describe('nginxVhost', () => {
     const v = nginxVhost(4321);
     expect(v).toContain('proxy_pass http://127.0.0.1:4321;');
     expect(v).toContain('proxy_buffering off;');
+    expect(v).toContain('http2 on;');
     expect(v).toContain('auth_basic_user_file /etc/cezar/htpasswd;');
   });
 });


### PR DESCRIPTION
## Problem

The cockpit was unusable past 3–4 concurrent connections — the browser froze and only closing windows recovered it.

**Root cause:** the generated nginx vhost serves the cockpit over **HTTP/1.1** (certbot writes `listen 443 ssl` with no `http2`). Browsers cap ~6 concurrent connections per origin on HTTP/1.1, and cezar holds **one long-lived SSE run-stream per open run**. A few active streams exhaust the connection pool, so every further request (navigation, assets, API) blocks until tabs are closed and connections free up.

## Fix

Emit `http2 on;` in `nginxVhost()`. HTTP/2 multiplexes every request over a single TCP connection, so the per-origin limit no longer applies. The directive:

- is valid on the plain `:80` block and only takes effect once the SSL step adds a `443 ssl` listener;
- is preserved by `certbot --nginx` across re-runs.

## Tests

`strategies.test.ts` and `ubuntu-vps.test.ts` now assert the vhost enables HTTP/2. Affected suites green (31/31).

## Live-server note

Existing installs still have HTTP/1.1 vhosts. They need a one-time in-place edit (`http2 on;` added to each `cezar-*` vhost + `nginx -t && systemctl reload nginx`); `worker_connections` can also be raised from the default 768. This PR only fixes what future installs generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)