### PR TITLE
fix(server): avoid boot slug collisions (#558)

### DIFF
--- a/src/server/projects-api.test.ts
+++ b/src/server/projects-api.test.ts
@@ -145,6 +145,22 @@ describe('workspace projects API', () => {
       expect(body.projectsDir).toBe('~/cezar/projects');
     });
 
+    it('keeps an unregistered boot project distinct from a registered project with the same slug', async () => {
+      const registeredRoot = join(otherRoot, basename(repoRoot));
+      mkdirSync(registeredRoot);
+      const registered = await registerProject(registeredRoot);
+      const contexts = new ProjectContexts({ listProjects });
+
+      const body = await getProjects({ contexts });
+      expect(registered.id).toBe(allocateProjectSlug(repoRoot, []));
+      expect(body.bootProject).toBe(allocateProjectSlug(repoRoot, [registered.id]));
+
+      const scoped = await apiRequest(makeApp({ contexts }), `/api/p/${registered.id}/repo`);
+      expect(scoped.status).toBe(200);
+      expect(contexts.peek(registered.id)?.root).toBe(await realpath(registeredRoot));
+      contexts.disposeAll();
+    });
+
     it('pins flagged reads to the boot project without pruning stored projects', async () => {
       const boot = await registerProject(repoRoot);
       const other = await registerProject(otherRoot);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -717,15 +717,16 @@ export function createApp(deps: ServerDeps): Hono {
   let bootProjectCache = bootProjectId;
   const resolveBootProject = async (projects?: readonly WorkspaceProject[]): Promise<string> => {
     if (bootProjectCache) return bootProjectCache;
+    let registry = projects ?? [];
     try {
-      const registry = projects ?? (await loadWorkspaceConfig()).projects;
+      registry = projects ?? (await loadWorkspaceConfig()).projects;
       const real = await realpath(bootRoot).catch(() => bootRoot);
       const match = registry.find((p) => p.root === real || p.root === bootRoot);
       if (match) bootProjectCache = match.id;
     } catch {
       // unreadable workspace — fall through to the slug fallback below
     }
-    return bootProjectCache ?? allocateProjectSlug(bootRoot, []);
+    return bootProjectCache ?? allocateProjectSlug(bootRoot, registry.map((project) => project.id));
   };
   // Health's workspace garnish: id+name ONLY — never `root` (#431, see the
   // health route). Reads only the registry file; no per-root status probes,


### PR DESCRIPTION
Fixes #558

## Problem
When boot-project registration is intentionally suppressed, the server derived its fallback boot slug without considering registered project IDs. A registered project with the same basename could therefore have its scoped requests routed to the boot context.

## Root Cause
`resolveBootProject` called `allocateProjectSlug(bootRoot, [])` after failing to match the boot root in the registry, discarding the registry IDs already loaded for the lookup.

## What Changed
- Preserve the loaded registry through the fallback path and allocate the boot slug against its project IDs.
- Add a regression test that creates the collision and proves the registered project's scoped route builds and uses its own context.

## Tests
- `npx vitest run src/server/projects-api.test.ts` — 35 tests passed.
- `npm run typecheck` — passed.
- `npm test` — 227 files and 4059 tests passed.
- `npm run test:unit` — 34 tests passed.
- `npm run build` — passed, including `check:pack`.
- `npm run test:package` — 8 tests passed.

## Breaking Changes
None. Existing routes and response shapes are unchanged; the fallback now preserves project-ID uniqueness as designed.

🤖 Generated by `om-auto-fix-issue`.
