### PR TITLE
test(test-env): cover detached launcher lifecycle (#574)

### DIFF
--- a/test/unit/test-env-launcher.test.ts
+++ b/test/unit/test-env-launcher.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { afterEach, test } from 'node:test';
+
+const repoRoot = resolve(import.meta.dirname, '../..');
+const fixtures: string[] = [];
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true });
+});
+
+function commandPath(command: string): string {
+  return execFileSync('/bin/sh', ['-c', `command -v ${command}`], { encoding: 'utf8' }).trim();
+}
+
+function makeFixture(withSetsid: boolean): { root: string; path: string } {
+  const root = mkdtempSync(join(tmpdir(), 'cez-test-env-launcher-'));
+  fixtures.push(root);
+  mkdirSync(join(root, '.ai/scripts'), { recursive: true });
+  mkdirSync(join(root, '.ai/browsers'), { recursive: true });
+  mkdirSync(join(root, 'bin'), { recursive: true });
+  copyFileSync(join(repoRoot, '.ai/scripts/test-env-up.sh'), join(root, '.ai/scripts/test-env-up.sh'));
+  copyFileSync(join(repoRoot, '.ai/scripts/test-env-down.sh'), join(root, '.ai/scripts/test-env-down.sh'));
+  writeFileSync(join(root, '.ai/browsers/agent-browser.md'), '# test provider\n');
+  writeFileSync(join(root, 'package.json'), '{"private":true}\n');
+  writeFileSync(join(root, 'package-lock.json'), '{}\n');
+
+  const commands = ['cat', 'chmod', 'curl', 'date', 'dirname', 'find', 'grep', 'id', 'kill', 'mkdir', 'mv', 'nohup', 'pwd', 'rm', 'sh', 'sleep', 'tail', 'uname'];
+  if (withSetsid) commands.push('setsid');
+  for (const command of commands) symlinkSync(commandPath(command), join(root, 'bin', command));
+  symlinkSync(process.execPath, join(root, 'bin/node'));
+
+  writeFileSync(
+    join(root, 'bin/npm'),
+    `#!/bin/sh
+set -eu
+mkdir -p dist web/dist
+cat > dist/index.js <<'EOF'
+const http = require('node:http');
+const port = Number(process.argv[process.argv.indexOf('--port') + 1]);
+http.createServer((req, res) => {
+  res.writeHead(200, { 'content-type': req.url === '/api/health' ? 'application/json' : 'text/html' });
+  res.end(req.url === '/api/health' ? '{"ok":true}' : '<!doctype html>');
+}).listen(port, '127.0.0.1');
+EOF
+printf '<!doctype html>' > web/dist/index.html
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(root, 'bin/agent-browser'),
+    `#!/bin/sh
+case "\${1:-}" in
+  doctor) printf '{"ok":true}\\n' ;;
+  --version) printf 'test-browser 1\\n' ;;
+  *) : ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  return { root, path: join(root, 'bin') };
+}
+
+function descriptor(root: string): { baseUrl: string; app: { pid: number } } {
+  return JSON.parse(readFileSync(join(root, '.ai/qa/test-env.json'), 'utf8')) as {
+    baseUrl: string;
+    app: { pid: number };
+  };
+}
+
+for (const withSetsid of [true, false]) {
+  test(`generated launcher survives its caller and stops by descriptor PID (${withSetsid ? 'setsid' : 'nohup fallback'})`, async () => {
+    const fixture = makeFixture(withSetsid);
+    const env = { ...process.env, PATH: fixture.path, TEST_ENV_CACHE_TTL_SECONDS: '600' };
+    const up = join(fixture.root, '.ai/scripts/test-env-up.sh');
+    const down = join(fixture.root, '.ai/scripts/test-env-down.sh');
+    const callerPidFile = join(fixture.root, 'caller.pid');
+
+    const coldCommand = withSetsid ? commandPath('setsid') : '/bin/sh';
+    const coldArgs = withSetsid
+      ? ['/bin/sh', '-c', 'echo $$ > "$2"; sh "$1"', 'launcher-parent', up, callerPidFile]
+      : ['-c', 'echo $$ > "$2"; sh "$1"', 'launcher-parent', up, callerPidFile];
+    const cold = spawnSync(coldCommand, coldArgs, {
+      cwd: tmpdir(),
+      encoding: 'utf8',
+      env,
+      timeout: 20_000,
+    });
+    assert.equal(cold.status, 0, cold.stderr);
+    assert.match(cold.stdout, /TEST_ENV_REUSED=0/);
+
+    const first = descriptor(fixture.root);
+    if (withSetsid) {
+      const callerPid = Number(readFileSync(callerPidFile, 'utf8').trim());
+      try {
+        process.kill(-callerPid, 'SIGTERM');
+      } catch (error) {
+        assert.equal((error as NodeJS.ErrnoException).code, 'ESRCH');
+      }
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+    }
+    assert.equal(process.kill(first.app.pid, 0), true);
+    const health = await fetch(`${first.baseUrl}/api/health`).then((response) => response.json());
+    assert.deepEqual(health, { ok: true });
+
+    const warm = spawnSync('/bin/sh', [up], { encoding: 'utf8', env, timeout: 20_000 });
+    assert.equal(warm.status, 0, warm.stderr);
+    assert.match(warm.stdout, /TEST_ENV_REUSED=1/);
+    assert.equal(descriptor(fixture.root).app.pid, first.app.pid);
+
+    const stopped = spawnSync('/bin/sh', [down], { encoding: 'utf8', env, timeout: 20_000 });
+    assert.equal(stopped.status, 0, stopped.stderr);
+    assert.match(stopped.stdout, /TEST_ENV_STATUS=stopped/);
+    assert.throws(() => process.kill(first.app.pid, 0));
+  });
+}

