### PR TITLE
fix(web): eliminate oversized chunk warning

### DIFF
--- a/.ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
+++ b/.ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
@@ -39,8 +39,8 @@ Remove the production build's oversized-chunk warning by splitting the stable Re
 
 ### Phase 1: Configure focused runtime splitting
 
-- [ ] 1.1 Add a named React-runtime code-splitting group to the cockpit Vite configuration.
-- [ ] 1.2 Add a regression test that locks in the focused group and default warning threshold.
+- [x] 1.1 Add a named React-runtime code-splitting group to the cockpit Vite configuration. — ba7024ff
+- [x] 1.2 Add a regression test that locks in the focused group and default warning threshold. — ba7024ff
 
 ### Phase 2: Verify the shipped build
 

--- a/.ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
+++ b/.ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
@@ -1,0 +1,48 @@
+# Eliminate the Vite chunk-size warning
+
+## Goal
+
+Remove the production build's oversized-chunk warning by splitting the stable React runtime out of the cockpit entry bundle without hiding the warning or changing application behavior.
+
+## Scope
+
+- Configure Vite 8's Rolldown code splitting for the React runtime dependencies.
+- Add a unit-level contract test for the chunking configuration.
+- Verify the production build emits no chunk-size warning and preserves the existing package checks.
+
+## Non-goals
+
+- Do not raise or disable Vite's chunk-size warning threshold.
+- Do not redesign route boundaries or alter cockpit navigation behavior.
+- Do not broadly repartition every third-party dependency.
+
+## Implementation Plan
+
+### Phase 1: Configure focused runtime splitting
+
+1. Add a named React-runtime code-splitting group to the cockpit Vite configuration.
+2. Add a regression test that locks in the focused group and default warning threshold.
+
+### Phase 2: Verify the shipped build
+
+1. Confirm the production bundle stays below Vite's warning threshold and run the full configured validation gate.
+2. Review the final diff and document the verified outcome for reviewers.
+
+## Risks
+
+- Manual splitting can affect module execution order; keep the group limited to React's tightly coupled runtime packages and verify through the full unit, build, and packaged-CLI gates.
+- Bundle sizes can drift as dependencies change; retaining Vite's default warning threshold ensures future growth remains visible.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Configure focused runtime splitting
+
+- [ ] 1.1 Add a named React-runtime code-splitting group to the cockpit Vite configuration.
+- [ ] 1.2 Add a regression test that locks in the focused group and default warning threshold.
+
+### Phase 2: Verify the shipped build
+
+- [ ] 2.1 Confirm the production bundle stays below Vite's warning threshold and run the full configured validation gate.
+- [ ] 2.2 Review the final diff and document the verified outcome for reviewers.

--- a/.ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
+++ b/.ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
@@ -35,6 +35,8 @@ Remove the production build's oversized-chunk warning by splitting the stable Re
 
 ## Progress
 
+PR: #692
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Configure focused runtime splitting
@@ -44,5 +46,5 @@ Remove the production build's oversized-chunk warning by splitting the stable Re
 
 ### Phase 2: Verify the shipped build
 
-- [ ] 2.1 Confirm the production bundle stays below Vite's warning threshold and run the full configured validation gate.
-- [ ] 2.2 Review the final diff and document the verified outcome for reviewers.
+- [x] 2.1 Confirm the production bundle stays below Vite's warning threshold and run the full configured validation gate. — ba7024ff
+- [x] 2.2 Review the final diff and document the verified outcome for reviewers. — ba7024ff

--- a/web/app/src/vite-config.test.ts
+++ b/web/app/src/vite-config.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import config, { reactRuntimeChunk } from '../vite.config'
+
+describe('production chunking', () => {
+  it('keeps the coupled React runtime in a focused vendor chunk', () => {
+    expect(reactRuntimeChunk.name).toBe('react-runtime')
+    expect(reactRuntimeChunk.test.test('/repo/node_modules/react/index.js')).toBe(true)
+    expect(reactRuntimeChunk.test.test('/repo/node_modules/react-dom/client.js')).toBe(true)
+    expect(reactRuntimeChunk.test.test('/repo/node_modules/scheduler/index.js')).toBe(true)
+
+    expect(reactRuntimeChunk.test.test('/repo/node_modules/react-router/index.js')).toBe(false)
+    expect(reactRuntimeChunk.test.test('/repo/node_modules/@tanstack/react-query/index.js')).toBe(
+      false,
+    )
+    expect(reactRuntimeChunk.test.test('/repo/web/app/src/routes.tsx')).toBe(false)
+  })
+
+  it('retains Vite default chunk-size warnings', () => {
+    expect(config.build?.chunkSizeWarningLimit).toBeUndefined()
+    expect(config.build?.rolldownOptions?.output).toMatchObject({
+      codeSplitting: { groups: [reactRuntimeChunk] },
+    })
+  })
+})

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -13,6 +13,15 @@ const webDir = resolve(appDir, '..')
 // can never end up behind the proxy. Standalone `npm run dev:web` keeps the 4321 default.
 const API_TARGET = `http://127.0.0.1:${process.env.CEZ_API_PORT ?? 4321}`
 
+// React DOM is large enough to push the otherwise route-split entry chunk over Vite's 500 kB
+// warning threshold. Keep the tightly coupled React runtime in one stable, cacheable chunk
+// rather than silencing the warning: future growth in either the app or vendor chunk stays
+// visible. Module ids from Vite/Rolldown use forward slashes on every platform.
+export const reactRuntimeChunk = {
+  name: 'react-runtime',
+  test: /node_modules\/(?:react(?:-dom)?|scheduler)\//,
+}
+
 export default defineConfig({
   root: appDir,
   base: '/',
@@ -26,6 +35,13 @@ export default defineConfig({
     // The built cockpit lives in web/dist (the legacy UI files were removed in R7).
     outDir: resolve(webDir, 'dist'),
     emptyOutDir: true,
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [reactRuntimeChunk],
+        },
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-26-eliminate-vite-chunk-warning.md
Status: complete

## 🎯 Goal
- Remove the production build's oversized-chunk warning by splitting the stable React runtime out of the cockpit entry bundle without hiding Vite's warning threshold.

## What Changed
- Added a focused Vite 8/Rolldown code-splitting group for React, React DOM, and Scheduler.
- Kept Vite's default 500 kB warning threshold intact so future bundle growth remains visible.
- Added regression coverage for the group boundary and warning-limit contract.

## 🧪 Tests
- `npm run typecheck` — passed.
- `npm test` — 4,597 tests passed across 254 files.
- `npm run test:unit` — 36 tests passed.
- `npm run build` — passed; entry reduced from 504.24 kB to 325.75 kB with no oversized-chunk warning.
- `npm run test:package` — 8 tests passed.
- `web/app/src/vite-config.test.ts` verifies the focused runtime group and unchanged warning threshold.

## 💥 Breaking Changes
- None.

## 📋 Progress
See the Progress section in the tracking plan.