### PR TITLE
fix(ui): remount routes when switching projects (#606)

### DIFF
--- a/web/app/src/routes.test.tsx
+++ b/web/app/src/routes.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, useLocation } from 'react-router'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createQueryClient } from './api/query-client'
@@ -82,6 +82,11 @@ function LocationProbe() {
       data-hash={location.hash}
     />
   )
+}
+
+function ProjectNavigationProbe() {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate('/p/other/')}>Switch project</button>
 }
 
 /** Cold-load the router at a URL, exactly as a pasted deep link would — under the same providers
@@ -251,6 +256,46 @@ describe('scoped route map (/p/:projectId)', () => {
     renderAt(`/p/${BOOT}/settings`)
     const link = document.querySelector('[data-slot="settings-index"] a[data-section="agents"]')
     expect(link?.getAttribute('href')).toBe(`/p/${BOOT}/settings/agents`)
+  })
+
+  it('remounts the same page and loads its new scope when the project param changes', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      if (path === '/api/runs' || path === '/api/p/other/runs') {
+        return new Response('[]', { headers: { 'content-type': 'application/json' } })
+      }
+      return new Promise<never>(() => {})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = createQueryClient()
+    client.setQueryData(queryKeys.health, HEALTH)
+    client.setQueryData(workspaceQueryKeys.projects, REGISTRY)
+    render(
+      <QueryClientProvider client={client}>
+        <ThemeProvider>
+          <AppearanceProvider>
+            <MemoryRouter initialEntries={[`/p/${BOOT}/`]}>
+              <ListViewProvider>
+                <AppRoutes />
+                <ProjectNavigationProbe />
+              </ListViewProvider>
+            </MemoryRouter>
+          </AppearanceProvider>
+        </ThemeProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([path]) => String(path) === '/api/runs')).toBe(true),
+    )
+    fireEvent.change(screen.getByLabelText('Search tasks'), { target: { value: 'stale filter' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Switch project' }))
+
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some(([path]) => String(path) === '/api/p/other/runs')).toBe(true),
+    )
+    expect((screen.getByLabelText('Search tasks') as HTMLInputElement).value).toBe('')
   })
 })
 

--- a/web/app/src/routes.tsx
+++ b/web/app/src/routes.tsx
@@ -189,7 +189,10 @@ function ProjectScopeRoute() {
 
   return (
     <ProjectScopeProvider projectId={scopeId}>
-      <Outlet />
+      {/* React Router keeps the matched child mounted when only this parent param changes.
+          Project-local queries and mount-time state must instead start from the project the URL
+          now names. Key the child boundary (not the provider, whose unmount resets API scope). */}
+      <Outlet key={projectId} />
     </ProjectScopeProvider>
   )
 }


### PR DESCRIPTION
Fixes #606

## Problem
Switching between projects on the same cockpit page updated the URL but could leave the previous project's routed view and local state mounted.

## Root Cause
React Router reuses the matched child when only the parent `:projectId` parameter changes. The project-scoped subtree therefore depended on render-order-sensitive module scope updates instead of starting a fresh route instance for the newly selected project.

## What Changed
- Key the project layout's `<Outlet>` by the URL project id, while leaving `ProjectScopeProvider` mounted so its API-scope cleanup cannot race the arriving child.
- Add a router regression test that switches from the boot project Tasks page to another project, verifies `/api/p/other/runs` is requested, and confirms route-local search state resets.

## Tests
- `npx vitest run web/app/src/routes.test.tsx` — 109 passed
- `npm run typecheck` — passed
- `npm test` — 3,966 passed
- `npm run test:unit` — 34 passed
- `npm run build` — passed, including `check:pack`
- `npm run test:package` — 8 passed

## Breaking Changes
None. URLs, API paths, query-key formats, and persisted state contracts are unchanged.

Manual browser QA remains pending.

🤖 Generated by autofix.