### PR TITLE
feat(cockpit): let a closed session's composer carry the Continue prompt

### DIFF
--- a/.ai/specs/2026-07-21-queued-session-prompt-stacking.md
+++ b/.ai/specs/2026-07-21-queued-session-prompt-stacking.md
@@ -286,12 +286,18 @@ The mockups are static illustrative HTML in `assets/queued-session-prompt-stacki
 - placeholder: `Add to the prompt — sent when the run starts…`
 - a `data-slot="queued-hint"` line under the queued placeholder:
   `Messages you add now are folded into the prompt before the run starts.`
-- the `disabledAction` (`<ContinueAction>`) is **not** rendered — Continue is
+- the engine pills (`<ContinueAction>`) are **not** rendered — Continue is
   meaningless for a run that has not run.
 
 The existing `"Session closed — Continue to reopen."` copy stays exactly as-is for
 `review` / `done` / `failed` / `cancelled`. (`composer.e2e.ts:242` asserts that string
 against a run already driven to `done`, so it is unaffected — confirmed, not assumed.)
+
+> **Superseded for the closed statuses.** A later change (the closed-composer prompt,
+> below in *Resolved assumptions* Q3) made the composer authorable on a closed run that
+> HAS a resumable session too, so that copy now survives only on a closed run with no
+> session to resume — where it reads `"Session closed — no session to resume."`. The
+> `queued` branch described here is unchanged.
 
 **Thread rows** — `buildThreadRows` (`task-thread.tsx:97-124`) already renders the
 initial prompt from the record rather than an event; stacked messages extend the same
@@ -508,7 +514,7 @@ step is a local change.
 |---|---|---|---|
 | Q1 | Are stacked messages folded into the opening prompt, or delivered as separate turns after it? | **Folded into `{{task}}` at dequeue** | Follow-up turns reach only the first step of a chain and race the opening turn; folding is deterministic and matches "extend the prompt". Rejected alternative documented in Proposed Solution. |
 | Q2 | Is the initial prompt (`run.task`) itself editable? Removable? | **Editable, not removable** | The issue explicitly asks to "fix the prompt"; a run with no prompt is not a run. |
-| Q3 | Does the enabled composer apply to any other closed status (`review`, `done`, `cancelled`)? | **`queued` only** | Narrowest scope that closes the issue; those statuses have a working answer already (Continue). |
+| Q3 | Does the enabled composer apply to any other closed status (`review`, `done`, `cancelled`)? | **`queued` only** — *later superseded, see below* | Narrowest scope that closes the issue; those statuses have a working answer already (Continue). |
 | Q4 | Where does the stack live — new record field, or replayed from the NDJSON event log? | **New optional `queuedMessages` array on `RunRecord`** | Edits and deletes are mutations; the NDJSON log is append-only and must never be rewritten (`BACKWARD_COMPATIBILITY.md` §3). |
 | Q5 | New routes, or overload `POST /api/runs/:id/messages`? | **Both — overload POST, add PATCH/DELETE for edit/remove** | The overload keeps one submit path in the composer; edit/remove need addressable ids, so they get their own routes. All additive. |
 | Q6 | Do edits propagate across a variant group (`groupId`)? | **No — per run** | Variants exist to diverge; silent cross-writes would be surprising. Listed as future work. |
@@ -530,6 +536,35 @@ expressed over two fields.
 
 None of these assumptions is high-stakes: no protected surface is broken, no data is
 migrated, and every one of them is a reversible design choice rather than a commitment.
+
+### Q3 superseded — the closed composer also takes a prompt
+
+Q3 scoped the enabled composer to `queued` on the grounds that the closed statuses "have a
+working answer already (Continue)". They did not, quite: Continue was a bare button beside a
+**disabled** textarea, so "reopen it and tell it what to do next" meant continuing blind and
+then typing once the session came back — and `POST /continue` had accepted a `text` prompt
+since spec 003. The composer was the only thing not offering it.
+
+So the closed-but-resumable case now works like `queued`: the composer stays enabled, and its
+send button IS Continue.
+
+- placeholder: `Continue — add a prompt, or send to just reopen the session…`
+- gated on `runActionFlags(run).continueRun` — a session to resume, exactly the gate the
+  header's Continue button already used. A closed run with **no** session keeps a disabled
+  composer, now reading `"Session closed — no session to resume."` (the old copy offered a
+  Continue that run could not perform).
+- an empty draft still posts no `text`, so one-click Continue is byte-identical to before.
+- `<ContinueAction>` became the `useContinueAction` hook: the runner/model pills moved into
+  the enabled footer (`footerEnd`), so the typed prompt and the picked engine reach
+  `POST /continue` in ONE request. Its own ▶ button is gone — the composer's send replaces
+  it; the header keeps a labelled one for the one-click path.
+- `POST /continue` gained `images` (≤ 4, same bound and shape as `messageSchema`). Without
+  it the newly-enabled paperclip would have silently dropped pasted screenshots. They are
+  persisted as `pasted-<n>` like every other attachment, ride the `user-message` event so the
+  bubble renders them, and reach the reopened session both inline and as absolute paths.
+
+Still additive on every protected surface: one new optional body field, no new route, no SSE
+name, no record field.
 
 ## Future work (explicitly out of scope)
 

--- a/src/server/continue-run.test.ts
+++ b/src/server/continue-run.test.ts
@@ -19,7 +19,13 @@ describe('POST /api/runs/:id/continue override', () => {
   let store: RunStore;
   let app: Hono;
   let runId: string;
-  let captured: { id: string; opts: { text?: string; runner?: string; model?: string } } | undefined;
+  type ContinueOpts = {
+    text?: string;
+    images?: Array<{ type: string; source: { media_type: string; data: string } }>;
+    runner?: string;
+    model?: string;
+  };
+  let captured: { id: string; opts: ContinueOpts } | undefined;
 
   beforeEach(() => {
     repoRoot = mkdtempSync(join(tmpdir(), 'cez-continue-'));
@@ -32,7 +38,7 @@ describe('POST /api/runs/:id/continue override', () => {
       steps: [],
     }).id;
     const manager = {
-      continueRun: (id: string, opts: { text?: string; runner?: string; model?: string } = {}) => {
+      continueRun: (id: string, opts: ContinueOpts = {}) => {
         captured = { id, opts };
         return { ok: true };
       },
@@ -71,6 +77,23 @@ describe('POST /api/runs/:id/continue override', () => {
     expect(res.status).toBe(200);
     expect(captured?.opts.text).toBe('keep going');
     expect(captured?.opts.runner).toBe('opencode');
+  });
+
+  /** The follow-up composer is a full composer, so a screenshot pasted into it has to reach the
+   *  reopened session — as content blocks, the same shape `POST /messages` hands the engine. */
+  it('converts pasted images into content blocks for the manager', async () => {
+    const res = await post({ text: 'like this', images: [{ mediaType: 'image/png', data: 'AAAA' }] });
+    expect(res.status).toBe(200);
+    expect(captured?.opts.images).toEqual([
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+    ]);
+  });
+
+  it('rejects a non-image media type, and more images than a message may carry', async () => {
+    expect((await post({ images: [{ mediaType: 'text/plain', data: 'AAAA' }] })).status).toBe(400);
+    const five = Array.from({ length: 5 }, () => ({ mediaType: 'image/png', data: 'AAAA' }));
+    expect((await post({ images: five })).status).toBe(400);
+    expect(captured).toBeUndefined();
   });
 
   it('rejects an unknown runner with a 400 and never reaches the manager', async () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -595,9 +595,12 @@ function foldedLength(task: string, stack: Array<{ text: string }>): number {
 // "Continue"/"Send back" body (spec 003 / #401): every field optional, so an empty POST reopens
 // the last session on the run's current backend (backward compat). A runner/model override lets
 // the follow-up composer choose which engine handles the continuation. `text` stays bounded like
-// the live-session message `text` (#429).
+// the live-session message `text` (#429), and `images` like a live-session message's — the
+// follow-up composer is a full composer, so a screenshot pasted into it must reach the reopened
+// session rather than being silently dropped.
 const continueSchema = z.object({
   text: z.string().max(100_000, 'text must be at most 100000 characters').optional(),
+  images: z.array(imageInputSchema).max(4).optional(),
   runner: z.enum(['claude', 'codex', 'opencode']).optional(),
   model: z.string().max(200).optional(),
 });
@@ -2043,6 +2046,10 @@ export function createApp(deps: ServerDeps): Hono {
     }
     const result = manager.continueRun(id, {
       text: parsed.data.text,
+      images: parsed.data.images?.map((img): ContentBlock => ({
+        type: 'image',
+        source: { type: 'base64', media_type: img.mediaType, data: img.data },
+      })),
       runner: parsed.data.runner,
       model: parsed.data.model,
     });

--- a/src/workflows/pasted-attachments.test.ts
+++ b/src/workflows/pasted-attachments.test.ts
@@ -205,4 +205,55 @@ describe('pasted screenshots materialize to disk and reach the agent as file pat
 
     manager.finish(record.id);
   }, 30_000);
+
+  /** Continue takes a prompt of its own, and the composer that writes it is a full composer —
+   *  so a screenshot pasted into a CLOSED run's composer has to travel the same road as one
+   *  pasted mid-session: onto disk, into the thread's bubble, and into the reopened session's
+   *  opening message as both an inline image and an absolute path. */
+  it('a Continue pasted image is saved, rendered on the bubble, and reaches the reopened session', async () => {
+    writeFileSync(stdinFile, '', 'utf8');
+    const workflow: WorkflowDef = {
+      name: 'pasted-continue-test',
+      source: 'built-in',
+      steps: [{ id: 'work', prompt: '{{task}}' }],
+    };
+    const record = manager.startRun(workflow, { task: 'do a thing' });
+    await waitForStatus(record.id, ['waiting']);
+    manager.finish(record.id);
+    await waitForStatus(record.id, ['done', 'review']);
+
+    writeFileSync(stdinFile, '', 'utf8');
+    const image: ContentBlock = {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: TINY_PNG_B64 },
+    };
+    expect(manager.continueRun(record.id, { text: 'fix what this shows', images: [image] })).toEqual({
+      ok: true,
+    });
+    await waitForStatus(record.id, ['waiting']);
+
+    const reopened = readStdinLines().find((line) => line.userText.includes('fix what this shows'));
+    expect(reopened).toBeDefined();
+    // Inline, so the model can view it…
+    expect(reopened?.imageCount).toBe(1);
+    // …and on disk, so it can operate on it.
+    const pathMatch = reopened?.userText.match(/- (.*pasted-\d+\.png)/);
+    expect(pathMatch).toBeTruthy();
+    const filePath = pathMatch?.[1] as string;
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath).equals(Buffer.from(TINY_PNG_B64, 'base64'))).toBe(true);
+
+    // The thread renders the bubble's image, not a bare count — and the base64 stays out of
+    // the event log, exactly as on the task-start and follow-up paths.
+    const ndjson = readFileSync(join(dataDir, 'runs', `${record.id}.ndjson`), 'utf8');
+    const userMessage = ndjson
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { type: string; text?: string; images?: string[] })
+      .find((event) => event.type === 'user-message' && event.text === 'fix what this shows');
+    expect(userMessage?.images?.[0]).toBe(`/api/runs/${record.id}/images/${filePath.split('/').pop()}`);
+    expect(ndjson).not.toContain(TINY_PNG_B64);
+
+    manager.finish(record.id);
+  }, 40_000);
 });

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -1078,7 +1078,7 @@ export class RunManager {
    */
   continueRun(
     runId: string,
-    opts: { text?: string; runner?: RunnerId; model?: string } = {},
+    opts: { text?: string; images?: ContentBlock[]; runner?: RunnerId; model?: string } = {},
   ): { ok: boolean; error?: string } {
     if (this.active.has(runId)) return { ok: false, error: 'run is still active' };
     const run = this.store.getRun(runId);
@@ -1139,6 +1139,7 @@ export class RunManager {
       resume ? sessionStep.sessionId : undefined,
       targetRunner,
       opts.text?.trim() || 'Continue.',
+      opts.images ?? [],
     ).catch(
       (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -1160,6 +1161,10 @@ export class RunManager {
     sessionId: string | undefined,
     backend: RunnerId,
     prompt: string,
+    /** Screenshots pasted into the follow-up composer — delivered with the
+     *  reopened session's opening message, exactly like a live-session
+     *  message's attachments. */
+    images: ContentBlock[] = [],
   ): Promise<void> {
     // Continuation runs in the task's worktree when it still exists (spec
     // 006) — the resumed session sees exactly what the original run left.
@@ -1214,7 +1219,22 @@ export class RunManager {
       backend,
     });
     this.store.appendEvent(runId, { type: 'step-start', stepId, name: 'Continue', kind: 'agent', iteration: 1 });
-    this.store.appendEvent(runId, { type: 'user-message', stepId, text: prompt, imageCount: 0 });
+    // Attachments pasted into the follow-up composer, on the same terms as a live-session
+    // message (#357): persisted to the run's own image store so the thread renders the bubble's
+    // images rather than a bare count, and handed to the agent BOTH as base64 blocks (so it can
+    // view them) and as absolute paths appended to the prompt (so it can operate on them — and
+    // because codex/opencode drop image blocks before they reach the model).
+    const attachments = images
+      .filter((b): b is Extract<ContentBlock, { type: 'image' }> => b.type === 'image')
+      .map((b) => this.persistImage(runId, b.source.media_type, b.source.data, 'pasted'))
+      .filter((saved): saved is PersistedAttachment => saved !== null);
+    this.store.appendEvent(runId, {
+      type: 'user-message',
+      stepId,
+      text: prompt,
+      imageCount: images.filter((b) => b.type === 'image').length,
+      ...(attachments.length ? { images: attachments.map((saved) => saved.url) } : {}),
+    });
 
     let stepCost = 0;
     let turnText = '';
@@ -1356,7 +1376,8 @@ export class RunManager {
           record?.systemPrompt,
           generateFollowups ? HANDOFF_INSTRUCTIONS : HANDOFF_ONLY_INSTRUCTIONS,
         ),
-        userPrompt: prompt,
+        userPrompt: attachments.length ? `${prompt}\n\n${pastedAttachmentsText(attachments)}` : prompt,
+        ...(images.length ? { images } : {}),
         cwd: state.cwd,
         allowedTools: DEFAULT_ALLOWED_TOOLS,
         additionalDirectories: [join(this.dataDir, 'runs')],

--- a/web/app/e2e/composer.e2e.ts
+++ b/web/app/e2e/composer.e2e.ts
@@ -224,7 +224,7 @@ describe('the thread composer against a live waiting session', () => {
     browser.fill('[data-slot="composer"] textarea', '')
   })
 
-  it('a closed session disables the composer with the legacy reason and a Continue way out', async () => {
+  it('a closed session keeps the composer authorable — sending it is Continue', async () => {
     // Finish the waiting session. When the mock's turns touched notes.md the run parks at
     // `review` first (the documented double-finish path) — accept that and finish again.
     await fetch(`${baseUrl}/api/runs/${runId}/finish`, { method: 'POST' })
@@ -234,14 +234,31 @@ describe('the thread composer against a live waiting session', () => {
     }
 
     browser.goto(`${baseUrl}/tasks/${runId}`)
+    // The run has a session to resume, so the composer stays live: the draft becomes the
+    // prompt the reopened session starts on, and its send button IS Continue.
     browser.waitForFunction(
-      `document.querySelector('[data-slot="composer"] textarea')?.disabled === true`,
+      `document.querySelector('[data-slot="composer"] textarea')?.disabled === false`,
     )
     expect(
       browser.evaluate(`document.querySelector('[data-slot="composer"] textarea').placeholder`),
-    ).toBe('Session closed — Continue to reopen.')
-    expect(browser.text('[data-slot="composer-disabled-action"]')).toContain('Continue')
+    ).toBe('Continue — add a prompt, or send to just reopen the session…')
+    // Nothing typed still continues — the legacy one-click behavior.
+    expect(browser.isVisible('[aria-label="Continue"]')).toBe(true)
+    expect(
+      browser.evaluate(`document.querySelector('[aria-label="Continue"]').disabled`),
+    ).toBe(false)
+    // The engine pills moved into the live footer with it.
+    expect(browser.count('[data-slot="follow-up-engine"]')).toBe(1)
     expect(browser.count('[data-slot="paused-hint"]')).toBe(0)
     browser.screenshot(`${artifactsDir}/composer-closed.png`)
+
+    // …and typing a prompt then sending reopens the session on it.
+    browser.fill('[data-slot="composer"] textarea', 'one more thing: add a note')
+    browser.click('[aria-label="Continue"]')
+    await waitForStatus(baseUrl, runId, ['running', 'waiting'])
+    browser.waitForFunction(
+      `[...document.querySelectorAll('[data-slot="user-bubble"]')].some((b) =>
+        b.textContent.includes('one more thing: add a note'))`,
+    )
   }, 60_000)
 })

--- a/web/app/src/api/client.ts
+++ b/web/app/src/api/client.ts
@@ -24,6 +24,7 @@ import type {
   GithubData,
   GroupResponse,
   HealthResponse,
+  ImageInput,
   LaunchKeyResponse,
   MessageInput,
   EditQueuedMessageResponse,
@@ -483,9 +484,12 @@ export function finishRun(id: string): Promise<FinishResponse> {
 }
 
 /** The follow-up composer's optional overrides for a Continue (#401): pick which backend and
- *  model handle the reopened session. Omitted fields keep the run's current backend/model. */
+ *  model handle the reopened session. Omitted fields keep the run's current backend/model.
+ *  `text`/`images` are the prompt the reopened session starts on — omitted, the engine opens
+ *  with its plain "Continue.". */
 export interface ContinueOptions {
   text?: string
+  images?: ImageInput[]
   runner?: Runner
   model?: string
 }
@@ -496,6 +500,7 @@ export interface ContinueOptions {
 export function continueRun(id: string, opts: ContinueOptions = {}): Promise<ContinueResponse> {
   const body: Record<string, unknown> = {}
   if (opts.text !== undefined) body.text = opts.text
+  if (opts.images !== undefined) body.images = opts.images
   if (opts.runner !== undefined) body.runner = opts.runner
   if (opts.model !== undefined) body.model = opts.model
   return mutate<ContinueResponse>('POST', runPath(id, '/continue'), body)

--- a/web/app/src/api/queries.ts
+++ b/web/app/src/api/queries.ts
@@ -162,11 +162,14 @@ export const workspaceQueryKeys = {
   fsBrowse: (path: string | null) => [...workspaceQueryKeys.fsBrowseRoot, path] as const,
 }
 
-export function useRunnerModels() {
+/** `enabled` lets a caller that only MIGHT render the model pills (the thread's Continue —
+ *  hooks cannot be called conditionally) skip the fetch when it definitely won't. */
+export function useRunnerModels(enabled = true) {
   return useQuery({
     queryKey: workspaceQueryKeys.models('codex'),
     queryFn: ({ signal }) => getRunnerModels({ signal }),
     staleTime: 5 * 60 * 1_000,
+    enabled,
   })
 }
 

--- a/web/app/src/components/composer/composer.test.tsx
+++ b/web/app/src/components/composer/composer.test.tsx
@@ -451,15 +451,27 @@ describe('disabled state', () => {
   it('disables everything and explains itself in the placeholder', () => {
     renderComposer({
       disabled: true,
-      disabledReason: 'Session closed — Continue to reopen.',
-      disabledAction: <button type="button">Continue</button>,
+      disabledReason: 'Session closed — no session to resume.',
     })
     const textarea = screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement
     expect(textarea.disabled).toBe(true)
-    expect(textarea.placeholder).toBe('Session closed — Continue to reopen.')
+    expect(textarea.placeholder).toBe('Session closed — no session to resume.')
     expect((screen.getByLabelText('Send') as HTMLButtonElement).disabled).toBe(true)
     expect((screen.getByLabelText('Attach images') as HTMLButtonElement).disabled).toBe(true)
-    expect(screen.getByText('Continue')).toBeTruthy()
+  })
+
+  /** `allowEmptySubmit` is the thread's Continue: an empty draft is a meaningful action there
+   *  (reopen the session on the engine's own "Continue."), so the send button stays live. */
+  it('allowEmptySubmit lets an empty draft submit — and disabled still wins over it', () => {
+    const { onSubmit } = renderComposer({ allowEmptySubmit: true })
+    const send = screen.getByLabelText('Send') as HTMLButtonElement
+    expect(send.disabled).toBe(false)
+    fireEvent.click(send)
+    expect(onSubmit).toHaveBeenCalledWith('', [])
+    cleanup()
+
+    renderComposer({ allowEmptySubmit: true, disabled: true })
+    expect((screen.getByLabelText('Send') as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('the mic is hidden entirely when the Web Speech API is absent — no fake button', () => {

--- a/web/app/src/components/composer/composer.tsx
+++ b/web/app/src/components/composer/composer.tsx
@@ -70,9 +70,12 @@ export interface ComposerProps {
   /** Shown as the placeholder while disabled — e.g. the legacy "Session closed — Continue to
    *  reopen." */
   disabledReason?: string
-  /** Rendered in the footer bar while disabled — the host's way out (the thread passes its
-   *  Continue button). */
-  disabledAction?: ReactNode
+  /**
+   * Let the send button fire on an empty draft. Off by default (an empty message is not a
+   * message); ON for the thread's closed-but-resumable state, where submitting IS "Continue"
+   * and continuing with no prompt is the legacy one-click behavior.
+   */
+  allowEmptySubmit?: boolean
   placeholder?: string
   ariaLabel?: string
   /** `/` opens the project-first skills autocomplete (#380). */
@@ -112,7 +115,7 @@ export function Composer({
   sendAriaLabel = 'Send',
   disabled = false,
   disabledReason = 'Session closed — Continue to reopen.',
-  disabledAction,
+  allowEmptySubmit = false,
   placeholder = 'Reply — / for skills, @ for files…',
   ariaLabel = 'Reply to the agent',
   autocompleteSkills = true,
@@ -306,7 +309,8 @@ export function Composer({
   const send = useCallback(
     async (messageText: string, messageImages: PendingImage[], restoreOnError: boolean) => {
       const body = messageText.trim()
-      if (disabled || busy || (body === '' && messageImages.length === 0)) return
+      if (disabled || busy) return
+      if (body === '' && messageImages.length === 0 && !allowEmptySubmit) return
       setBusy(true)
       try {
         await onSubmit(
@@ -325,11 +329,11 @@ export function Composer({
         setBusy(false)
       }
     },
-    [busy, disabled, onSubmit],
+    [allowEmptySubmit, busy, disabled, onSubmit],
   )
 
   const submitDraft = useCallback(() => {
-    if (text.trim() === '' && images.length === 0) return
+    if (text.trim() === '' && images.length === 0 && !allowEmptySubmit) return
     const draftText = text
     const draftImages = images
     // Optimistic clear — the reply feels instant; a rejection restores it above.
@@ -337,7 +341,7 @@ export function Composer({
     setImages([])
     setTrigger(null)
     void send(draftText, draftImages, true)
-  }, [images, send, text])
+  }, [allowEmptySubmit, images, send, text])
 
   const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (menuOpen) {
@@ -489,11 +493,6 @@ export function Composer({
                 {footerStart}
               </div>
               <div className="ml-auto flex items-center gap-1">
-                {disabled && disabledAction ? (
-                  <div data-slot="composer-disabled-action" className="mr-1">
-                    {disabledAction}
-                  </div>
-                ) : null}
                 {dictation.supported ? (
                   <Button
                     type="button"
@@ -518,7 +517,9 @@ export function Composer({
                   type="button"
                   size="icon-sm"
                   aria-label={sendAriaLabel}
-                  disabled={disabled || busy || (text.trim() === '' && images.length === 0)}
+                  disabled={
+                    disabled || busy || (text.trim() === '' && images.length === 0 && !allowEmptySubmit)
+                  }
                   className="size-8"
                   onClick={submitDraft}
                 >

--- a/web/app/src/routes/task-thread/follow-up-engine.test.tsx
+++ b/web/app/src/routes/task-thread/follow-up-engine.test.tsx
@@ -6,12 +6,15 @@ import { createQueryClient } from '@/api/query-client'
 import type { ApiRun, HealthResponse, StepState } from '@/api/types'
 import { resetToasts, Toaster } from '@/components/ui/toaster'
 
-import { ContinueAction } from './follow-up-engine'
+import { useContinueAction } from './follow-up-engine'
 
 /**
  * The follow-up composer's Continue control (#401): the runner + model pills default to the
  * run's current backend, so an untouched Continue posts nothing extra (backward compat); a pick
  * rides through to `POST /continue`; the runner pill is hidden on a single-backend host.
+ *
+ * The hook has no button of its own — the composer's send is what fires it — so the harness
+ * below supplies one, standing in for that send.
  */
 
 beforeAll(() => {
@@ -108,10 +111,24 @@ const makeRun = (extra: Partial<ApiRun> = {}): ApiRun => ({
   ...extra,
 })
 
-function renderAction(record: ApiRun) {
+/** Stands in for the thread composer: the pills, plus a send that submits `draft`. */
+function Harness({ run, draft = '' }: { run: ApiRun; draft?: string }) {
+  const action = useContinueAction(run)
+  if (!action.available) return null
+  return (
+    <>
+      {action.pills}
+      <button type="button" onClick={() => void action.continueWith(draft, [])}>
+        Continue
+      </button>
+    </>
+  )
+}
+
+function renderAction(record: ApiRun, draft?: string) {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <ContinueAction run={record} />
+      <Harness run={record} draft={draft} />
       <Toaster />
     </QueryClientProvider>,
   )
@@ -127,6 +144,15 @@ describe('follow-up ContinueAction runner/model selection (#401)', () => {
     fireEvent.click(await screen.findByRole('button', { name: /continue/i }))
     await waitFor(() => expect(continueBody()).toBeDefined())
     expect(continueBody()).toEqual({})
+  })
+
+  it('carries the composer draft as the prompt the reopened session starts on', async () => {
+    serve()
+    renderAction(makeRun(), 'now also update the changelog')
+    fireEvent.click(await screen.findByRole('button', { name: /continue/i }))
+    await waitFor(() => expect(continueBody()).toBeDefined())
+    // Only `text` — the pills were never touched, so the run keeps its backend.
+    expect(continueBody()).toEqual({ text: 'now also update the changelog' })
   })
 
   it('sends the chosen runner + model through to /continue', async () => {

--- a/web/app/src/routes/task-thread/follow-up-engine.tsx
+++ b/web/app/src/routes/task-thread/follow-up-engine.tsx
@@ -1,13 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { PlayIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 
 import { continueRun } from '@/api/client'
 import { queryKeys, useConfig, useHealth, useRunnerModels } from '@/api/queries'
-import type { ApiRun, Runner } from '@/api/types'
+import type { ApiRun, ContinueResponse, ImageInput, Runner } from '@/api/types'
 import { PickerPill, RunnerPill } from '@/components/picker-pill'
-import { Button } from '@/components/ui/button'
-import { toast } from '@/components/ui/toaster'
 import {
   availableRunners,
   modelsForRunner,
@@ -17,19 +14,40 @@ import {
 } from '@/routes/new-task-form'
 import { runActionFlags } from './run-actions'
 
+/** What the thread needs to offer Continue from its composer. */
+export interface ContinueAction {
+  /** Is there a session to reopen at all? (`runActionFlags.continueRun` — the same gate the
+   *  header's Continue button uses.) Everything else is inert when this is false. */
+  available: boolean
+  /** The runner + model pills — which backend and model the reopened session runs on. */
+  pills: ReactNode
+  /**
+   * Reopen the session, starting it on this prompt. An empty draft is the legacy one-click
+   * Continue: the engine opens with its own "Continue.". REJECTS with the server's message
+   * rather than toasting itself, so the composer can restore the draft it optimistically
+   * cleared — nothing the user typed is lost to a 409.
+   */
+  continueWith: (text: string, images: ImageInput[]) => Promise<ContinueResponse>
+}
+
 /**
- * The follow-up composer's "Continue" control (#401): the same runner + model pills the /new
- * composer offers, so a follow-up can pick which backend and model reopen the session. The
- * pills DEFAULT to the run's current backend/model — untouched, the POST omits both and the
- * server keeps the run's engine (backward compat). Rendered as the closed composer's
- * `disabledAction`, and hidden (like the header's Continue) when the run has no session to
- * resume — `runActionFlags.continueRun`.
+ * The follow-up composer's Continue (#401): the same runner + model pills the /new composer
+ * offers, so a follow-up can pick which backend and model reopen the session. The pills DEFAULT
+ * to the run's current backend/model — untouched, the POST omits both and the server keeps the
+ * run's engine (backward compat).
+ *
+ * A hook rather than a self-contained button, because the composer owns the draft: the prompt
+ * the user typed and the engine they picked have to reach `POST /continue` in ONE request, and
+ * the pills' state lives here.
  */
-export function ContinueAction({ run }: { run: ApiRun }) {
+export function useContinueAction(run: ApiRun): ContinueAction {
   const queryClient = useQueryClient()
+  const available = runActionFlags(run).continueRun
   const health = useHealth()
   const config = useConfig()
-  const catalog = useRunnerModels()
+  // Only a run that can actually be continued needs the model catalog — every other thread
+  // (running, queued, or closed with no session) would be fetching it to render nothing.
+  const catalog = useRunnerModels(available)
   // null = "not touched": the pills fall back to the run's current backend/model, so an
   // untouched Continue behaves exactly as before this feature existed.
   const [pickedRunner, setPickedRunner] = useState<Runner | null>(null)
@@ -52,50 +70,45 @@ export function ContinueAction({ run }: { run: ApiRun }) {
   const model = resolveModel(pickedModel, runner, modelDefaults, catalog.data)
 
   const mutation = useMutation({
-    mutationFn: () =>
+    mutationFn: ({ text, images }: { text: string; images: ImageInput[] }) =>
       continueRun(run.id, {
+        // An empty draft posts no `text` at all, so the server's default opening prompt
+        // ("Continue.") still applies — one-click Continue, unchanged.
+        text: text.trim() ? text : undefined,
+        images: images.length ? images : undefined,
         // Send an override only for a pill the user actually touched; otherwise omit it so the
         // server keeps the run's current backend/model.
         runner: pickedRunner !== null ? runner : undefined,
         model: pickedModel !== null ? model : undefined,
       }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.runs.all }),
-    onError: (error: Error) => toast(error.message, { tone: 'danger' }),
   })
 
-  if (!runActionFlags(run).continueRun) return null
-
-  return (
-    <div data-slot="follow-up-engine" className="flex flex-wrap items-center gap-1.5">
-      {runners.length > 1 ? (
-        <RunnerPill
-          runners={runners}
-          value={runner}
-          onPick={(next) => {
-            setPickedRunner(next)
-            setPickedModel(null) // a runner switch invalidates the previous model pick
-          }}
+  return {
+    available,
+    pills: (
+      <div data-slot="follow-up-engine" className="flex flex-wrap items-center gap-1.5">
+        {runners.length > 1 ? (
+          <RunnerPill
+            runners={runners}
+            value={runner}
+            onPick={(next) => {
+              setPickedRunner(next)
+              setPickedModel(null) // a runner switch invalidates the previous model pick
+            }}
+          />
+        ) : null}
+        <PickerPill
+          slot="follow-up-model-pill"
+          ariaLabel="Model"
+          label={models.find((m) => m.id === model)?.label ?? 'auto'}
+          value={model}
+          onPick={(next) => setPickedModel(next)}
+          options={models.map((m) => ({ value: m.id, label: m.label, desc: m.desc }))}
+          status={modelCatalogStatus(runner, catalog.data, catalog.isError)}
         />
-      ) : null}
-      <PickerPill
-        slot="follow-up-model-pill"
-        ariaLabel="Model"
-        label={models.find((m) => m.id === model)?.label ?? 'auto'}
-        value={model}
-        onPick={(next) => setPickedModel(next)}
-        options={models.map((m) => ({ value: m.id, label: m.label, desc: m.desc }))}
-        status={modelCatalogStatus(runner, catalog.data, catalog.isError)}
-      />
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={mutation.isPending}
-        onClick={() => mutation.mutate()}
-      >
-        <PlayIcon aria-hidden="true" className="size-3.5" />
-        Continue
-      </Button>
-    </div>
-  )
+      </div>
+    ),
+    continueWith: (text, images) => mutation.mutateAsync({ text, images }),
+  }
 }

--- a/web/app/src/routes/task-thread/task-thread.test.tsx
+++ b/web/app/src/routes/task-thread/task-thread.test.tsx
@@ -155,7 +155,9 @@ describe('ThreadView', () => {
     expect(textarea.placeholder).toBe('Message the agent — / for skills, @ for files…')
   })
 
-  it('closed → the composer is disabled with the legacy reason and the Continue way out', () => {
+  /** A closed run with a session to resume is still AUTHORABLE: Continue takes a prompt, so
+   *  the composer stays live and its send is that Continue. */
+  it('closed but resumable → the composer stays enabled, and sending is Continue', () => {
     renderView(
       <ThreadView
         run={run('done', {
@@ -167,12 +169,12 @@ describe('ThreadView', () => {
       />,
     )
     const textarea = screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement
-    expect(textarea.disabled).toBe(true)
-    expect(textarea.placeholder).toBe('Session closed — Continue to reopen.')
-    // The way out, only because this run HAS a session to resume.
-    expect(
-      document.querySelector('[data-slot="composer-disabled-action"]')?.textContent,
-    ).toContain('Continue')
+    expect(textarea.disabled).toBe(false)
+    expect(textarea.placeholder).toBe('Continue — add a prompt, or send to just reopen the session…')
+    // Empty is still the one-click Continue, so send is live with nothing typed.
+    expect((screen.getByLabelText('Continue') as HTMLButtonElement).disabled).toBe(false)
+    // The engine pills ride along, so the prompt and the picked backend go in one request.
+    expect(document.querySelector('[data-slot="follow-up-engine"]')).not.toBeNull()
   })
 
   /** #472 — stacked messages render as their own bubbles, after the task. */
@@ -440,28 +442,23 @@ describe('ThreadView', () => {
     expect(document.querySelector('[data-slot="queued-hint"]')?.textContent).toContain(
       'folded into the prompt before the run starts',
     )
-    // Continue is meaningless for a run that has not run.
-    expect(document.querySelector('[data-slot="composer-disabled-action"]')).toBeNull()
+    // Continue is meaningless for a run that has not run, so no engine pills either.
+    expect(document.querySelector('[data-slot="follow-up-engine"]')).toBeNull()
   })
 
   /**
-   * The scope boundary: the queued branch is `queued` ONLY. Every other closed
-   * status keeps the legacy copy — including the string `composer.e2e.ts` asserts.
+   * The scope boundary: the queued branch is `queued` ONLY, and the composer only stays live
+   * on a closed run that HAS a session to resume. This `done` run has none, so it is the one
+   * remaining genuinely-disabled state — and it is told so honestly, without offering a
+   * Continue it cannot perform.
    */
-  it('done keeps the legacy disabled copy and shows no queued hint', () => {
+  it('closed with no resumable session → disabled composer, and no Continue invented', () => {
     renderView(<ThreadView run={run('done')} thread={reduceThread(EVENTS)} />)
     const textarea = screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement
     expect(textarea.disabled).toBe(true)
-    expect(textarea.placeholder).toBe('Session closed — Continue to reopen.')
+    expect(textarea.placeholder).toBe('Session closed — no session to resume.')
+    expect(document.querySelector('[data-slot="follow-up-engine"]')).toBeNull()
     expect(document.querySelector('[data-slot="queued-hint"]')).toBeNull()
-  })
-
-  it('closed with no resumable session → disabled composer, and no Continue button invented', () => {
-    renderView(<ThreadView run={run('done')} thread={reduceThread(EVENTS)} />)
-    expect((screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement).disabled).toBe(true)
-    expect(document.querySelector('[data-slot="composer-disabled-action"]')?.textContent ?? '').not.toContain(
-      'Continue',
-    )
   })
 
   it('done → the closed footer; failed → the danger footer carrying the run error', () => {

--- a/web/app/src/routes/task-thread/task-thread.tsx
+++ b/web/app/src/routes/task-thread/task-thread.tsx
@@ -34,7 +34,7 @@ import {
   UserBubble,
   WorkingIndicator,
 } from './thread-items'
-import { ContinueAction } from './follow-up-engine'
+import { useContinueAction } from './follow-up-engine'
 import { AgentsDock } from './agents-dock'
 import { PlanDock, planCounts } from './plan-dock'
 import { collectSubagents, findSubagent, subagentChildren } from './subagent-dock'
@@ -194,6 +194,13 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
   // that has not run. Deliberately `queued` only: review/done/failed/cancelled keep the
   // existing copy and their Continue action.
   const queued = run.status === 'queued'
+  // …and the fourth: a closed run whose last session can be reopened. Continue used to be a
+  // bare button beside a DISABLED textarea, so "reopen it and say what to do next" meant
+  // continuing blind and then typing into the thread once the session came back. The composer
+  // stays authorable here instead: the draft is the prompt the reopened session starts on, and
+  // submitting an empty one is still the plain one-click Continue.
+  const continueAction = useContinueAction(run)
+  const continuable = !sessionOpen && !queued && continueAction.available
   // A closed session can never settle its in-flight items — nothing in the reducer rewrites a
   // `running` item on `session.ended`, so an interrupted fan-out stays `running` in the
   // persisted stream forever. Without this, reopening it pulses `Agents · 0/1` above a dead
@@ -375,14 +382,25 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
           ) : null}
 
           <Composer
-            onSubmit={(text, images) => sendMessage.mutateAsync({ text, images })}
-            disabled={!sessionOpen && !queued}
-            disabledReason="Session closed — Continue to reopen."
-            // Continue is meaningless for a run that has not run, so the queued branch
-            // renders no disabled action at all (it is not disabled in the first place).
-            disabledAction={<ContinueAction run={run} />}
+            onSubmit={
+              continuable
+                ? (text, images) => continueAction.continueWith(text, images)
+                : (text, images) => sendMessage.mutateAsync({ text, images })
+            }
+            disabled={!sessionOpen && !queued && !continuable}
+            // Only reachable now by a closed run with NO session to resume — which is exactly
+            // the one case where Continue is not on offer either. Left honest rather than
+            // rewritten: "closed" is all such a run can be told.
+            disabledReason="Session closed — no session to resume."
+            // The engine pills ride the enabled footer, so the picked runner/model and the
+            // typed prompt reach `POST /continue` in one request.
+            footerEnd={continuable ? continueAction.pills : undefined}
+            // Continuing with nothing typed is the legacy one-click Continue.
+            allowEmptySubmit={continuable}
+            sendAriaLabel={continuable ? 'Continue' : 'Send'}
             placeholder={
               queued ? 'Add to the prompt — sent when the run starts…'
+              : continuable ? 'Continue — add a prompt, or send to just reopen the session…'
               : run.status === 'waiting' ? 'Reply — / for skills, @ for files…'
               : 'Message the agent — / for skills, @ for files…'
             }


### PR DESCRIPTION
## The problem

A closed run's composer was disabled, reading *"Session closed — Continue to reopen."*, with a bare **Continue** button beside it. So "reopen it and tell it what to do next" meant continuing blind and then typing once the session came back.

`POST /api/runs/:id/continue` has accepted a `text` prompt since spec 003 — the review panel's "Send back" already uses it. The composer was the only surface not offering it.


## What changed

The composer now stays **enabled** on a closed run that has a resumable session, and its send button *is* Continue.

- Placeholder: `Continue — add a prompt, or send to just reopen the session…`
- **One-click Continue is unchanged.** An empty draft posts no `text`, so the server's own `"Continue."` still applies.
- Gated on `runActionFlags(run).continueRun` — the same gate the header's Continue button already used. A closed run with *no* session to resume keeps a disabled composer, now reading `"Session closed — no session to resume."` instead of offering a Continue it cannot perform.
- `ContinueAction` became the `useContinueAction` hook. The runner/model pills moved into the enabled footer, so the typed prompt and the picked engine reach `POST /continue` in **one** request. Its own ▶ button is gone — the composer's send replaces it; the header keeps a labelled one for the one-click path.
- `POST /continue` gained `images` (≤ 4, same bound and shape as `messageSchema`). Without it the newly-enabled paperclip would have silently dropped pasted screenshots. They persist as `pasted-<n>` like every other attachment, ride the `user-message` event so the bubble renders them, and reach the reopened session both inline *and* as absolute paths (codex/opencode drop image blocks before the model sees them).

## Compatibility

Additive on every protected surface per `BACKWARD_COMPATIBILITY.md`: one new optional body field, no new route, no SSE event name, no `RunRecord` field. The one behavioral change to an existing path is that the closed composer submits instead of being inert.

## Spec record

Supersedes **Q3** of `.ai/specs/2026-07-21-queued-session-prompt-stacking.md`, which scoped the enabled composer to `queued` only on the grounds that the closed statuses "have a working answer already (Continue)". They did not, quite — that is this PR. The spec is updated in place rather than rewritten; the `queued` branch it describes is untouched.

## Testing

Full documented gate, all green:

| Gate | Result |
|---|---|
| `npm run typecheck` | clean (server + web) |
| `npm test` | 3971 server + 2268 cockpit |
| `npm run test:unit` | 34 |
| `npm run build` | ok |
| `npm run test:package` | 8 |
| `npm run test:e2e` — `composer.e2e.ts` | 8/8 in real Chrome |

New coverage: the route converts pasted images to content blocks and rejects a non-image media type / a 5th image; the engine persists a Continue attachment, renders it on the bubble and delivers its path to the reopened session (mutation-checked — deleting the image pass-through fails it); the composer's `allowEmptySubmit` submits an empty draft while `disabled` still wins; the thread keeps its composer live and shows the engine pills when resumable, and stays disabled with the honest copy when not.

`composer.e2e.ts` was rewritten rather than deleted — it now types a prompt, sends it, and asserts the reopened session carries it.

Two e2e specs fail on this machine (`task-thread.e2e.ts` Shiki colors, `review-gate.e2e.ts` send-back) — confirmed pre-existing by stashing onto a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
