### PR TITLE
fix(ui): repair concatenated task titles (#623)

### DIFF
--- a/src/runs/auto-name.test.ts
+++ b/src/runs/auto-name.test.ts
@@ -95,6 +95,13 @@ describe('composeNameResult', () => {
     expect(composeNameResult('{"nope": true}', ctx)).toBeNull();
   });
 
+  it.each([
+    'Loading the pipeline config and tracker descriptor, then claim PR #469.Config loaded',
+    'Reading the handoff file for context.The task is UI QA verification of PR #476',
+  ])('rejects concatenated progress narration: %s', (title) => {
+    expect(composeNameResult(JSON.stringify({ title }), ctx)).toBeNull();
+  });
+
   it('drops hallucinated refs but keeps the validated title', () => {
     const raw = '{"title": "renaming the settings page", "pr": 999}';
     expect(composeNameResult(raw, { task: 'rename the settings page' })).toEqual({

--- a/src/runs/auto-name.ts
+++ b/src/runs/auto-name.ts
@@ -183,6 +183,11 @@ export async function generateRunName(repoRoot: string, ctx: NamerContext): Prom
 export function composeNameResult(rawText: string, ctx: NamerContext): NameResult | null {
   const parsed = parseStructured(rawText, namerResponseSchema);
   if (!parsed) return null;
+  // #623: a terse title is one phrase, not concatenated progress narration. Reject
+  // unambiguous missing sentence whitespace (the observed `.Config` / `.The`
+  // shape) and keep the honest heuristic title instead of trying to guess
+  // where a model's prose should have been split.
+  if (/[.!?][A-Z]/.test(parsed.title)) return null;
   const refs = refineTaskRefs(extractTaskRefs(ctx.task), ctx.skillName);
   const checked = crossCheckRefs(parsed, ctx.task, refs);
   const refNumber = checked.prNumber ?? checked.issueNumber ?? titleRefNumber(refs);

--- a/web/app/src/lib/task-groups.test.ts
+++ b/web/app/src/lib/task-groups.test.ts
@@ -305,6 +305,37 @@ describe('runTitle — the one name every surface shows', () => {
       over: { title: 'Login 500 fix', titleSummary: 'Login 500 fix' },
       expected: 'Login 500 fix',
     },
+    {
+      label: 'legacy concatenated narration falls back without rewriting persisted state',
+      over: {
+        title: '469: /om-auto-review-pr',
+        titleSummary: 'Loading the pipeline config and tracker descriptor, then claim PR #469.Config loaded',
+      },
+      expected: '469: /om-auto-review-pr',
+    },
+    {
+      label: 'user-owned titles preserve punctuation byte-for-byte',
+      over: {
+        title: 'Release v2.Config migration',
+        titleSummary: 'Release v2.Config migration',
+        titleOrigin: 'user' as const,
+      },
+      expected: 'Release v2.Config migration',
+    },
+    {
+      label: 'marker-owned titles preserve punctuation byte-for-byte',
+      over: {
+        title: 'raw task',
+        titleSummary: 'Testing SDK.Config support',
+        titleOrigin: 'marker' as const,
+      },
+      expected: 'Testing SDK.Config support',
+    },
+    {
+      label: 'well-formed identifiers and acronyms remain untouched',
+      over: { title: 'raw task', titleSummary: 'updating README.md for OAuth2' },
+      expected: 'updating README.md for OAuth2',
+    },
   ])('$label', ({ over, expected }) => {
     expect(runTitle(run(over))).toBe(expected)
   })

--- a/web/app/src/lib/task-groups.ts
+++ b/web/app/src/lib/task-groups.ts
@@ -74,16 +74,19 @@ export function bucketOf(run: RunRecord, view: ListView): BucketLabel {
 /**
  * What every surface calls a run — the R1-marked plug-in point, now wired (R2 Step 2.4).
  *
- * `titleSummary ?? title`, per the server's contract (`api/types.ts`): `titleSummary` is the
- * auto-derived summary of the first agent turn, and a user's inline rename (`PATCH
- * /api/runs/:id`) writes BOTH fields, so an edit always wins over any past or future
- * auto-summary. Old records have no `titleSummary` and honestly show the raw title.
+ * `titleSummary ?? title`, per the server's contract (`api/types.ts`), except (#623) for malformed
+ * auto/legacy summaries whose sentence punctuation was persisted without following whitespace.
+ * Those fall back to the honest raw title at display time; persisted state is never rewritten.
+ * User and marker titles remain byte-for-byte authoritative.
  *
  * `??`, not `||`: the server never stores an empty summary (trimmed, 1–300 chars), so only
  * absence falls back — a falsy-but-present value would be a server bug worth seeing.
  */
 export function runTitle(run: RunRecord): string {
-  return run.titleSummary ?? run.title
+  const summary = run.titleSummary
+  if (summary === undefined) return run.title
+  const protectedTitle = run.titleOrigin === 'user' || run.titleOrigin === 'marker'
+  return !protectedTitle && /[.!?][A-Z]/.test(summary) ? run.title : summary
 }
 
 /**

--- a/web/app/src/lib/tasks-table.test.ts
+++ b/web/app/src/lib/tasks-table.test.ts
@@ -114,6 +114,18 @@ describe('filterRuns', () => {
     expect(filterRuns(summarized, 'plz')).toEqual([])
   })
 
+  it('searches the same fallback title shown for a malformed legacy summary', () => {
+    const malformed = [
+      run({
+        id: 'legacy',
+        title: '476: verifying pr ui',
+        titleSummary: 'Reading the handoff file for context.The task is UI QA verification of PR #476',
+      }),
+    ]
+    expect(filterRuns(malformed, 'verifying pr ui').map((r) => r.id)).toEqual(['legacy'])
+    expect(filterRuns(malformed, 'handoff')).toEqual([])
+  })
+
   it('matches the branch', () => {
     expect(ids('e5f6')).toEqual(['b'])
   })


### PR DESCRIPTION
Fixes #623

## Problem
Auto-generated and legacy task summaries can contain stripped sentence boundaries such as `.Config` or `.The`, producing unreadable titles in the cockpit.

## Root Cause
The structured namer accepted narration-shaped titles before post-validation, while the shared UI title selector gave every persisted `titleSummary` precedence even when legacy records had no provenance.

## What Changed
- Reject current namer output with unambiguous concatenated sentence boundaries so the honest heuristic title remains.
- Fall back from malformed auto/legacy summaries at the shared display-title seam without rewriting persisted run state.
- Preserve user- and marker-owned titles byte-for-byte and keep Tasks-table search aligned with the displayed title.

## Tests
- Added observed `.Config` and `.The` fixtures for namer generation, legacy display, title ownership, identifiers/acronyms, and Tasks-table search.
- `npm run typecheck`
- `npm test` (3,993 tests)
- `npm run test:unit` (34 tests)
- `npm run build` (including `check:pack`)
- `npm run test:package` (8 tests)

## Breaking Changes
None. Existing `runs.json` remains unchanged and older optional-field records continue to parse.

🤖 Generated by autofix.