### PR TITLE
fix(web): preserve auth across background checks

### DIFF
--- a/.ai/runs/2026-07-26-provider-auth-check-cadence.md
+++ b/.ai/runs/2026-07-26-provider-auth-check-cadence.md
@@ -1,0 +1,55 @@
+# Provider auth and update check cadence
+
+## Goal
+
+Prevent authenticated remote cockpit sessions from being interrupted by recurring Basic Auth challenges by making API credentials explicit and replacing permanent background checks with session-scoped, conservative refresh behavior.
+
+## Scope
+
+- Make same-origin API reads and mutations explicitly include browser credentials.
+- Load provider authentication status once per session cache lifetime, then refresh only after a five-minute stale window on focus or explicit user action.
+- Let the skills update snapshot start one server-side check per session mount and poll only while that operation is transient, at a one-minute cadence.
+- Add focused frontend regression tests for credential forwarding and both query cadences.
+
+## Non-goals
+
+- Do not change provider CLI credential discovery, vendor login flows, or server-side credential storage.
+- Do not replace reverse-proxy Basic Auth or introduce a new cezar authentication system.
+- Do not change update installation behavior, the six-hour server cache, or WebSocket/SSE protocols.
+
+## Implementation Plan
+
+### Phase 1: Authenticated request boundary
+
+1. Make the typed HTTP client explicitly include same-origin credentials for every request and cover the boundary with client tests.
+
+### Phase 2: Session-safe check cadence
+
+2. Change provider status from interval polling to one cached session load with a five-minute focus refresh window and update query tests.
+3. Slow transient skills-update convergence to one minute while preserving the one-time mount check and update query tests.
+
+### Phase 3: Verification and handoff
+
+4. Run the configured validation gate, review compatibility/security/scope, and publish the verified PR for review.
+
+## Risks
+
+- Provider status may remain stale for up to five minutes after credentials change outside cezar; explicit Check again and provider SSE events remain immediate recovery paths.
+- A skills update check may take up to one minute to appear complete in the shell after a long-running background operation; explicit controls remain immediate.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Authenticated request boundary
+
+- [ ] 1.1 Make the typed HTTP client explicitly include same-origin credentials for every request and cover the boundary with client tests.
+
+### Phase 2: Session-safe check cadence
+
+- [ ] 2.1 Change provider status from interval polling to one cached session load with a five-minute focus refresh window and update query tests.
+- [ ] 2.2 Slow transient skills-update convergence to one minute while preserving the one-time mount check and update query tests.
+
+### Phase 3: Verification and handoff
+
+- [ ] 3.1 Run the configured validation gate, review compatibility/security/scope, and publish the verified PR for review.

--- a/.ai/runs/2026-07-26-provider-auth-check-cadence.md
+++ b/.ai/runs/2026-07-26-provider-auth-check-cadence.md
@@ -36,6 +36,7 @@ Prevent authenticated remote cockpit sessions from being interrupted by recurrin
 
 - Provider status may remain stale for up to five minutes after credentials change outside cezar; explicit Check again and provider SSE events remain immediate recovery paths.
 - A skills update check may take up to one minute to appear complete in the shell after a long-running background operation; explicit controls remain immediate.
+- Review blocker: the authoritative review pass found no issues, but GitHub does not permit the PR author to submit an approval review. The PR remains a draft until an independent reviewer approves it and manual Basic Auth QA is completed.
 
 ## Progress
 

--- a/.ai/runs/2026-07-26-provider-auth-check-cadence.md
+++ b/.ai/runs/2026-07-26-provider-auth-check-cadence.md
@@ -47,8 +47,8 @@ Prevent authenticated remote cockpit sessions from being interrupted by recurrin
 
 ### Phase 2: Session-safe check cadence
 
