### PR TITLE
fix(skills): auto-refresh the team-repo cache so codex reviews use current skills

### DIFF
--- a/src/skills-remote.test.ts
+++ b/src/skills-remote.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { bareDirFor, isPinnedSha, shouldPassiveFetch } from './skills-remote.js';
+
+const TTL = 6 * 60 * 60 * 1_000;
+
+describe('shouldPassiveFetch', () => {
+  it('fetches on the first passive touch this process', () => {
+    // A clone left by an earlier run must be refreshed on first read, else a
+    // long-running server serves whatever ref that old clone happened to have.
+    expect(shouldPassiveFetch({ attempted: false, fetchedAt: 0, now: 1_000, ttlMs: TTL })).toBe(true);
+  });
+
+  it('does not re-fetch within the TTL once touched', () => {
+    const now = 10 * 60 * 60 * 1_000;
+    expect(shouldPassiveFetch({ attempted: true, fetchedAt: now - 60_000, now, ttlMs: TTL })).toBe(false);
+  });
+
+  it('re-fetches once the last fetch is older than the TTL', () => {
+    const now = 10 * 60 * 60 * 1_000;
+    expect(shouldPassiveFetch({ attempted: true, fetchedAt: now - TTL - 1, now, ttlMs: TTL })).toBe(true);
+  });
+
+  it('treats exactly-TTL as still fresh (strictly greater re-fetches)', () => {
+    const now = 10 * 60 * 60 * 1_000;
+    expect(shouldPassiveFetch({ attempted: true, fetchedAt: now - TTL, now, ttlMs: TTL })).toBe(false);
+  });
+});
+
+describe('bareDirFor', () => {
+  it('keys the global cache on owner__name regardless of URL shape', () => {
+    const expected = bareDirFor('open-mercato/skills');
+    expect(bareDirFor('https://github.com/open-mercato/skills.git')).toBe(expected);
+    expect(bareDirFor('git@github.com:open-mercato/skills')).toBe(expected);
+    expect(expected.endsWith('open-mercato__skills')).toBe(true);
+  });
+});
+
+describe('isPinnedSha', () => {
+  it('accepts 40- and 64-hex, rejects branch names', () => {
+    expect(isPinnedSha('a'.repeat(40))).toBe(true);
+    expect(isPinnedSha('b'.repeat(64))).toBe(true);
+    expect(isPinnedSha('main')).toBe(false);
+  });
+});

--- a/src/skills-remote.ts
+++ b/src/skills-remote.ts
@@ -400,6 +400,30 @@ async function excludeFromGit(repoRoot: string, pattern: string): Promise<void> 
 // DNS/TCP), so each source gets one implicit attempt per process. "Refresh"
 // always retries.
 const cloneAttempted = new Set<string>();
+// Isolated review worktrees have no local `.agents/skills` (gitignored, absent
+// in a fresh checkout), so codex reads skills straight from this global bare
+// cache. A clone left by an earlier run — or one this long-running process
+// fetched hours ago — silently serves a stale template. Passive loads therefore
+// fetch on the first touch per process and then at most once per TTL, keeping
+// the cache current without a manual "Refresh" and without fetching on every
+// catalog read. `refresh` (the explicit button / #613's post-update
+// invalidateCatalog) still fetches unconditionally.
+const PASSIVE_FETCH_TTL_MS = 6 * 60 * 60 * 1_000;
+const lastFetchByRepo = new Map<string, number>();
+
+/**
+ * Whether a passive (non-`refresh`) load should `git fetch` an existing bare
+ * clone: yes on the first touch this process, and yes once the last fetch is
+ * older than `ttlMs`. Pure so the freshness policy is unit-tested without git.
+ */
+export function shouldPassiveFetch(opts: {
+  attempted: boolean;
+  fetchedAt: number;
+  now: number;
+  ttlMs: number;
+}): boolean {
+  return !opts.attempted || opts.now - opts.fetchedAt > opts.ttlMs;
+}
 // Both maps are keyed by `repoRoot` (multi-project workspace, step 2.6): each
 // project resolves its own `.ai/cezar/config.json` → `skillsRepos`, so one
 // project's team-skill list must never be served under another project's scope.
@@ -451,9 +475,21 @@ async function loadTeamSkills(repoRoot: string, refresh: boolean): Promise<Skill
         const { bareDir, created } = await ensureBareClone(src.repo);
         if (!created) await fetchAll(bareDir);
         cloneAttempted.add(src.repo);
-      } else if (!cloneAttempted.has(src.repo)) {
+        lastFetchByRepo.set(src.repo, Date.now());
+      } else if (
+        shouldPassiveFetch({
+          attempted: cloneAttempted.has(src.repo),
+          fetchedAt: lastFetchByRepo.get(src.repo) ?? 0,
+          now: Date.now(),
+          ttlMs: PASSIVE_FETCH_TTL_MS,
+        })
+      ) {
         cloneAttempted.add(src.repo);
-        await ensureBareClone(src.repo);
+        const { bareDir, created } = await ensureBareClone(src.repo);
+        // A clone left by an earlier run is very likely behind origin; fetch it
+        // so worktree reviews never read a stale skills template.
+        if (!created) await fetchAll(bareDir);
+        lastFetchByRepo.set(src.repo, Date.now());
       }
     } catch {
       // offline / no access — list whatever an older clone has (or nothing)


### PR DESCRIPTION
## 🎯 Goal
Stop cezar (codex) code reviews from rendering a **stale** `om-code-review` template — the root cause behind reviews still using the old, non-emoji format after the upstream `open-mercato/skills` repo moved on (e.g. PR #639).

## Root cause
An isolated review worktree has **no local `.agents/skills`** (gitignored → absent in a fresh checkout), so codex resolves skills from the **global bare team-repo cache** `~/.cache/cez/skills/<owner>__<name>`, read at `refs/heads/<ref>`. The passive load path (`loadTeamSkills(root, false)`) only cloned that cache **once per process** and **never fetched an existing clone**, so a long-running server served whatever ref the clone had at startup — indefinitely. (`npx skills` only moves `FETCH_HEAD`, not `refs/heads/main`, so per-project updates never advanced it either.)

## What changed
- Passive loads now `git fetch` an existing bare clone on the **first touch per process** and then **at most once per `PASSIVE_FETCH_TTL_MS` (6h)** — advancing `refs/heads/*` exactly like the explicit *Refresh* button and #613's post-update `invalidateCatalog` already do.
- The freshness policy is a pure, unit-tested predicate `shouldPassiveFetch(...)` — no git/network needed to test it.
- Offline still degrades silently (fetch failures are already caught); no fetch on every catalog read.

## Tests
- New `src/skills-remote.test.ts`: `shouldPassiveFetch` (first-touch, within-TTL, past-TTL, exactly-TTL), plus `bareDirFor` cache-key stability and `isPinnedSha`. 6/6 green; typecheck clean.

## 💥 Breaking Changes
None. Same public surface; only the passive-load fetch cadence changes.

## Related
Complements #613 (automatic skills updates): #613 refreshes lock-based `.agents/skills` and calls `refreshTeamSkills` **only when a lock update actually happened**; this keeps the team cache current even when the lock is already up to date, and for a server that simply stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)