### PR TITLE
fix(ui): label Codex context compaction (#596)

### DIFF
--- a/src/core/codex-ui-mapper.test.ts
+++ b/src/core/codex-ui-mapper.test.ts
@@ -349,7 +349,7 @@ describe('mapCodexNotification edge cases', () => {
     });
   });
 
-  it('review-mode items map to task tools; unknown item types stay visible as generic tools', () => {
+  it('review-mode and context-compaction items have human labels', () => {
     const [review] = mapCodexNotification(
       { method: 'item/started', params: { item: { type: 'enteredReviewMode', id: 'item_rv' } } },
       state,
@@ -359,13 +359,20 @@ describe('mapCodexNotification edge cases', () => {
       item: { kind: 'tool', id: 'item_rv', name: 'enteredReviewMode', toolKind: 'task', title: 'Review', status: 'running' },
     });
 
-    const [unknown] = mapCodexNotification(
+    const [compaction] = mapCodexNotification(
       { method: 'item/completed', params: { item: { type: 'contextCompaction', id: 'item_cc' } } },
       state,
     ).events;
-    expect(unknown).toMatchObject({
+    expect(compaction).toMatchObject({
       type: 'item.completed',
-      item: { kind: 'tool', id: 'item_cc', name: 'contextCompaction', toolKind: 'other', status: 'completed' },
+      item: {
+        kind: 'tool',
+        id: 'item_cc',
+        name: 'contextCompaction',
+        toolKind: 'other',
+        title: 'Compacted context',
+        status: 'completed',
+      },
     });
   });
 

--- a/src/core/tool-display.test.ts
+++ b/src/core/tool-display.test.ts
@@ -180,6 +180,7 @@ describe('toolDisplay', () => {
       { name: 'todowrite', expected: { toolKind: 'plan', title: 'Update plan' } },
       { name: 'todoList', expected: { toolKind: 'plan', title: 'Update plan' } },
       { name: 'plan', expected: { toolKind: 'plan', title: 'Update plan' } },
+      { name: 'contextCompaction', expected: { toolKind: 'other', title: 'Compacted context' } },
       { name: 'TaskCreate', input: { subject: 'x' }, expected: { toolKind: 'plan', title: 'Update plan' } },
       { name: 'TaskUpdate', input: { taskId: '1' }, expected: { toolKind: 'plan', title: 'Update plan' } },
       { name: 'TaskList', expected: { toolKind: 'plan', title: 'Update plan' } },

--- a/src/core/tool-display.ts
+++ b/src/core/tool-display.ts
@@ -13,7 +13,8 @@
  *  - claude:   Bash, Edit, Write, NotebookEdit, Read, Glob, Grep, WebFetch,
  *              WebSearch, Task, Agent, Skill, TodoWrite, TaskCreate,
  *              TaskUpdate, TaskList, mcp__server__tool
- *  - codex:    commandExecution, fileChange, imageView, mcpToolCall, webSearch, plan
+ *  - codex:    commandExecution, contextCompaction, fileChange, imageView,
+ *              mcpToolCall, webSearch, plan
  *              (codex's checklist arrives as the `turn/plan/updated`
  *              notification, not as a tool call — `todoList` is kept below only
  *              as tolerance for its non-app-server transports)
@@ -171,6 +172,9 @@ export function toolDisplay(name: string, input?: unknown): ToolDisplay {
     case 'taskupdate':
     case 'tasklist':
       return { toolKind: 'plan', title: 'Update plan' };
+
+    case 'contextcompaction':
+      return { toolKind: 'other', title: 'Compacted context' };
 
     case 'mcptoolcall': {
       const server = field(input, 'server');

--- a/src/server/tool-display-mirror.test.ts
+++ b/src/server/tool-display-mirror.test.ts
@@ -122,6 +122,7 @@ const TABLE: Array<{ name: string; input?: unknown; expected: ToolDisplay }> = [
   // plan
   { name: 'TodoWrite', input: { todos: [] }, expected: { toolKind: 'plan', title: 'Update plan' } },
   { name: 'todoList', expected: { toolKind: 'plan', title: 'Update plan' } },
+  { name: 'contextCompaction', expected: { toolKind: 'other', title: 'Compacted context' } },
 
   // MCP, both naming schemes
   {

--- a/web/app/src/protocol/tool-display.test.ts
+++ b/web/app/src/protocol/tool-display.test.ts
@@ -51,6 +51,7 @@ describe('protocol/tool-display — the mirror works under the bundle resolver',
     { name: 'TaskCreate', input: { subject: 'x' }, expected: { toolKind: 'plan', title: 'Update plan' } },
     { name: 'TaskUpdate', input: { taskId: '1' }, expected: { toolKind: 'plan', title: 'Update plan' } },
     { name: 'TaskList', expected: { toolKind: 'plan', title: 'Update plan' } },
+    { name: 'contextCompaction', expected: { toolKind: 'other', title: 'Compacted context' } },
     {
       name: 'mcp__github__list_prs',
       input: { state: 'open' },

--- a/web/app/src/protocol/tool-display.ts
+++ b/web/app/src/protocol/tool-display.ts
@@ -20,6 +20,9 @@
  * Pure function over untrusted input: tool inputs come off the wire and may
  * be null, partial (streamed incrementally) or arbitrarily malformed —
  * `toolDisplay` must never throw.
+ *
+ * Known Codex items include commandExecution, contextCompaction, fileChange,
+ * imageView, mcpToolCall, webSearch and plan.
  */
 
 import type { ToolKind } from './ui-events.js'
@@ -173,6 +176,9 @@ export function toolDisplay(name: string, input?: unknown): ToolDisplay {
     case 'taskupdate':
     case 'tasklist':
       return { toolKind: 'plan', title: 'Update plan' }
+
+    case 'contextcompaction':
+      return { toolKind: 'other', title: 'Compacted context' }
 
     case 'mcptoolcall': {
       const server = field(input, 'server')


### PR DESCRIPTION
Fixes #596

## Problem
Codex context-compaction items appeared in the transcript as the opaque internal identifier `contextCompaction`, leaving users without a human-readable explanation of the event.

## Root Cause
The Codex mapper intentionally preserves unknown item types as generic tool cards, but `contextCompaction` had no known entry in the shared tool-display model. Both the server and browser mirrors therefore used the raw backend name as the title.

## What Changed
- Added a case-insensitive `contextCompaction` display mapping with the title `Compacted context` in both protocol mirrors.
- Added mapper, display-model, and mirror-parity regression coverage so the friendly title remains consistent across server and browser consumers.

## Tests
- Focused Vitest coverage: 4 files, 182 tests passed.
- `npm run typecheck` passed.
- `npm test` passed: 227 files, 4,061 tests.
- `npm run test:unit` passed: 34 tests.
- `npm run build` passed, including `check:pack`.
- `npm run test:package` passed: 8 tests.

## Breaking Changes
None. Existing event names and persisted payloads are unchanged; only the derived human-facing title improves.

Manual UI QA remains pending because this changes user-visible transcript copy.

🤖 Generated by `om-auto-fix-issue`.