### PR TITLE
fix(ui): contain split diff line overflow (#651)

### DIFF
--- a/web/app/src/components/diff/diff-view.tsx
+++ b/web/app/src/components/diff/diff-view.tsx
@@ -646,7 +646,7 @@ function SplitCell({
     <div
       data-slot="diff-cell"
       data-line={line.kind}
-      className={cn('flex min-w-0', LINE_BG[line.kind], side === 'new' && 'border-l border-border/40')}
+      className={cn('flex min-w-0 overflow-x-auto', LINE_BG[line.kind], side === 'new' && 'border-l border-border/40')}
     >
       <Gutter value={side === 'old' ? line.oldLine : line.newLine} />
       <span className="w-4 shrink-0 text-soft-foreground select-none">{MARKER[line.kind]}</span>

--- a/web/app/src/components/diff/diff.test.tsx
+++ b/web/app/src/components/diff/diff.test.tsx
@@ -80,6 +80,14 @@ describe('Diff facade', () => {
     expect(pair.querySelector('[data-line="add"]')).not.toBeNull()
   })
 
+  it('contains unwrapped lines within each split pane', async () => {
+    await renderDiff(<Diff files={[MODIFIED]} mode="split" />)
+
+    const cells = document.querySelectorAll('[data-slot="diff-cell"]')
+    expect(cells.length).toBeGreaterThan(0)
+    for (const cell of cells) expect(cell.className).toContain('overflow-x-auto')
+  })
+
   it('marks the word-level change on both sides of a paired edit', async () => {
     await renderDiff(<Diff files={[MODIFIED]} />)
 


### PR DESCRIPTION
Fixes #651

## Problem

In split diff mode, long unwrapped lines could paint beyond their grid column and overlap the adjacent pane, making both sides unreadable.

## Root Cause

Each split pane was allowed to shrink with `min-w-0`, but it did not establish its own horizontal overflow boundary. Since unwrapped line content uses `whitespace-pre`, long content escaped its `1fr` grid track.

## What Changed

- Give every populated split diff cell its own horizontal scroll boundary.
- Add a component regression test that verifies split cells contain unwrapped content.

## Tests

- `npm test -- web/app/src/components/diff/diff.test.tsx` — 19 tests passed.
- `npm run typecheck` — passed.
- `npm test` — 4,179 tests passed.
- `npm run test:unit` — 36 tests passed.
- `npm run build` — passed, including `check:pack`.
- `npm run test:package` — 8 tests passed.

## Breaking Changes

None.

🤖 Generated by `om-auto-fix-issue`.
