### PR TITLE
fix(runs): track issue number provenance (#539)

### DIFF
--- a/.ai/specs/2026-07-21-report-ref-discovery.md
+++ b/.ai/specs/2026-07-21-report-ref-discovery.md
@@ -58,9 +58,10 @@ pretty distinguished"):
   subject; several resolve only when the task prompt names exactly one;
   ambiguity clears the chip.
 - An unambiguous resolution seeds `issueNumber` when nothing owns that field;
-  ambiguity takes the janitor's own seed back. Marker and namer outrank the
-  janitor and overwrite freely (a namer-written number equal to a revoked
-  seed being cleared alongside it is the documented residual).
+  the persisted `referencedIssueNumberSeeded` provenance bit lets ambiguity
+  take back only the janitor's own seed, including after a restart. Prompt,
+  marker, and namer writes clear that provenance and are never revoked merely
+  because their number equals the previous fuzzy resolution.
 - Issue tracking runs regardless of the created-PR state — a task that opened
   a PR can still be *about* an issue.
 
@@ -84,6 +85,7 @@ pretty distinguished"):
   markers, decorated/suffixed lines, skill-doc placeholders are inert);
   CRLF tolerance; strip leaves report lines visible.
 - Store: single-link adoption + `issueNumber` seed; independence from the
-  created-PR tier; ambiguity clearing chip and seeded number; task-prompt
+  created-PR tier; ambiguity clearing the chip and a persisted janitor seed;
+  ambiguity preserving an equal prompt-owned number; task-prompt
   disambiguation; declared-issue candidate filtering; marker-owned
   `issueNumber` never overwritten by stray links.

