### PR TITLE
feat(ui): show task references in session header (#544)

### DIFF
--- a/web/app/src/components/reference-chip.tsx
+++ b/web/app/src/components/reference-chip.tsx
@@ -1,0 +1,53 @@
+import { ArrowUpRightIcon } from 'lucide-react'
+
+import { cn, isHttpUrl } from '@/lib/utils'
+
+/** A task's out-of-app tracker link. The record carries no open/closed state, so PR and issue
+ * references deliberately share one neutral treatment. */
+export function ReferenceChip({
+  reference,
+  taskTitle,
+  className,
+  compact = false,
+}: {
+  reference: { kind: 'PR' | 'Issue'; number?: number; url?: string }
+  taskTitle: string
+  className?: string
+  /** The narrow sidebar keeps its established `PR` label instead of spelling out a number. */
+  compact?: boolean
+}) {
+  const { kind, number, url } = reference
+  const chipClass = cn(
+    'inline-flex h-[22px] items-center gap-1 rounded-full border border-violet/35 px-2 font-mono text-[11px] font-semibold text-violet',
+    className,
+  )
+  const label =
+    compact && kind === 'PR'
+      ? 'PR'
+      : number
+        ? `${kind === 'Issue' ? 'Issue ' : ''}#${number}`
+        : kind
+
+  // href protocol guard (#431): a transcript-scraped non-http URL degrades to inert text.
+  if (!url || !isHttpUrl(url)) {
+    return (
+      <span data-slot={kind === 'PR' ? 'pr-chip' : 'issue-chip'} className={chipClass}>
+        {label}
+      </span>
+    )
+  }
+  return (
+    <a
+      data-slot={kind === 'PR' ? 'pr-chip' : 'issue-chip'}
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={url}
+      aria-label={`Open the ${kind === 'PR' ? 'pull request' : 'issue'} for ${taskTitle}`}
+      className={cn(chipClass, 'hover:bg-violet/10')}
+    >
+      {label}
+      <ArrowUpRightIcon className="size-2.5" aria-hidden="true" />
+    </a>
+  )
+}

--- a/web/app/src/components/task-quick-list.tsx
+++ b/web/app/src/components/task-quick-list.tsx
@@ -1,10 +1,11 @@
-import { ArrowUpRightIcon, ChevronDownIcon, ScaleIcon } from 'lucide-react'
+import { ChevronDownIcon, ScaleIcon } from 'lucide-react'
 import * as React from 'react'
 import { useRuns } from '@/api/queries'
 import { Link, scopeTo, useProjectMatch } from '@/lib/project-router'
 import type { RunRecord } from '@/api/types'
 import { DiffStatLabel } from '@/components/diff-stat'
 import { useListView } from '@/components/list-view'
+import { ReferenceChip } from '@/components/reference-chip'
 import { StatusDot } from '@/components/status-dot'
 import { deriveAttention } from '@/lib/attention'
 import { compactTokens, shortAge } from '@/lib/format'
@@ -16,7 +17,7 @@ import {
   type QuickListBucket,
   type QuickListRow,
 } from '@/lib/task-groups'
-import { taskPrUrl } from '@/lib/tasks-table'
+import { prNumber, taskPrUrl } from '@/lib/tasks-table'
 import { useNow } from '@/lib/use-now'
 import { cn, isHttpUrl } from '@/lib/utils'
 
@@ -312,18 +313,16 @@ function RunRow({
       </Link>
       {/* href protocol guard (#431): link only for http(s) URLs. */}
       {prUrl && isHttpUrl(prUrl) ? (
-        <a
-          data-slot="pr-chip"
-          href={prUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={prUrl}
-          aria-label={`Open the pull request for ${runTitle(run)}`}
-          className="mr-2.5 inline-flex shrink-0 items-center gap-[3px] rounded-full border border-violet/35 px-1.5 py-px font-mono text-[10.5px] font-semibold text-violet hover:bg-violet/10"
-        >
-          PR
-          <ArrowUpRightIcon className="size-[9px]" aria-hidden="true" />
-        </a>
+        <ReferenceChip
+          reference={{
+            kind: 'PR',
+            ...(prNumber(prUrl) ? { number: Number(prNumber(prUrl)) } : {}),
+            url: prUrl,
+          }}
+          taskTitle={runTitle(run)}
+          compact
+          className="mr-2.5 h-auto shrink-0 gap-[3px] px-1.5 py-px text-[10.5px]"
+        />
       ) : null}
     </div>
   )

--- a/web/app/src/lib/tasks-table.test.ts
+++ b/web/app/src/lib/tasks-table.test.ts
@@ -10,6 +10,7 @@ import {
   prNumber,
   taskReference,
   taskPrUrl,
+  taskIssueUrl,
   usageCells,
   workflowLabel,
 } from '@/lib/tasks-table'
@@ -180,6 +181,18 @@ describe('taskPrUrl', () => {
 
   it('is undefined when the task has no PR association at all', () => {
     expect(taskPrUrl(run())).toBeUndefined()
+  })
+})
+
+describe('taskIssueUrl', () => {
+  it('returns the discovered issue URL for display', () => {
+    expect(taskIssueUrl(run({ referencedIssueUrl: 'https://github.com/o/r/issues/544' }))).toBe(
+      'https://github.com/o/r/issues/544',
+    )
+  })
+
+  it('is undefined when the task has no issue URL association', () => {
+    expect(taskIssueUrl(run({ issueNumber: 544 }))).toBeUndefined()
   })
 })
 

--- a/web/app/src/lib/tasks-table.ts
+++ b/web/app/src/lib/tasks-table.ts
@@ -82,6 +82,12 @@ export function taskPrUrl(run: RunRecord): string | undefined {
   return run.pullRequestUrl ?? run.referencedPullRequestUrl
 }
 
+/** Display-only issue association. Action gates must continue to use their created-resource
+ * fields directly; this accessor exists only for links painted by the cockpit. */
+export function taskIssueUrl(run: RunRecord): string | undefined {
+  return run.referencedIssueUrl
+}
+
 export interface TaskReference {
   kind: 'PR' | 'Issue'
   number: number
@@ -96,9 +102,10 @@ export function taskReference(run: RunRecord): TaskReference | undefined {
   if (pullRequestNumber && Number.isInteger(pullRequestNumber)) {
     return { kind: 'PR', number: pullRequestNumber, ...(pullRequestUrl ? { url: pullRequestUrl } : {}) }
   }
-  const issueNumber = run.issueNumber ?? (run.referencedIssueUrl ? Number(prNumber(run.referencedIssueUrl)) : undefined)
+  const issueUrl = taskIssueUrl(run)
+  const issueNumber = run.issueNumber ?? (issueUrl ? Number(prNumber(issueUrl)) : undefined)
   if (issueNumber && Number.isInteger(issueNumber)) {
-    return { kind: 'Issue', number: issueNumber, ...(run.referencedIssueUrl ? { url: run.referencedIssueUrl } : {}) }
+    return { kind: 'Issue', number: issueNumber, ...(issueUrl ? { url: issueUrl } : {}) }
   }
   return undefined
 }

--- a/web/app/src/routes/task-thread/run-header.test.tsx
+++ b/web/app/src/routes/task-thread/run-header.test.tsx
@@ -472,6 +472,50 @@ describe('meta line, tabs, pill and resume hint', () => {
     expect(badge.getAttribute('data-slot')).toBe('agent-badge')
   })
 
+  it.each([
+    {
+      name: 'both',
+      refs: {
+        referencedPullRequestUrl: 'https://github.com/open-mercato/cezar/pull/534',
+        referencedIssueUrl: 'https://github.com/open-mercato/cezar/issues/544',
+      },
+      pr: true,
+      issue: true,
+    },
+    {
+      name: 'PR only',
+      refs: { referencedPullRequestUrl: 'https://github.com/open-mercato/cezar/pull/534' },
+      pr: true,
+      issue: false,
+    },
+    {
+      name: 'issue only',
+      refs: { referencedIssueUrl: 'https://github.com/open-mercato/cezar/issues/544' },
+      pr: false,
+      issue: true,
+    },
+    { name: 'neither', refs: {}, pr: false, issue: false },
+  ])('shows discovered tracker chips next to the branch ($name)', ({ refs, pr, issue }) => {
+    stubFetch()
+    renderHeader(run('done', { branch: 'cez/r1', ...refs }))
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    const branch = meta.querySelector('[data-slot="branch-chip"]')
+    const prChip = meta.querySelector('[data-slot="pr-chip"]')
+    const issueChip = meta.querySelector('[data-slot="issue-chip"]')
+
+    expect(Boolean(prChip)).toBe(pr)
+    expect(Boolean(issueChip)).toBe(issue)
+    if (prChip) {
+      expect(prChip.getAttribute('href')).toBe('https://github.com/open-mercato/cezar/pull/534')
+      expect(prChip.textContent).toContain('#534')
+      expect(branch?.nextElementSibling?.nextElementSibling).toBe(prChip)
+    }
+    if (issueChip) {
+      expect(issueChip.getAttribute('href')).toBe('https://github.com/open-mercato/cezar/issues/544')
+      expect(issueChip.textContent).toContain('Issue #544')
+    }
+  })
+
   it('the agent badge reveals runner and model on click, reading "auto" when the model is unset', async () => {
     stubFetch()
     renderHeader(run('done', { runner: 'opencode' }))

--- a/web/app/src/routes/task-thread/run-header.tsx
+++ b/web/app/src/routes/task-thread/run-header.tsx
@@ -42,6 +42,7 @@ import type { ApiRun, OpenTarget } from '@/api/types'
 import { DiffStatLabel } from '@/components/diff-stat'
 import { TitleEditInput, useTitleEditor } from '@/components/editable-title'
 import { Pill } from '@/components/pill'
+import { ReferenceChip } from '@/components/reference-chip'
 import { TabLink } from '@/components/tab-link'
 import {
   AlertDialog,
@@ -66,7 +67,8 @@ import { toast } from '@/components/ui/toaster'
 import { deriveAttention } from '@/lib/attention'
 import { compactTokens } from '@/lib/format'
 import { queuePositions, runTitle } from '@/lib/task-groups'
-import { formatCost, workflowLabel } from '@/lib/tasks-table'
+import { formatCost, prNumber, taskIssueUrl, taskPrUrl, workflowLabel } from '@/lib/tasks-table'
+import { isHttpUrl } from '@/lib/utils'
 
 import { Markdown } from './markdown'
 import { cliTargetResumes, finishTitle, resumeHint, runActionFlags } from './run-actions'
@@ -452,6 +454,30 @@ function MetaRow({ run }: { run: ApiRun }) {
       >
         {run.branch}
       </span>,
+    )
+  }
+  const prUrl = taskPrUrl(run)
+  if (prUrl && isHttpUrl(prUrl)) {
+    const number = prNumber(prUrl)
+    parts.push(
+      <ReferenceChip
+        key="pr"
+        reference={{ kind: 'PR', ...(number ? { number: Number(number) } : {}), url: prUrl }}
+        taskTitle={runTitle(run)}
+        className="h-5"
+      />,
+    )
+  }
+  const issueUrl = taskIssueUrl(run)
+  if (issueUrl && isHttpUrl(issueUrl)) {
+    const number = prNumber(issueUrl)
+    parts.push(
+      <ReferenceChip
+        key="issue"
+        reference={{ kind: 'Issue', ...(number ? { number: Number(number) } : {}), url: issueUrl }}
+        taskTitle={runTitle(run)}
+        className="h-5"
+      />,
     )
   }
   if (run.diffStat) parts.push(<DiffStatLabel key="diff" stat={run.diffStat} />)

--- a/web/app/src/routes/tasks-overview.tsx
+++ b/web/app/src/routes/tasks-overview.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ArchiveIcon,
-  ArrowUpRightIcon,
   ListChecksIcon,
   PencilIcon,
   PlusIcon,
@@ -21,6 +20,7 @@ import { DiffStatLabel } from '@/components/diff-stat'
 import { TitleEditInput, useTitleEditor } from '@/components/editable-title'
 import { useListView } from '@/components/list-view'
 import { Pill } from '@/components/pill'
+import { ReferenceChip } from '@/components/reference-chip'
 import { Button } from '@/components/ui/button'
 import { toast } from '@/components/ui/toaster'
 import { deriveAttention } from '@/lib/attention'
@@ -37,7 +37,7 @@ import {
   type UsageCell,
 } from '@/lib/tasks-table'
 import { useNow } from '@/lib/use-now'
-import { cn, isHttpUrl } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 
 /**
  * The Tasks overview — the table that IS the home at `/` (spec, "Task list & table", per PR
@@ -549,48 +549,6 @@ function BranchChip({ branch }: { branch: string }) {
     <span className="rounded-[6px] bg-muted px-1.5 py-0.5 font-mono text-[11.5px] font-medium text-muted-foreground">
       {branch}
     </span>
-  )
-}
-
-/** The out-of-app link. One style for every PR — the record carries no merged/closed state to
- *  honestly split violet-open from green-merged (that is R5's forge driver). */
-function ReferenceChip({
-  reference,
-  taskTitle,
-  className,
-}: {
-  reference: NonNullable<ReturnType<typeof taskReference>>
-  taskTitle: string
-  className?: string
-}) {
-  const { kind, number, url } = reference
-  const chipClass = cn(
-    'inline-flex h-[22px] items-center gap-1 rounded-full border border-violet/35 px-2 font-mono text-[11px] font-semibold text-violet',
-    className
-  )
-  // href protocol guard (#431): render a link only for http(s) URLs; a
-  // non-http value (e.g. a `javascript:` PR URL scraped from a transcript)
-  // degrades to inert text instead of an executable link.
-  if (!url || !isHttpUrl(url)) {
-    return (
-      <span data-slot={kind === 'PR' ? 'pr-chip' : 'issue-chip'} className={chipClass}>
-        {kind === 'Issue' ? 'Issue ' : ''}#{number}
-      </span>
-    )
-  }
-  return (
-    <a
-      data-slot={kind === 'PR' ? 'pr-chip' : 'issue-chip'}
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      title={url}
-      aria-label={`Open the ${kind === 'PR' ? 'pull request' : 'issue'} for ${taskTitle}`}
-      className={cn(chipClass, 'hover:bg-violet/10')}
-    >
-      {kind === 'Issue' ? 'Issue ' : ''}#{number}
-      <ArrowUpRightIcon className="size-2.5" aria-hidden="true" />
-    </a>
   )
 }
 


### PR DESCRIPTION
Closes #544

## Problem
The session header shows a task's workflow, branch, and diff statistics, but does not expose the discovered pull request and issue links already associated with the run.

## What Changed
- Extracted the existing tracker reference chip into a shared component used by the overview, quick list, and session header.
- Added a display-only issue URL accessor alongside the existing PR accessor.
- Rendered discovered PR and issue chips immediately after the branch chip, with no placeholder when either association is absent.
- Preserved the HTTP(S)-only link guard and the compact quick-list presentation.

## Tests
- Added header coverage for both links, PR-only, issue-only, and neither.
- Added focused coverage for the issue URL accessor.
- Full validation passed: `npm run typecheck`, `npm test` (4,067 tests), `npm run test:unit` (34 tests), `npm run build`, and `npm run test:package` (8 tests).

## Breaking Changes
None. The change is display-only and uses existing optional run fields.

Manual QA remains pending for the session header at desktop and mobile widths.

🤖 Generated by `om-auto-fix-issue`.
