### PR TITLE
feat(github): add merge status and rule overrides

### DIFF
--- a/.ai/runs/2026-07-26-github-pr-merge-controls.md
+++ b/.ai/runs/2026-07-26-github-pr-merge-controls.md
@@ -48,13 +48,13 @@ Add scannable requirement status icons to the GitHub pull-request merge box and 
 
 ### Phase 1: Merge policy contract
 
-- [ ] 1.1 Extend merge contracts and classify overridable requirements
-- [ ] 1.2 Enforce hard merge safeguards and test override behavior
+- [x] 1.1 Extend merge contracts and classify overridable requirements — 21a27c92
+- [x] 1.2 Enforce hard merge safeguards and test override behavior — 21a27c92
 
 ### Phase 2: Visual merge controls
 
-- [ ] 2.1 Add accessible requirement status icons
-- [ ] 2.2 Add explicit override selection, confirmation, and component tests
+- [x] 2.1 Add accessible requirement status icons — f22b5472
+- [x] 2.2 Add explicit override selection, confirmation, and component tests — f22b5472
 
 ### Phase 3: Verification
 

--- a/.ai/runs/2026-07-26-github-pr-merge-controls.md
+++ b/.ai/runs/2026-07-26-github-pr-merge-controls.md
@@ -1,0 +1,62 @@
+# GitHub PR merge controls
+
+## Overview
+
+Add scannable requirement status icons to the GitHub pull-request merge box and an explicit, confirmed path for authorized users to ask GitHub to merge without waiting for non-hard requirements.
+
+## Scope
+
+- Show success, failure, pending, and unknown icons for reviews, conflicts, and checks.
+- Add an opt-in override control only when cezar's normal merge eligibility is blocked by requirements that GitHub may allow an authorized user to bypass.
+- Carry the override intent through the validated HTTP API while preserving exact-head, method, PR-state, draft, and conflict safeguards.
+- Cover normalization, API validation/behavior, and UI confirmation with regression tests.
+
+## Non-goals
+
+- Do not bypass merge conflicts, stale-head protection, disabled merge methods, closed/merged PRs, or draft status.
+- Do not change GitHub repository rules, permissions, or branch protection.
+- Do not add automatic merging or delete branches.
+
+## Implementation Plan
+
+### Phase 1: Merge policy contract
+
+- Extend the additive merge-state and mutation contracts with explicit override eligibility and intent.
+- Preserve hard blockers server-side while delegating authorized requirement bypasses to GitHub.
+- Add server normalization and API regression tests.
+
+### Phase 2: Visual merge controls
+
+- Render accessible status icons for reviews, conflicts, and individual checks.
+- Add a clearly labeled override checkbox and strengthened confirmation copy for blocked-but-overridable PRs.
+- Add component tests for visual statuses, normal merge, and override payloads.
+
+### Phase 3: Verification
+
+- Run targeted type and test checks, inspect the final diff for scope, and complete the configured validation gate.
+- Run code review and compatibility/security checks, then prepare the tracked PR and QA handoff.
+
+## Risks
+
+- An override affordance could imply permissions cezar cannot know; copy must make clear GitHub still authorizes and may refuse the merge.
+- Over-broad bypass logic could weaken conflict or stale-head safeguards; these remain unconditional server-side gates with tests.
+- UI status icons must include text or accessible labels so color is never the sole signal.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Merge policy contract
+
+- [ ] 1.1 Extend merge contracts and classify overridable requirements
+- [ ] 1.2 Enforce hard merge safeguards and test override behavior
+
+### Phase 2: Visual merge controls
+
+- [ ] 2.1 Add accessible requirement status icons
+- [ ] 2.2 Add explicit override selection, confirmation, and component tests
+
+### Phase 3: Verification
+
+- [ ] 3.1 Run targeted and full validation gates
+- [ ] 3.2 Complete self-review, PR review, and QA handoff

--- a/.ai/runs/2026-07-26-github-pr-merge-controls.md
+++ b/.ai/runs/2026-07-26-github-pr-merge-controls.md
@@ -58,5 +58,5 @@ Add scannable requirement status icons to the GitHub pull-request merge box and 
 
 ### Phase 3: Verification
 
-- [ ] 3.1 Run targeted and full validation gates
+- [x] 3.1 Run targeted and full validation gates — f22b5472
 - [ ] 3.2 Complete self-review, PR review, and QA handoff

