### PR TITLE
fix(skills): worktree agents read the current main-repo skill files (streamline skill currency)

### DIFF
--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { parseAskMarker, stripAskMarker, type AskRequest } from '../core/ask.js';
 import { type AgentSession } from '../core/claude-cli-runner.js';
 import { onUsage, registerRunProcess, unregisterRunProcess, type ProcessUsage } from '../core/process-usage.js';
@@ -2407,13 +2407,35 @@ export function makeRunTitle(task: string, workflow: WorkflowDef): string {
   return chars.length > 80 ? `${chars.slice(0, 79).join('').trimEnd()}…` : chars.join('');
 }
 
-/** Skill identity is context, while the Markdown body remains instructions. */
-export function skillSystemPrompt(skill: Pick<Skill, 'name' | 'description' | 'body'>): string {
-  return [
+/**
+ * Skill identity is context, while the Markdown body remains instructions.
+ *
+ * For an on-disk skill we also hand the agent the ABSOLUTE directory of the
+ * installed copy. A run executes in an isolated worktree that has no local
+ * `.agents/skills` (gitignored, absent in a fresh checkout), so without this
+ * the agent cannot read the skill's companion files (`references/*.md`) — or,
+ * worse, reads a stale copy materialized from the team-repo cache. The path
+ * resolves against the MAIN project root (`discoverSkills(repoRoot)`), i.e. the
+ * current `npx skills`-installed copy, so a worktree agent and the main
+ * checkout read the exact same, up-to-date files. Team skills are omitted here:
+ * they are materialized into the worktree separately (see the call site).
+ */
+export function skillSystemPrompt(
+  skill: Pick<Skill, 'name' | 'description' | 'body'> & Partial<Pick<Skill, 'path' | 'source'>>,
+): string {
+  const lines = [
     `Selected skill: /${skill.name}`,
     ...(skill.description ? [`Description: ${skill.description}`] : []),
-    '',
-    'Skill instructions:',
-    skill.body.trim(),
-  ].join('\n');
+  ];
+  if (skill.source && skill.source !== 'team' && skill.path) {
+    const dir = dirname(skill.path);
+    lines.push(
+      '',
+      `Skill files are installed on disk at: ${dir}`,
+      `Read any file this skill references (for example references/*.md) from that absolute directory. ` +
+        `It is the current installed copy — use it even though your working directory is a separate worktree that does not contain the skill.`,
+    );
+  }
+  lines.push('', 'Skill instructions:', skill.body.trim());
+  return lines.join('\n');
 }

--- a/src/workflows/skill-system-prompt.test.ts
+++ b/src/workflows/skill-system-prompt.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { skillSystemPrompt } from './run.js';
+
+describe('skillSystemPrompt — installed-path hint for worktree agents', () => {
+  const base = { name: 'om-code-review', description: 'Review a diff.', body: 'Do the review.' };
+
+  it('points an on-disk skill at its absolute installed directory', () => {
+    const out = skillSystemPrompt({
+      ...base,
+      source: 'agents',
+      path: '/home/u/Projects/app/.agents/skills/om-code-review/SKILL.md',
+    });
+    expect(out).toContain('Skill files are installed on disk at: /home/u/Projects/app/.agents/skills/om-code-review');
+    expect(out).toContain('references/*.md');
+    // Body still present and last.
+    expect(out.trimEnd().endsWith('Do the review.')).toBe(true);
+  });
+
+  it('omits the path hint for team skills (they are materialized separately)', () => {
+    const out = skillSystemPrompt({ ...base, source: 'team', path: '/cache/whatever/SKILL.md' });
+    expect(out).not.toContain('installed on disk at');
+  });
+
+  it('omits the path hint when no path/source is known', () => {
+    const out = skillSystemPrompt(base);
+    expect(out).not.toContain('installed on disk at');
+  });
+});

--- a/src/workflows/system-prompt.test.ts
+++ b/src/workflows/system-prompt.test.ts
@@ -378,6 +378,11 @@ describe('systemPrompt end-to-end (dry run)', () => {
       name: 'om-auto-review-pr',
       description: SKILL_DESCRIPTION,
       body: SKILL_BODY,
+      // The runner passes the full discovered skill, so the prompt carries the
+      // absolute path of the installed copy (read from the MAIN repo even in a
+      // worktree). Mirror that here so the expected prompt matches.
+      path: join(repoRoot, '.ai/skills/om-auto-review-pr/SKILL.md'),
+      source: 'ai',
     });
     expect(capturedSystemPrompt()).toBe(
       composeSystemPrompt(skillPrompt, CONFIG_PROMPT, HANDOFF_INSTRUCTIONS),


### PR DESCRIPTION
## 🎯 Goal
Close the last gap that let cezar **codex** code reviews render a **stale** `om-code-review` template (e.g. PR #639): a review runs in an isolated worktree, and the agent could not reach the *current* skill files.

## Background — the full staleness story
Skills reach agents through several layers; each is now kept current:
- **Deploy** (`~/deploy-cezar.sh`): step 5b installs/updates per-project `.agents/skills` for every attached project via `npx skills`; new step 5c fast-forwards cezar's bare team-repo cache ref. *(ops script, not in this repo)*
- **Runtime reads** — **#644 (merged)**: `loadTeamSkills` passive path now `git fetch`es the bare team-repo cache on first touch per process and on a 6h TTL, so a long-running server stops serving a clone frozen at startup.
- **This PR** — worktree agents.

## The problem this PR fixes
`discoverSkills(repoRoot)` resolves skills against the **main project root**, so `skill.path` is the current, `npx`-installed copy. But an isolated worktree has **no local `.agents/skills`** (gitignored, absent in a fresh checkout), so when a skill's body says *"read `references/output-format.md`"*, the agent had no current copy on disk in its cwd — it fell back to a stale one materialized from the team cache. Only `source: 'team'` skills were materialized; `npx`-installed (`source: 'agents'`) skills were left with body-only.

## What changed
`skillSystemPrompt` now hands the agent the **absolute directory of the installed skill** (`dirname(skill.path)`, resolved against the main repo) for every on-disk skill, instructing it to read companion files (`references/*.md`) from there — *"the current installed copy, even though your working directory is a separate worktree."* No symlinks, no per-worktree copies; the worktree agent and the main checkout read the exact same files. Team skills are unchanged (still materialized).

## Tests
- `src/workflows/skill-system-prompt.test.ts` (new): path hint present for on-disk skills, omitted for team skills and when no path is known.
- `src/workflows/system-prompt.test.ts`: updated the pinned end-to-end assertion to carry the installed path. 33/33 green; typecheck clean.

## 💥 Breaking Changes
None. `skillSystemPrompt`'s new `path`/`source` inputs are optional; the single runtime caller already passes the full skill.

## Related
- #644 (merged) — team-cache passive auto-refresh.
- #613 — automatic skills updates; its `invalidateCatalog: refreshTeamSkills` fires on lock updates. Recommendation there: also refresh the team cache on the coordinator's cadence even when the lock is already current (this PR + #644 already cover the read path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)