### PR TITLE
fix(workflows): expand registry slash skills in chat (#676)

### DIFF
--- a/src/server/providers-api.test.ts
+++ b/src/server/providers-api.test.ts
@@ -57,11 +57,13 @@ describe('workspace provider API', () => {
   let root: string;
   let store: RunStore;
   const savedDryRun = process.env.CEZ_DRY_RUN;
+  const savedRemote = process.env.CEZ_REMOTE;
 
   beforeEach(() => {
     root = mkdtempSync(join(tmpdir(), 'cez-providers-api-'));
     store = RunStore.open(join(root, '.ai/cezar'));
     delete process.env.CEZ_DRY_RUN;
+    delete process.env.CEZ_REMOTE;
   });
 
   afterEach(() => {
@@ -69,6 +71,8 @@ describe('workspace provider API', () => {
     rmSync(root, { recursive: true, force: true });
     if (savedDryRun === undefined) delete process.env.CEZ_DRY_RUN;
     else process.env.CEZ_DRY_RUN = savedDryRun;
+    if (savedRemote === undefined) delete process.env.CEZ_REMOTE;
+    else process.env.CEZ_REMOTE = savedRemote;
   });
 
   const service = (

--- a/src/workflows/run.ts
+++ b/src/workflows/run.ts
@@ -127,6 +127,9 @@ interface ActiveRun {
    *  going until it signals done or the safety cap is hit. */
   autonomous?: boolean;
   autoContinues?: number;
+  /** Registry snapshot used to expand `/skill` follow-ups before a backend can
+   *  mistake them for its own slash commands (#676). */
+  skills?: Skill[];
   /** Release for exclusive execution in the user's repository working tree.
    *  Worktree-backed runs never need it; every degradation/opt-out path does. */
   releaseRepoRoot?: () => void;
@@ -1148,7 +1151,8 @@ export class RunManager {
     // ride along so the model can *view* them, but a real path is what lets it *operate* on them
     // (save, `cp`, attach to a GitHub issue/PR) — and it's the only usable reference on backends
     // (codex, opencode) that drop image blocks entirely before reaching the model.
-    const deliverable = persisted.length ? [...content, pastedAttachmentsNote(persisted)] : content;
+    const expanded = userAuthored ? expandRegistrySlashSkill(content, state.skills ?? []) : content;
+    const deliverable = persisted.length ? [...expanded, pastedAttachmentsNote(persisted)] : expanded;
     const delivered = state.session.sendMessage(deliverable);
     if (delivered) {
       this.clearIdleTimer(state);
@@ -1678,6 +1682,7 @@ export class RunManager {
     if (seeded) seedHandoffFile(this.dataDir, seeded);
 
     const skills = await discoverSkills(this.repoRoot);
+    state.skills = skills;
     const retriesUsed = new Map<string, number>();
     let checkFailure: string | null = null;
     let runError: string | null = null;
@@ -2542,4 +2547,36 @@ export function skillSystemPrompt(
   }
   lines.push('', 'Skill instructions:', skill.body.trim());
   return lines.join('\n');
+}
+
+/**
+ * Expand a registry-backed slash skill in a live chat message before it reaches
+ * a backend. Claude otherwise intercepts an unknown leading slash command, and
+ * Codex/OpenCode have no native slash-skill lookup at all (#676).
+ *
+ * Only the first text block is eligible, only at character zero, and unknown
+ * commands pass through byte-for-byte. The caller persists the original user
+ * content before applying this delivery-only rewrite.
+ */
+export function expandRegistrySlashSkill(
+  content: ContentBlock[],
+  skills: readonly Skill[],
+): ContentBlock[] {
+  const textIndex = content.findIndex((block) => block.type === 'text');
+  if (textIndex < 0) return content;
+  const block = content[textIndex];
+  if (!block || block.type !== 'text') return content;
+  const match = /^\/([A-Za-z0-9][A-Za-z0-9._-]*)(?=\s|$)/.exec(block.text);
+  if (!match) return content;
+  const skill = skills.find((candidate) => candidate.name === match[1]);
+  if (!skill) return content;
+
+  const request = block.text.slice(match[0].length).trim();
+  const replacement: ContentBlock = {
+    type: 'text',
+    text: request ? `${skillSystemPrompt(skill)}\n\nUser request:\n${request}` : skillSystemPrompt(skill),
+  };
+  const expanded = [...content];
+  expanded[textIndex] = replacement;
+  return expanded;
 }

--- a/src/workflows/skill-system-prompt.test.ts
+++ b/src/workflows/skill-system-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { skillSystemPrompt } from './run.js';
+import type { ContentBlock } from '../core/agent-runner.js';
+import { expandRegistrySlashSkill, skillSystemPrompt } from './run.js';
 
 describe('skillSystemPrompt — installed-path hint for worktree agents', () => {
   const base = { name: 'om-code-review', description: 'Review a diff.', body: 'Do the review.' };
@@ -24,5 +25,50 @@ describe('skillSystemPrompt — installed-path hint for worktree agents', () => 
   it('omits the path hint when no path/source is known', () => {
     const out = skillSystemPrompt(base);
     expect(out).not.toContain('installed on disk at');
+  });
+});
+
+describe('expandRegistrySlashSkill — live chat delivery', () => {
+  const skill = {
+    name: 'om-code-review',
+    description: 'Review a diff.',
+    body: 'Do the review.',
+    path: '/home/u/.agents/skills/om-code-review/SKILL.md',
+    source: 'global' as const,
+  };
+
+  it('replaces a matching leading slash skill with the canonical selected-skill prompt', () => {
+    const content: ContentBlock[] = [{ type: 'text', text: '/om-code-review PR 42' }];
+
+    const expanded = expandRegistrySlashSkill(content, [skill]);
+
+    expect(expanded).not.toBe(content);
+    expect(expanded[0]).toEqual({
+      type: 'text',
+      text: expect.stringContaining('Selected skill: /om-code-review'),
+    });
+    expect((expanded[0] as Extract<ContentBlock, { type: 'text' }>).text).toContain(
+      'Skill instructions:\nDo the review.\n\nUser request:\nPR 42',
+    );
+    expect(content[0]).toEqual({ type: 'text', text: '/om-code-review PR 42' });
+  });
+
+  it.each(['/unknown PR 42', ' /om-code-review PR 42', '/om-code-reviewer PR 42'])(
+    'leaves non-matching text unchanged: %s',
+    (text) => {
+      const content: ContentBlock[] = [{ type: 'text', text }];
+      expect(expandRegistrySlashSkill(content, [skill])).toBe(content);
+    },
+  );
+
+  it('preserves image blocks while expanding the first text block', () => {
+    const image: ContentBlock = {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'AAA' },
+    };
+    const expanded = expandRegistrySlashSkill([image, { type: 'text', text: '/om-code-review' }], [skill]);
+
+    expect(expanded[0]).toBe(image);
+    expect((expanded[1] as Extract<ContentBlock, { type: 'text' }>).text).toContain('Do the review.');
   });
 });


### PR DESCRIPTION
Fixes #676

## Problem
Registry-only skills offered by the running-task chat composer were forwarded as bare slash commands. Claude Code intercepted them as unknown native commands before the model could act, while Codex and OpenCode had no slash-skill lookup at all.

## Root Cause
The workflow engine discovered the skill catalog for task startup but did not retain it on the active run. `RunManager.deliverMessage` therefore had no synchronous registry context when forwarding live follow-up messages.

## What Changed
- Retain the discovered skill registry snapshot on each active run.
- Expand a matching leading `/skill` into the canonical selected-skill prompt for backend delivery while preserving the original user transcript and attachments.
- Leave unknown commands and non-leading slash text unchanged.
- Add regression coverage for matching, unknown, whitespace-prefixed, prefix-collision, argument, immutability, and attachment cases.

## Tests
- `npm run typecheck`
- `npm test` — 4,551 passed
- `npm run test:unit` — 36 passed
- `npm run build`
- `npm run test:package` — 8 passed
- `npx vitest run src/workflows/skill-system-prompt.test.ts src/workflows/run.test.ts` — 74 passed

The inherited `CEZ_REMOTE` task-runner flag was removed for the local-mode full test invocation because five provider terminal-launch tests intentionally assert local handoff behavior.

## Breaking Changes
None.

🤖 Generated by autofix.