--- a/.ai/runs/2026-07-26-github-pr-merge-controls.md
+++ b/.ai/runs/2026-07-26-github-pr-merge-controls.md
@@ -44,6 +44,8 @@ Add scannable requirement status icons to the GitHub pull-request merge box and 
 
 ## Progress
 
+PR: #686
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Merge policy contract
@@ -59,4 +61,4 @@ Add scannable requirement status icons to the GitHub pull-request merge box and 
 ### Phase 3: Verification
 
 - [x] 3.1 Run targeted and full validation gates — f22b5472
-- [ ] 3.2 Complete self-review, PR review, and QA handoff
+- [x] 3.2 Complete self-review, PR review, and QA handoff — 2196e90f

--- a/src/server/forge/github.test.ts
+++ b/src/server/forge/github.test.ts
@@ -28,6 +28,7 @@ import {
   ghCheckRunSchema,
   ghTimelineEventSchema,
   mergeThread,
+  mergePreflightAllowed,
   normalizeComments,
   normalizeEvents,
   normalizeReviews,
@@ -156,25 +157,52 @@ describe('normalizeMergeState', () => {
     expect(state.methods).toEqual(['squash', 'rebase']);
     expect(state.defaultMethod).toBe('squash');
     expect(state.canMerge).toBe(true);
+    expect(state.canOverride).toBe(false);
     expect(state.checks[0]).toMatchObject({ name: 'test', state: 'passing', required: true });
   });
 
   it('never presents unknown rules or a changed review decision as ready', () => {
-    expect(normalizeMergeState({ ...ready, mergeStateStatus: 'UNKNOWN' }, {
+    const unknown = normalizeMergeState({ ...ready, mergeStateStatus: 'UNKNOWN' }, {
       allow_merge_commit: true,
       allow_squash_merge: true,
       allow_rebase_merge: true,
-    }, { readable: true, requiredChecks: [] }).eligibility).toBe('unknown');
-    expect(normalizeMergeState({ ...ready, reviewDecision: 'CHANGES_REQUESTED' }, {
+    }, { readable: true, requiredChecks: [] });
+    expect(unknown.eligibility).toBe('unknown');
+    expect(unknown.canOverride).toBe(true);
+    const changesRequested = normalizeMergeState({ ...ready, reviewDecision: 'CHANGES_REQUESTED' }, {
       allow_merge_commit: true,
       allow_squash_merge: true,
       allow_rebase_merge: true,
-    }, { readable: true, requiredChecks: [] }).eligibility).toBe('blocked');
+    }, { readable: true, requiredChecks: [] });
+    expect(changesRequested.eligibility).toBe('blocked');
+    expect(changesRequested.canOverride).toBe(true);
     expect(normalizeMergeState(ready, {
       allow_merge_commit: true,
       allow_squash_merge: true,
       allow_rebase_merge: true,
     }).eligibility).toBe('unknown');
+  });
+
+  it('never makes terminal, draft, or conflicting pull requests overridable', () => {
+    const policy = {
+      allow_merge_commit: true,
+      allow_squash_merge: true,
+      allow_rebase_merge: true,
+    };
+    expect(normalizeMergeState({ ...ready, state: 'CLOSED' }, policy).canOverride).toBe(false);
+    expect(normalizeMergeState({ ...ready, isDraft: true }, policy).canOverride).toBe(false);
+    expect(normalizeMergeState({ ...ready, mergeable: 'CONFLICTING' }, policy).canOverride).toBe(false);
+  });
+
+  it('requires explicit override intent before attempting an overridable merge', () => {
+    const state = normalizeMergeState({ ...ready, reviewDecision: 'REVIEW_REQUIRED' }, {
+      allow_merge_commit: true,
+      allow_squash_merge: true,
+      allow_rebase_merge: true,
+    }, { readable: true, requiredChecks: [] });
+    expect(mergePreflightAllowed(state)).toBe(false);
+    expect(mergePreflightAllowed(state, true)).toBe(true);
+    expect(mergePreflightAllowed({ ...state, canOverride: false }, true)).toBe(false);
   });
 });
 

--- a/src/server/forge/github.ts
+++ b/src/server/forge/github.ts
@@ -1665,6 +1665,13 @@ export function normalizeMergeState(
     eligibility = 'unknown';
     blockers.push({ code: 'unknown', message: 'GitHub could not confirm every merge requirement.' });
   }
