### PR TITLE
fix(ui): refresh branch markers and add filtering (#605)

### DIFF
--- a/web/app/src/routes/repo-git/repo-branches.tsx
+++ b/web/app/src/routes/repo-git/repo-branches.tsx
@@ -4,7 +4,7 @@ import { useState, type FormEvent } from 'react'
 
 import { createRepoBranch, putConfig } from '@/api/client'
 import { queryKeys, useGithub, useHealth } from '@/api/queries'
-import type { GithubItem, RepoInfo, RepoResponse } from '@/api/types'
+import type { GithubItem, HealthResponse, RepoInfo, RepoResponse } from '@/api/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { toast } from '@/components/ui/toaster'
@@ -29,12 +29,23 @@ export function RepoBranchesSection({ repo, info }: { repo: RepoResponse; info: 
 
   const branchAction = useMutation({
     mutationFn: (name: string) => createRepoBranch({ name }),
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       toast(result.created ? `Created and switched to ${result.branch}` : `Switched to ${result.branch}`)
-      // The checkout moved: the repo payload (branch, log), the working-tree diff (children
-      // of the same key) and the sidebar's health chip are all stale now.
-      void queryClient.invalidateQueries({ queryKey: queryKeys.repo })
-      void queryClient.invalidateQueries({ queryKey: queryKeys.health })
+      // Refresh the rest of both payloads first, then preserve the mutation's authoritative
+      // checkout result even if a read races and briefly returns the previous HEAD.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.repo }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.health }),
+      ])
+      queryClient.setQueryData<RepoResponse>(queryKeys.repo, (current) =>
+        current?.info ? { ...current, info: { ...current.info, branch: result.branch } } : current,
+      )
+      // Health is workspace-level, so only patch it when it describes this repo.
+      queryClient.setQueryData<HealthResponse>(queryKeys.health, (current) =>
+        current?.repo?.root === info.root
+          ? { ...current, repo: { ...current.repo, branch: result.branch } }
+          : current,
+      )
     },
     onError,
   })
@@ -53,6 +64,11 @@ export function RepoBranchesSection({ repo, info }: { repo: RepoResponse; info: 
   })
 
   const [newName, setNewName] = useState('')
