### PR TITLE
fix(ui): base-branch picker "current checkout" reads as run-in-place (#663)

### DIFF
--- a/web/app/e2e/settings-agents.e2e.ts
+++ b/web/app/e2e/settings-agents.e2e.ts
@@ -107,7 +107,7 @@ describe('settings → agents against the live dry-run server', () => {
   })
 
   it('base branch: picking a real branch persists; clearing goes back to the checkout', async () => {
-    // Whatever branch the dry-run repo actually has, first option after "current checkout".
+    // Whatever branch the dry-run repo actually has, first option after "follow checked-out branch".
     const branch = String(
       browser.evaluate(`document.querySelector('[data-slot="agents-base-branch"]').options[1]?.value ?? ''`),
     )

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -902,7 +902,7 @@ export interface ConfigResponse {
 }
 
 /** `PUT /api/config` (Settings → Agents; the Repo tab's base-branch picker). `baseBranch: null`
- *  clears the setting back to "current checkout"; `systemPrompt` and per-runner `defaultModels`
+ *  clears the setting back to "follow checked-out branch"; `systemPrompt` and per-runner `defaultModels`
  *  entries clear on `null` (or `''`) too. Merged into the raw config.json server-side —
  *  `defaultModels` merges per runner, so one write never clobbers another runner's preset. */
 export interface SetConfigInput {

--- a/web/app/src/routes/new-task.test.tsx
+++ b/web/app/src/routes/new-task.test.tsx
@@ -311,7 +311,7 @@ describe('picker data flows', () => {
     fireEvent.pointerDown(basePill())
     const options = await screen.findAllByRole('menuitemradio')
     expect(options.map((o) => o.textContent)).toEqual([
-      expect.stringContaining('current checkout (main)'),
+      expect.stringContaining('follow checked-out branch (main)'),
       expect.stringContaining('main'),
       expect.stringContaining('develop'),
     ])

--- a/web/app/src/routes/new-task.tsx
+++ b/web/app/src/routes/new-task.tsx
@@ -983,7 +983,7 @@ function BaseBranchPill({ repo }: { repo: RepoResponse }) {
       toast(
         result.baseBranch
           ? `New tasks will branch off "${result.baseBranch}" (PRs target it too).`
-          : 'Base branch cleared — tasks follow the current checkout.',
+          : 'Base branch cleared — new tasks fork from the checked-out branch.',
       )
     },
     onError: (error: Error) => toast(error.message, { tone: 'danger' }),
@@ -998,7 +998,7 @@ function BaseBranchPill({ repo }: { repo: RepoResponse }) {
       value={repo.baseBranch ?? ''}
       onPick={(value) => mutation.mutate(value === '' ? null : value)}
       options={[
-        { value: '', label: `current checkout (${repo.info.branch})`, desc: 'Follow whatever is checked out' },
+        { value: '', label: `follow checked-out branch (${repo.info.branch})`, desc: 'New task worktrees fork from whatever branch is checked out' },
         ...repo.branches.map((branch) => ({ value: branch, label: branch })),
       ]}
     />

--- a/web/app/src/routes/repo-git/repo-branches.tsx
+++ b/web/app/src/routes/repo-git/repo-branches.tsx
@@ -56,7 +56,7 @@ export function RepoBranchesSection({ repo, info }: { repo: RepoResponse; info: 
       toast(
         result.baseBranch
           ? `Agents now branch from ${result.baseBranch}`
-          : 'Agents now branch from the current checkout',
+          : 'Agents now fork from the checked-out branch',
       )
       void queryClient.invalidateQueries({ queryKey: queryKeys.repo })
     },
@@ -161,7 +161,7 @@ export function RepoBranchesSection({ repo, info }: { repo: RepoResponse; info: 
           onChange={(event) => setBase.mutate(event.target.value === '' ? null : event.target.value)}
           className="mt-1.5 block w-full rounded-md border border-input bg-card px-3 py-1.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
         >
-          <option value="">current checkout (default)</option>
+          <option value="">follow checked-out branch (default)</option>
           {repo.branches.map((name) => (
             <option key={name} value={name}>
               {name}

--- a/web/app/src/routes/repo-git/repo-git.test.tsx
+++ b/web/app/src/routes/repo-git/repo-git.test.tsx
@@ -381,7 +381,7 @@ describe('the repo view Branches segment', () => {
     })
     renderAt('/git/branches')
     const picker = (await screen.findByLabelText('Agents’ base branch')) as HTMLSelectElement
-    expect(picker.value).toBe('') // baseBranch: null = current checkout
+    expect(picker.value).toBe('') // baseBranch: null = follow checked-out branch
 
     fireEvent.change(picker, { target: { value: 'feature' } })
     await waitFor(() => {

--- a/web/app/src/routes/settings/agents-section.test.tsx
+++ b/web/app/src/routes/settings/agents-section.test.tsx
@@ -236,7 +236,7 @@ describe('the agents form', () => {
     expect(puts()).toHaveLength(0)
   })
 
-  it('base branch round-trips through the same PUT — "" means back to current checkout', async () => {
+  it('base branch round-trips through the same PUT — "" means follow the checked-out branch', async () => {
     serve({ config: { baseBranch: 'develop' } })
     renderAt('/settings/agents')
     await waitFor(() => expect(form()).not.toBeNull())

--- a/web/app/src/routes/settings/agents-section.tsx
+++ b/web/app/src/routes/settings/agents-section.tsx
@@ -262,7 +262,7 @@ function AgentsForm({ config, catalog }: { config: ConfigResponse; catalog: Retu
             onChange={(event) => save.mutate({ baseBranch: event.target.value || null })}
             className="block w-full max-w-md rounded-md border border-input bg-card px-3 py-1.5 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
           >
-            <option value="">current checkout (default)</option>
+            <option value="">follow checked-out branch (default)</option>
             {repo.data.branches.map((name) => (
               <option key={name} value={name}>
                 {name}


### PR DESCRIPTION
## What

Relabels the base-branch pickers' `baseBranch: null` state across every surface so it can no longer be read as "run this task in my checkout, without a worktree" (the misread behind #650).

The base-branch setting controls one thing: what new task worktrees fork from (and what PRs target). It never disables worktree creation — that is the separate Worktree toggle. "current checkout" promised more than the setting does.

## Changes (copy only)

Applied matgren's recommended **Option A** vocabulary consistently:

| Surface | Before | After |
|---|---|---|
| Base pill option (`new-task.tsx`) | `current checkout (<branch>)` / "Follow whatever is checked out" | `follow checked-out branch (<branch>)` / "New task worktrees fork from whatever branch is checked out" |
| Base pill cleared toast | "tasks follow the current checkout." | "new tasks fork from the checked-out branch." |
| Settings & Repo `<option>` selects | `current checkout (default)` | `follow checked-out branch (default)` |
| Repo cleared toast | "Agents now branch from the current checkout" | "Agents now fork from the checked-out branch" |
| `SetConfigInput` doc comment | "current checkout" | "follow checked-out branch" |

No behavior change: `value: ''` semantics, the `/api/config` contract, and the stored config are untouched. Unit + e2e string assertions/comments updated to match.

## Verification

Full validation gate green: `typecheck`, `build`, `npm test` (4027), `test:unit` (34), `test:package` (8). The rendered option text is asserted by `new-task.test.tsx`.

Fixes #663