### PR TITLE
fix(ui): link per-project resource limits (#634)

### DIFF
--- a/web/app/src/routes/settings/resources-section.test.tsx
+++ b/web/app/src/routes/settings/resources-section.test.tsx
@@ -110,6 +110,15 @@ describe('Global settings → Resources', () => {
     expect(requests.some((r) => r.method === 'PUT' && r.url === '/api/config')).toBe(false)
   })
 
+  it('links workspace limits to the per-project controls', async () => {
+    serve()
+    renderResources()
+
+    const link = await screen.findByRole('link', { name: 'Configure per-project limits' })
+    expect(link.getAttribute('href')).toBe('/settings/global/projects')
+    expect(screen.getByText(/Need a different limit for one project/)).not.toBeNull()
+  })
+
   it('saves a memory limit, and an empty field clears it back to "no limit"', async () => {
     serve({ memoryLimitMb: null })
     renderResources()

--- a/web/app/src/routes/settings/resources-section.tsx
+++ b/web/app/src/routes/settings/resources-section.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { GaugeIcon } from 'lucide-react'
 import { useState } from 'react'
+import { Link } from 'react-router'
 
 import { putWorkspaceConfig } from '@/api/client'
 import { useWorkspaceConfig, workspaceQueryKeys } from '@/api/queries'
@@ -110,6 +111,17 @@ function ResourcesForm({ config }: { config: WorkspaceConfigResponse }) {
             ),
           )}
         </select>
+        <p className="text-[11px] text-soft-foreground">
+          Need a different limit for one project?{' '}
+          <Link
+            to="/settings/global/projects"
+            data-slot="resources-project-limits-link"
+            className="font-medium text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground"
+          >
+            Configure per-project limits
+          </Link>
+          .
+        </p>
       </SettingsField>
 
       <SettingsField


### PR DESCRIPTION
Fixes #634

## Problem
Settings → Resources exposes the workspace-wide parallel-task ceiling but gives users no path to the related per-project overrides in Settings → Projects.

## Root Cause
The Resources form rendered only its two workspace controls. The per-project selector already existed in the Projects section, but no navigation affordance connected the related settings.

## What Changed
- Added explanatory copy and a keyboard-accessible link from Resources to Settings → Projects.
- Added a component regression test for the link label and destination.

## Tests
- `npx vitest run web/app/src/routes/settings/resources-section.test.tsx`
- `npm run typecheck`
- `npm test` (227 files, 4,055 tests)
- `npm run test:unit` (34 tests)
- `npm run build`
- `npm run test:package` (8 tests)

## Breaking Changes
None.

🤖 Generated by autofix.
