### PR TITLE
fix(cli): prevent single-project registry leak (#626)

### DIFF
--- a/src/workspace/projects-cli.test.ts
+++ b/src/workspace/projects-cli.test.ts
@@ -215,6 +215,20 @@ describe('cezar projects CLI', () => {
       ).toBe(0);
       expect((await loadWorkspaceConfig()).projects.map((project) => project.id)).toEqual(['existing', 'allowed']);
     });
+
+    it('does not expose the registry when boot project identity is unavailable', async () => {
+      await registerProject(makeRepo('hidden'));
+
+      expect(
+        await runProjectsCommand(['list'], {
+          defaultRoot: repos,
+          env: { CEZ_SINGLE_PROJECT: '1' },
+          io,
+        }),
+      ).toBe(0);
+      expect(io.out.join('\n')).toContain('no projects registered yet');
+      expect(io.out.join('\n')).not.toContain('hidden');
+    });
   });
 
   it('exits 1 with the usage block on an unknown subcommand', async () => {

--- a/src/workspace/projects-cli.ts
+++ b/src/workspace/projects-cli.ts
@@ -49,7 +49,7 @@ export async function runProjectsCommand(
   const [sub = 'list', ...rest] = args;
   switch (sub) {
     case 'list':
-      return listCommand(io, opts.bootProjectId);
+      return listCommand(io, singleProject, opts.bootProjectId);
     case 'add':
       if (singleProject) {
         io.error(SINGLE_PROJECT_ADD_ERROR);
@@ -82,8 +82,16 @@ function statusMark(status: string): string {
   return status === 'missing' ? '✗' : status === 'not-git' ? '·' : '✓';
 }
 
-async function listCommand(io: ProjectsCommandIo, bootProjectId?: string): Promise<number> {
-  const projects = await listProjects(bootProjectId ? { projectId: bootProjectId } : undefined);
+async function listCommand(
+  io: ProjectsCommandIo,
+  singleProject: boolean,
+  bootProjectId?: string,
+): Promise<number> {
+  const projects = bootProjectId
+    ? await listProjects({ projectId: bootProjectId })
+    : singleProject
+      ? []
+      : await listProjects();
   if (projects.length === 0) {
     io.log('\n  no projects registered yet');
     io.log('  start the cockpit in a repo (npx cezar) or add one: cezar projects add <dir>\n');


### PR DESCRIPTION
Fixes #626

## Problem
When `CEZ_SINGLE_PROJECT=1` is used from `$HOME` or a cezar task worktree, boot registration is intentionally suppressed. The resulting undefined boot project id caused `projects list` to fall back to the unrestricted workspace registry.

## Root Cause
`listCommand()` treated an absent selector as an ordinary multi-project request without retaining whether single-project mode was active.

## What Changed
- Preserve the single-project capability when dispatching the list subcommand.
- Return the existing empty-registry presentation when boot identity is unavailable, while retaining explicit-id pinning and default multi-project behavior.
- Add regression coverage proving stored projects are not exposed in the suppressed-root case.

## Tests
- `npx vitest run src/workspace/projects-cli.test.ts`
- `npm run typecheck`
- `npm test` (226 files, 4,028 tests)
- `npm run test:unit` (34 tests)
- `npm run build`
- `npm run test:package` (8 tests)

## Breaking Changes
None.

🤖 Generated by autofix.
