### PR TITLE
feat(github): toast the hand-off confirmation from the PR/issue view

### DIFF
--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -1131,6 +1131,16 @@ describe('the hand-to-agent run (legacy three-way body)', () => {
     expect(document.querySelector('[data-slot="gh-queued-flag"]')).not.toBeNull()
   })
 
+  it('confirms the hand-off with a toast — the inline affordance is off-screen on a phone', async () => {
+    stubFetch()
+    await openDetail()
+
+    fireEvent.click(screen.getByRole('button', { name: /Run agent on this issue/ }))
+
+    await waitFor(() => expect(screen.getByText('Added to the queue — issue #142')).toBeTruthy())
+    expect(document.querySelector('[data-slot="toast"]')?.getAttribute('data-tone')).toBe('default')
+  })
+
   it('a custom prompt is handed over WITH the item reference, not instead of it (#524)', async () => {
     const sent = stubFetch()
     await openDetail()

--- a/web/app/src/routes/github/hand-to-agent.tsx
+++ b/web/app/src/routes/github/hand-to-agent.tsx
@@ -103,6 +103,7 @@ export function HandToAgent({
 }) {
   const queryClient = useQueryClient()
   const uiState = useUiState()
+  const kindLabel = item.kind === 'pr' ? 'PR' : 'issue'
   // A skill deleted since it was toggled must not reach the server (legacy rule).
   const validSkills = selectedSkills.filter((name) => skills.some((skill) => skill.name === name))
   // The box is PRE-FILLED with the item's reference (#524) rather than starting empty: what you
@@ -183,6 +184,12 @@ export function HandToAgent({
       // The GitHub tab never starts variants, so the answer is a single record.
       const run = 'runs' in created ? created.runs[0] : created
       if (run) onQueued(item.url, run.id)
+      // The "✓ queued / View task →" affordance sits BELOW the button, which on a phone is
+      // typically off-screen or behind the keyboard right after the tap — so the hand-off also
+      // confirms itself as a toast, the way every other cockpit action does. Unconditional, not
+      // mobile-only: a second confirmation costs nothing on desktop, and a viewport-conditional
+      // toast is one more thing to get wrong.
+      toast(`Added to the queue — ${kindLabel} #${item.number}`)
       // Frequency sort (#408): every hand-off skill counts, mirroring the /new composer.
       // Only bump once the CURRENT map is actually known (`uiState.data` present). The PUT
       // merge is shallow (`uiStateSchema` passthrough, src/server/server.ts), so the client
@@ -294,7 +301,7 @@ export function HandToAgent({
           onClick={() => start.mutate()}
         >
           <PlayIcon aria-hidden="true" className="size-3.5" />
-          Run agent on this {item.kind === 'pr' ? 'PR' : 'issue'}
+          Run agent on this {kindLabel}
         </Button>
         <kbd
           aria-hidden="true"


### PR DESCRIPTION
Handing a PR or issue to the agent confirmed itself only with the inline `✓ queued / View task →` row, which sits **below** the run button — on a phone that lands off-screen or behind the keyboard right after the tap, so there was no visible sign the task had been queued.

The hand-off now also toasts (`Added to the queue — PR #4367`), the way every other cockpit action confirms itself. The toaster is fixed to the bottom of the viewport with a safe-area inset, so it's visible regardless of scroll position.

Unconditional rather than mobile-only: a second confirmation costs nothing on desktop, and a viewport-conditional toast is one more branch to get wrong. The inline affordance stays — it's the one that links to the run.

Also folded the run button's duplicated `pr ? 'PR' : 'issue'` expression into a single `kindLabel`.

## Changes
- `web/app/src/routes/github/hand-to-agent.tsx` — success toast in the run mutation's `onSuccess`.
- `web/app/src/routes/github/github.test.tsx` — covering test.

## Validation
- `npm run typecheck` — clean
- `npm test` — 4028 passed
- `npm run test:unit` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)