+  const canMerge = eligibility === 'ready';
+  const canOverride =
+    !canMerge &&
+    state === 'open' &&
+    !pr.isDraft &&
+    mergeable !== 'conflicting' &&
+    methods.length > 0;
   return {
     number: pr.number,
     title: pr.title,
@@ -1681,7 +1688,8 @@ export function normalizeMergeState(
     defaultMethod,
     eligibility,
     blockers,
-    canMerge: eligibility === 'ready',
+    canMerge,
+    canOverride,
   };
 }
 
@@ -1775,7 +1783,7 @@ async function mergePullRequest(
     if (!current.methods.includes(input.method)) {
       return { merged: false, status: 409, error: 'That merge method is no longer enabled.', code: 'disabled-method', current };
     }
-    if (!current.canMerge) {
+    if (!mergePreflightAllowed(current, input.overrideRules)) {
       return { merged: false, status: 409, error: current.blockers[0]?.message ?? 'The pull request is not eligible to merge.', code: current.eligibility, current };
     }
     if (process.env.CEZ_DRY_RUN === '1') {
@@ -1798,6 +1806,10 @@ async function mergePullRequest(
   } finally {
     mergeInflight.delete(key);
   }
+}
+
+export function mergePreflightAllowed(current: ForgePrMergeState, overrideRules = false): boolean {
+  return current.canMerge || (overrideRules && current.canOverride);
 }
 
 /** owner/repo parsed out of the origin remote — feeds `viewUrl`. */

--- a/src/server/forge/types.ts
+++ b/src/server/forge/types.ts
@@ -169,6 +169,7 @@ export interface ForgePrMergeState {
   eligibility: 'ready' | 'blocked' | 'pending' | 'unauthorized' | 'terminal' | 'unknown';
   blockers: Array<{ code: string; message: string }>;
   canMerge: boolean;
+  canOverride: boolean;
 }
 
 export type ForgePrMergeStateResult =
@@ -178,6 +179,7 @@ export type ForgePrMergeStateResult =
 export interface ForgeMergeInput {
   method: ForgeMergeMethod;
   expectedHeadSha: string;
+  overrideRules?: boolean;
 }
 
 export type ForgeMergeResult =

--- a/src/server/github-merge-api.test.ts
+++ b/src/server/github-merge-api.test.ts
@@ -46,9 +46,9 @@ describe('the GitHub merge API', () => {
     expect(stateResponse.status).toBe(200);
     const state = (await stateResponse.json()) as {
       available: true;
-      mergeState: { canMerge: boolean; headSha: string; methods: string[] };
+      mergeState: { canMerge: boolean; canOverride: boolean; headSha: string; methods: string[] };
     };
-    expect(state.mergeState).toMatchObject({ canMerge: true, methods: ['squash', 'merge', 'rebase'] });
+    expect(state.mergeState).toMatchObject({ canMerge: true, canOverride: false, methods: ['squash', 'merge', 'rebase'] });
 
     const mergeResponse = await apiRequest(app, '/api/github/prs/128/merge', {
       method: 'POST',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3355,6 +3355,7 @@ export function createApp(deps: ServerDeps): Hono {
   const mergeBodySchema = z.object({
     method: z.enum(['merge', 'squash', 'rebase']),
     expectedHeadSha: z.string().regex(/^[0-9a-f]{40}$/),
+    overrideRules: z.boolean().optional().default(false),
   }).strict();
 
   api.get('/github/prs/:number/merge-state', async (c) => {

--- a/web/app/src/api/client.ts
+++ b/web/app/src/api/client.ts
@@ -410,7 +410,7 @@ export function getGithubPrMergeState(
 
 export function mergeGithubPr(
   number: number,
-  input: { method: GithubMergeMethod; expectedHeadSha: string },
+  input: { method: GithubMergeMethod; expectedHeadSha: string; overrideRules?: boolean },
 ): Promise<GithubMergeResponse> {
   return mutate<GithubMergeResponse>('POST', `/api/github/prs/${number}/merge`, input)
 }

--- a/web/app/src/api/types.ts
+++ b/web/app/src/api/types.ts
@@ -795,6 +795,7 @@ export interface GithubPrMergeState {
   eligibility: 'ready' | 'blocked' | 'pending' | 'unauthorized' | 'terminal' | 'unknown'
   blockers: Array<{ code: string; message: string }>
   canMerge: boolean
+  canOverride: boolean
 }
 
 export type GithubPrMergeStateResponse =

--- a/web/app/src/routes/github/github.test.tsx
+++ b/web/app/src/routes/github/github.test.tsx
@@ -561,6 +561,7 @@ describe('the GitHub detail pane', () => {
           eligibility: 'ready',
           blockers: [],
           canMerge: true,
+          canOverride: false,
         },
       }),
       'GET /api/github/prs/137/merge-state?refresh=1': () => jsonResponse({
@@ -582,6 +583,7 @@ describe('the GitHub detail pane', () => {
           eligibility: 'ready',
           blockers: [],
           canMerge: true,
+          canOverride: false,
         },
       }),
       'POST /api/github/prs/137/merge': () => jsonResponse({
@@ -594,6 +596,7 @@ describe('the GitHub detail pane', () => {
     renderAt('/github/prs/137')
 
     await waitFor(() => expect(document.querySelector('[data-slot="gh-merge-box"]')?.textContent).toContain('Ready to merge'))
+    expect(document.querySelectorAll('[data-slot="gh-merge-status-passing"]')).toHaveLength(3)
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
     await waitFor(() => expect(sent.some((request) => request.path.endsWith('merge-state?refresh=1'))).toBe(true))
     fireEvent.click(screen.getByRole('button', { name: 'Squash and merge' }))
@@ -603,6 +606,54 @@ describe('the GitHub detail pane', () => {
     await waitFor(() => expect(sent.find((request) => request.method === 'POST')?.body).toEqual({
       method: 'squash',
       expectedHeadSha: '0123456789abcdef0123456789abcdef01234567',
+    }))
+  })
+
+  it('allows an explicit rules override while warning that GitHub still authorizes it', async () => {
+    const sent = stubFetch({
+      'GET /api/github/prs/137/merge-state': () => jsonResponse({
+        available: true,
+        mergeState: {
+          number: 137,
+          title: PR_137.title,
+          url: PR_137.url,
+          state: 'open',
+          isDraft: false,
+          headRef: 'feat/sse',
+          baseRef: 'main',
+          headSha: '0123456789abcdef0123456789abcdef01234567',
+          mergeable: 'mergeable',
+          reviewDecision: 'review-required',
+          checks: [{ name: 'test', state: 'pending', required: true }],
+          methods: ['squash'],
+          defaultMethod: 'squash',
+          eligibility: 'blocked',
+          blockers: [{ code: 'reviews', message: 'A required review is missing.' }],
+          canMerge: false,
+          canOverride: true,
+        },
+      }),
+      'POST /api/github/prs/137/merge': () => jsonResponse({
+        merged: true,
+        number: 137,
+        url: PR_137.url,
+        method: 'squash',
+      }),
+    })
+    renderAt('/github/prs/137')
+
+    const override = await screen.findByRole('checkbox', { name: /Merge without waiting for requirements/ })
+    expect(screen.getByRole('button', { name: 'Squash and merge' }).hasAttribute('disabled')).toBe(true)
+    expect(document.querySelectorAll('[data-slot="gh-merge-status-failing"]')).toHaveLength(1)
+    expect(document.querySelectorAll('[data-slot="gh-merge-status-pending"]')).toHaveLength(1)
+    fireEvent.click(override)
+    fireEvent.click(screen.getByRole('button', { name: 'Squash and merge' }))
+    expect(await screen.findByText(/asking GitHub to bypass unmet repository requirements/)).toBeTruthy()
+    fireEvent.click(within(document.querySelector('[data-slot="gh-merge-confirm"]')!).getByRole('button', { name: 'Squash and merge' }))
+    await waitFor(() => expect(sent.find((request) => request.method === 'POST')?.body).toEqual({
+      method: 'squash',
+      expectedHeadSha: '0123456789abcdef0123456789abcdef01234567',
+      overrideRules: true,
     }))
   })
 })

--- a/web/app/src/routes/github/github.tsx
+++ b/web/app/src/routes/github/github.tsx
@@ -1,13 +1,17 @@
 import { hashKey, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   ArrowLeftIcon,
+  CircleCheckIcon,
   CheckIcon,
+  CircleIcon,
   CircleDotIcon,
+  CircleXIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   ExternalLinkIcon,
   GitPullRequestIcon,
   MessageSquareIcon,
+  LoaderCircleIcon,
   RefreshCwIcon,
   SearchIcon,
   TagIcon,
@@ -734,6 +738,16 @@ const mergeLabels: Record<GithubMergeMethod, string> = {
   rebase: 'Rebase and merge',
 }
 
+type MergeRequirementState = 'passing' | 'failing' | 'pending' | 'unknown'
+
+function MergeRequirementIcon({ state }: { state: MergeRequirementState }) {
+  const iconClass = 'size-4 shrink-0'
+  if (state === 'passing') return <CircleCheckIcon aria-hidden="true" data-slot="gh-merge-status-passing" className={cn(iconClass, 'text-success')} />
+  if (state === 'failing') return <CircleXIcon aria-hidden="true" data-slot="gh-merge-status-failing" className={cn(iconClass, 'text-danger')} />
+  if (state === 'pending') return <LoaderCircleIcon aria-hidden="true" data-slot="gh-merge-status-pending" className={cn(iconClass, 'animate-spin text-warning')} />
+  return <CircleIcon aria-hidden="true" data-slot="gh-merge-status-unknown" className={cn(iconClass, 'text-soft-foreground')} />
+}
+
 function GithubMergeBox({ number }: { number: number }) {
   const queryClient = useQueryClient()
   const mergeState = useQuery({
@@ -744,6 +758,7 @@ function GithubMergeBox({ number }: { number: number }) {
   const state = mergeState.data?.available ? mergeState.data.mergeState : null
   const [method, setMethod] = useState<GithubMergeMethod | null>(null)
   const [confirming, setConfirming] = useState(false)
+  const [overrideRules, setOverrideRules] = useState(false)
   const refreshMergeState = useMutation({
     mutationFn: () => getGithubPrMergeState(number, { refresh: true }),
     onSuccess: (data) => queryClient.setQueryData(queryKeys.githubMergeState(number), data),
@@ -755,7 +770,11 @@ function GithubMergeBox({ number }: { number: number }) {
   const merge = useMutation({
     mutationFn: () => {
       if (!state || !selectedMethod) throw new Error('No merge method is available.')
-      return mergeGithubPr(number, { method: selectedMethod, expectedHeadSha: state.headSha })
+      return mergeGithubPr(number, {
+        method: selectedMethod,
+        expectedHeadSha: state.headSha,
+        ...(overrideRules && state.canOverride ? { overrideRules: true } : {}),
+      })
     },
     onSuccess: () => {
       setConfirming(false)
@@ -792,6 +811,15 @@ function GithubMergeBox({ number }: { number: number }) {
           : state.mergeable === 'conflicting' ? 'Conflicts must be resolved'
             : state.canMerge ? 'Ready to merge'
               : 'Merge blocked'
+  const reviewState: MergeRequirementState =
+    state.reviewDecision === 'approved' ? 'passing'
+      : state.reviewDecision === 'unknown' ? 'unknown'
+        : 'failing'
+  const conflictState: MergeRequirementState =
+    state.mergeable === 'mergeable' ? 'passing'
+      : state.mergeable === 'conflicting' ? 'failing'
+        : 'unknown'
+  const mergeEnabled = Boolean(selectedMethod && (state.canMerge || (state.canOverride && overrideRules)))
 
   return (
     <section data-slot="gh-merge-box" aria-live="polite" className="mt-6 rounded-lg border border-border bg-card p-4">
@@ -819,16 +847,39 @@ function GithubMergeBox({ number }: { number: number }) {
             {state.headRef} ({state.headSha.slice(0, 7)}) → {state.baseRef}
           </p>
           <ul className="mt-3 space-y-2 text-xs">
-            <li>Reviews: {state.reviewDecision.replaceAll('-', ' ')}</li>
-            <li>Conflicts: {state.mergeable === 'conflicting' ? 'present' : state.mergeable === 'mergeable' ? 'none' : 'unknown'}</li>
+            <li className="flex items-center gap-2">
+              <MergeRequirementIcon state={reviewState} />
+              <span>Reviews: {state.reviewDecision.replaceAll('-', ' ')}</span>
+            </li>
+            <li className="flex items-center gap-2">
+              <MergeRequirementIcon state={conflictState} />
+              <span>Conflicts: {state.mergeable === 'conflicting' ? 'present' : state.mergeable === 'mergeable' ? 'none' : 'unknown'}</span>
+            </li>
             {state.checks.length === 0 ? <li>No checks configured</li> : state.checks.map((check) => (
               <li key={check.name} className="flex items-center justify-between gap-3">
-                <span>{check.name} · {check.state}{check.required === true ? ' · required' : check.required === null ? ' · requiredness unknown' : ''}</span>
+                <span className="flex min-w-0 items-center gap-2">
+                  <MergeRequirementIcon state={check.state} />
+                  <span>{check.name} · {check.state}{check.required === true ? ' · required' : check.required === null ? ' · requiredness unknown' : ''}</span>
+                </span>
                 {check.url && isHttpUrl(check.url) ? <a href={check.url} target="_blank" rel="noopener noreferrer" className="text-muted-foreground underline">details</a> : null}
               </li>
             ))}
             {state.blockers.map((blocker) => <li key={blocker.code} className="text-soft-foreground">{blocker.message}</li>)}
           </ul>
+          {state.canOverride ? (
+            <label className="mt-4 flex cursor-pointer items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-xs">
+              <input
+                type="checkbox"
+                checked={overrideRules}
+                onChange={(event) => setOverrideRules(event.target.checked)}
+                className="mt-0.5 size-4 accent-primary"
+              />
+              <span>
+                <span className="block font-medium">Merge without waiting for requirements</span>
+                <span className="mt-0.5 block text-soft-foreground">GitHub will allow this only if your permissions can bypass the repository rules.</span>
+              </span>
+            </label>
+          ) : null}
           {state.state === 'open' && state.methods.length > 0 ? (
             <div className="mt-4 flex flex-col gap-2 sm:flex-row">
               <select
@@ -839,7 +890,7 @@ function GithubMergeBox({ number }: { number: number }) {
               >
                 {state.methods.map((candidate) => <option key={candidate} value={candidate}>{mergeLabels[candidate]}</option>)}
               </select>
-              <Button disabled={!state.canMerge || !selectedMethod} onClick={() => setConfirming(true)}>
+              <Button disabled={!mergeEnabled} onClick={() => setConfirming(true)}>
                 {selectedMethod ? mergeLabels[selectedMethod] : 'Merge'}
               </Button>
             </div>
@@ -852,6 +903,7 @@ function GithubMergeBox({ number }: { number: number }) {
             <DialogTitle>{selectedMethod ? mergeLabels[selectedMethod] : 'Merge'} pull request #{number}?</DialogTitle>
             <DialogDescription>
               This will merge “{state.title}” into {state.baseRef}. GitHub will re-check the exact reviewed head before changing the repository.
+              {overrideRules && state.canOverride ? ' You are asking GitHub to bypass unmet repository requirements; GitHub may refuse if your permissions do not allow it.' : ''}
             </DialogDescription>
           </DialogHeader>
           {merge.error ? <p className="text-sm text-danger">{merge.error.message}</p> : null}


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-26-github-pr-merge-controls.md
Status: complete

## Goal
- Make GitHub PR merge requirements visually scannable and let authorized users explicitly ask GitHub to merge without waiting for bypassable repository rules.

## What Changed
- Added status icons for reviews, conflicts, and individual checks in the PR merge box.
- Added an explicit “Merge without waiting for requirements” control with strengthened confirmation copy.
- Added an additive `canOverride` merge-state field and optional `overrideRules` mutation input.
- Preserved hard server-side gates for stale heads, disabled methods, terminal/draft PRs, and known conflicts; GitHub remains the final authorization boundary.

## Tests
- `npm run typecheck`
- `npm test` — 252 files / 4,584 tests passed
- `npm run test:unit` — 36 tests passed
- `npm run build` — passed, including package-content gate
- `npm run test:package` — 8 tests passed
- Focused merge suite — 202 tests passed
- Scoped GitHub browser QA — 5/7 passed, including merge-state and confirmation flows. Two unrelated scenarios failed on a missing handoff workflow fixture followed by a transient socket error; the app remained healthy.

## Breaking Changes
- None. HTTP response/input additions are additive, and the new mutation field is optional with a false default.

## Progress
See the Progress section in the tracking plan.
