### PR TITLE
fix(e2e): pin CEZ_HOME in specs that boot their own server

### DIFF
--- a/web/app/e2e/agents-dock.e2e.ts
+++ b/web/app/e2e/agents-dock.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser } from './agent-browser'
+import { AgentBrowser, fixtureServeEnv } from './agent-browser'
 import record from './fixtures/subagents-run.record.json'
 
 /**
@@ -74,7 +74,7 @@ beforeAll(async () => {
   server = spawn(
     process.execPath,
     [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
-    { env: { ...process.env, CEZ_DRY_RUN: '1' }, stdio: 'ignore' },
+    { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)
 

--- a/web/app/e2e/commit-list.e2e.ts
+++ b/web/app/e2e/commit-list.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser } from './agent-browser'
+import { AgentBrowser, fixtureServeEnv } from './agent-browser'
 import record from './fixtures/thread-run.record.json'
 
 /**
@@ -141,7 +141,7 @@ beforeAll(async () => {
   server = spawn(
     process.execPath,
     [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
-    { env: { ...process.env, CEZ_DRY_RUN: '1' }, stdio: 'ignore' },
+    { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)
   const commits = (await (await fetch(`${baseUrl}/api/runs/${RUN_ID}/commits`)).json()) as {

--- a/web/app/e2e/diff-scroll.e2e.ts
+++ b/web/app/e2e/diff-scroll.e2e.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser } from './agent-browser'
+import { AgentBrowser, fixtureServeEnv } from './agent-browser'
 
 /**
  * Diff virtualization in a real browser (`components/diff/diff-scroll.ts` §"THE PERFORMANCE
@@ -128,7 +128,7 @@ beforeAll(async () => {
   server = spawn(
     process.execPath,
     [join(repoRoot, 'dist/index.js'), 'serve', '--repo', repo, '--port', String(port), '--no-open'],
-    { env: { ...process.env, CEZ_DRY_RUN: '1' }, stdio: 'ignore' },
+    { env: fixtureServeEnv(repo), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)
   changedFiles = ((await (await fetch(`${baseUrl}/api/repo/changes`)).json()) as { files: unknown[] }).files.length

--- a/web/app/src/design-guardian.test.ts
+++ b/web/app/src/design-guardian.test.ts
@@ -93,6 +93,14 @@ const RULES: Rule[] = [
     applies: styleSources,
   },
   {
+    name: 'fixture-serve-must-pin-cez-home',
+    why: "a spec-owned `cezar serve` takes its env from fixtureServeEnv(dataRoot) — a hand-rolled { CEZ_DRY_RUN } leaves CEZ_HOME at the developer's real ~/.cezar, so every run appends a dead /tmp fixture to their project registry",
+    // Line-level: a CEZ_DRY_RUN that is not accompanied by a CEZ_HOME on the same line. Both
+    // fixtureServeEnv() and the specs that spell the pair inline satisfy it.
+    pattern: /^(?![^\n]*CEZ_HOME)[^\n]*\bCEZ_DRY_RUN\b/g,
+    applies: (f) => f.isE2e,
+  },
+  {
     name: 'no-100vh',
     why: 'viewport height is 100dvh/h-dvh — 100vh ignores mobile browser chrome (iOS rule)',
     pattern: /\b(?:(?:h|min-h|max-h)-screen|100vh)\b/g,


### PR DESCRIPTION
## The bug

Ghost projects appear in the sidebar as `cezar-e2e-…` rows badged **folder not found**. Reported as "open the Add-project folder dialog, cancel, and new repos show up".

## What actually causes it

The dialog is innocent — it only writes on the **Add project** click. It mounts `useProjects()`, so opening it refetches `/api/projects` and *reveals* entries that were already in `~/.cezar/config.json`.

Those entries come from local e2e runs. Three specs — `agents-dock`, `commit-list`, `diff-scroll` — spawned their own `cezar serve` with a hand-rolled `{ CEZ_DRY_RUN: '1' }` env instead of `fixtureServeEnv()`. Since the multi-project workspace landed, booting in an unregistered folder appends it to the registry, so every run left a dead `/tmp/cezar-e2e-…` project behind. The temp dir is cleaned up at teardown; the registry row is not.

`agent-browser.ts` already documented this hazard and already had the helper — these three just predated/missed it. One developer's registry had accumulated 9 dead rows.

## The fix

- The three specs take their env from `fixtureServeEnv(dataRoot)`, which pins `CEZ_HOME` inside the throwaway dir so the spec's own `rmSync(dataRoot)` takes it too.
- New design-guardian rule `fixture-serve-must-pin-cez-home`: a `CEZ_DRY_RUN` in an e2e spec with no `CEZ_HOME` on the same line fails `npm test`. It flags the old form and passes both `fixtureServeEnv()` and the specs (`queued-stack`) that spell the pair inline.

There was a second, order-dependence cost too: once the registry holds more than one project the sidebar renders the grouped multi-project shell instead of the flat one these specs assert against.

## Verification

- `npm run typecheck:web` — clean (tsconfig covers `e2e/**`).
- design-guardian suite — 8 tests pass; regex checked against the old and new forms directly.

Full validation gate re-run on `3b50394` (`om-auto-continue-pr`):

- `npm run typecheck` (server + web) — clean.
- `npm test` — 226 files, 3968 tests pass.
- `npm run test:unit` — 34 pass.
- `npm run build` (tsc + vite + check:pack) — clean, 332 files packed.
- `npm run test:package` — 8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
