### PR TITLE
feat(skills): add interactive composer defaults

### DIFF
--- a/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
+++ b/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
@@ -1,0 +1,59 @@
+# Interactive skill composer defaults implementation
+
+Source doc: .ai/specs/2026-07-25-interactive-skill-composer-defaults.md
+
+## Goal
+
+Honor additive `interactive: true` skill metadata in New Task so untouched Autonomous and Worktree choices default off while explicit choices and hard run-shape constraints remain authoritative.
+
+## Scope
+
+- Extend skill discovery and the skills API type with the optional metadata.
+- Centralize composer run-mode resolution and wire interactive skill recommendations into New Task.
+- Add parser, resolver, and route regression coverage plus accessible explanatory copy.
+
+## Non-goals
+
+- Workspace/environment-configurable defaults, quick-task cold selection, and generalized workflow Worktree controls belong to the companion spec.
+- Runner, workflow YAML, and run persistence contracts remain unchanged.
+
+## Risks
+
+- Running in the current checkout widens edit exposure, so the UI must explain the recommendation and retain an explicit Worktree override.
+- Resolver precedence must preserve plan-first, parallel-variant, and no-git constraints.
+
+## Implementation Plan
+
+### Phase 1: Metadata and contracts
+
+1. Extend skill discovery with strict scalar `interactive: true` recognition and parser coverage.
+2. Mirror the optional metadata through the web skills API contract.
+
+### Phase 2: Composer behavior
+
+3. Extract and test the pure run-mode resolver with hard constraints, explicit values, and interactive recommendations.
+4. Wire selected skill metadata into New Task while preserving touched choices across source changes.
+5. Add accessible explanatory copy and route regression coverage.
+
+### Phase 3: Verification
+
+6. Run the configured validation gate and browser smoke verification.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Metadata and contracts
+
+- [ ] 1.1 Extend skill discovery with strict scalar recognition and parser coverage
+- [ ] 1.2 Mirror metadata through the web skills API contract
+
+### Phase 2: Composer behavior
+
+- [ ] 2.1 Extract and test the pure run-mode resolver
+- [ ] 2.2 Wire selected skill metadata into New Task
+- [ ] 2.3 Add accessible explanatory copy and route regression coverage
+
+### Phase 3: Verification
+
+- [ ] 3.1 Run validation and browser smoke verification

--- a/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
+++ b/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
@@ -56,4 +56,4 @@ Honor additive `interactive: true` skill metadata in New Task so untouched Auton
 
 ### Phase 3: Verification
 
-- [ ] 3.1 Run validation and browser smoke verification
+- [x] 3.1 Run validation and browser smoke verification — validation passed; browser evidence follows on the PR

--- a/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
+++ b/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
@@ -41,6 +41,8 @@ Honor additive `interactive: true` skill metadata in New Task so untouched Auton
 
 ## Progress
 
+PR: #665
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Metadata and contracts

--- a/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
+++ b/.ai/runs/2026-07-25-interactive-skill-composer-defaults.md
@@ -45,14 +45,14 @@ Honor additive `interactive: true` skill metadata in New Task so untouched Auton
 
 ### Phase 1: Metadata and contracts
 
-- [ ] 1.1 Extend skill discovery with strict scalar recognition and parser coverage
-- [ ] 1.2 Mirror metadata through the web skills API contract
+- [x] 1.1 Extend skill discovery with strict scalar recognition and parser coverage — 048e5b9e
+- [x] 1.2 Mirror metadata through the web skills API contract — 048e5b9e
 
 ### Phase 2: Composer behavior
 
