### PR TITLE
fix(codex): label image view tool calls (#593)

### DIFF
--- a/src/core/codex-ui-mapper.test.ts
+++ b/src/core/codex-ui-mapper.test.ts
@@ -369,6 +369,28 @@ describe('mapCodexNotification edge cases', () => {
     });
   });
 
+  it('labels imageView items with the inspected path', () => {
+    const [imageView] = mapCodexNotification(
+      {
+        method: 'item/completed',
+        params: { item: { type: 'imageView', id: 'item_image', path: '/tmp/checkout-preview.png' } },
+      },
+      state,
+    ).events;
+    expect(imageView).toEqual({
+      type: 'item.completed',
+      item: {
+        kind: 'tool',
+        id: 'item_image',
+        name: 'imageView',
+        toolKind: 'read',
+        title: 'View image /tmp/checkout-preview.png',
+        status: 'completed',
+        input: { type: 'imageView', id: 'item_image', path: '/tmp/checkout-preview.png' },
+      },
+    });
+  });
+
   // The pair is ONE span of work: mapped literally it would be two childless task
   // items, which the Agents dock reads as two sub-agents that each did nothing (#474).
   describe('review mode folds into one task item', () => {

--- a/src/core/tool-display.test.ts
+++ b/src/core/tool-display.test.ts
@@ -81,6 +81,11 @@ describe('toolDisplay', () => {
         expected: { toolKind: 'read', title: 'Read src/index.ts' },
       },
       {
+        name: 'imageView',
+        input: { path: '/tmp/checkout-preview.png' },
+        expected: { toolKind: 'read', title: 'View image /tmp/checkout-preview.png' },
+      },
+      {
         name: 'Glob',
         input: { pattern: 'src/**/*.ts' },
         expected: { toolKind: 'search', title: 'Search src/**/*.ts', subtitle: undefined },

--- a/src/core/tool-display.ts
+++ b/src/core/tool-display.ts
@@ -13,7 +13,7 @@
  *  - claude:   Bash, Edit, Write, NotebookEdit, Read, Glob, Grep, WebFetch,
  *              WebSearch, Task, Agent, Skill, TodoWrite, TaskCreate,
  *              TaskUpdate, TaskList, mcp__server__tool
- *  - codex:    commandExecution, fileChange, mcpToolCall, webSearch, plan
+ *  - codex:    commandExecution, fileChange, imageView, mcpToolCall, webSearch, plan
  *              (codex's checklist arrives as the `turn/plan/updated`
  *              notification, not as a tool call — `todoList` is kept below only
  *              as tolerance for its non-app-server transports)
@@ -121,6 +121,8 @@ export function toolDisplay(name: string, input?: unknown): ToolDisplay {
 
     case 'read':
       return { toolKind: 'read', title: titled('Read', field(input, 'file_path', 'filePath', 'path')) };
+    case 'imageview':
+      return { toolKind: 'read', title: titled('View image', field(input, 'path')) };
     case 'glob':
     case 'grep':
       return {

--- a/src/server/tool-display-mirror.test.ts
+++ b/src/server/tool-display-mirror.test.ts
@@ -66,6 +66,11 @@ const TABLE: Array<{ name: string; input?: unknown; expected: ToolDisplay }> = [
   // read / search
   { name: 'Read', input: { file_path: 'package.json' }, expected: { toolKind: 'read', title: 'Read package.json' } },
   {
+    name: 'imageView',
+    input: { path: '/tmp/checkout-preview.png' },
+    expected: { toolKind: 'read', title: 'View image /tmp/checkout-preview.png' },
+  },
+  {
     name: 'Grep',
     input: { pattern: 'AgentEvent', path: 'src/core' },
     expected: { toolKind: 'search', title: 'Search AgentEvent', subtitle: 'src/core' },

--- a/web/app/src/protocol/tool-display.test.ts
+++ b/web/app/src/protocol/tool-display.test.ts
@@ -28,6 +28,11 @@ describe('protocol/tool-display — the mirror works under the bundle resolver',
       expected: { toolKind: 'search', title: 'Search AgentEvent', subtitle: 'src/core' },
     },
     {
+      name: 'imageView',
+      input: { path: '/tmp/checkout-preview.png' },
+      expected: { toolKind: 'read', title: 'View image /tmp/checkout-preview.png' },
+    },
+    {
       name: 'Task',
       input: { description: 'Explore the repo', subagent_type: 'Explore' },
       expected: { toolKind: 'task', title: 'Task: Explore the repo', subtitle: 'Explore' },

--- a/web/app/src/protocol/tool-display.ts
+++ b/web/app/src/protocol/tool-display.ts
@@ -123,6 +123,8 @@ export function toolDisplay(name: string, input?: unknown): ToolDisplay {
 
     case 'read':
       return { toolKind: 'read', title: titled('Read', field(input, 'file_path', 'filePath', 'path')) }
+    case 'imageview':
+      return { toolKind: 'read', title: titled('View image', field(input, 'path')) }
     case 'glob':
     case 'grep':
       return {


### PR DESCRIPTION
Fixes #593

## Problem
Codex image-view tool cards exposed only the raw `imageView` event name, so collapsed rows did not identify the image being inspected.

## Root Cause
The shared tool display model had no `imageView` branch. Codex therefore used the unknown-tool fallback, leaving the raw event name as the primary title even though the app-server payload provides a `path`.

## What Changed
- Render Codex `imageView` calls as read operations titled `View image <path>`.
- Keep the server and cockpit display-model mirrors synchronized.
- Add regression coverage for display mapping, Codex event mapping, and the server/web mirror.

## Tests
- Focused protocol tests: 179 passed.
- `npm run typecheck`: passed.
- `npm test`: 4,031 passed.
- `npm run test:unit`: 34 passed.
- `npm run build`: passed, including package-content verification.
- `npm run test:package`: 8 passed.

## Breaking Changes
None. The existing `UiEvent` shape and event names are unchanged.

🤖 Generated by autofix.