+  const [branchQuery, setBranchQuery] = useState('')
+  const normalizedBranchQuery = branchQuery.trim().toLowerCase()
+  const filteredBranches = normalizedBranchQuery
+    ? repo.branches.filter((name) => name.toLowerCase().includes(normalizedBranchQuery))
+    : repo.branches
   const submitCreate = (event: FormEvent) => {
     event.preventDefault()
     const name = newName.trim()
@@ -64,8 +80,15 @@ export function RepoBranchesSection({ repo, info }: { repo: RepoResponse; info: 
     <section data-slot="repo-branches" className="flex flex-col gap-6 px-4 py-4 md:px-6">
       <div>
         <h2 className="text-xs font-semibold tracking-wide text-soft-foreground uppercase">Branches</h2>
+        <Input
+          aria-label="Filter branches"
+          placeholder="Filter branches…"
+          value={branchQuery}
+          onChange={(event) => setBranchQuery(event.target.value)}
+          className="mt-2 max-w-xl"
+        />
         <ul data-slot="repo-branch-list" className="mt-2 flex max-w-xl flex-col divide-y divide-border">
-          {repo.branches.map((name) => {
+          {filteredBranches.map((name) => {
             const current = name === info.branch
             return (
               <li key={name} data-slot="branch-row" data-branch={name} className="flex min-h-9 items-center gap-2 py-1">
@@ -94,6 +117,11 @@ export function RepoBranchesSection({ repo, info }: { repo: RepoResponse; info: 
               </li>
             )
           })}
+          {filteredBranches.length === 0 ? (
+            <li data-slot="branch-empty" className="py-3 text-xs text-soft-foreground">
+              No branches match “{branchQuery.trim()}”.
+            </li>
+          ) : null}
         </ul>
 
         <form data-slot="branch-create" className="mt-3 flex max-w-md items-center gap-2" onSubmit={submitCreate}>

--- a/web/app/src/routes/repo-git/repo-git.test.tsx
+++ b/web/app/src/routes/repo-git/repo-git.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createQueryClient } from '@/api/query-client'
+import { queryKeys } from '@/api/queries'
 import type { ChangesPayload, GithubData, HealthResponse, RepoCommitPayload, RepoResponse } from '@/api/types'
 import { Toaster, resetToasts } from '@/components/ui/toaster'
 
@@ -124,8 +125,9 @@ function stubFetch(overrides: Record<string, () => Response> = {}): SentRequest[
 
 /** Cold-load the repo view at a URL, with the same route map routes.tsx registers. */
 function renderAt(entry: string) {
+  const client = createQueryClient()
   render(
-    <QueryClientProvider client={createQueryClient()}>
+    <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={[entry]}>
         <Routes>
           <Route path="/git" element={<RepoGitRoute tab="changes" />} />
@@ -137,6 +139,7 @@ function renderAt(entry: string) {
       </MemoryRouter>
     </QueryClientProvider>,
   )
+  return client
 }
 
 // ---- changes ----------------------------------------------------------------------------------
@@ -308,7 +311,7 @@ describe('the repo view Branches segment', () => {
     const sent = stubFetch({
       'POST /api/repo/branch': () => jsonResponse({ branch: 'feature', created: false }),
     })
-    renderAt('/git/branches')
+    const client = renderAt('/git/branches')
     await waitFor(() => expect(document.querySelector('[data-action="switch-branch"]')).not.toBeNull())
 
     fireEvent.click(document.querySelector('[data-action="switch-branch"]')!)
@@ -317,6 +320,25 @@ describe('the repo view Branches segment', () => {
       expect(post?.body).toEqual({ name: 'feature' })
     })
     await waitFor(() => expect(document.body.textContent).toContain('Switched to feature'))
+    await waitFor(() => expect(document.querySelector('[data-slot="branch-chip"]')?.textContent).toBe('feature'))
+    await waitFor(() => expect(client.getQueryData<HealthResponse>(queryKeys.health)?.repo?.branch).toBe('feature'))
+  })
+
+  it('filters branch rows without narrowing the base-branch picker', async () => {
+    stubFetch()
+    renderAt('/git/branches')
+    const filter = await screen.findByLabelText('Filter branches')
+    const picker = (await screen.findByLabelText('Agents’ base branch')) as HTMLSelectElement
+
+    fireEvent.change(filter, { target: { value: 'FEAT' } })
+    expect(document.querySelector('[data-slot="branch-row"][data-branch="feature"]')).not.toBeNull()
+    expect(document.querySelector('[data-slot="branch-row"][data-branch="main"]')).toBeNull()
+    expect([...picker.options].map((option) => option.value)).toEqual(['', 'feature', 'main'])
+
+    fireEvent.change(filter, { target: { value: 'missing' } })
+    expect(document.querySelector('[data-slot="branch-empty"]')?.textContent).toContain(
+      'No branches match “missing”.',
+    )
   })
 
   it('a switch 409 surfaces git’s own reason as a danger toast', async () => {


### PR DESCRIPTION
Fixes #605

## Problem
Switching branches from the Git tab completes the checkout but can leave the displayed branch marker stale, and long branch lists cannot be searched.

## Root Cause
The branch mutation only invalidated the repo and health queries, leaving both visible branch indicators dependent on refetch timing. The branch list also rendered the full payload directly without local query state.

## What Changed
- Refresh the repo and health payloads, then preserve the completed checkout result in both scoped caches; health is patched only when its repo root matches.
- Add a case-insensitive branch filter with an accessible input and empty-result state.
- Keep the agents base-branch selector backed by the full branch list.

## Tests
- Extended the Git route tests to cover repo and health branch-marker refresh after switching.
- Added branch filtering, case-insensitivity, empty state, and full base-picker coverage.
- Full gate passed: `npm run typecheck`, `npm test` (3966), `npm run test:unit` (34), `npm run build`, `npm run test:package` (8).

## Breaking Changes
None.

🤖 Generated by autofix.