### PR TITLE
fix(codex): group subagent activity in cockpit (#598)

### DIFF
--- a/src/core/__fixtures__/codex/mock-codex-app-server.mjs
+++ b/src/core/__fixtures__/codex/mock-codex-app-server.mjs
@@ -47,6 +47,14 @@ rl.on('line', (line) => {
     emit({ id: msg.id, result: { turn: { id: 'turn_mock_1' } } });
     emit({ method: 'turn/started', params: { turn: { id: 'turn_mock_1', status: 'inProgress', items: [] } } });
     const turnText = msg.params?.input?.map?.((part) => part.text ?? '').join('\n') ?? '';
+    if (turnText.includes('mock:subagent-activity')) {
+      emit({ method: 'item/started', params: { item: { type: 'subAgentActivity', id: 'activity_1', kind: 'started', agentThreadId: 'th_child', agentPath: '/root/scope_review' } } });
+      emit({ method: 'item/completed', params: { item: { type: 'subAgentActivity', id: 'activity_1', kind: 'started', agentThreadId: 'th_child', agentPath: '/root/scope_review' } } });
+      emit({ method: 'item/started', params: { item: { type: 'collabAgentToolCall', id: 'wait_1', tool: 'wait', status: 'inProgress', receiverThreadIds: [] } } });
+      emit({ method: 'item/completed', params: { item: { type: 'collabAgentToolCall', id: 'wait_1', tool: 'wait', status: 'completed', receiverThreadIds: [] } } });
+      emit({ method: 'turn/completed', params: { turn: { id: 'turn_mock_1', status: 'completed' } } });
+      return;
+    }
     if (process.env.MOCK_CODEX_ASK === '1' || turnText.includes('mock:native-codex-ask')) {
       const questions = turnText.includes('multi free text')
         ? [{ id: 'first', header: 'First', question: 'First choice?', isOther: true, isSecret: false,

--- a/src/core/__fixtures__/codex/sub-agent-activity.expected.json
+++ b/src/core/__fixtures__/codex/sub-agent-activity.expected.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "turn.started",
+    "turnId": "turn_activity"
+  },
+  {
+    "type": "item.started",
+    "item": {
+      "kind": "tool",
+      "id": "activity_started",
+      "name": "spawnAgent",
+      "toolKind": "task",
+      "title": "Task: scope review",
+      "status": "running",
+      "input": {
+        "agentPath": "/root/scope_review",
+        "agentThreadId": "th_child"
+      }
+    }
+  }
+]

--- a/src/core/__fixtures__/codex/sub-agent-activity.ndjson
+++ b/src/core/__fixtures__/codex/sub-agent-activity.ndjson
@@ -1,0 +1,4 @@
+{"method":"turn/started","params":{"threadId":"th_parent","turn":{"id":"turn_activity","status":"inProgress","items":[]}}}
+{"method":"item/completed","params":{"threadId":"th_parent","turnId":"turn_activity","item":{"type":"subAgentActivity","id":"activity_started","kind":"started","agentThreadId":"th_child","agentPath":"/root/scope_review"}}}
+{"method":"item/completed","params":{"threadId":"th_parent","turnId":"turn_activity","item":{"type":"subAgentActivity","id":"activity_interacted","kind":"interacted","agentThreadId":"th_parent","agentPath":"/root"}}}
+{"method":"item/completed","params":{"threadId":"th_parent","turnId":"turn_activity","item":{"type":"collabAgentToolCall","id":"wait_empty","tool":"wait","status":"completed","receiverThreadIds":[],"agentsStates":{}}}}

--- a/src/core/codex-ui-mapper.test.ts
+++ b/src/core/codex-ui-mapper.test.ts
@@ -68,6 +68,7 @@ const GOLDEN_FIXTURES = [
   // Codex 0.144.6 generated schema, plus the current upstream spelling.
   'collab-agent-tool-call',
   'collab-tool-call',
+  'sub-agent-activity',
 ] as const;
 
 describe('codex → v2 golden fixtures', () => {
@@ -743,6 +744,22 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
     });
     expect(v2).toContainEqual({ type: 'usage.updated', usage: { input: 1200, output: 300, total: 1500 } });
     expect(v2).toContainEqual({ type: 'turn.completed', turnId: 'turn_mock_1', stopReason: 'end_turn' });
+  }, 30_000);
+
+  it('normalizes collaboration telemetry while preserving the legacy stream', async () => {
+    const runner = new CodexAppServerRunner({ bin: mockBin, timeoutMs: 60_000 });
+    const v1: AgentEvent[] = [];
+    const v2: UiEvent[] = [];
+    const session = runner.startSession(
+      { userPrompt: 'mock:subagent-activity', cwd: process.cwd() },
+      (event) => v1.push(event),
+      { autoEndAfterFirstTurn: true, onUiEvent: (event) => v2.push(event) },
+    );
+    await session.result;
+    const tools = v1.flatMap((event) => event.type === 'tool-call' ? [event.tool] : []);
+    expect(tools).toContain('subAgentActivity');
+    expect(tools).toContain('collabAgentToolCall');
+    expect(v2.filter((event) => event.type === 'item.started' && event.item.kind === 'tool' && event.item.toolKind === 'task')).toHaveLength(1);
   }, 30_000);
 
   it('keeps autonomous full-access permissions when resuming a thread', async () => {

--- a/src/core/codex-ui-mapper.ts
+++ b/src/core/codex-ui-mapper.ts
@@ -346,6 +346,11 @@ function mapItemLifecycle(
     return mapReviewMode(raw, id, type, eventType, state);
   }
 
+  // Internal collaboration telemetry is not a user tool. Codex emits one
+  // `subAgentActivity(kind: started)` when it creates a child thread, followed
+  // by `interacted` bookkeeping as control returns between threads.
+  if (type === 'subAgentActivity') return mapSubAgentActivity(raw, id, state);
+
   const item =
     type === 'agentMessage'
       ? messageItem(raw, id)
@@ -374,6 +379,31 @@ function mapItemLifecycle(
   }
   if (state.knownItems.has(id)) return { events, state };
   return { events, state: { ...state, knownItems: new Set(state.knownItems).add(id) } };
+}
+
+function mapSubAgentActivity(
+  raw: Record<string, unknown>,
+  id: string,
+  state: CodexUiMapperState,
+): CodexUiMapping {
+  if (str(raw.kind) !== 'started' || state.knownItems.has(id)) return { events: [], state };
+  const agentPath = str(raw.agentPath);
+  const agentName = agentPath?.split('/').filter(Boolean).at(-1)?.replaceAll('_', ' ');
+  const agentThreadId = str(raw.agentThreadId);
+  const display = toolDisplay('Task', agentName ? { description: agentName } : undefined);
+  const task: CodexCollabTask = { itemId: id, ...(agentName ? { prompt: agentName } : {}) };
+  const collabTasks = new Map(state.collabTasks);
+  if (agentThreadId) collabTasks.set(agentThreadId, task);
+  return {
+    events: [{
+      type: 'item.started',
+      item: {
+        kind: 'tool', id, name: 'spawnAgent', toolKind: 'task', title: display.title, status: 'running',
+        input: { ...(agentPath ? { agentPath } : {}), ...(agentThreadId ? { agentThreadId } : {}) },
+      },
+    }],
+    state: { ...state, knownItems: new Set(state.knownItems).add(id), collabTasks },
+  };
 }
 
 /** A spawn creates one task row; later send/wait/resume/close calls update the

--- a/web/app/src/routes/task-thread/thread-state.test.ts
+++ b/web/app/src/routes/task-thread/thread-state.test.ts
@@ -132,6 +132,15 @@ describe('reduceThread — item ids across workflow steps', () => {
 })
 
 describe('reduceThread — v1-only fallback (pre-v2 transcripts)', () => {
+  it('hides Codex collaboration bookkeeping that protocol v2 renders as grouped agents', () => {
+    const { turns } = reduceThread([
+      line(1, 'tool-call', { id: 'activity', tool: 'subAgentActivity', input: { kind: 'started' } }),
+      line(2, 'tool-call', { id: 'wait', tool: 'collabAgentToolCall', input: { tool: 'wait' } }),
+      line(3, 'tool-call', { id: 'wait-new', tool: 'collabToolCall', input: { tool: 'wait' } }),
+    ])
+    expect(turns.flatMap((turn) => turn.items)).toEqual([])
+  })
+
   // Verbatim shapes from a real pre-R2 transcript (.ai/cezar/runs/2d012907….ndjson), trimmed.
   const v1Only: RunEvent[] = [
     line(1, 'lifecycle', { message: 'run started — workflow "quick-task" (runner: claude)' }),

--- a/web/app/src/routes/task-thread/thread-state.ts
+++ b/web/app/src/routes/task-thread/thread-state.ts
@@ -467,6 +467,10 @@ export function reduceThread(events: RunEvent[]): ThreadState {
         const turn = currentTurn()
         if (turn.v2Items) break
         const name = str(event.tool) ?? 'Tool'
+        // Codex collaboration bookkeeping has no user-facing meaning. Protocol
+        // v2 normalizes it into task rows and parented child tools; old/mixed
+        // recordings can still carry a receiver-less v1 wait in a child turn.
+        if (CODEX_COLLAB_BOOKKEEPING.has(name)) break
         const display = toolDisplay(name, event.input)
         if (display.toolKind === 'plan') {
           // v1-only fallback: the dock's data lives in the TodoWrite input on old transcripts.
@@ -681,3 +685,5 @@ export function reduceThread(events: RunEvent[]): ThreadState {
     ...(sessionEnded !== undefined ? { sessionEnded } : {}),
   }
 }
+
+const CODEX_COLLAB_BOOKKEEPING = new Set(['subAgentActivity', 'collabAgentToolCall', 'collabToolCall'])


### PR DESCRIPTION
Fixes #598

## Problem
Codex collaboration activity appeared as raw subAgentActivity and collabAgentToolCall cards, while spawned Codex agents did not populate the grouped Agents pane.

## Root Cause
Codex 0.144.6 emits subAgentActivity lifecycle records in addition to collaboration tool calls. The protocol-v2 mapper treated those records as unknown generic tools, and receiver-less legacy collaboration waits could render in a v1-only child turn.

## What Changed
- Normalize subAgentActivity started records into task items associated with their child thread, so child tools nest under the grouped agent.
- Ignore only Codex collaboration bookkeeping in the cockpit v1 fallback while preserving the protected v1 event stream.
- Add wire-faithful golden fixtures and focused mapper, runner-wiring, and reducer regressions.

## Tests
- npm run typecheck
- npm test (252 files, 4,584 tests)
- npm run test:unit (36 tests)
- npm run build
- npm run test:package (8 tests)

## Breaking Changes
None. Existing v1 and v2 event discriminators and persisted NDJSON remain compatible.

🤖 Generated by autofix.