### PR TITLE
fix(ui): separate a project group's header from its first nav row

### DIFF
--- a/web/app/src/components/project-groups.tsx
+++ b/web/app/src/components/project-groups.tsx
@@ -299,7 +299,16 @@ function ProjectGroup({
       </button>
 
       {collapsed ? null : (
-        <div id={bodyId} data-slot="project-group-body" className="pl-3">
+        <div
+          id={bodyId}
+          data-slot="project-group-body"
+          // The gap and the rail are what make the header read as the PARENT of these rows.
+          // Without them the active group's `bg-muted` header sits flush against the active nav
+          // row's `bg-muted` and the two fuse into one block — the project name then reads as
+          // just another menu item. The rail is offset to sit under the chevron, so the whole
+          // body hangs off the same vertical the disclosure control is on.
+          className="mt-1 ml-[14px] border-l border-border pl-2"
+        >
           <nav aria-label={`${project.name} navigation`}>
             {visibleNavItems({ forge: forgeAvailable, inbox: inboxAvailable }).map((item) => {
               // Only the active group can own the current URL: the flat route map is


### PR DESCRIPTION
## Problem

In the multi-project sidebar the group header (project name + branch + attention badge) sat flush against the group's first nav row. On the **active** project both rows carry `bg-muted`, so they fused into a single filled block and the project name read as just another menu item — exactly the "no separation between project name and first menu item" the report shows.

## Fix

`project-groups.tsx` — the group body (`data-slot="project-group-body"`) gets a 4px gap and a hanging rail aligned under the disclosure chevron, so its nav, quick list and "More…" visibly hang off the header instead of continuing it. One class change; no behaviour, no markup, no API touched.

## Verification

- `npx vitest run` — 226 files / 3967 tests pass.
- `npm run typecheck:web` — clean.
- `web/app/e2e/project-groups.e2e.ts` against the live dry-run server — 3/3 pass.
- Visual: captured the grouped sidebar before and after against the running cockpit (see comment below).
- Full `npm run test:e2e` fails the same way with and without this commit (12–18 flaky failures across `new-task`, `github`, `workflows`, … on the unmodified tree too) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)