### PR TITLE
fix(core): coalesce codex/opencode streamed deltas into whole v1 text events

### DIFF
--- a/src/core/codex-app-server-runner.ts
+++ b/src/core/codex-app-server-runner.ts
@@ -17,6 +17,7 @@ import {
 } from './claude-cli-runner.js';
 import { parseAskRequest, type AskQuestion } from './ask.js';
 import { readNdjson } from './ndjson.js';
+import { V1TextCoalescer } from './v1-text-coalescer.js';
 import {
   CodexAppServerRpc,
   codexSpawnError,
@@ -104,9 +105,14 @@ class CodexSession implements AgentSession {
   private pendingUserInput: PendingUserInput | undefined;
   private readonly toolCalls: AgentToolCallRecord[] = [];
   private readonly textChunks: string[] = [];
-  /** agentMessage item ids that streamed deltas — so `item/completed` for the
-   *  same item doesn't re-emit the full text on top of the deltas. */
-  private readonly streamedItems = new Set<string>();
+  /** Streamed agentMessage deltas buffered per item — v1 `text` is emitted
+   *  once per completed item (claude parity: one event per complete block),
+   *  never per delta, so the persisted transcript and the headless CLI get
+   *  whole paragraphs. Streaming display rides protocol v2's `item.delta`. */
+  private readonly textCoalescer = new V1TextCoalescer((text) => {
+    this.textChunks.push(text);
+    this.emit({ type: 'text', text });
+  });
   private tokensUsed = 0;
   private ready!: Promise<void>;
   private autoEndTimer: NodeJS.Timeout | undefined;
@@ -204,6 +210,8 @@ class CodexSession implements AgentSession {
       if (this.spawnFailed) throw this.spawnFailed;
       if (sessionError) throw sessionError;
 
+      // Timeout/interrupt can end the read loop mid-item — recover buffered prose.
+      this.textCoalescer.flush();
       const text = this.textChunks.join('\n').trim();
       const base: AgentRunResult = {
         text,
@@ -384,12 +392,7 @@ class CodexSession implements AgentSession {
       }
       case 'item/agentMessage/delta': {
         const delta = typeof params.delta === 'string' ? params.delta : '';
-        if (delta) {
-          const itemId = stringField(params, 'itemId');
-          if (itemId) this.streamedItems.add(itemId);
-          this.textChunks.push(delta);
-          this.emit({ type: 'text', text: delta });
-        }
+        if (delta) this.textCoalescer.append(stringField(params, 'itemId'), delta);
         break;
       }
       case 'item/started': {
@@ -408,14 +411,9 @@ class CodexSession implements AgentSession {
         const type = stringField(item, 'type');
         const id = stringField(item, 'id') ?? '';
         if (type === 'agentMessage') {
-          // Some turns only send the final item (no deltas) → emit it then.
-          if (!id || !this.streamedItems.has(id)) {
-            const text = typeof item.text === 'string' ? item.text : '';
-            if (text) {
-              this.textChunks.push(text);
-              this.emit({ type: 'text', text });
-            }
-          }
+          // One v1 `text` per finished message — the snapshot's full text when
+          // present (also covers turns that send no deltas), else the deltas.
+          this.textCoalescer.complete(id || undefined, typeof item.text === 'string' ? item.text : undefined);
         } else if (type && !NON_TOOL_ITEMS.has(type) && id) {
           this.emit({
             type: 'tool-result',
@@ -438,6 +436,9 @@ class CodexSession implements AgentSession {
       case 'turn/failed': {
         this.pendingUserInput = undefined;
         this.activeTurnId = undefined;
+        // An interrupted/failed item never sees item/completed — surface its
+        // partial prose before the turn boundary (run.ts reads markers there).
+        this.textCoalescer.flush();
         this.emit({ type: 'turn-end' });
         if (this.opts.autoEndAfterFirstTurn && this.stdinOpen && !this.autoEndTimer) {
           this.autoEndTimer = setTimeout(() => this.end(), AUTO_END_DELAY_MS);

--- a/src/core/opencode-server-runner.ts
+++ b/src/core/opencode-server-runner.ts
@@ -12,6 +12,7 @@ import { prependSystemPrompt } from './agent-runner.js';
 import { buildChildEnv } from './agent-env.js';
 import { AUTO_END_DELAY_MS, DEFAULT_RUN_TIMEOUT_MS } from './claude-cli-runner.js';
 import { parseModelIdentity } from './model-identity.js';
+import { V1TextCoalescer } from './v1-text-coalescer.js';
 import {
   createOpencodeUiState,
   mapOpencodeEvent,
@@ -87,8 +88,16 @@ class OpencodeSession implements AgentSession {
   private readonly sse = new AbortController();
   private readonly toolCalls: AgentToolCallRecord[] = [];
   private readonly textChunks: string[] = [];
-  /** Per text-part cursor so we emit only newly-appended text (deltas). */
+  /** Per text-part cursor so only newly-appended text is buffered (deltas). */
   private readonly textSeen = new Map<string, number>();
+  /** Streamed part deltas buffered per part — v1 `text` is emitted once per
+   *  finished part (claude parity: one event per complete block), never per
+   *  delta, so the persisted transcript and the headless CLI get whole
+   *  paragraphs. Streaming display rides protocol v2's `item.delta`. */
+  private readonly textCoalescer = new V1TextCoalescer((text) => {
+    this.textChunks.push(text);
+    this.emit({ type: 'text', text });
+  });
   private readonly toolsSeen = new Set<string>();
   /** messageID → role. Parts carry no role; only assistant parts are surfaced
    *  (the user's own message also streams as parts over the same SSE feed). */
@@ -176,7 +185,11 @@ class OpencodeSession implements AgentSession {
       await this.exited;
       if (this.spawnFailed) throw this.spawnFailed;
 
-      const text = this.textChunks.join('').trim();
+      // Timeout/interrupt can cut the SSE feed mid-part — recover buffered prose.
+      this.textCoalescer.flush();
+      // Chunks are whole blocks now (one per finished part), so newline-join
+      // like the other runners, not the old delta concatenation.
+      const text = this.textChunks.join('\n').trim();
       const base: AgentRunResult = {
         text,
         toolCalls: this.toolCalls,
@@ -304,6 +317,9 @@ class OpencodeSession implements AgentSession {
       this.absorbUsage(res);
     } finally {
       this.turnInFlight = false;
+      // A part that never saw `time.end` (abort, server quirk) still surfaces
+      // its prose before the turn boundary (run.ts reads markers there).
+      this.textCoalescer.flush();
       this.emit({ type: 'turn-end' });
       if (this.opts.autoEndAfterFirstTurn && this.serverOpen && !this.autoEndTimer) {
         this.autoEndTimer = setTimeout(() => this.end(), AUTO_END_DELAY_MS);
@@ -394,10 +410,14 @@ class OpencodeSession implements AgentSession {
       const full = stringField(part, 'text') ?? '';
       const seen = this.textSeen.get(id) ?? 0;
       if (full.length > seen) {
-        const delta = full.slice(seen);
         this.textSeen.set(id, full.length);
-        this.textChunks.push(delta);
-        this.emit({ type: 'text', text: delta });
+        this.textCoalescer.append(id, full.slice(seen));
+      }
+      // `time.end` marks the part finished (same signal the v2 mapper uses) —
+      // emit the whole block once, preferring the snapshot's full text.
+      const time = part.time as Record<string, unknown> | undefined;
+      if (time && typeof time === 'object' && typeof time.end === 'number') {
+        this.textCoalescer.complete(id, full);
       }
     } else if (kind === 'tool') {
       const state = (part.state as Record<string, unknown> | undefined) ?? {};

--- a/src/core/v1-text-coalescer.test.ts
+++ b/src/core/v1-text-coalescer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { V1TextCoalescer } from './v1-text-coalescer.js';
+
+const collect = () => {
+  const texts: string[] = [];
+  return { texts, coalescer: new V1TextCoalescer((t) => texts.push(t)) };
+};
+
+describe('V1TextCoalescer', () => {
+  it('buffers deltas and emits ONE text on complete — never one per delta', () => {
+    const { texts, coalescer } = collect();
+    for (const delta of ['github', '.com', '/open', '-merc', 'ato']) coalescer.append('m1', delta);
+    expect(texts).toEqual([]);
+    coalescer.complete('m1');
+    expect(texts).toEqual(['github.com/open-mercato']);
+  });
+
+  it('prefers the completion snapshot over accumulated deltas', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append('m1', 'partial');
+    coalescer.complete('m1', 'the full authoritative text');
+    expect(texts).toEqual(['the full authoritative text']);
+  });
+
+  it('emits the snapshot for an item that never streamed (no-delta turns)', () => {
+    const { texts, coalescer } = collect();
+    coalescer.complete('m1', 'whole message at once');
+    expect(texts).toEqual(['whole message at once']);
+  });
+
+  it('emits nothing for an empty completion', () => {
+    const { texts, coalescer } = collect();
+    coalescer.complete('m1');
+    coalescer.complete('m2', '');
+    expect(texts).toEqual([]);
+  });
+
+  it('never double-emits: repeated complete for the same item is a no-op', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append('m1', 'hello');
+    coalescer.complete('m1', 'hello');
+    coalescer.complete('m1', 'hello');
+    expect(texts).toEqual(['hello']);
+  });
+
+  it('claims id-less deltas for the completing item', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append(undefined, 'no id ');
+    coalescer.append(undefined, 'yet');
+    coalescer.complete('m1');
+    expect(texts).toEqual(['no id yet']);
+  });
+
+  it('flush surfaces buffered prose of items that never completed, in arrival order', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append('a', 'first');
+    coalescer.append('b', 'second');
+    coalescer.flush();
+    expect(texts).toEqual(['first', 'second']);
+    coalescer.flush();
+    expect(texts).toEqual(['first', 'second']);
+  });
+
+  it('a re-sent snapshot after flush does not re-emit (the latch survives the boundary)', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append('m1', 'partial prose');
+    coalescer.flush();
+    coalescer.complete('m1', 'partial prose plus tail');
+    expect(texts).toEqual(['partial prose']);
+  });
+
+  it('keeps items independent — interleaved deltas do not mix', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append('a', 'aaa');
+    coalescer.append('b', 'bbb');
+    coalescer.complete('b');
+    coalescer.complete('a');
+    expect(texts).toEqual(['bbb', 'aaa']);
+  });
+
+  it('the anonymous bucket is reusable across items (never latched)', () => {
+    const { texts, coalescer } = collect();
+    coalescer.append(undefined, 'one');
+    coalescer.complete(undefined);
+    coalescer.append(undefined, 'two');
+    coalescer.complete(undefined);
+    expect(texts).toEqual(['one', 'two']);
+  });
+});

--- a/src/core/v1-text-coalescer.ts
+++ b/src/core/v1-text-coalescer.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-item coalescing of streamed assistant text into whole v1 `text` events.
+ *
+ * The v1 `AgentEvent` contract treats `text` as a complete assistant block —
+ * that is what claude emits, what the RunManager persists one NDJSON line per
+ * event, and what every consumer renders as one paragraph (cockpit thread,
+ * headless CLI). Codex and opencode stream deltas, so emitting each delta as
+ * its own `text` event persisted one line per token: transcripts rendered one
+ * paragraph per token, and turn-end markers split across deltas (`CE`+`Z`+
+ * `:D`+`ONE`) slipped past the server's per-event marker stripping.
+ *
+ * Streaming display does not go through v1 at all — protocol v2's
+ * `item.delta` (coalesced by `UiEventSink`) carries it — so v1 can afford
+ * whole-block granularity.
+ */
+export class V1TextCoalescer {
+  /** Accumulated deltas per open item. Deltas with no item id share the ''
+   *  bucket (at most one anonymous item streams at a time). */
+  private readonly pending = new Map<string, string>();
+  /** Items already emitted — a late snapshot/delta must not double-emit. */
+  private readonly done = new Set<string>();
+
+  constructor(private readonly emitText: (text: string) => void) {}
+
+  /** Buffer one streamed delta of an item. */
+  append(itemId: string | undefined, delta: string): void {
+    if (delta === '') return;
+    const key = itemId ?? '';
+    if (this.done.has(key)) return;
+    this.pending.set(key, (this.pending.get(key) ?? '') + delta);
+  }
+
+  /**
+   * The item is final: emit its text exactly once — the wire snapshot when the
+   * backend sent one (authoritative full text), else the accumulated deltas.
+   */
+  complete(itemId: string | undefined, snapshotText?: string): void {
+    const key = itemId ?? '';
+    if (this.done.has(key)) return;
+    // The anonymous bucket is never latched: without an identity, "already
+    // emitted" can't be told apart from "the next id-less item".
+    if (key !== '') this.done.add(key);
+    let buffered = this.pending.get(key);
+    this.pending.delete(key);
+    if (buffered === undefined && key !== '') {
+      // Deltas that arrived without an item id belong to the only in-flight item.
+      buffered = this.pending.get('');
+      this.pending.delete('');
+    }
+    const text = snapshotText !== undefined && snapshotText !== '' ? snapshotText : (buffered ?? '');
+    if (text !== '') this.emitText(text);
+  }
+
+  /** Turn/session boundary: emit whatever never saw its item complete, in
+   *  arrival order, so interrupted turns still surface their partial prose.
+   *  The `done` latch survives on purpose — item/part ids are unique per
+   *  session, and a re-sent snapshot after the boundary must not re-emit. */
+  flush(): void {
+    for (const [key, text] of this.pending) {
+      if (text !== '') this.emitText(text);
+      if (key !== '') this.done.add(key);
+    }
+    this.pending.clear();
+  }
+}

--- a/web/app/src/routes/task-thread/thread-state.test.ts
+++ b/web/app/src/routes/task-thread/thread-state.test.ts
@@ -287,6 +287,64 @@ describe('reduceThread — mixed v1+v2 files (the dedup rule)', () => {
   })
 })
 
+describe('reduceThread — legacy per-delta transcripts (codex/opencode runs recorded before v1 text coalescing)', () => {
+  // Verbatim shape from a real broken recording: the codex runner used to emit one v1 `text`
+  // per streaming delta, so the file holds one line per token — and the exact-match dedup
+  // never fired, rendering one paragraph per token. The v2 item carries the whole message.
+  const full = 'QA done — see github.com/open-mercato/cezar/pull/628\n\nCEZ:DONE'
+  // Per-token persistence: the server stripped markers per event (a split marker slips
+  // through: CE / Z / :D / ONE) and dropped whitespace-only deltas entirely.
+  const tokens = ['QA', ' done', ' —', ' see', ' github', '.com', '/open', '-merc', 'ato', '/ce', 'zar', '/p', 'ull', '/', '628', 'CE', 'Z', ':D', 'ONE']
+
+  it('drops a token run that reassembles the v2 message — including the split CEZ:DONE', () => {
+    const events: RunEvent[] = [
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'item.started', { item: { kind: 'message', id: 'item_1', role: 'assistant', text: '' } }),
+      line(3, 'item.completed', { item: { kind: 'message', id: 'item_1', role: 'assistant', text: full } }),
+      ...tokens.map((text, i) => line(4 + i, 'text', { text })),
+      line(40, 'turn.completed', { turnId: 'turn_1', stopReason: 'end_turn' }),
+    ]
+    const { turns } = reduceThread(events)
+    expect(kinds(turns[0]!.items)).toEqual(['message'])
+    expect((turns[0]!.items[0] as UiMessageItem).id).toBe('item_1')
+    expect((turns[0]!.items[0] as UiMessageItem).text).toBe('QA done — see github.com/open-mercato/cezar/pull/628')
+  })
+
+  it('drops one run spanning TWO v2 messages (v1 tool suppression made them adjacent)', () => {
+    const events: RunEvent[] = [
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'item.completed', { item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'First thought.' } }),
+      line(3, 'item.completed', { item: { kind: 'message', id: 'item_2', role: 'assistant', text: 'Second thought.' } }),
+      line(4, 'text', { text: 'First' }),
+      line(5, 'text', { text: ' thought.' }),
+      line(6, 'text', { text: 'Second' }),
+      line(7, 'text', { text: ' thought.' }),
+    ]
+    const { turns } = reduceThread(events)
+    expect(kinds(turns[0]!.items)).toEqual(['message', 'message'])
+  })
+
+  it('keeps a run that reassembles NOTHING — v1-only prose never vanishes', () => {
+    const events: RunEvent[] = [
+      line(1, 'turn.started', { turnId: 'turn_1' }),
+      line(2, 'item.completed', { item: { kind: 'message', id: 'item_1', role: 'assistant', text: 'Unrelated v2 prose.' } }),
+      line(3, 'text', { text: 'Two separate' }),
+      line(4, 'text', { text: 'v1-only messages.' }),
+    ]
+    const { turns } = reduceThread(events)
+    expect(kinds(turns[0]!.items)).toEqual(['message', 'message', 'message'])
+  })
+
+  it('does not touch v1-only transcripts (no v2 items — nothing to reassemble against)', () => {
+    const events: RunEvent[] = [
+      line(1, 'text', { text: 'First paragraph.' }),
+      line(2, 'text', { text: 'Second paragraph.' }),
+    ]
+    const { turns } = reduceThread(events)
+    expect(kinds(turns[0]!.items)).toEqual(['message', 'message'])
+  })
+})
+
 describe('reduceThread — live-stream mechanics', () => {
   it('item.delta appends to the right field; a later snapshot replaces the accumulation', () => {
     const events: RunEvent[] = [

--- a/web/app/src/routes/task-thread/thread-state.ts
+++ b/web/app/src/routes/task-thread/thread-state.ts
@@ -195,6 +195,56 @@ function stripDoneMarker(text: string): string {
     .join('\n')
 }
 
+/**
+ * Repair for legacy per-delta transcripts: codex/opencode runs recorded before the runners
+ * coalesced v1 `text` per item persisted one `text` line PER STREAMING TOKEN, so the fold
+ * synthesized one message per token ("github" / ".com" / "merc" / "ato" …, each its own
+ * paragraph) and the exact-match dedup never fired — no single token equals the v2 message.
+ * The tokens ARE the v2 message, just cut up: a run of consecutive v1 messages whose
+ * concatenation reassembles a v2 message of the turn (or all of them in order, when v1 tool
+ * suppression made several messages adjacent) is dropped as a whole; the v2 twin renders.
+ * The comparison ignores whitespace — the server dropped whitespace-only deltas at persist
+ * time — and strips markers on the CONCATENATION, catching `CEZ:DONE` split across tokens,
+ * which per-event stripping let through. A run that reassembles nothing is kept untouched.
+ */
+function dropLegacyDeltaRuns(draft: DraftTurn): void {
+  const norm = (text: string) => stripDoneMarker(text).replace(/\s+/g, '')
+  const v2Norms = new Set<string>()
+  const inOrder: string[] = []
+  for (const { origin, entry } of draft.entries) {
+    if (origin === 'v2' && entry.kind === 'message') {
+      const n = norm(entry.text)
+      v2Norms.add(n)
+      inOrder.push(n)
+    }
+  }
+  if (inOrder.length === 0) return
+  v2Norms.add(inOrder.join(''))
+  const kept: DraftEntry[] = []
+  let run: { entries: DraftEntry[]; texts: string[] } = { entries: [], texts: [] }
+  const flushRun = () => {
+    // Single entries already had their chance in the exact-match filter above — only a
+    // genuine run (≥2 fragments) is a delta artifact worth reassembling.
+    if (run.entries.length >= 2 && v2Norms.has(norm(run.texts.join('')))) {
+      run = { entries: [], texts: [] }
+      return
+    }
+    kept.push(...run.entries)
+    run = { entries: [], texts: [] }
+  }
+  for (const e of draft.entries) {
+    if (e.origin === 'v1' && e.entry.kind === 'message') {
+      run.entries.push(e)
+      run.texts.push(e.entry.text)
+    } else {
+      flushRun()
+      kept.push(e)
+    }
+  }
+  flushRun()
+  draft.entries = kept
+}
+
 /** v1 tool results are strings today; anything else is rendered as JSON rather than dropped. */
 function resultText(value: unknown): string {
   if (typeof value === 'string') return value
@@ -575,6 +625,7 @@ export function reduceThread(events: RunEvent[]): ThreadState {
       (e) =>
         !(e.origin === 'v1' && e.entry.kind === 'message' && v2Texts.has(stripDoneMarker(e.entry.text).trim())),
     )
+    dropLegacyDeltaRuns(draft)
   }
 
   return {


### PR DESCRIPTION
## Problem

Codex/opencode session transcripts render one paragraph **per streaming token** ("github" / ".com" / "/open" / "merc" / "ato" …), the headless CLI prints one token per line, and the `CEZ:DONE` marker shows up in the transcript split as `CE` `Z` `:D` `ONE`. Observed on a live `om-auto-qa-pr` session; unrelated to #622/#624, which fixed a CSS width collapse in the virtualized renderer.

## Root Cause

The codex runner (`item/agentMessage/delta`) and opencode runner (text-part growth) emitted one v1 `text` event **per streaming delta**. The v1 `text` contract is a complete assistant block — that is what claude emits, what the RunManager persists one NDJSON line per event, and what the fold renders as one message. Per-delta emission therefore persisted one transcript line per token; the fold's v1↔v2 twin dedup compares full texts, so no token ever matched its v2 twin and every token rendered as its own paragraph. Marker stripping runs per event, so a marker split across deltas leaked through. Streaming display never needed v1 granularity: protocol v2's `item.delta` (coalesced by `UiEventSink`, never persisted) carries it.

## What Changed

- New `V1TextCoalescer` (shared, unit-tested): buffers streamed deltas per item, emits exactly **one** v1 `text` per completed item (wire snapshot preferred over the accumulated buffer), flush backstop at turn boundaries and session settle so interrupted prose still surfaces, re-emit latch so re-sent snapshots can't duplicate.
- **codex**: buffer `item/agentMessage/delta`; emit on `item/completed`; flush on `turn/completed`/`turn/failed` and at result assembly.
- **opencode**: buffer per text part; emit on the part's `time.end` (the same finished signal the v2 mapper uses); flush at the turn boundary and result assembly; result text now newline-joins whole blocks.
- **web fold repair for existing recordings**: a run of ≥2 consecutive v1 messages in a v2-covered turn whose concatenation reassembles a v2 message of that turn (whitespace-insensitive; markers stripped on the concatenation, so a split `CEZ:DONE` matches) is a per-delta artifact and is dropped — the v2 twin renders. Anything that reassembles nothing is kept, preserving the #agent-log-vanishing-text guarantee. This makes already-broken transcripts display correctly without touching the files.

## Tests

- `npm run typecheck` — passed
- `npm test` — passed (4,054 tests)
- `npm run test:unit` — passed
- `npm run build` — passed
- `npm run test:package` — passed
- New: 10 `V1TextCoalescer` unit tests; 4 fold tests covering the token-run repair (split-marker reassembly, multi-message runs, v1-only prose kept, v1-only transcripts untouched)

## Breaking Changes

None. v1 consumers now receive whole blocks (claude parity); live streaming continues to ride protocol v2 deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)