-- [ ] 2.1 Extract and test the pure run-mode resolver
-- [ ] 2.2 Wire selected skill metadata into New Task
-- [ ] 2.3 Add accessible explanatory copy and route regression coverage
+- [x] 2.1 Extract and test the pure run-mode resolver — 048e5b9e
+- [x] 2.2 Wire selected skill metadata into New Task — 048e5b9e
+- [x] 2.3 Add accessible explanatory copy and route regression coverage — 048e5b9e
 
 ### Phase 3: Verification
 

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -102,6 +102,27 @@ describe('filterImportedTeamSkills', () => {
 });
 
 describe('discoverSkills local entrypoints', () => {
+  it('recognizes only scalar true as the interactive composer hint', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'cezar-skills-'));
+    tempDirs.push(repoRoot);
+    const skillsDir = join(repoRoot, '.ai/cezar/skills');
+    await mkdir(skillsDir, { recursive: true });
+    await writeFile(join(skillsDir, 'true.md'), '---\r\ninteractive: "true"\r\n---\r\nBody');
+    await writeFile(join(skillsDir, 'false.md'), '---\ninteractive: false\n---\nBody');
+    await writeFile(join(skillsDir, 'array.md'), '---\ninteractive: [true]\n---\nBody');
+    await writeFile(join(skillsDir, 'yes.md'), '---\ninteractive: yes\n---\nBody');
+    await writeFile(join(skillsDir, 'missing.md'), 'Body');
+
+    const skills = (await discoverSkills(repoRoot)).filter((skill) => skill.source === 'cezar');
+    expect(skills.find((skill) => skill.name === 'true')).toMatchObject({
+      interactive: true,
+      body: 'Body',
+    });
+    for (const name of ['false', 'array', 'yes', 'missing']) {
+      expect(skills.find((skill) => skill.name === name)?.interactive).toBeUndefined();
+    }
+  });
+
   it('keeps flat and SKILL.md skills while excluding nested reference files', async () => {
     const repoRoot = await mkdtemp(join(tmpdir(), 'cezar-skills-'));
     tempDirs.push(repoRoot);

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -16,6 +16,8 @@ import { readWorkspaceUiState } from './workspace/ui-state.js';
 export interface Skill {
   name: string;
   description?: string;
+  /** Advisory composer hint: untouched run-mode choices default to interactive, in-place execution. */
+  interactive?: true;
   body: string;
   path: string;
   source: 'ai' | 'cezar' | 'agents' | 'global' | 'team';
@@ -217,7 +219,8 @@ async function readMarkdownSkills(dir: string, source: Skill['source']): Promise
       typeof frontmatter.description === 'string' && frontmatter.description.trim()
         ? frontmatter.description.trim()
         : undefined;
-    skills.push({ name, description, body, path: absPath, source });
+    const interactive = frontmatter.interactive === 'true' ? true : undefined;
+    skills.push({ name, description, interactive, body, path: absPath, source });
   }
   return skills;
 }

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -664,6 +664,8 @@ export interface DeleteWorkflowResponse {
 export interface Skill {
   name: string
   description?: string
+  /** Advisory hint for untouched composer run-mode choices. */
+  interactive?: true
   body: string
   path: string
   source: 'ai' | 'cezar' | 'agents' | 'global' | 'team'

--- a/web/app/src/routes/new-task-draft.test.ts
+++ b/web/app/src/routes/new-task-draft.test.ts
@@ -1,8 +1,61 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { clearDraftText, readDraft, resetDraft, writeDraft } from './new-task-draft'
+import {
+  clearDraftText,
+  readDraft,
+  resetDraft,
+  resolveComposerRunMode,
+  writeDraft,
+} from './new-task-draft'
 
 afterEach(resetDraft)
+
+describe('resolveComposerRunMode', () => {
+  const base = {
+    hasGit: true,
+    variants: 1,
+    planFirst: false,
+    explicitAutonomous: null,
+    explicitWorktree: null,
+    fallbackAutonomous: true,
+    fallbackWorktree: true,
+  }
+
+  it('applies an interactive recommendation only to untouched fields', () => {
+    expect(resolveComposerRunMode({ ...base, interactive: true })).toEqual({
+      autonomous: false,
+      worktree: false,
+    })
+    expect(resolveComposerRunMode({
+      ...base,
+      interactive: true,
+      explicitAutonomous: true,
+    })).toEqual({ autonomous: true, worktree: false })
+  })
+
+  it('keeps hard run-shape constraints authoritative', () => {
+    expect(resolveComposerRunMode({
+      ...base,
+      planFirst: true,
+      explicitAutonomous: true,
+    }).autonomous).toBe(false)
+    expect(resolveComposerRunMode({
+      ...base,
+      variants: 2,
+      interactive: true,
+      explicitWorktree: false,
+    }).worktree).toBe(true)
+    expect(resolveComposerRunMode({
+      ...base,
+      hasGit: false,
+      explicitWorktree: true,
+    }).worktree).toBe(false)
+  })
+
+  it('preserves historical fallbacks when no recommendation exists', () => {
+    expect(resolveComposerRunMode(base)).toEqual({ autonomous: true, worktree: true })
+  })
+})
 
 describe('the new-task draft store', () => {
   it('starts empty with the never-chosen sentinels', () => {

--- a/web/app/src/routes/new-task-draft.ts
+++ b/web/app/src/routes/new-task-draft.ts
@@ -32,6 +32,35 @@ export interface NewTaskDraft {
   generateFollowups: boolean | null
 }
 
+export interface ComposerRunModeInput {
+  hasGit: boolean
+  variants: number
+  planFirst: boolean
+  explicitAutonomous: boolean | null
+  explicitWorktree: boolean | null
+  interactive?: boolean
+  fallbackAutonomous: boolean
+  fallbackWorktree: boolean
+}
+
+/** Resolve run-mode values once, in precedence order: hard constraints, explicit draft
+ * choices, an interactive-skill recommendation, then the historical fallback. */
+export function resolveComposerRunMode(input: ComposerRunModeInput): {
+  autonomous: boolean
+  worktree: boolean
+} {
+  const recommended = input.interactive === true ? false : undefined
+  const autonomous = input.planFirst
+    ? false
+    : (input.explicitAutonomous ?? recommended ?? input.fallbackAutonomous)
+  const worktree = !input.hasGit
+    ? false
+    : input.variants > 1
+      ? true
+      : (input.explicitWorktree ?? recommended ?? input.fallbackWorktree)
+  return { autonomous, worktree }
+}
+
 const EMPTY: NewTaskDraft = {
   text: '',
   source: null,

--- a/web/app/src/routes/new-task.test.tsx
+++ b/web/app/src/routes/new-task.test.tsx
@@ -795,6 +795,25 @@ describe('submit', () => {
     ).toBe('false')
   })
 
+  it('applies an interactive skill hint to untouched controls while keeping both overridable', async () => {
+    serve({ skills: [{ ...SKILLS[0]!, interactive: true }, SKILLS[1]!] })
+    renderNewTask()
+    await pillReady()
+
+    const autonomous = document.querySelector(
+      '[data-slot="autonomous-toggle"]',
+    ) as HTMLButtonElement
+    const worktree = document.querySelector('[data-slot="worktree-toggle"]') as HTMLButtonElement
+    expect(autonomous.getAttribute('aria-checked')).toBe('false')
+    expect(worktree.getAttribute('aria-checked')).toBe('false')
+    expect(screen.getByText(/recommends an interactive run in the current checkout/i)).toBeTruthy()
+
+    fireEvent.click(autonomous)
+    fireEvent.click(worktree)
+    expect(autonomous.getAttribute('aria-checked')).toBe('true')
+    expect(worktree.getAttribute('aria-checked')).toBe('true')
+  })
+
   // #471 — the composer must not offer a switch the server overrides anyway.
   const inboxOffHealth: HealthResponse = {
     ...HEALTH,

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -74,7 +74,13 @@ import {
   unknownSkillPrefillText,
   type DeepLinkNotice,
 } from './new-task-autostart'
-import { clearDraftText, readDraft, writeDraft, type NewTaskDraft } from './new-task-draft'
+import {
+  clearDraftText,
+  readDraft,
+  resolveComposerRunMode,
+  writeDraft,
+  type NewTaskDraft,
+} from './new-task-draft'
 import {
   buildCreateRunBody,
   modelsForRunner,
@@ -168,6 +174,9 @@ export function NewTaskRoute() {
   const sourcesReady =
     skills.data !== undefined && workflows.data !== undefined && !uiState.isPending
   const source = resolveSource([draft.source, uiState.data?.lastTask], skillList, workflowList)
+  const selectedSkill = source.source === 'skill'
+    ? skillList.find((skill) => skill.name === source.ref)
+    : undefined
 
   // ---- prompt templates (#413 follow-up) ----------------------------------------------------
   // The same list the GitHub hand-over and Inbox composers read. Two ways in here: the footer's
@@ -230,15 +239,18 @@ export function NewTaskRoute() {
   // workflows and variants always isolate, and a non-git repo already runs in place. The choice
   // is remembered (draft → last-used → default on).
   const worktreeToggleShown = hasGit && source.source === 'skill' && variants <= 1
-  const worktreeOn = worktreeToggleShown ? (draft.worktree ?? uiState.data?.lastWorktree ?? true) : true
-
-  // Autonomous (#autonomous): the run never pauses for the user. An explicit toggle this session
-  // wins; otherwise skills default ON (a skill run is meant to just execute), workflows fall back
-  // to the remembered choice, else off. Plan-first forces it OFF (and disables the toggle):
-  // planning is inherently interactive, so the run must be able to hand the ball back.
-  const autonomousOn = draft.planFirst
-    ? false
-    : (draft.autonomous ?? (source.source === 'skill' ? true : (uiState.data?.lastAutonomous ?? false)))
+  const runMode = resolveComposerRunMode({
+    hasGit,
+    variants,
+    planFirst: draft.planFirst,
+    explicitAutonomous: draft.autonomous,
+    explicitWorktree: draft.worktree,
+    interactive: selectedSkill?.interactive,
+    fallbackAutonomous: source.source === 'skill' ? true : (uiState.data?.lastAutonomous ?? false),
+    fallbackWorktree: uiState.data?.lastWorktree ?? true,
+  })
+  const worktreeOn = runMode.worktree
+  const autonomousOn = runMode.autonomous
 
   // Follow-up generation (#444) is offered only while the server has the global inbox on
   // (#471, `CEZ_FOLLOWUPS=1`) — there is no inbox for the follow-ups to land in otherwise, and
@@ -592,6 +604,11 @@ export function NewTaskRoute() {
                 disabled={draft.planFirst}
                 onChange={(on) => update({ autonomous: on })}
               />
+              {selectedSkill?.interactive && (draft.autonomous === null || draft.worktree === null) ? (
+                <p className="basis-full text-xs text-muted-foreground" data-slot="interactive-skill-hint">
+                  This skill recommends an interactive run in the current checkout. You can change either setting.
+                </p>
+              ) : null}
               {followupsToggleShown ? (
                 <GenerateFollowupsToggle
                   on={generateFollowupsOn}


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-25-interactive-skill-composer-defaults.md
Source doc: .ai/specs/2026-07-25-interactive-skill-composer-defaults.md
Refs #660
Status: complete

## Goal
- Honor `interactive: true` skill metadata so untouched Autonomous and Worktree choices default off without weakening explicit choices or run-shape constraints.

## What Changed
- Added strict scalar interactive metadata discovery and the additive skills API field.
- Added one tested composer run-mode resolver for constraints, explicit draft choices, interactive recommendations, and historical fallbacks.
- Wired New Task to show safe interactive defaults, accessible explanatory copy, and overridable controls.

## Tests
- `npm run typecheck`
- `npm test` (4,530 tests)
- `npm run test:unit`
- `npm run build`
- `npm run test:package` (8 tests)

## Breaking Changes
- None. The metadata and API field are additive, and existing skill/run contracts retain historical behavior when the field is absent.

## Progress
See the Progress section in the tracking plan.
