### PR TITLE
feat(server-install): --external-proxy for boxes that already run a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,9 +520,24 @@ On `ubuntu-vps` a single host can run several independent cockpits — add
 `--domain <host>` and each gets its own port, nginx site, login and service; a
 new domain never resumes or clobbers the first install.
 
+**Already running a reverse proxy?** If Dokploy, Coolify, Caddy or your own
+nginx already owns `:80/:443`, cezar's would fight it for the ports. Install the
+service only and let your proxy front it:
+
+```bash
+npx cezar-cli server-install --platform ubuntu-vps \
+  --external-proxy --domain cezar.example.com --bind-host 172.17.0.1
+```
+
+`--bind-host` is only needed when the proxy runs in a **container** (Traefik
+can't reach the host's loopback); a host-installed proxy uses the `127.0.0.1`
+default. In this mode **your proxy must enforce authentication** — cezar has
+none of its own. [Details →](docs/server-install/ubuntu-vps.md#the-box-already-has-a-reverse-proxy-dokploy-coolify-caddy)
+
 | Provider | `--platform` | Public front | Guide |
 |----------|--------------|--------------|-------|
 | Ubuntu / Debian VPS | `ubuntu-vps` | nginx + Let's Encrypt HTTPS, htpasswd login, systemd | [Step-by-step →](docs/server-install/ubuntu-vps.md) |
+| Ubuntu + existing proxy | `ubuntu-vps --external-proxy` | your Dokploy/Traefik/Caddy front; cezar ships the service only | [Step-by-step →](docs/server-install/ubuntu-vps.md#the-box-already-has-a-reverse-proxy-dokploy-coolify-caddy) |
 | macOS + ngrok | `macosx-ngrok` | ngrok tunnel + `--basic-auth`, launchd | [Step-by-step →](docs/server-install/macosx-ngrok.md) |
 
 See the **[Remote access overview](docs/server-install/README.md)** for how it

--- a/docs/server-install/ubuntu-vps.md
+++ b/docs/server-install/ubuntu-vps.md
@@ -26,6 +26,9 @@ command is verified before the installer moves on.
 - At least one logged-in agent CLI on that user — `claude`, `codex`, or
   OpenCode (experimental). (The installer can install `gh` and the npm-based CLIs for you.)
 - For HTTPS: a domain with a DNS `A`/`AAAA` record pointing at the box.
+- **Ports 80/443 free.** If another reverse proxy already owns them (Dokploy,
+  Coolify, Caddy…), don't run the default install — see
+  [The box already has a reverse proxy](#the-box-already-has-a-reverse-proxy-dokploy-coolify-caddy).
 
 > Tools installed in `~/.local/bin` or via nvm are found automatically — the
 > installer merges your **login-shell PATH** before probing, so `claude`/`gh`
@@ -76,6 +79,69 @@ For each root action you're asked:
 - **"Run it now via sudo"** — the installer runs it for you and streams output.
 
 Your choice is remembered for the rest of the run.
+
+---
+
+## The box already has a reverse proxy (Dokploy, Coolify, Caddy…)
+
+The default install above assumes cezar owns the HTTP front. If something else
+already serves **:80/:443** — Dokploy/Coolify (which run **Traefik** in Docker),
+a hand-rolled nginx, Caddy — installing cezar's nginx would fight it for those
+ports. Use `--external-proxy`:
+
+```bash
+npx cezar-cli server-install --platform ubuntu-vps \
+  --external-proxy --domain cezar.example.com --bind-host 172.17.0.1
+```
+
+That installs **the service only** — no nginx, no certbot. Steps run:
+`deps → autostart → identity`. Your proxy terminates TLS and enforces auth.
+
+```
+internet ──HTTPS──► your proxy (Traefik/Caddy/nginx) ──► cezar (172.17.0.1:4321)
+                    TLS + auth are YOURS to configure          systemd service
+```
+
+> ⚠️ **cezar has no built-in authentication.** In the default install nginx's
+> basic-auth is that gate; with `--external-proxy` there is none, and anyone who
+> can reach the bound host:port can run agents on your box. Put auth on the proxy
+> and keep the port off the public internet (ufw / cloud firewall).
+
+### Which `--bind-host`?
+
+| Your proxy runs… | `--bind-host` | Why |
+|---|---|---|
+| **in a container** (Dokploy/Coolify → Traefik) | `172.17.0.1` (docker bridge) | a container cannot dial the host's `127.0.0.1` |
+| **on the host** (nginx, Caddy, HAProxy) | omit (defaults to `127.0.0.1`) | loopback is reachable and stays private |
+
+Check your bridge address with `ip -brief addr show docker0`.
+
+### Wiring it to Dokploy / Traefik
+
+Traefik needs a route to a **host** address, so use a file-provider config
+(the installer prints this snippet, filled in, at the end of the run):
+
+```yaml
+http:
+  routers:
+    cezar:
+      rule: "Host(`cezar.example.com`)"
+      entryPoints: [websecure]
+      middlewares: [cezar-auth]
+      service: cezar
+      tls: { certResolver: letsencrypt }
+  services:
+    cezar:
+      loadBalancer:
+        servers: [{ url: "http://172.17.0.1:4321" }]
+  middlewares:
+    cezar-auth:
+      basicAuth:
+        users: ["me:$$apr1$$...."]   # htpasswd -nb me 'pass' — double every $
+```
+
+`server-deploy` and `server-uninstall` work the same in this mode (uninstall
+only removes the service — it never touches the proxy it doesn't own).
 
 ---
 
@@ -186,5 +252,8 @@ break other vhosts).
 | "no gh / claude installed" but you have them | Launched from a non-login shell without `~/.local/bin`/nvm on PATH. The current installer merges your login-shell PATH; update and re-run. |
 | certbot "verification failed" but it succeeded | Fixed — verification now reads the world-readable nginx vhost, not root-only `/etc/letsencrypt/live`. |
 | Cockpit unreachable, nginx fine | Ports 80/443 blocked. Check `ufw status` **and** any cloud firewall (Hetzner/AWS security groups). |
+| nginx won't start: `Address already in use` | Another proxy (Dokploy/Coolify → Traefik, Caddy) owns :80/:443. Re-run with `--external-proxy` (see above). `sudo ss -ltnp \| grep -E ':80\|:443'` shows who holds them. |
+| `run server-install as a normal sudo-capable user, not root` | You're `root`. `adduser cezar && usermod -aG sudo cezar`, `su - cezar`, log your agent CLI in **as that user**, then re-run. |
+| External-proxy install: proxy returns 502 | Traefik runs in a container and can't reach `127.0.0.1`. Reinstall with `--bind-host 172.17.0.1` (or your `docker0` address). |
 
 ← Back to [Remote access overview](./README.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -496,9 +496,11 @@ async function serverCommand(
     domain,
     port,
     // Only an install decides proxy mode; deploy/uninstall read it back from
-    // the recorded state (passing `false` here would flip a recorded install).
+    // the recorded state. Preserve an omitted flag as `undefined`: a flag-less
+    // resume must keep an external-proxy install external instead of flipping
+    // it back to cezar-managed nginx/SSL.
     ...(mode === 'install'
-      ? { externalProxy: Boolean(flags.externalProxy), bindHost: flags.bindHost }
+      ? { externalProxy: flags.externalProxy || undefined, bindHost: flags.bindHost }
       : {}),
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,14 @@ Options:
       --domain <host>         server-install (ubuntu-vps): host a SECOND, independent
                               cockpit for this domain (own nginx site + service + port).
                               A new domain never resumes/clobbers the first install.
+      --external-proxy        server-install (ubuntu-vps): the box ALREADY has a
+                              reverse proxy owning :80/:443 (Dokploy/Traefik, Coolify,
+                              Caddy, your own nginx). Installs the service only — no
+                              nginx, no certbot. That proxy must provide TLS + auth.
+      --bind-host <host>      host the cockpit binds (default 127.0.0.1). Use with
+                              --external-proxy when the proxy runs in a container and
+                              cannot reach loopback (e.g. docker bridge 172.17.0.1).
+                              cezar has NO built-in auth — never expose this publicly.
       --yes                   server-install: accept safe defaults (never auto-sudo)
       --reconfigure <ids>     server-install: force re-run of step id(s), comma-separated
       --reinstall             server-install: force re-run of every step (full reinstall)
@@ -64,6 +72,8 @@ async function main(): Promise<void> {
       'no-open': { type: 'boolean', default: false },
       platform: { type: 'string' },
       domain: { type: 'string' },
+      'bind-host': { type: 'string' },
+      'external-proxy': { type: 'boolean', default: false },
       yes: { type: 'boolean', default: false },
       reconfigure: { type: 'string' },
       reinstall: { type: 'boolean', default: false },
@@ -92,7 +102,7 @@ async function main(): Promise<void> {
 
   switch (command) {
     case 'serve':
-      await serveCommand(repoRoot, Number(values.port), !values['no-open']);
+      await serveCommand(repoRoot, Number(values.port), !values['no-open'], values['bind-host']);
       return;
     case 'run':
       await runCommand(repoRoot, positionals.slice(1).join(' ').trim(), values.workflow, values.model);
@@ -111,6 +121,8 @@ async function main(): Promise<void> {
         reinstall: Boolean(values.reinstall),
         domain: values.domain,
         port: portExplicit ? Number(values.port) : undefined,
+        externalProxy: Boolean(values['external-proxy']),
+        bindHost: values['bind-host'],
       });
       return;
     case 'server-deploy':
@@ -162,7 +174,12 @@ async function initWorkspace(repoRoot: string): Promise<string | undefined> {
 
 // ---- serve -----------------------------------------------------------------
 
-async function serveCommand(repoRoot: string, preferredPort: number, openBrowser: boolean): Promise<void> {
+async function serveCommand(
+  repoRoot: string,
+  preferredPort: number,
+  openBrowser: boolean,
+  bindHost?: string,
+): Promise<void> {
   const bootProjectId = await initWorkspace(repoRoot);
   // ONE workspace semaphore for the whole process (spec 2026-07-20, step 2.5):
   // the boot manager and every lazily-built project context count their runs
@@ -214,7 +231,18 @@ async function serveCommand(repoRoot: string, preferredPort: number, openBrowser
   });
 
   const port = await pickPort(preferredPort);
-  startServer({ repoRoot, store, manager, version, update, bootProjectId, semaphore }, port);
+  // SECURITY: cezar executes agents. A non-loopback bind exposes that box to
+  // whatever can reach the interface, and cezar itself has NO auth — it is only
+  // for a deliberate hosted setup where a reverse proxy in front provides TLS +
+  // auth (see `server-install --external-proxy`). Say so, loudly, every start.
+  if (bindHost && !['127.0.0.1', 'localhost', '::1'].includes(bindHost)) {
+    console.log(
+      `\n  ⚠ binding ${bindHost}:${port} — cezar has no built-in auth.\n` +
+        `    Only do this behind a reverse proxy that enforces authentication,\n` +
+        `    and make sure this interface is not reachable from the internet.\n`,
+    );
+  }
+  startServer({ repoRoot, store, manager, version, update, bootProjectId, semaphore, bindHost }, port);
   const url = `http://localhost:${port}`;
 
   console.log(`\n  cezar v${version} — ${repoRoot}`);
@@ -379,7 +407,15 @@ async function serverCommand(
   mode: 'install' | 'uninstall' | 'deploy',
   repoRoot: string,
   platform: string | undefined,
-  flags: { yes: boolean; reconfigure?: string; reinstall?: boolean; domain?: string; port?: number },
+  flags: {
+    yes: boolean;
+    reconfigure?: string;
+    reinstall?: boolean;
+    domain?: string;
+    port?: number;
+    externalProxy?: boolean;
+    bindHost?: string;
+  },
 ): Promise<void> {
   // Detection (claude/gh/codex) and tool installs resolve executables off the
   // process PATH. When the installer is launched from a non-login shell (an
@@ -459,6 +495,11 @@ async function serverCommand(
     instance,
     domain,
     port,
+    // Only an install decides proxy mode; deploy/uninstall read it back from
+    // the recorded state (passing `false` here would flip a recorded install).
+    ...(mode === 'install'
+      ? { externalProxy: Boolean(flags.externalProxy), bindHost: flags.bindHost }
+      : {}),
   };
 
   // e.g. "ubuntu-vps" or "ubuntu-vps, shop.example.com" for a named instance.

--- a/src/server-install/engine.test.ts
+++ b/src/server-install/engine.test.ts
@@ -70,6 +70,24 @@ describe('engine', () => {
     expect(a2.run).not.toHaveBeenCalled(); // resolved from state → skipped
   });
 
+  it('a flag-less resume preserves the recorded external-proxy mode', async () => {
+    const externalStep = fakeStep('external');
+    const managedProxyStep = fakeStep('managed-proxy');
+    const strategy: PlatformStrategy = {
+      id: 'ubuntu-vps',
+      label: 'Ubuntu VPS',
+      preflight: async () => {},
+      steps: (ctx) => (ctx.state.externalProxy ? [externalStep] : [managedProxyStep]),
+    };
+
+    await runInstall(strategy, opts({ externalProxy: true }));
+    expect(loadServerState().externalProxy).toBe(true);
+
+    await runInstall(strategy, opts({ externalProxy: undefined }));
+    expect(loadServerState().externalProxy).toBe(true);
+    expect(managedProxyStep.run).not.toHaveBeenCalled();
+  });
+
   it('--reconfigure re-runs a named done step', async () => {
     const a = fakeStep('a');
     await runInstall(strategyOf([a]), opts());

--- a/src/server-install/engine.ts
+++ b/src/server-install/engine.ts
@@ -46,6 +46,11 @@ export interface RunOptions {
   /** Loopback port for this instance. For a NEW named instance the caller
    * passes an auto-picked free port; a resume keeps the recorded one. */
   port?: number;
+  /** `--external-proxy`: an existing reverse proxy fronts cezar, so the
+   * platform installs no nginx/SSL of its own. */
+  externalProxy?: boolean;
+  /** `--bind-host`: interface the cockpit binds so that proxy can reach it. */
+  bindHost?: string;
 }
 
 export type RunStatus = 'complete' | 'cancelled' | 'failed';
@@ -147,6 +152,10 @@ export async function runInstall(strategy: PlatformStrategy, opts: RunOptions): 
     // uninstall/deploy runs (and `server-instances/` listings) agree on it.
     state.instance = opts.instance ?? state.instance ?? 'default';
     if (opts.domain) state.domain = opts.domain;
+    // Proxy mode + bind host are recorded before `steps(ctx)` runs, because the
+    // platform selects its step list from them (external proxy ⇒ no nginx/SSL).
+    if (opts.externalProxy !== undefined) state.externalProxy = opts.externalProxy;
+    if (opts.bindHost) state.bindHost = opts.bindHost;
     // A caller-supplied port wins (a new named instance auto-picks a free one);
     // otherwise keep whatever the resumed record already carries.
     if (opts.port) state.primaryPort = opts.port;

--- a/src/server-install/platforms/ubuntu-vps.test.ts
+++ b/src/server-install/platforms/ubuntu-vps.test.ts
@@ -9,9 +9,14 @@ import type { InstallContext, InstallStep, Runner, Ui } from '../types.js';
 
 const okRunner: Runner = { capture: async () => ({ code: 0, stdout: '', stderr: '' }), interactive: async () => 0 };
 
-function ctxWith(over: { ui?: Ui; runner?: Runner; dryRun?: boolean }): InstallContext {
+function ctxWith(over: {
+  ui?: Ui;
+  runner?: Runner;
+  dryRun?: boolean;
+  state?: Partial<InstallContext['state']>;
+}): InstallContext {
   return {
-    state: { schema: 1, installed: false, primaryPort: 4321, steps: {} },
+    state: { schema: 1, installed: false, primaryPort: 4321, steps: {}, ...over.state },
     ui: over.ui ?? createAutoUi(),
     instance: 'default',
     runner: over.runner ?? okRunner,
@@ -51,6 +56,38 @@ describe('ubuntu-vps ssl step', () => {
     // The service step is required now — after install cezar must actually run.
     expect(stepById('autostart').optional).toBeFalsy();
     expect(stepById('identity').optional).toBeFalsy();
+  });
+
+  it('--external-proxy drops our nginx + SSL steps (an existing front owns :80/:443)', () => {
+    const ids = ubuntuVps.steps(ctxWith({ state: { externalProxy: true } })).map((s) => s.id);
+    expect(ids).toEqual(['deps', 'autostart', 'identity']);
+    expect(ids).not.toContain('nginx-proxy');
+    expect(ids).not.toContain('ssl');
+  });
+
+  it('external-proxy verify passes when cezar answers on the bound host', async () => {
+    const seen: string[] = [];
+    const runner: Runner = {
+      capture: async (program, args) => {
+        if (program === 'curl') seen.push(args.join(' '));
+        return { code: 0, stdout: program === 'curl' ? '200' : '', stderr: '' };
+      },
+      interactive: async () => 0,
+    };
+    const ctx = ctxWith({ runner, state: { externalProxy: true, bindHost: '172.17.0.1' } });
+    await expect(stepById('identity').run(ctx)).resolves.toBeTruthy();
+    // It must probe the bind host, not loopback — a container proxy can't use 127.0.0.1.
+    expect(seen.some((a) => a.includes('http://172.17.0.1:4321/'))).toBe(true);
+  });
+
+  it('external-proxy verify aborts when nothing is listening', async () => {
+    const runner: Runner = {
+      // curl "000" = no connection; `sleep` between polls returns 0.
+      capture: async (program) => ({ code: 0, stdout: program === 'curl' ? '000' : '', stderr: '' }),
+      interactive: async () => 0,
+    };
+    const ctx = ctxWith({ runner, state: { externalProxy: true, bindHost: '172.17.0.1' } });
+    await expect(stepById('identity').run(ctx)).rejects.toBeInstanceOf(StepAborted);
   });
 
   it('dry-run records the cert as a shared artifact and sets publicUrl', async () => {
@@ -198,6 +235,17 @@ describe('systemdUnit', () => {
   it('takes an absolute "<node> <entry.js>" ExecStart verbatim (no bare name → no 203/EXEC)', () => {
     const unit = systemdUnit('/srv/app', 4321, 'system', '/usr/bin/node /srv/app/dist/index.js');
     expect(unit).toContain('ExecStart=/usr/bin/node /srv/app/dist/index.js serve --no-open --port 4321');
+  });
+
+  it('passes --bind-host when an external-proxy install needs a reachable interface', () => {
+    const unit = systemdUnit('/srv/app', 4321, 'user', '/usr/local/bin/cezar', '172.17.0.1');
+    expect(unit).toContain('ExecStart=/usr/local/bin/cezar serve --no-open --port 4321 --bind-host 172.17.0.1');
+  });
+
+  it('stays flag-free for loopback so existing units are unchanged', () => {
+    const plain = systemdUnit('/srv/app', 4321, 'user', '/usr/local/bin/cezar');
+    expect(systemdUnit('/srv/app', 4321, 'user', '/usr/local/bin/cezar', '127.0.0.1')).toBe(plain);
+    expect(plain).not.toContain('--bind-host');
   });
 });
 

--- a/src/server-install/platforms/ubuntu-vps.ts
+++ b/src/server-install/platforms/ubuntu-vps.ts
@@ -71,13 +71,34 @@ async function curlCode(ctx: InstallContext, args: string[], opts?: { input?: st
   return r.stdout.trim() || '000';
 }
 
-/** True once cezar answers on 127.0.0.1:<port> (any HTTP status = the process is up). */
+/**
+ * Name of the process listening on `port`, or null when nothing is. Best effort
+ * (`ss` output varies, and without root the process name may be hidden) — used
+ * only to make a port collision explainable, never to gate the install.
+ */
+export async function portListener(ctx: InstallContext, port: number): Promise<string | null> {
+  if (ctx.dryRun) return null;
+  const r = await ctx.runner.capture('ss', ['-ltnp', `( sport = :${port} )`]);
+  if (r.code !== 0) return null;
+  const line = r.stdout.split('\n').find((l) => /LISTEN/.test(l));
+  if (!line) return null;
+  // `users:(("docker-proxy",pid=123,fd=4))` → docker-proxy; unnamed → "another process".
+  return /users:\(\("([^"]+)"/.exec(line)?.[1] ?? 'another process';
+}
+
+/** The interface the cockpit listens on — loopback unless an external-proxy
+ *  install bound it somewhere the proxy can reach (e.g. the docker bridge). */
+export function upstreamHost(ctx: InstallContext): string {
+  return ctx.state.bindHost?.trim() || '127.0.0.1';
+}
+
+/** True once cezar answers on <host>:<port> (any HTTP status = the process is up). */
 async function isCezarUp(ctx: InstallContext, port: number): Promise<boolean> {
-  const code = await curlCode(ctx, [`http://127.0.0.1:${port}/`]);
+  const code = await curlCode(ctx, [`http://${upstreamHost(ctx)}:${port}/`]);
   return code !== '000';
 }
 
-/** Poll the loopback upstream until cezar responds or the attempts run out. */
+/** Poll the upstream until cezar responds or the attempts run out. */
 async function waitForCezar(ctx: InstallContext, port: number, attempts = 15): Promise<boolean> {
   for (let i = 0; i < attempts; i++) {
     if (await isCezarUp(ctx, port)) return true;
@@ -95,7 +116,7 @@ async function waitForCezar(ctx: InstallContext, port: number, attempts = 15): P
  */
 async function confirmCezarRunning(ctx: InstallContext, statusCmd: string, logsCmd: string): Promise<void> {
   if (ctx.dryRun) {
-    ctx.ui.info(`DRY RUN — would wait for cezar on 127.0.0.1:${ctx.state.primaryPort}.`);
+    ctx.ui.info(`DRY RUN — would wait for cezar on ${upstreamHost(ctx)}:${ctx.state.primaryPort}.`);
     return;
   }
   const sp = ctx.ui.spinner();
@@ -535,7 +556,13 @@ const sslStep: InstallStep = {
  * absolute `"<node> <entry.js>"`. We still set `Environment=PATH` (with the
  * installer's node dir) for any child process the app spawns.
  */
-export function systemdUnit(repoRoot: string, port: number, scope: 'user' | 'system', execStart: string): string {
+export function systemdUnit(
+  repoRoot: string,
+  port: number,
+  scope: 'user' | 'system',
+  execStart: string,
+  bindHost?: string,
+): string {
   const userLine = scope === 'system' ? `User=${userInfo().username}\n` : '';
   const installTarget = scope === 'system' ? 'multi-user.target' : 'default.target';
   // Give the service the operator's own PATH (node dir + the login PATH the CLI
@@ -546,6 +573,10 @@ export function systemdUnit(repoRoot: string, port: number, scope: 'user' | 'sys
   // systemd expands `%` specifiers in Environment/ExecStart values — a literal
   // `%` (possible in an nvm dir name) must be doubled or the unit fails to load.
   const sysd = (s: string) => s.replace(/%/g, '%%');
+  // Loopback stays the default (and stays flag-less, so existing units are
+  // byte-identical); an external-proxy install binds an interface its proxy can
+  // actually reach — a container-based proxy cannot dial the host's loopback.
+  const bind = bindHost?.trim() && bindHost.trim() !== '127.0.0.1' ? ` --bind-host ${bindHost.trim()}` : '';
   return `# Managed by cezar server-install — do not edit by hand.
 [Unit]
 Description=cezar cockpit
@@ -557,7 +588,7 @@ Type=simple
 ${userLine}WorkingDirectory=${repoRoot}
 Environment=CEZ_REMOTE=1
 Environment=PATH=${sysd(pathDirs.join(':'))}
-ExecStart=${sysd(execStart)} serve --no-open --port ${port}
+ExecStart=${sysd(execStart)} serve --no-open --port ${port}${sysd(bind)}
 Restart=on-failure
 RestartSec=5
 
@@ -648,7 +679,11 @@ const autostartStep: InstallStep = {
         ctx.ui.info(`DRY RUN — would write ${unitPath} and enable it (systemctl --user enable --now cezar).`);
       } else {
         mkdirSync(join(homedir(), '.config', 'systemd', 'user'), { recursive: true });
-        writeFileSync(unitPath, systemdUnit(ctx.repoRoot, ctx.state.primaryPort, 'user', execStart), 'utf8');
+        writeFileSync(
+          unitPath,
+          systemdUnit(ctx.repoRoot, ctx.state.primaryPort, 'user', execStart, ctx.state.bindHost),
+          'utf8',
+        );
         await ctx.runner.interactive('systemctl', ['--user', 'daemon-reload']);
         await ctx.runner.interactive('systemctl', ['--user', 'enable', '--now', UNIT_NAME]);
         if ((await ctx.runner.capture('systemctl', ['--user', 'is-enabled', UNIT_NAME])).code !== 0) {
@@ -681,7 +716,7 @@ const autostartStep: InstallStep = {
     await writeFileStep(ctx, {
       description: 'Install the cezar systemd unit, start it now, and enable it at boot.',
       path: `/etc/systemd/system/${UNIT_NAME}`,
-      content: systemdUnit(ctx.repoRoot, ctx.state.primaryPort, 'system', execStart),
+      content: systemdUnit(ctx.repoRoot, ctx.state.primaryPort, 'system', execStart, ctx.state.bindHost),
       extra: `systemctl daemon-reload && systemctl enable --now ${UNIT_NAME}`,
       verify: (c) => verifyCommand(c, 'systemctl', ['is-enabled', UNIT_NAME]),
     });
@@ -721,6 +756,71 @@ const autostartStep: InstallStep = {
   },
 };
 
+/**
+ * `--external-proxy` verification: confirm the cockpit is listening on the
+ * interface the operator's proxy will dial, then hand them the routing snippet.
+ * cezar ships no auth of its own, so this is also where we say — unmissably —
+ * that the front they own has to enforce it.
+ */
+async function verifyBehindExternalProxy(ctx: InstallContext): Promise<{ artifacts: StepArtifact[] }> {
+  const port = ctx.state.primaryPort;
+  const host = upstreamHost(ctx);
+  const target = `http://${host}:${port}`;
+  const domain = ctx.state.domain ?? '<your-domain>';
+
+  if (ctx.dryRun) {
+    ctx.ui.info(`DRY RUN — would verify cezar answers on ${target} and print the proxy routing snippet.`);
+    return { artifacts: [] };
+  }
+
+  if (!(await waitForCezar(ctx, port))) {
+    ctx.ui.error(
+      `cezar is not answering on ${target}.\n\n` +
+        `Diagnostics on the server:\n` +
+        `  • systemctl --user status ${unitName(ctx)}   (or: sudo systemctl status ${unitName(ctx)})\n` +
+        `  • sudo ss -ltnp | grep :${port}\n` +
+        (host === '127.0.0.1'
+          ? ''
+          : `  • is ${host} a real local interface? (ip -brief addr) — a container-based proxy\n` +
+            `    usually reaches the host on the docker bridge, commonly 172.17.0.1\n`),
+    );
+    throw new StepAborted('cockpit verification failed — see the diagnostics above');
+  }
+
+  ctx.ui.success(`Cockpit is up and listening on ${target}.`);
+  ctx.ui.warn(
+    'cezar has NO built-in authentication in this mode — your reverse proxy MUST enforce it. ' +
+      'Anyone who can reach ' + target + ' can run agents on this box.',
+  );
+  ctx.ui.message(
+    [
+      `Point your existing proxy at ${target} for ${domain}. For Dokploy / Traefik,`,
+      `add a file-provider config (Traefik runs in a container, so it cannot use 127.0.0.1):`,
+      ``,
+      `  http:`,
+      `    routers:`,
+      `      cezar:`,
+      `        rule: "Host(\`${domain}\`)"`,
+      `        entryPoints: [websecure]`,
+      `        middlewares: [cezar-auth]`,
+      `        service: cezar`,
+      `        tls: { certResolver: letsencrypt }`,
+      `    services:`,
+      `      cezar:`,
+      `        loadBalancer:`,
+      `          servers: [{ url: "${target}" }]`,
+      `    middlewares:`,
+      `      cezar-auth:`,
+      `        basicAuth:`,
+      `          users: ["USER:$$apr1$$...."]   # htpasswd -nb user pass (double every $)`,
+      ``,
+      `Keep ${host}:${port} off the public internet (ufw / cloud firewall) — the proxy`,
+      `should be the only thing that can reach it.`,
+    ].join('\n'),
+  );
+  return { artifacts: [] };
+}
+
 const identityStep: InstallStep = {
   id: 'identity',
   title: 'Verify the cockpit end-to-end (auth + HTTPS reach cezar)',
@@ -728,6 +828,10 @@ const identityStep: InstallStep = {
     return false; // always re-verify; it creates nothing
   },
   async run(ctx): Promise<{ artifacts: StepArtifact[] }> {
+    // External proxy: cezar installed no nginx, so there is no auth challenge of
+    // ours to probe. All we can (and should) verify is that the cockpit is
+    // actually listening where the operator's proxy will look for it.
+    if (ctx.state.externalProxy) return verifyBehindExternalProxy(ctx);
     if (ctx.dryRun) {
       ctx.ui.info('DRY RUN — would verify auth (401 for anon) AND that an authenticated request reaches cezar.');
       return { artifacts: [] };
@@ -824,9 +928,30 @@ export const ubuntuVps: PlatformStrategy = {
     if ((await ctx.runner.capture('id', ['-u'])).stdout.trim() === '0') {
       throw new PreflightError('run server-install as a normal sudo-capable user, not root.');
     }
+    // Someone else already owns the HTTP front (Dokploy/Traefik, Coolify, Caddy,
+    // a hand-rolled nginx)? Installing ours would fight it for :80/:443 and the
+    // proxy step would fail with a confusing bind error — point at the mode that
+    // actually fits instead.
+    if (!ctx.state.externalProxy) {
+      const holder = await portListener(ctx, 80);
+      if (holder && !/nginx/i.test(holder)) {
+        ctx.ui.warn(
+          `Port 80 is already served by "${holder}" on this host.\n` +
+            `cezar's ubuntu-vps install wants :80/:443 for its own nginx, so these will collide.\n\n` +
+            `If that is a reverse proxy you rely on (Dokploy/Traefik, Coolify, Caddy), re-run with:\n` +
+            `  cezar server-install --platform ubuntu-vps --external-proxy${ctx.state.domain ? ` --domain ${ctx.state.domain}` : ''} [--bind-host 172.17.0.1]\n` +
+            `That installs the cezar service only and lets your proxy front it.`,
+        );
+      }
+    }
   },
-  steps(): InstallStep[] {
-    // deps → proxy → (optional) ssl → (optional) autostart → identity.
+  steps(ctx: InstallContext): InstallStep[] {
+    // `--external-proxy`: the box already has a front owning :80/:443 (Dokploy/
+    // Traefik, Coolify, Caddy, an existing nginx). Installing our own nginx
+    // there would fight it for the ports, so we ship the service only and let
+    // that proxy terminate TLS + auth.
+    if (ctx.state.externalProxy) return [depCheckStep(), autostartStep, identityStep];
+    // deps → proxy → (optional) ssl → autostart → identity.
     return [depCheckStep(), nginxProxyStep, sslStep, autostartStep, identityStep];
   },
   async redeploy(ctx: InstallContext) {

--- a/src/server-install/types.ts
+++ b/src/server-install/types.ts
@@ -80,6 +80,19 @@ export const serverStateSchema = z
     /** Public domain this instance answers on (drives nginx `server_name` +
      * the SSL cert). Absent for a plain HTTP / default install. */
     domain: z.string().optional().catch(undefined),
+    /**
+     * External-reverse-proxy mode (`--external-proxy`): the box already has a
+     * front (Dokploy/Traefik, Coolify, Caddy, an existing nginx) that owns
+     * :80/:443 and provides TLS + auth. cezar then installs NO nginx and NO
+     * cert of its own — just the service — and that proxy routes to `bindHost`.
+     */
+    externalProxy: z.boolean().optional().catch(undefined),
+    /**
+     * Interface the cockpit binds. Loopback by default; an external-proxy
+     * install may need a host the proxy can actually reach (e.g. the docker
+     * bridge `172.17.0.1` when the proxy runs in a container).
+     */
+    bindHost: z.string().optional().catch(undefined),
     /** Flips true only when every required step is `done`. */
     installed: z.boolean().default(false).catch(false),
     /** True when this record was written by a CEZ_DRY_RUN preview — a real

--- a/test/e2e/package-cli.test.ts
+++ b/test/e2e/package-cli.test.ts
@@ -146,6 +146,23 @@ test('the release tarball installs and runs the dry-run CLI workflow', { timeout
     assert.deepEqual(reversed.steps, {}, 'server-uninstall reverses every step');
     assert.equal(reversed.installed, false, 'server-uninstall clears installed');
 
+    await execFile(
+      process.execPath,
+      [cliPath, 'server-install', '--platform', 'ubuntu-vps', '--external-proxy', '--yes', '--repo', fixtureRepo],
+      serverExec,
+    );
+    await execFile(
+      process.execPath,
+      [cliPath, 'server-install', '--platform', 'ubuntu-vps', '--yes', '--repo', fixtureRepo],
+      serverExec,
+    );
+    const resumedExternal = JSON.parse(await readFile(join(cezHome, 'server.json'), 'utf8')) as {
+      externalProxy?: boolean;
+      steps: Record<string, unknown>;
+    };
+    assert.equal(resumedExternal.externalProxy, true, 'a flag-less resume preserves external-proxy mode');
+    assert.ok(!resumedExternal.steps['nginx-proxy'], 'a flag-less resume does not add cezar-managed nginx');
+
     // Unknown platform exits non-zero.
     await assert.rejects(
       execFile(process.execPath, [cliPath, 'server-install', '--platform', 'nope'], serverExec),


### PR DESCRIPTION
## Why

`server-install --platform ubuntu-vps` assumes cezar owns the HTTP front: it installs nginx on **:80/:443** and disables the distro default site. On a host already running **Dokploy/Coolify** (Traefik in Docker), Caddy, or a hand-rolled nginx, that fights the existing proxy for those ports — the `nginx-proxy` step fails with a bind error, and it can disturb the apps already served there.

There was no way to opt out: the step list was fixed, and `--reconfigure` only *forces* steps, never skips them. Hit in the wild trying to host a cockpit on a Dokploy VPS.

## What

**`--external-proxy`** — ship the service only (`deps → autostart → identity`; no nginx, no certbot). The operator's existing proxy terminates TLS and enforces auth.

```bash
npx cezar-cli server-install --platform ubuntu-vps \
  --external-proxy --domain cezar.example.com --bind-host 172.17.0.1
```

**`--bind-host <host>`** — wires the already-present `ServerDeps.bindHost` through the CLI into the systemd unit's `ExecStart`. Required when the fronting proxy runs in a **container**: Traefik cannot dial the host's `127.0.0.1`, so the cockpit must listen on a reachable interface (docker bridge, commonly `172.17.0.1`). Loopback stays the default *and stays flag-free*, so existing units are byte-identical.

**Mode-aware verification** — with no nginx of ours there's no 401 to probe, so it confirms cezar answers on the *bound* host and prints a filled-in Traefik file-provider snippet (router + `basicAuth` middleware + service). `redeploy` and `uninstall` route through the same branch; uninstall only removes the service and never touches a proxy it doesn't own.

**Better failure mode** — preflight now names the process holding `:80` (e.g. `docker-proxy`) and points at `--external-proxy`, instead of failing later with an opaque bind error.

## ⚠️ Security

cezar has **no authentication of its own** — in the default install nginx's basic-auth is that gate. In external-proxy mode the front must provide it. Both the installer and every non-loopback `serve` start say so loudly, and the docs call it out. The default remains loopback-only.

## Testing

- `vitest run` — **3972 passed** (226 files), incl. 7 new tests: external-proxy step list, `--bind-host` in the unit, loopback stays flag-free, verify pass/abort paths.
- Dry-run install in both modes: external skips nginx/ssl and probes `172.17.0.1:4321`; default path unchanged (nginx + htpasswd + vhost).
- Live bind check: default refuses connections on the LAN IP; `--bind-host 0.0.0.0` serves 200 and prints the warning.

Not exercised against a real Dokploy box — the Traefik snippet follows their file-provider docs.

## Docs

New "The box already has a reverse proxy" section in `docs/server-install/ubuntu-vps.md` (bind-host choice table, Traefik wiring, security note), a prerequisite about ports 80/443 being free, three troubleshooting rows (`Address already in use`, running as root, external-proxy 502), and a README entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)