--- a/src/runs/store.test.ts
+++ b/src/runs/store.test.ts
@@ -765,12 +765,14 @@ describe('RunStore — referenced-issue discovery (spec 2026-07-21-report-ref-di
   });
 
   it('ambiguity clears the chip and takes back the number the janitor seeded', () => {
-    const { store, run } = freshRun();
-    store.appendEvent(run.id, {
+    const { store: firstStore, run } = freshRun();
+    firstStore.appendEvent(run.id, {
       type: 'result',
       result: 'See https://github.com/open-mercato/cezar/issues/1',
     });
-    expect(store.getRun(run.id)?.issueNumber).toBe(1);
+    expect(firstStore.getRun(run.id)?.issueNumber).toBe(1);
+    firstStore.flush();
+    const store = RunStore.open(dataDir, { keepLive: true });
     store.appendEvent(run.id, {
       type: 'result',
       result: 'Also https://github.com/open-mercato/cezar/issues/2',
@@ -778,6 +780,22 @@ describe('RunStore — referenced-issue discovery (spec 2026-07-21-report-ref-di
     const loaded = store.getRun(run.id);
     expect(loaded?.referencedIssueUrl).toBeUndefined();
     expect(loaded?.issueNumber).toBeUndefined();
+  });
+
+  it('ambiguity preserves a prompt-derived issueNumber equal to the previous resolution', () => {
+    const { store, run } = freshRun('port the fix from issue 12 into issue 433');
+    store.updateRun(run.id, { issueNumber: 12 });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/open-mercato/cezar/issues/12',
+    });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Also https://github.com/open-mercato/cezar/issues/433',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.referencedIssueUrl).toBeUndefined();
+    expect(loaded?.issueNumber).toBe(12);
   });
 
   it('disambiguates several issue links by the number named in the task prompt', () => {

--- a/src/runs/store.ts
+++ b/src/runs/store.ts
@@ -123,6 +123,10 @@ const runRecordSchema = z.object({
    *  cross-checked output. Display tier — never gates actions. */
   prNumber: z.number().optional(),
   issueNumber: z.number().optional(),
+  /** Provenance for an `issueNumber` seeded by referenced-issue discovery.
+   *  Persisted so ambiguity can revoke only the janitor's own value, including
+   *  after a restart. Any prompt, namer, or marker write clears this flag. */
+  referencedIssueNumberSeeded: z.boolean().optional(),
   /** Who owns the display title: `user` (PATCH rename — never auto-overwritten),
    *  `marker` (agent-declared via `CEZ:TITLE`, spec 2026-07-18-task-ref-markers —
    *  beats the namer, silences live refresh) or `auto` (namer-owned — a later
@@ -399,6 +403,9 @@ export class RunStore extends EventEmitter {
   updateRun(id: string, patch: Partial<Omit<RunRecord, 'id' | 'steps'>>): RunRecord | undefined {
     const run = this.runs.get(id);
     if (!run) return undefined;
+    if (Object.prototype.hasOwnProperty.call(patch, 'issueNumber')) {
+      delete run.referencedIssueNumberSeeded;
+    }
     Object.assign(run, this.redactPatch(patch));
     this.touch(run);
     return run;
@@ -572,12 +579,15 @@ export class RunStore extends EventEmitter {
     if (run.markerRefs?.issue === undefined) {
       if (run.referencedIssueUrl && run.issueNumber === undefined) {
         const n = Number(run.referencedIssueUrl.split('/').pop());
-        if (Number.isInteger(n) && n > 0) run.issueNumber = n;
-      } else if (!run.referencedIssueUrl && prev && run.issueNumber === Number(prev.split('/').pop())) {
+        if (Number.isInteger(n) && n > 0) {
+          run.issueNumber = n;
+          run.referencedIssueNumberSeeded = true;
+        }
+      } else if (!run.referencedIssueUrl && prev && run.referencedIssueNumberSeeded) {
         // Ambiguity revoked the resolution — take back the number this janitor
-        // seeded from it (a namer-written number that happens to match is the
-        // documented residual). No chip beats a wrong chip.
+        // seeded from it. No chip beats a wrong chip.
         delete run.issueNumber;
+        delete run.referencedIssueNumberSeeded;
       }
     }
     return true;
@@ -600,7 +610,10 @@ export class RunStore extends EventEmitter {
       ...(refs.issue !== undefined ? { issue: refs.issue } : {}),
     };
     if (refs.pr !== undefined) run.prNumber = refs.pr;
-    if (refs.issue !== undefined) run.issueNumber = refs.issue;
+    if (refs.issue !== undefined) {
+      run.issueNumber = refs.issue;
+      delete run.referencedIssueNumberSeeded;
+    }
     if (run.markerRefs.pr !== undefined) {
       run.referencedPullRequestUrl = resolveReferencedRef(
         run.referencedPrCandidates ?? [],

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -117,6 +117,8 @@ export interface RunRecord {
   /** The PR/issue number this task is ABOUT (task auto-naming spec) — display tier only. */
   prNumber?: number
   issueNumber?: number
+  /** Server-side provenance: referenced-issue discovery currently owns `issueNumber`. */
+  referencedIssueNumberSeeded?: boolean
   /** 'user' = renamed via PATCH, never auto-overwritten; 'marker' = agent-declared
    *  via CEZ:TITLE (spec 2026-07-18-task-ref-markers); 'auto' = namer-owned. */
   titleOrigin?: 'user' | 'auto' | 'marker'


### PR DESCRIPTION
Fixes #539

## Problem
When referenced-issue discovery became ambiguous, it revoked `issueNumber` by comparing values. A prompt-derived number equal to the janitor’s previous resolution could therefore be deleted.

## Root Cause
`RunStore.trackReferencedIssues` had no provenance for the value it seeded, so equality with the prior resolved URL was used as a proxy for ownership.

## What Changed
- Persist whether referenced-issue discovery seeded `issueNumber`, and clear that provenance whenever prompt, namer, or marker logic writes the field.
- Revoke `issueNumber` only when the janitor still owns it.
- Cover prompt-owned equality and janitor ownership across a store restart.
- Update the report-reference design record and the mirrored cockpit API type.

## Tests
- `npm run typecheck`
- `npm test` — 227 files, 4,062 tests
- `npm run test:unit` — 34 tests
- `npm run build`
- `npm run test:package` — 8 tests

## Breaking Changes
None. The persisted provenance field is optional, so older run records remain valid.

🤖 Generated by `om-auto-fix-issue`.