--- a/test/unit/test-env-launcher.test.ts
+++ b/test/unit/test-env-launcher.test.ts
@@ -2,13 +2,22 @@ import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { afterEach, test } from 'node:test';
 
 const repoRoot = resolve(import.meta.dirname, '../..');
 const fixtures: string[] = [];
+const launchedPids = new Set<number>();
 
 afterEach(() => {
+  for (const pid of launchedPids) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // The down script already stopped the fixture process.
+    }
+  }
+  launchedPids.clear();
   for (const fixture of fixtures.splice(0)) rmSync(fixture, { recursive: true, force: true });
 });
 
@@ -93,6 +102,7 @@ for (const withSetsid of [true, false]) {
     assert.match(cold.stdout, /TEST_ENV_REUSED=0/);
 
     const first = descriptor(fixture.root);
+    launchedPids.add(first.app.pid);
     if (withSetsid) {
       const callerPid = Number(readFileSync(callerPidFile, 'utf8').trim());
       try {
@@ -115,5 +125,6 @@ for (const withSetsid of [true, false]) {
     assert.equal(stopped.status, 0, stopped.stderr);
     assert.match(stopped.stdout, /TEST_ENV_STATUS=stopped/);
     assert.throws(() => process.kill(first.app.pid, 0));
+    launchedPids.delete(first.app.pid);
   });
 }


### PR DESCRIPTION
Closes #574

## 🎯 Goal
- Keep the generated POSIX test-environment launcher reliable after its invoking non-interactive shell or PTY exits, and prevent regressions in both supported detachment paths.

## 🔍 Problem
Browser QA exposed that a launcher could report a healthy environment while its child server was still tied to the bootstrap shell lifecycle. The runtime repair landed incidentally in PR #597, but no automated test verified survival after the parent returned, descriptor PID ownership, warm reuse, or safe shutdown.

## 🔍 Root Cause
The fast test gate did not cross the launcher process boundary. That left the `setsid` plus `nohup` repair and the portable no-`setsid` fallback unprotected, so a regenerated or edited launcher could regress without any unit or integration failure.

## What Changed
- Added a self-contained Node test fixture that executes the real generated `test-env-up.sh` and `test-env-down.sh` scripts from an unrelated working directory.
- Covered cold launch, a health probe from the separate test process after the launcher returns, warm reuse of the same descriptor PID, and shutdown through that PID.
- Covered both the `setsid` path and the `nohup` fallback. The `setsid` case explicitly reaps the bootstrap process group before probing health, matching the failure mode seen under task runners.

## 🧪 Tests
- `node --import tsx --test test/unit/test-env-launcher.test.ts` — 2 passed.
- `npm run typecheck` — passed.
- `npm test` — passed.
- `npm run test:unit` — 36 passed.
- `npm run build` — passed, including the package-content gate.
- `npm run test:package` — 8 passed.

## 💥 Breaking Changes
- None. This is regression coverage for the existing launcher contract.