-- [ ] 2.1 Change provider status from interval polling to one cached session load with a five-minute focus refresh window and update query tests.
-- [ ] 2.2 Slow transient skills-update convergence to one minute while preserving the one-time mount check and update query tests.
+- [x] 2.1 Change provider status from interval polling to one cached session load with a five-minute focus refresh window and update query tests. — f20e572d
+- [x] 2.2 Slow transient skills-update convergence to one minute while preserving the one-time mount check and update query tests. — f20e572d
 
 ### Phase 3: Verification and handoff
 

--- a/.ai/runs/2026-07-26-provider-auth-check-cadence.md
+++ b/.ai/runs/2026-07-26-provider-auth-check-cadence.md
@@ -43,7 +43,7 @@ Prevent authenticated remote cockpit sessions from being interrupted by recurrin
 
 ### Phase 1: Authenticated request boundary
 
-- [ ] 1.1 Make the typed HTTP client explicitly include same-origin credentials for every request and cover the boundary with client tests.
+- [x] 1.1 Make the typed HTTP client explicitly include same-origin credentials for every request and cover the boundary with client tests. — 0f44be53
 
 ### Phase 2: Session-safe check cadence
 

--- a/web/app/src/api/client.test.ts
+++ b/web/app/src/api/client.test.ts
@@ -71,7 +71,7 @@ const VALID_PROVIDER_STATUS = {
 }
 
 /** The (path, init) the client actually asked for. */
