### PR TITLE
fix(ui): preserve virtual transcript width (#622)

### DIFF
--- a/web/app/e2e/thread-scroll.e2e.ts
+++ b/web/app/e2e/thread-scroll.e2e.ts
@@ -84,6 +84,8 @@ const MAIN = `document.querySelector('[data-slot="main"]')`
 const nearBottom = `(() => { const m = ${MAIN}; return m.scrollHeight - m.scrollTop - m.clientHeight < 80 })()`
 const rowCount = () => browser.count('[data-slot="thread-row"]')
 const domSize = () => Number(browser.evaluate(`document.querySelectorAll('*').length`))
+const assistantWidth = () =>
+  Number(browser.evaluate(`document.querySelector('[data-slot="assistant-message"]')?.getBoundingClientRect().width ?? 0`))
 
 /**
  * Scroll away from the tail like a reader would — and INSIST, like a reader would.
@@ -157,13 +159,16 @@ afterAll(() => {
 describe('thread virtualization on a 1,000-row transcript', () => {
   let flatRows = 0
   let flatDom = 0
+  let flatAssistantWidth = 0
 
   it('force-flat renders every row (the before measurement)', () => {
     openThread('?thread=flat')
     expect(browser.evaluate(`document.querySelector('[data-slot="thread-rows"]').dataset.virtualized`)).toBe('false')
     flatRows = rowCount()
     flatDom = domSize()
+    flatAssistantWidth = assistantWidth()
     expect(flatRows).toBe(ROWS) // the generator's own arithmetic, end to end
+    expect(flatAssistantWidth).toBeGreaterThan(200)
   }, 90_000)
 
   it('auto mode virtualizes past the threshold and keeps the DOM bounded', () => {
@@ -178,6 +183,9 @@ describe('thread virtualization on a 1,000-row transcript', () => {
     expect(virtualRows).toBeGreaterThan(0)
     expect(virtualRows).toBeLessThan(flatRows / 10)
     expect(virtualDom).toBeLessThan(flatDom / 2)
+    const virtualAssistantWidth = assistantWidth()
+    expect(virtualAssistantWidth).toBeGreaterThan(200)
+    expect(Math.abs(virtualAssistantWidth - flatAssistantWidth)).toBeLessThan(2)
     // The numbers themselves are checkpoint material — persisted next to the screenshots.
     mkdirSync(artifactsDir, { recursive: true })
     writeFileSync(

--- a/web/app/src/routes/task-thread/thread-scroller.test.tsx
+++ b/web/app/src/routes/task-thread/thread-scroller.test.tsx
@@ -40,6 +40,7 @@ describe('ThreadRows — the threshold-switched renderer', () => {
     expect(rendered[0]!.className).toContain('[content-visibility:auto]')
     // Bubbles rely on flex alignment inside their row — every wrapper is a flex column.
     expect(rendered[0]!.className).toContain('flex-col')
+    expect(rendered[0]!.className).toContain('w-full')
   })
 
   it('virtual mode mounts the virtua container instead', () => {
@@ -51,6 +52,7 @@ describe('ThreadRows — the threshold-switched renderer', () => {
     // thread-scroll.e2e.ts's).
     const rendered = document.querySelectorAll('[data-slot="thread-row"]')
     expect(rendered.length).toBeLessThan(400)
+    for (const row of rendered) expect(row.className).toContain('w-full')
   })
 
   it('flat rows keep their content in render order', () => {

--- a/web/app/src/routes/task-thread/thread-scroller.tsx
+++ b/web/app/src/routes/task-thread/thread-scroller.tsx
@@ -259,7 +259,7 @@ export function ThreadRows({
         <div
           key={row.key}
           data-slot="thread-row"
-          className="flex flex-col pb-2.5 [contain-intrinsic-block-size:auto_3rem] [content-visibility:auto]"
+          className="flex w-full flex-col pb-2.5 [contain-intrinsic-block-size:auto_3rem] [content-visibility:auto]"
         >
           {row.node}
         </div>
@@ -341,7 +341,7 @@ function VirtualRows({
         {...(measurements !== undefined ? { cache: measurements } : {})}
       >
         {rows.map((row) => (
-          <div key={row.key} data-slot="thread-row" className="flex flex-col pb-2.5">
+          <div key={row.key} data-slot="thread-row" className="flex w-full flex-col pb-2.5">
             {row.node}
           </div>
         ))}


### PR DESCRIPTION
Fixes #622

## Problem
Long Session transcripts switch to the virtualized renderer above 300 rows, where assistant prose could collapse to its min-content width and render one word or character per line.

## Root Cause
Both thread render modes relied on flex stretch for row width. In virtual mode, `virtua` inserts contained and absolutely positioned wrappers, so the nested row did not always receive a definite width during measurement or the live flat-to-virtual swap.

## What Changed
- Give both flat and virtual `thread-row` wrappers an explicit `w-full` width while preserving their mirrored layout.
- Assert the width invariant in the component tests.
- Verify in the real-browser large-transcript test that virtual assistant prose remains wider than 200px and matches flat mode.

## Tests
- `npm run typecheck` — passed
- `npm test` — passed (3,986 tests)
- `npm run test:unit` — passed (34 tests)
- `npm run build` — passed
- `npm run test:package` — passed (8 tests)
- `npm run test:e2e` — changed `thread-scroll.e2e.ts` passed; the full run reported 6 unrelated failures in other suites (GitHub, commit list, review gate, changes toolbar, and syntax highlighting)

## Breaking Changes
None.

🤖 Generated by autofix.
