### PR TITLE
fix(skills): reduce update status polling

### DIFF
--- a/.ai/runs/2026-07-26-reduce-skills-update-polling.md
+++ b/.ai/runs/2026-07-26-reduce-skills-update-polling.md
@@ -1,0 +1,46 @@
+# Reduce skills update polling
+
+## Goal
+
+Prevent the skills update status query from flooding the local API while a bounded background check is still running, without changing update ownership, security boundaries, or the six-hour backend cache.
+
+## Scope
+
+- Adjust the cockpit query's transient retry cadence so slow checks converge with materially fewer requests.
+- Add focused query-hook coverage that locks in the retry cadence and terminal-state behavior.
+- Verify the affected frontend tests and the repository's configured validation gate.
+
+## Non-goals
+
+- Changing the updater CLI commands, lock-file provenance checks, automatic-apply preference, or backend TTL.
+- Adding a new WebSocket topic for this isolated low-frequency status signal.
+- Changing update-card content or visual design.
+
+## Implementation Plan
+
+### Phase 1: Fix and regression coverage
+
+1. Increase the transient skills-update snapshot retry interval to a conservative cadence and document why it remains a bounded convergence poll.
+2. Extend the query-hook regression test to assert the exact cadence and that terminal states stop polling.
+
+### Phase 2: Verification and handoff
+
+1. Run targeted tests, the configured validation gate, and the authoritative PR review; address any findings.
+
+## Risks
+
+- A slower retry can delay status convergence by a few seconds after a check completes; the chosen cadence must balance responsiveness with avoiding request storms.
+- The backend remains authoritative and deduplicates expensive checks, so this change affects only local snapshot HTTP traffic.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix and regression coverage
+
+- [ ] 1.1 Increase the transient skills-update snapshot retry interval to a conservative cadence and document why it remains a bounded convergence poll.
+- [ ] 1.2 Extend the query-hook regression test to assert the exact cadence and that terminal states stop polling.
+
+### Phase 2: Verification and handoff
+
+- [ ] 2.1 Run targeted tests, the configured validation gate, and the authoritative PR review; address any findings.

--- a/.ai/runs/2026-07-26-reduce-skills-update-polling.md
+++ b/.ai/runs/2026-07-26-reduce-skills-update-polling.md
@@ -36,6 +36,8 @@ Prevent the skills update status query from flooding the local API while a bound
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
+PR: #682
+
 ### Phase 1: Fix and regression coverage
 
 - [x] 1.1 Increase the transient skills-update snapshot retry interval to a conservative cadence and document why it remains a bounded convergence poll. — da94c02a
@@ -43,4 +45,4 @@ Prevent the skills update status query from flooding the local API while a bound
 
 ### Phase 2: Verification and handoff
 
-- [ ] 2.1 Run targeted tests, the configured validation gate, and the authoritative PR review; address any findings.
+- [x] 2.1 Run targeted tests, the configured validation gate, and the authoritative PR review; address any findings. — 4069bb67

--- a/.ai/runs/2026-07-26-reduce-skills-update-polling.md
+++ b/.ai/runs/2026-07-26-reduce-skills-update-polling.md
@@ -38,8 +38,8 @@ Prevent the skills update status query from flooding the local API while a bound
 
 ### Phase 1: Fix and regression coverage
 
-- [ ] 1.1 Increase the transient skills-update snapshot retry interval to a conservative cadence and document why it remains a bounded convergence poll.
-- [ ] 1.2 Extend the query-hook regression test to assert the exact cadence and that terminal states stop polling.
+- [x] 1.1 Increase the transient skills-update snapshot retry interval to a conservative cadence and document why it remains a bounded convergence poll. — da94c02a
+- [x] 1.2 Extend the query-hook regression test to assert the exact cadence and that terminal states stop polling. — da94c02a
 
 ### Phase 2: Verification and handoff
 

--- a/web/app/src/api/queries.test.tsx
+++ b/web/app/src/api/queries.test.tsx
@@ -474,7 +474,7 @@ describe('useSkills', () => {
 })
 
 describe('useSkillsUpdate', () => {
-  it('polls a transient snapshot until the background server check converges', async () => {
+  it('retries a transient snapshot conservatively until the background server check converges', async () => {
     fetchMock.mockResolvedValue(json({
       status: 'idle',
       available: false,
@@ -497,9 +497,12 @@ describe('useSkillsUpdate', () => {
     const query = client.getQueryCache().find({ queryKey: key })
     const interval = query?.observers[0]?.options.refetchInterval
     expect(typeof interval).toBe('function')
-    expect((interval as (current: typeof query) => number | false)(query)).toBe(1_000)
+    expect((interval as (current: typeof query) => number | false)(query)).toBe(10_000)
 
     client.setQueryData(key, { ...result.current.data!, status: 'current' })
+    expect((interval as (current: typeof query) => number | false)(query)).toBe(false)
+
+    client.setQueryData(key, { ...result.current.data!, status: 'available' })
     expect((interval as (current: typeof query) => number | false)(query)).toBe(false)
   })
 })

--- a/web/app/src/api/queries.ts
+++ b/web/app/src/api/queries.ts
@@ -726,12 +726,13 @@ export function useSkillsUpdate(projectId: string, enabled = true) {
     queryFn: ({ signal }) => getSkillsUpdate(projectId, { signal }),
     enabled,
     // GET deliberately answers the current snapshot and starts a stale check in the
-    // background. Poll only while that snapshot is transient so an initial `idle`
-    // response converges without turning every open cockpit into a permanent poller.
+    // background. Retry only while that snapshot is transient so an initial `idle`
+    // response converges. Checks may legitimately take tens of seconds, so a ten-second
+    // cadence avoids flooding the local API while still refreshing promptly after completion.
     refetchInterval: (query) => {
       const status = query.state.data?.status
       return status === undefined || status === 'idle' || status === 'checking' || status === 'updating'
-        ? 1_000
+        ? 10_000
         : false
     },
   })


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-26-reduce-skills-update-polling.md
Status: complete

## 🎯 Goal
- Prevent slow skills update checks from causing a one-request-per-second API storm while preserving bounded status convergence.

## What Changed
- Increased the transient `useSkillsUpdate` snapshot retry cadence from one second to ten seconds.
- Extended the focused query-hook regression test to pin the cadence and prove terminal `current` and `available` states stop polling.

## 🧪 Tests
- `npm test -- web/app/src/api/queries.test.tsx` — 31 passed.
- `npm run typecheck` — passed.
- `npm test` — 4,569 passed across 252 files.
- `npm run test:unit` — 36 passed.
- `npm run build` — passed, including the 355-file package-content check.
- `npm run test:package` — 8 passed.

## 💥 Breaking Changes
- None. Backend update execution, the six-hour cache, updater security boundaries, API shapes, and configuration defaults are unchanged.

## 📋 Progress
See the Progress section in the tracking plan.
