### PR TITLE
fix(web): heal a stale run record when the transcript says the session closed

### DIFF
--- a/web/app/src/api/queries.ts
+++ b/web/app/src/api/queries.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { mergeProviderStatusResponse } from '@/lib/provider-status'
 
 import {
+  ApiError,
   browseFs,
   checkoutProject,
   getAgentConfig,
@@ -760,12 +761,20 @@ export function usePatchRun(id: string) {
 /** Deliver a reply into a live session (`POST /api/runs/:id/messages`). The transcript itself
  *  grows over SSE (`user-message`, then the agent's turn); the invalidation refreshes the
  *  record (status flips waiting → running). Errors are the CALLER's to surface — the composer
- *  restores the draft and toasts, so no toast fires here. */
+ *  restores the draft and toasts, so no toast fires here. A 409 ("session closed") still
+ *  invalidates: it means the cached record claimed a live session the server no longer has, so
+ *  the refetch flips the composer to its closed/Continue form instead of leaving it aimed at a
+ *  session that will keep refusing. */
 export function useSendMessage(id: string) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (message: MessageInput) => sendMessage(id, message),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.runs.all }),
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 409) {
+        void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
+      }
+    },
   })
 }
 

--- a/web/app/src/routes/task-thread/run-reconcile.test.ts
+++ b/web/app/src/routes/task-thread/run-reconcile.test.ts
@@ -1,0 +1,131 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, renderHook } from '@testing-library/react'
+import { createElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createQueryClient } from '@/api/query-client'
+import { queryKeys } from '@/api/queries'
+import type { ApiRun, RunEvent } from '@/api/types'
+
+import { settledSessionSeq, STALE_RECORD_GRACE_MS, useRunRecordReconcile } from './run-reconcile'
+
+/**
+ * The stale-record healer (run-reconcile.ts): the transcript's `session.ended` arbitrates a
+ * record still claiming a live session. The reported shape: the thread shows "goal achieved —
+ * session closed" / "run finished" while the record says `running`, so Working… spins forever
+ * and the composer sends into a session that 409s.
+ */
+
+const line = (seq: number, type: string, extra: Record<string, unknown> = {}): RunEvent => ({
+  seq,
+  ts: '2026-07-25T10:43:36.000Z',
+  type,
+  ...extra,
+})
+
+const run = (over: Partial<ApiRun> = {}): ApiRun =>
+  ({ id: 'r1', status: 'running', ...over }) as ApiRun
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('settledSessionSeq', () => {
+  it('no events → 0', () => {
+    expect(settledSessionSeq([])).toBe(0)
+  })
+
+  it('a session.ended with nothing after it is the settle signal', () => {
+    const events = [line(1, 'step-start'), line(5, 'lifecycle'), line(8, 'session.ended')]
+    expect(settledSessionSeq(events)).toBe(8)
+  })
+
+  it('a session opening after the end (Continue) makes the end history, not news', () => {
+    const events = [line(1, 'step-start'), line(8, 'session.ended'), line(9, 'step-start')]
+    expect(settledSessionSeq(events)).toBe(0)
+  })
+
+  it('session.started counts as an opening too', () => {
+    const events = [line(8, 'session.ended'), line(9, 'session.started')]
+    expect(settledSessionSeq(events)).toBe(0)
+  })
+
+  it('across several sessions the LAST boundary decides', () => {
+    const events = [
+      line(1, 'step-start'),
+      line(8, 'session.ended'),
+      line(9, 'step-start'),
+      line(20, 'session.ended'),
+    ]
+    expect(settledSessionSeq(events)).toBe(20)
+  })
+
+  it('a malformed line without a numeric seq is skipped, not fatal', () => {
+    const bad = { ts: '', type: 'session.ended' } as unknown as RunEvent
+    expect(settledSessionSeq([bad])).toBe(0)
+  })
+})
+
+function renderReconcile(record: ApiRun | undefined, events: RunEvent[]) {
+  const client = createQueryClient()
+  const invalidate = vi.spyOn(client, 'invalidateQueries')
+  const view = renderHook(
+    ({ r, e }: { r: ApiRun | undefined; e: RunEvent[] }) => useRunRecordReconcile(r, e),
+    {
+      initialProps: { r: record, e: events },
+      wrapper: ({ children }) => createElement(QueryClientProvider, { client }, children),
+    },
+  )
+  return { ...view, invalidate }
+}
+
+describe('useRunRecordReconcile', () => {
+  it('a record still claiming `running` over a settled transcript refetches after the grace', () => {
+    vi.useFakeTimers()
+    const { invalidate } = renderReconcile(run(), [line(8, 'session.ended')])
+    expect(invalidate).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(STALE_RECORD_GRACE_MS)
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.runs.detail('r1') })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.runs.list() })
+  })
+
+  it('`waiting` is a live-session claim too', () => {
+    vi.useFakeTimers()
+    const { invalidate } = renderReconcile(run({ status: 'waiting' }), [line(8, 'session.ended')])
+    vi.advanceTimersByTime(STALE_RECORD_GRACE_MS)
+    expect(invalidate).toHaveBeenCalled()
+  })
+
+  it('the healthy path stays quiet: the record settles within the grace and cancels the refetch', () => {
+    vi.useFakeTimers()
+    const { rerender, invalidate } = renderReconcile(run(), [line(8, 'session.ended')])
+    rerender({ r: run({ status: 'done' }), e: [line(8, 'session.ended')] })
+    vi.advanceTimersByTime(STALE_RECORD_GRACE_MS * 2)
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it('a live session (no settle signal) never refetches', () => {
+    vi.useFakeTimers()
+    const { invalidate } = renderReconcile(run(), [line(1, 'step-start'), line(5, 'text')])
+    vi.advanceTimersByTime(STALE_RECORD_GRACE_MS * 2)
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it('a settled record over a settled transcript is consistent — no refetch', () => {
+    vi.useFakeTimers()
+    const { invalidate } = renderReconcile(run({ status: 'done' }), [line(8, 'session.ended')])
+    vi.advanceTimersByTime(STALE_RECORD_GRACE_MS * 2)
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it('a Continue reopening the session (step-start after the end) stops a pending refetch', () => {
+    vi.useFakeTimers()
+    const events = [line(8, 'session.ended')]
+    const { rerender, invalidate } = renderReconcile(run(), events)
+    rerender({ r: run(), e: [...events, line(9, 'step-start')] })
+    vi.advanceTimersByTime(STALE_RECORD_GRACE_MS * 2)
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+})

--- a/web/app/src/routes/task-thread/run-reconcile.ts
+++ b/web/app/src/routes/task-thread/run-reconcile.ts
@@ -1,0 +1,74 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useMemo } from 'react'
+
+import { queryKeys } from '@/api/queries'
+import type { ApiRun, RunEvent } from '@/api/types'
+
+/**
+ * The thread's stale-record healer.
+ *
+ * The doctrine (task-thread.tsx) splits the page across two feeds: `useRun` (fetch, patched by
+ * the workspace stream) is authoritative for the record, `useRunEvents` (per-run SSE) is the
+ * transcript. The two can drift: the per-run socket has its own liveness watchdog (#424) and a
+ * full replay on reconnect, so the transcript recovers from anything — but a record update lost
+ * on the workspace stream (a half-open socket, a dropped frame across a server restart) is gone
+ * until something refetches. The thread then renders an impossible mix: the transcript says
+ * "goal achieved — session closed" / "run finished" while the record still says `running`, so
+ * the Working… spinner keeps spinning and the composer stays in live-session mode — whose sends
+ * then 409 against the closed session.
+ *
+ * The transcript itself carries the truth, so use it: when the latest session boundary in the
+ * event list is a `session.ended` and the record still claims a live session, the record is
+ * stale — refetch it (the reconcile-on-reconnect doctrine, applied to the one seam reconnect
+ * cannot see). A grace period keeps the healthy path quiet: `session.ended` always lands
+ * moments before the workspace stream's own record update, and that update cancels the timer.
+ */
+
+/** How long the workspace stream gets to deliver the record update on its own before the
+ *  transcript's session end is treated as proof of a stale record. Long enough for the engine's
+ *  settle write (diff stat, review gate) plus the stream hop; short enough that the reader sees
+ *  the thread close instead of a spinner over a "run finished" line. */
+export const STALE_RECORD_GRACE_MS = 2_000
+
+/**
+ * The seq of the transcript's last session end, when that end is the latest session boundary —
+ * 0 when the stream says a session is (or may be) live. `session.ended` is the sink's one
+ * guaranteed end-of-session line (ui-event-sink.ts persists it exactly once per session, on
+ * every exit path); `step-start` / `session.started` mark a session opening after it (a
+ * Continue, a follow-up step), which makes an older end stale history, not news.
+ */
+export function settledSessionSeq(events: RunEvent[]): number {
+  let lastEnd = 0
+  let lastStart = 0
+  for (const event of events) {
+    if (typeof event.seq !== 'number') continue
+    if (event.type === 'session.ended' && event.seq > lastEnd) lastEnd = event.seq
+    if ((event.type === 'session.started' || event.type === 'step-start') && event.seq > lastStart)
+      lastStart = event.seq
+  }
+  return lastEnd > lastStart ? lastEnd : 0
+}
+
+/** Reconcile the run record against the transcript (see module doc). Mounted by the thread
+ *  route, next to the two feeds it reconciles. */
+export function useRunRecordReconcile(run: ApiRun | undefined, events: RunEvent[]): void {
+  const queryClient = useQueryClient()
+  const settledSeq = useMemo(() => settledSessionSeq(events), [events])
+  const runId = run?.id
+  const status = run?.status
+
+  useEffect(() => {
+    if (settledSeq === 0 || runId === undefined) return
+    // Only a record that claims a live session can be stale in the reported way. Every settled
+    // status is what the transcript predicts, and `queued` has no session to have ended.
+    if (status !== 'running' && status !== 'waiting') return
+    const timer = setTimeout(() => {
+      // The list gets the same refresh: the sidebar buckets ("Working") read from it.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.runs.detail(runId) })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.runs.list() })
+    }, STALE_RECORD_GRACE_MS)
+    // The healthy path's exit: the workspace stream patches the record, `status` flips to a
+    // settled one, and this cleanup cancels the refetch before it fires.
+    return () => clearTimeout(timer)
+  }, [settledSeq, runId, status, queryClient])
+}

--- a/web/app/src/routes/task-thread/task-thread.tsx
+++ b/web/app/src/routes/task-thread/task-thread.tsx
@@ -44,6 +44,7 @@ import { AcceptCelebration, ReviewPanel } from './review-panel'
 import { queuePosition } from './run-actions'
 import { RunHeader } from './run-header'
 import { AskCard } from './ask-card'
+import { useRunRecordReconcile } from './run-reconcile'
 import { useActiveProviderAvailability } from './active-provider'
 import { groupThreadItems, type ThreadBlock } from './thread-groups'
 import { ThreadLoading } from './thread-loading'
@@ -75,6 +76,10 @@ export function TaskThreadRoute() {
   const run = useRun(id)
   const events = useRunEvents(id)
   const thread = useMemo(() => reduceThread(events), [events])
+  // The two feeds can drift: a record update lost on the workspace stream leaves the thread
+  // showing Working… over a "run finished" transcript. The transcript is live here, so it
+  // arbitrates — a session end with no session after it refetches a record still claiming one.
+  useRunRecordReconcile(run.data, events)
 
   if (run.isPending) return <ThreadLoading />
 


### PR DESCRIPTION
Closes #672

## Problem

After `CEZ:DONE` the transcript shows `goal achieved — session closed` / `run finished`, yet the thread can keep rendering the **Working… spinner** with the composer in live-session mode — every send then hits `409 session closed`. Observed on 0.9.1 (see the issue for the reconstructed timeline from the affected run's NDJSON).

The record (`useRun`, gates `WorkingIndicator` and the composer mode) is patched by the workspace SSE stream; the transcript (`useRunEvents`) has its own watchdog + full replay (#424) and always recovers. A `run` frame lost on the workspace stream (half-open socket, server restart) leaves the record claiming `running` indefinitely while the transcript says the run is over.

## Fix

- **`run-reconcile.ts` (new)** — `useRunRecordReconcile(run, events)`, mounted by the thread route next to the two feeds it reconciles. `settledSessionSeq(events)` finds the transcript's last session boundary: a `session.ended` with no `session.started`/`step-start` after it means the session is over (`ui-event-sink.ts` persists `session.ended` exactly once per session, on every exit path). When that signal is present and the record still claims `running`/`waiting`, the hook invalidates the run detail + list queries after a 2 s grace — on the healthy path the workspace stream's own patch flips the status first and the cleanup cancels the timer, so no extra request is ever made.
- **`queries.ts`** — `useSendMessage` also invalidates `runs.*` on a `409`: a send refused with "session closed" proves the cached record is stale, so the refetch immediately flips the composer to its closed/Continue form instead of leaving it aimed at a dead session.

## Tests

- `run-reconcile.test.ts` — 12 cases: the boundary arithmetic (end-latest, Continue-after-end, malformed lines) and the hook (stale `running`/`waiting` → refetch after grace; record settling within grace, live session, already-settled record, and a Continue reopening the session → no refetch).
- `npm run typecheck`, `npm test` (web suites green; the only failures are the known environment-dependent `run-lease`/`run-isolation`/git-fixture files, failing identically with the change stashed), `npm run test:unit`, `npm run build` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)