-function lastCall(): { path: string; method: string; body: unknown; headers: Headers } {
+function lastCall(): { path: string; method: string; body: unknown; headers: Headers; credentials: RequestCredentials | undefined } {
   const call = fetchMock.mock.calls.at(-1)
   if (!call) throw new Error('fetch was never called')
   const [path, init = {}] = call as [string, RequestInit]
@@ -80,6 +80,7 @@ function lastCall(): { path: string; method: string; body: unknown; headers: Hea
     method: String(init.method),
     body: typeof init.body === 'string' ? JSON.parse(init.body) : undefined,
     headers: new Headers(init.headers),
+    credentials: init.credentials,
   }
 }
 
@@ -292,6 +293,7 @@ describe('request shapes', () => {
     expect(sent.path).toBe(path)
     expect(sent.method).toBe(method)
     expect(sent.body).toEqual(body)
+    expect(sent.credentials).toBe('include')
     if (body !== undefined) expect(sent.headers.get('content-type')).toBe('application/json')
   })
 

--- a/web/app/src/api/client.ts
+++ b/web/app/src/api/client.ts
@@ -166,7 +166,12 @@ function errorFor(status: number, statusText: string, body: string): ApiError {
 
 async function send(path: string, init: RequestInit): Promise<Response> {
   try {
-    return await fetch(scopeApiPath(path), init)
+    // Be explicit at the shared boundary: remote installations are commonly protected by
+    // reverse-proxy Basic Auth, and every background query/mutation must reuse that authenticated
+    // browser session just like navigation does. `include` is harmless for the root-relative,
+    // same-origin paths enforced above and prevents an individual call site from silently losing
+    // credentials when the browser/proxy combination is stricter than the fetch default.
+    return await fetch(scopeApiPath(path), { ...init, credentials: 'include' })
   } catch (cause) {
     // The request never got an answer. Not an HTTP failure — hence status 0 — but callers get
     // one error type either way instead of two.

--- a/web/app/src/api/queries.test.tsx
+++ b/web/app/src/api/queries.test.tsx
@@ -156,27 +156,9 @@ describe('provider status workspace query', () => {
     expect(workspaceQueryKeys.providerStatus).toEqual(['workspace', 'providers', 'status'])
   })
 
-  it('polls exactly every 30 seconds', async () => {
-    vi.useFakeTimers()
-    fetchMock.mockResolvedValue(json(PROVIDERS))
-    const { result } = renderHook(() => useProviderStatus(), { wrapper: wrapper() })
-
-    await act(() => vi.advanceTimersByTimeAsync(0))
-    expect(result.current.isSuccess).toBe(true)
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-
-    await act(() => vi.advanceTimersByTimeAsync(29_999))
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    await act(() => vi.advanceTimersByTimeAsync(1))
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('refetches on window focus', async () => {
+  it('loads once without interval polling and becomes focus-refreshable after five minutes', async () => {
     fetchMock.mockResolvedValue(json(PROVIDERS))
     const client = createQueryClient()
-    client.setDefaultOptions({
-      queries: { ...client.getDefaultOptions().queries, staleTime: 0 },
-    })
     const { result } = renderHook(() => useProviderStatus(), {
       wrapper: ({ children }: { children: ReactNode }) => (
         <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -185,6 +167,25 @@ describe('provider status workspace query', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    const query = client.getQueryCache().find({ queryKey: workspaceQueryKeys.providerStatus })
+    expect(query?.observers[0]?.options.refetchInterval).toBe(false)
+    expect(query?.observers[0]?.options.staleTime).toBe(5 * 60_000)
+  })
+
+  it('refetches on window focus', async () => {
+    fetchMock.mockResolvedValue(json(PROVIDERS))
+    const client = createQueryClient()
+    const { result } = renderHook(() => useProviderStatus(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const query = client.getQueryCache().find({ queryKey: workspaceQueryKeys.providerStatus })
+    if (!query) throw new Error('provider status query was not created')
+    query.setState({ ...query.state, dataUpdatedAt: Date.now() - 5 * 60_000 - 1 })
     window.dispatchEvent(new Event('visibilitychange'))
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
   })
@@ -497,7 +498,7 @@ describe('useSkillsUpdate', () => {
     const query = client.getQueryCache().find({ queryKey: key })
     const interval = query?.observers[0]?.options.refetchInterval
     expect(typeof interval).toBe('function')
-    expect((interval as (current: typeof query) => number | false)(query)).toBe(10_000)
+    expect((interval as (current: typeof query) => number | false)(query)).toBe(60_000)
 
     client.setQueryData(key, { ...result.current.data!, status: 'current' })
     expect((interval as (current: typeof query) => number | false)(query)).toBe(false)

--- a/web/app/src/api/queries.ts
+++ b/web/app/src/api/queries.ts
@@ -215,7 +215,13 @@ export function useProviderStatus() {
         response,
       )
     },
-    refetchInterval: 30_000,
+    // One bootstrap per session cache. Runtime incidents arrive over the workspace stream and
+    // user-driven Connect/Check again/Try again actions update this same key immediately; a
+    // background interval only re-probes unchanged credentials and can repeatedly challenge a
+    // reverse-proxy-authenticated mobile browser. A focus refresh is allowed once the answer is
+    // five minutes old, covering credentials changed outside cezar without permanent polling.
+    staleTime: 5 * 60_000,
+    refetchInterval: false,
     refetchOnWindowFocus: true,
   })
 }
@@ -727,12 +733,13 @@ export function useSkillsUpdate(projectId: string, enabled = true) {
     enabled,
     // GET deliberately answers the current snapshot and starts a stale check in the
     // background. Retry only while that snapshot is transient so an initial `idle`
-    // response converges. Checks may legitimately take tens of seconds, so a ten-second
-    // cadence avoids flooding the local API while still refreshing promptly after completion.
+    // response converges. Checks may legitimately take tens of seconds, so a one-minute cadence
+    // avoids repeatedly challenging authenticated remote sessions while still converging after
+    // a long-running operation. The initial mount remains the session's one automatic check.
     refetchInterval: (query) => {
       const status = query.state.data?.status
       return status === undefined || status === 'idle' || status === 'checking' || status === 'updating'
-        ? 10_000
+        ? 60_000
         : false
     },
   })


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-26-provider-auth-check-cadence.md
Status: in-progress

## 🎯 Goal
- Keep authenticated remote cockpit sessions usable by forwarding browser credentials on every typed API request and removing recurring provider/update polling.

## What Changed
- Execution plan only; implementation is in progress.

## 🧪 Tests
- Pending implementation and validation.

## 💥 Breaking Changes
- None.

## 📋 Progress
See the Progress section in the tracking plan.
