### PR TITLE
fix(web): keep add-project dialog contents inside the card (grid blow…

### DIFF
--- a/web/app/src/components/add-project-dialog.test.tsx
+++ b/web/app/src/components/add-project-dialog.test.tsx
@@ -198,6 +198,8 @@ describe('AddProjectDialog', () => {
     )
     expect(screen.getByTestId('location').textContent).toBe('/p/cezar/')
     expect(onOpenChange).not.toHaveBeenCalled()
+    // Server messages quote unbreakable paths — they must wrap, not widen the grid column.
+    expect(document.querySelector('[data-slot="add-project-error"]')?.className).toContain('break-words')
   })
 
   it('shows a browse failure instead of an empty listing', async () => {
@@ -209,12 +211,34 @@ describe('AddProjectDialog', () => {
       ),
     )
     expect(document.querySelector('[data-slot="fs-listing"]')).toBeNull()
+    // Same wrap-don't-widen contract as the register error.
+    expect(document.querySelector('[data-slot="fs-error"]')?.className).toContain('break-words')
   })
 
   it('surfaces the truncated flag rather than showing a silently short list', async () => {
     serve({ browse: { '': json({ ...PROJECTS, truncated: true }) } })
     renderDialog()
     await waitFor(() => expect(document.querySelector('[data-slot="fs-truncated"]')).toBeTruthy())
+  })
+
+  it('keeps a long target path from widening the dialog (grid-blowout regression)', async () => {
+    const DEEP: FsBrowseResponse = {
+      path: '/home/me/projects/workspace/whisper/whisper-admin-with-a-very-long-name',
+      parent: '/home/me',
+      dirs: [{ name: 'docs', path: '/home/me/projects/workspace/whisper/whisper-admin-with-a-very-long-name/docs', isRepo: false }],
+      truncated: false,
+    }
+    serve({ browse: { '': json(DEEP) } })
+    renderDialog()
+    await waitFor(() => expect(target().textContent).toBe(DEEP.path))
+    // jsdom does no layout, so the guard is the class contract. DialogContent is a CSS grid,
+    // and a grid item with visible overflow cannot shrink below its min-content: without
+    // min-w-0 on the footer, the unbreakable mono path forces the grid column wider than the
+    // card, and every row — the folder list included — renders past the dialog's right edge.
+    const footer = document.querySelector('[data-slot="dialog-footer"]') as HTMLElement
+    expect(footer.className).toContain('min-w-0')
+    // …and the path itself must be the thing that gives way, by truncating.
+    expect(target().className).toContain('truncate')
   })
 
   it('refetches the project registry after a successful add so the sidebar picks it up', async () => {

--- a/web/app/src/components/add-project-dialog.tsx
+++ b/web/app/src/components/add-project-dialog.tsx
@@ -103,7 +103,7 @@ export function AddProjectDialog({
         </p>
 
         {listing.isError ? (
-          <p data-slot="fs-error" className="text-[13px] text-danger">
+          <p data-slot="fs-error" className="min-w-0 break-words text-[13px] text-danger">
             {listing.error instanceof Error ? listing.error.message : 'could not list that folder'}
           </p>
         ) : (
@@ -180,12 +180,16 @@ export function AddProjectDialog({
         ) : null}
 
         {register.isError ? (
-          <p data-slot="add-project-error" className="text-[13px] text-danger">
+          <p data-slot="add-project-error" className="min-w-0 break-words text-[13px] text-danger">
             {register.error instanceof Error ? register.error.message : 'could not add that folder'}
           </p>
         ) : null}
 
-        <DialogFooter className="sm:items-center sm:justify-between">
+        {/* min-w-0 matters: DialogContent is a grid, and a grid item with visible overflow
+            cannot shrink below its min-content — a long target path (unbreakable, mono) would
+            widen the whole column and push every row past the card edge. With the floor removed
+            the path truncates instead. */}
+        <DialogFooter className="min-w-0 sm:items-center sm:justify-between">
           <span
             data-slot="add-project-target"
             className="min-w-0 truncate font-mono text-[11.5px] text-muted-foreground"
@@ -193,7 +197,7 @@ export function AddProjectDialog({
           >
             {target ?? ''}
           </span>
-          <span className="flex gap-2">
+          <span className="flex shrink-0 gap-2">
             <Button variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>


### PR DESCRIPTION
…out) (#667)

DialogContent is a CSS grid; the footer (a grid item with visible overflow) could not shrink below its min-content — the unbreakable mono target path plus both buttons — so a long path widened the grid column past the 512px card and every row (folder list included) rendered past the dialog's right edge.

min-w-0 on the DialogFooter removes that floor so the existing truncate on the path takes over; shrink-0 keeps the button group intact; min-w-0 break-words on both error paragraphs stops the same blowout from long unbreakable paths quoted verbatim in server error messages.