### PR TITLE
fix(runners): stop reporting cezar's own teardown signal as an agent failure (fixes #703)

### DIFF
--- a/AGENT_PROTOCOL.md
+++ b/AGENT_PROTOCOL.md
@@ -75,6 +75,14 @@ interface AgentSession {
 }
 ```
 
+A termination the runner itself caused is **not** an agent failure (#703).
+`end()` arms a SIGTERM→SIGKILL watchdog for CLIs that ignore EOF, and
+`interrupt()` signals outright; the agent CLIs install their own handlers and
+exit `128 + signal`. A runner MUST therefore record that it sent the signal and
+settle such an exit on the normal path — `isSignalTerminationExit(exitCode)`
+(`packages/cezar/src/core/agent-runner.ts`) plus a `note` — instead of throwing. Throwing makes
+a finished run settle as `failed` and a cancelled run settle as `failed` too.
+
 `SessionOptions`:
 
 - `autoEndAfterFirstTurn?` — single-turn behavior for non-interactive workflow

--- a/packages/cezar/src/core/__fixtures__/claude/stub-ignores-eof-exits-143.mjs
+++ b/packages/cezar/src/core/__fixtures__/claude/stub-ignores-eof-exits-143.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Stub `claude` binary reproducing the teardown shape of #703: it emits one
+// assistant turn, then NEVER exits on its own — it ignores stdin EOF (the
+// janitor-confirmed CLI hang the EOF watchdog exists for) and handles SIGTERM
+// itself, exiting 143 instead of dying from the signal.
+
+process.on('SIGTERM', () => process.exit(143));
+
+process.stdout.write(
+  `${JSON.stringify({
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'text', text: 'work done' }] },
+  })}\n`,
+);
+
+// Keep the event loop alive and stay deaf to EOF, exactly like the real hang.
+process.stdin.resume();
+process.stdin.on('end', () => {});
+setInterval(() => {}, 60_000);

--- a/packages/cezar/src/core/__fixtures__/codex/mock-codex-app-server.mjs
+++ b/packages/cezar/src/core/__fixtures__/codex/mock-codex-app-server.mjs
@@ -4,10 +4,21 @@
 // `codex-ui-mapper.test.ts`: initialize/thread/turn handshake, one scripted
 // turn with an agentMessage + a commandExecution (with live outputDelta),
 // cumulative token usage, then exits on stdin EOF like the real server.
+//
+// `MOCK_CODEX_IGNORE_EOF=1` switches to the #703 teardown shape instead: the
+// server stays deaf to stdin EOF (the CLI hang the EOF watchdog exists for)
+// and handles SIGTERM itself, exiting 143 rather than dying from the signal.
 import { createInterface } from 'node:readline';
 
 const emit = (obj) => process.stdout.write(`${JSON.stringify(obj)}\n`);
 const rl = createInterface({ input: process.stdin });
+
+const ignoreEof = process.env.MOCK_CODEX_IGNORE_EOF === '1';
+if (ignoreEof) {
+  process.on('SIGTERM', () => process.exit(143));
+  // Keep the event loop alive so EOF alone can never end the process.
+  setInterval(() => {}, 60_000);
+}
 
 rl.on('line', (line) => {
   let msg;
@@ -81,4 +92,6 @@ rl.on('line', (line) => {
   }
 });
 
-rl.on('close', () => process.exit(0));
+rl.on('close', () => {
+  if (!ignoreEof) process.exit(0);
+});

--- a/packages/cezar/src/core/agent-runner.ts
+++ b/packages/cezar/src/core/agent-runner.ts
@@ -66,6 +66,20 @@ export function prependSystemPrompt(systemPrompt: string | undefined, userPrompt
   return systemPrompt ? `${systemPrompt}\n\n---\n\n${userPrompt}` : userPrompt;
 }
 
+/**
+ * True for the `128 + signal` exit codes an agent CLI reports when it handles
+ * a stop signal itself instead of dying from it (SIGINT/SIGKILL/SIGTERM).
+ *
+ * Every runner arms a SIGTERM→SIGKILL watchdog on `end()` and signals on
+ * `interrupt()` (#703): the CLIs install their own handlers, so a session the
+ * runner tore down on purpose comes back as a NON-ZERO exit. Paired with a
+ * "we sent the signal" flag, this predicate keeps that teardown out of the
+ * error path — an exit cezar caused is never an agent failure.
+ */
+export function isSignalTerminationExit(exitCode: number | null): boolean {
+  return exitCode === 130 || exitCode === 137 || exitCode === 143;
+}
+
 /** One content block of a user message — mirrors the Anthropic wire format
  *  so it can be written to the claude CLI's stdin verbatim. */
 export type ContentBlock =

--- a/packages/cezar/src/core/claude-cli-runner.test.ts
+++ b/packages/cezar/src/core/claude-cli-runner.test.ts
@@ -1,6 +1,8 @@
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { prependSystemPrompt } from './agent-runner.js';
-import { buildClaudeArgs } from './claude-cli-runner.js';
+import type { AgentEvent } from './agent-runner.js';
+import { isSignalTerminationExit, prependSystemPrompt } from './agent-runner.js';
+import { ClaudeCliRunner, buildClaudeArgs } from './claude-cli-runner.js';
 
 /**
  * The per-backend system-prompt delivery mechanism (spec §protocol v2
@@ -37,6 +39,57 @@ describe('buildClaudeArgs approval gate', () => {
     const idx = args.indexOf('--permission-mode');
     expect(args[idx + 1]).toBe('acceptEdits');
   });
+});
+
+/**
+ * #703 — a session cezar tore down itself must not settle as an agent
+ * failure. Every agent CLI installs its own stop-signal handler and exits
+ * `128 + signal`, so the runner sees a NON-ZERO code for a teardown it
+ * asked for (goal achieved → `end()`, or a user cancel → `interrupt()`).
+ */
+describe('isSignalTerminationExit', () => {
+  it('recognizes the 128+signal codes a signalled CLI reports', () => {
+    expect(isSignalTerminationExit(130)).toBe(true); // SIGINT
+    expect(isSignalTerminationExit(137)).toBe(true); // SIGKILL
+    expect(isSignalTerminationExit(143)).toBe(true); // SIGTERM
+  });
+
+  it('leaves genuine failures and clean exits alone', () => {
+    for (const code of [0, 1, 2, 127, null]) {
+      expect(isSignalTerminationExit(code)).toBe(false);
+    }
+  });
+});
+
+describe('a teardown cezar initiated', () => {
+  const stubBin = fileURLToPath(
+    new URL('./__fixtures__/claude/stub-ignores-eof-exits-143.mjs', import.meta.url),
+  );
+
+  it('settles the session instead of failing it when the CLI exits 143', async () => {
+    const runner = new ClaudeCliRunner({ bin: stubBin, timeoutMs: 0 });
+    const events: AgentEvent[] = [];
+    let sawText: () => void = () => {};
+    const firstText = new Promise<void>((resolve) => {
+      sawText = resolve;
+    });
+    const session = runner.startSession({ userPrompt: 'do it', cwd: process.cwd() }, (event) => {
+      events.push(event);
+      if (event.type === 'text') sawText();
+    });
+    await firstText;
+
+    // The cancel path; the EOF watchdog reaches the same `signalChild`.
+    session.interrupt();
+    const result = await session.result;
+
+    expect(result.text).toBe('work done');
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    expect(events.at(-1)).toEqual({ type: 'done' });
+    expect(
+      events.some((e) => e.type === 'note' && e.message.includes('terminated by cezar (code 143)')),
+    ).toBe(true);
+  }, 15_000);
 });
 
 describe('prependSystemPrompt (codex/opencode delivery)', () => {

--- a/packages/cezar/src/core/claude-cli-runner.ts
+++ b/packages/cezar/src/core/claude-cli-runner.ts
@@ -14,6 +14,7 @@ import type {
 
 // Re-exported for backends and the run manager that still import them from here.
 export type { AgentSession, SessionOptions } from './agent-runner.js';
+import { isSignalTerminationExit } from './agent-runner.js';
 import { buildChildEnv } from './agent-env.js';
 import { costWeightedTokens, type RawUsage } from './usage.js';
 import { readNdjson } from './ndjson.js';
@@ -146,6 +147,16 @@ export class ClaudeCliRunner implements AgentRunner {
       }
     };
 
+    // Set the moment WE signal the child — the EOF watchdog, a cancel, or the
+    // wall-clock kill switch. claude installs its own SIGTERM handler and exits
+    // 143 instead of dying from the signal, so without this flag our own
+    // teardown reads as an agent failure (#703).
+    let terminatedByCezar = false;
+    const signalChild = (signal: 'SIGTERM' | 'SIGKILL'): void => {
+      terminatedByCezar = true;
+      child.kill(signal);
+    };
+
     const end = (): void => {
       if (!stdinOpen) return;
       stdinOpen = false;
@@ -155,9 +166,9 @@ export class ClaudeCliRunner implements AgentRunner {
         // already gone
       }
       eofTermTimer = setTimeout(() => {
-        if (child.exitCode == null && !child.killed) child.kill('SIGTERM');
+        if (child.exitCode == null && !child.killed) signalChild('SIGTERM');
         eofKillTimer = setTimeout(() => {
-          if (child.exitCode == null && !child.killed) child.kill('SIGKILL');
+          if (child.exitCode == null && !child.killed) signalChild('SIGKILL');
         }, EOF_KILL_GRACE_MS);
         eofKillTimer.unref?.();
       }, EOF_TERM_GRACE_MS);
@@ -166,7 +177,7 @@ export class ClaudeCliRunner implements AgentRunner {
 
     const interrupt = (): void => {
       stdinOpen = false;
-      if (!child.killed) child.kill('SIGTERM');
+      if (!child.killed) signalChild('SIGTERM');
     };
 
     // Seed the first user message — the same path every follow-up takes.
@@ -198,7 +209,7 @@ export class ClaudeCliRunner implements AgentRunner {
         interrupt();
         child.stdout.destroy();
         killTimer = setTimeout(() => {
-          if (child.exitCode == null && !child.killed) child.kill('SIGKILL');
+          if (child.exitCode == null && !child.killed) signalChild('SIGKILL');
         }, KILL_GRACE_MS);
         killTimer.unref?.();
       }, limitMs);
@@ -266,6 +277,18 @@ export class ClaudeCliRunner implements AgentRunner {
       if (timedOut) {
         const mins = Math.round((limitMs / 60_000) * 10) / 10;
         onEvent?.({ type: 'error', message: `claude CLI timed out after ${mins}m and was killed` });
+        onEvent?.({ type: 'done' });
+        return { text, toolCalls, tokensUsed, sessionId: spec.sessionId };
+      }
+
+      // A session cezar itself tore down (EOF watchdog after `end()`, or a
+      // cancel) exits 143/137 — that is our own signal coming back, not an
+      // agent failure, so it settles on the normal path with a note (#703).
+      if (terminatedByCezar && isSignalTerminationExit(exitCode)) {
+        onEvent?.({
+          type: 'note',
+          message: `claude CLI did not exit on its own after close; terminated by cezar (code ${exitCode})`,
+        });
         onEvent?.({ type: 'done' });
         return { text, toolCalls, tokensUsed, sessionId: spec.sessionId };
       }

--- a/packages/cezar/src/core/codex-app-server-runner.test.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { AgentEvent } from './agent-runner.js';
+import { CodexAppServerRunner } from './codex-app-server-runner.js';
+
+/**
+ * #703 backend parity — `claude-cli-runner.test.ts` proves the Claude half;
+ * this is the same session-level shape for Codex. The fix only holds if BOTH
+ * runners classify a cezar-initiated 128+signal exit as a teardown note rather
+ * than an agent failure, so the Codex branch needs its own regression.
+ */
+describe('a teardown cezar initiated (codex app-server)', () => {
+  const mockBin = fileURLToPath(
+    new URL('./__fixtures__/codex/mock-codex-app-server.mjs', import.meta.url),
+  );
+
+  it('settles the session instead of failing it when the app-server exits 143', async () => {
+    const runner = new CodexAppServerRunner({ bin: mockBin, timeoutMs: 0 });
+    const events: AgentEvent[] = [];
+    let sawText: () => void = () => {};
+    const firstText = new Promise<void>((resolve) => {
+      sawText = resolve;
+    });
+    const session = runner.startSession(
+      // MOCK_CODEX_IGNORE_EOF makes the mock stay deaf to stdin EOF and exit
+      // 143 on SIGTERM — the real shape reported in #703.
+      { userPrompt: 'check the working tree', cwd: process.cwd(), env: { MOCK_CODEX_IGNORE_EOF: '1' } },
+      (event) => {
+        events.push(event);
+        if (event.type === 'text') sawText();
+      },
+    );
+    await firstText;
+
+    // The cancel path; the EOF watchdog reaches the same `terminatedByCezar`.
+    session.interrupt();
+    const result = await session.result;
+
+    expect(result.text).toBe('Checking the working tree.');
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    expect(events.at(-1)).toEqual({ type: 'done' });
+    expect(
+      events.some((e) => e.type === 'note' && e.message.includes('terminated by cezar (code 143)')),
+    ).toBe(true);
+  }, 15_000);
+});

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -9,7 +9,7 @@ import type {
   ContentBlock,
   SessionOptions,
 } from './agent-runner.js';
-import { prependSystemPrompt } from './agent-runner.js';
+import { isSignalTerminationExit, prependSystemPrompt } from './agent-runner.js';
 import {
   AUTO_END_DELAY_MS,
   DEFAULT_RUN_TIMEOUT_MS,
@@ -120,6 +120,10 @@ class CodexSession implements AgentSession {
   private eofKillTimer: NodeJS.Timeout | undefined;
   private spawnFailed: Error | null = null;
   private timedOut = false;
+  /** Set the moment WE signal the child (EOF watchdog, cancel, kill switch).
+   *  codex handles the signal and exits 143, so without this the runner reads
+   *  its own teardown as a codex failure (#703). */
+  private terminatedByCezar = false;
   /** Protocol v2 emission — additive alongside v1 (`onEvent` keeps flowing
    *  byte-identical); the channel is `opts.onUiEvent` (RunManager wiring
    *  lands in R2 step 2.1). */
@@ -156,7 +160,10 @@ class CodexSession implements AgentSession {
         this.interrupt();
         this.child.stdout.destroy();
         killTimer = setTimeout(() => {
-          if (this.child.exitCode == null && !this.child.killed) this.child.kill('SIGKILL');
+          if (this.child.exitCode == null && !this.child.killed) {
+            this.terminatedByCezar = true;
+            this.child.kill('SIGKILL');
+          }
         }, KILL_GRACE_MS);
         killTimer.unref?.();
       }, limitMs);
@@ -227,6 +234,17 @@ class CodexSession implements AgentSession {
         return base;
       }
 
+      // Our own EOF watchdog / cancel signal coming back as 143/137 — the
+      // teardown cezar asked for, not a codex failure (#703).
+      if (this.terminatedByCezar && isSignalTerminationExit(exitCode)) {
+        this.emit({
+          type: 'note',
+          message: `codex app-server did not exit on its own after close; terminated by cezar (code ${exitCode})`,
+        });
+        this.emit({ type: 'done' });
+        return base;
+      }
+
       if (exitCode !== 0 && exitCode !== null) {
         const stderr = stderrChunks.join('').trim();
         const detail = stderr ? ` — ${stderr.split('\n').slice(-3).join(' | ')}` : '';
@@ -277,10 +295,16 @@ class CodexSession implements AgentSession {
     this.rejectPendingUserInput('session ended');
     this.stdinOpen = false;
     try {
-      endCodexAppServer(this.child, (term, kill) => {
-        this.eofTermTimer = term;
-        this.eofKillTimer = kill;
-      });
+      endCodexAppServer(
+        this.child,
+        (term, kill) => {
+          this.eofTermTimer = term;
+          this.eofKillTimer = kill;
+        },
+        () => {
+          this.terminatedByCezar = true;
+        },
+      );
     } catch {
       // already gone
     }
@@ -295,7 +319,10 @@ class CodexSession implements AgentSession {
         () => undefined,
       );
     }
-    if (!this.child.killed) this.child.kill('SIGTERM');
+    if (!this.child.killed) {
+      this.terminatedByCezar = true;
+      this.child.kill('SIGTERM');
+    }
   }
 
   // ---- protocol -----------------------------------------------------------

--- a/packages/cezar/src/core/codex-app-server-transport.test.ts
+++ b/packages/cezar/src/core/codex-app-server-transport.test.ts
@@ -1,9 +1,11 @@
 import { PassThrough } from 'node:stream';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EOF_KILL_GRACE_MS, EOF_TERM_GRACE_MS } from './claude-cli-runner.js';
 import {
   buildCodexAppServerEnv,
   CodexAppServerRpc,
+  endCodexAppServer,
   resolveCodexExecutable,
 } from './codex-app-server-transport.js';
 
@@ -69,5 +71,68 @@ describe('Codex app-server transport', () => {
     const request = rpc.request('model/list', {});
     rpc.dispatchResponse({ id: 1, error: { code: -32601, message: 'method unavailable' } });
     await expect(request).rejects.toThrow('method unavailable');
+  });
+});
+
+/**
+ * #703 — the runner can only tell its own teardown apart from a codex failure
+ * if the watchdog reports every signal it sends. Without the callback firing,
+ * the SIGTERM the escalation issues comes back as an unexplained 143.
+ */
+describe('endCodexAppServer watchdog', () => {
+  function signallableChild(): { child: ChildProcessWithoutNullStreams; signals: NodeJS.Signals[] } {
+    const signals: NodeJS.Signals[] = [];
+    const child = {
+      stdin: new PassThrough(),
+      exitCode: null,
+      killed: false,
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal);
+        return true;
+      },
+    } as unknown as ChildProcessWithoutNullStreams;
+    return { child, signals };
+  }
+
+  it('reports each escalation step so the runner can classify the exit', () => {
+    vi.useFakeTimers();
+    try {
+      const { child, signals } = signallableChild();
+      // How many signals had been sent when the callback fired — the flag must
+      // be set BEFORE each kill, or the exit can race ahead of it.
+      const reportedBeforeKill: number[] = [];
+      endCodexAppServer(child, undefined, () => reportedBeforeKill.push(signals.length));
+
+      // EOF alone: the server is given the full grace period first.
+      expect(signals).toEqual([]);
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
+      expect(reportedBeforeKill).toEqual([0]);
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+      expect(reportedBeforeKill).toEqual([0, 1]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stays silent when the app-server exits on EOF by itself', () => {
+    vi.useFakeTimers();
+    try {
+      const { child, signals } = signallableChild();
+      let reported = 0;
+      endCodexAppServer(child, undefined, () => {
+        reported += 1;
+      });
+      (child as unknown as { exitCode: number | null }).exitCode = 0;
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS + EOF_KILL_GRACE_MS);
+      expect(signals).toEqual([]);
+      expect(reported).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/cezar/src/core/codex-app-server-transport.ts
+++ b/packages/cezar/src/core/codex-app-server-transport.ts
@@ -100,9 +100,15 @@ export class CodexAppServerRpc {
   }
 }
 
+/**
+ * Close stdin, then escalate SIGTERM→SIGKILL for a server that ignores EOF.
+ * `onSignal` fires when the watchdog actually signals: the caller needs to
+ * know a non-zero exit was its own doing, not a codex failure (#703).
+ */
 export function endCodexAppServer(
   child: ChildProcessWithoutNullStreams,
   onTimers?: (term: NodeJS.Timeout, kill: NodeJS.Timeout | undefined) => void,
+  onSignal?: () => void,
 ): void {
   try {
     child.stdin.end();
@@ -111,9 +117,15 @@ export function endCodexAppServer(
   }
   let killTimer: NodeJS.Timeout | undefined;
   const termTimer = setTimeout(() => {
-    if (child.exitCode == null && !child.killed) child.kill('SIGTERM');
+    if (child.exitCode == null && !child.killed) {
+      onSignal?.();
+      child.kill('SIGTERM');
+    }
     killTimer = setTimeout(() => {
-      if (child.exitCode == null && !child.killed) child.kill('SIGKILL');
+      if (child.exitCode == null && !child.killed) {
+        onSignal?.();
+        child.kill('SIGKILL');
+      }
     }, EOF_KILL_GRACE_MS);
     killTimer.unref?.();
     onTimers?.(termTimer, killTimer);


### PR DESCRIPTION
Fixes #703.

## Problem

A run that finishes cleanly settles as **failed**:

```
· goal achieved — session closed
✕ claude CLI exited with code 143
· continue failed — claude CLI exited with code 143
```

143 is cezar's own SIGTERM coming back. `end()` closes stdin and arms the EOF watchdog (the CLIs can ignore EOF and hang — the comment above `EOF_TERM_GRACE_MS` documents this); claude and codex install their own SIGTERM handlers and exit `128 + signal` instead of dying from it. The exit classifier had a flag for the wall-clock timeout but none for "we sent this signal", so every runner-initiated teardown fell through to `throw` and `run.ts` recorded `status: 'failed'`.

The cancel path had the same defect: `interrupt()` → SIGTERM → 143 → throw → the catch block settles the run as `failed` before it can reach the `state.cancelled` branch, so a user cancel was reported as an error too.

## Change

- `isSignalTerminationExit(exitCode)` in `agent-runner.ts` — one shared predicate for the `128+signal` codes (130/137/143), next to the runner seam both backends implement.
- `claude-cli-runner.ts`: all three signal sites (EOF term timer, EOF kill timer, `interrupt()`) go through a `signalChild()` helper that sets `terminatedByCezar`. A signal-shaped exit under that flag settles on the normal path with a `note` instead of throwing.
- `codex-app-server-runner.ts` + `codex-app-server-transport.ts`: same treatment for parity — `endCodexAppServer` gained an `onSignal` callback so the runner learns when its watchdog fired.
- `AGENT_PROTOCOL.md`: states the rule so a new runner inherits it.

Genuine failures are untouched: the flag is only set where the runner itself calls `child.kill()`, so a CLI that exits 143 on its own still raises. The wall-clock `timedOut` branch is unchanged and still reports an error.

Deliberately **not** included: raising `EOF_TERM_GRACE_MS`. A longer grace makes the window rarer while keeping a finished session hanging in the cockpit — the classification was the bug.

## Tests

- `isSignalTerminationExit` — accepts 130/137/143, rejects 0/1/2/127/null.
- Session-level regression with a stub CLI fixture (`__fixtures__/claude/stub-ignores-eof-exits-143.mjs`) that reproduces the real shape: emits a turn, ignores EOF, exits 143 on SIGTERM. The test interrupts the session and asserts `session.result` **resolves**, that no `error` event was emitted, and that the teardown surfaces as a `note`. It drives the same `signalChild` path the EOF watchdog uses, without waiting out the 8 s grace.

**Codex parity** (added after review — the backends must classify identically or the fix is half-done):

- `MOCK_CODEX_IGNORE_EOF=1` mode in `__fixtures__/codex/mock-codex-app-server.mjs`: the app-server stays deaf to stdin EOF and exits 143 on SIGTERM. The default path (clean exit on EOF) is untouched, so the existing wiring tests keep their semantics.
- `codex-app-server-runner.test.ts` — the twin of the Claude regression against that mock: `session.result` resolves, no `error` event, the teardown surfaces as a `note`, the stream still ends with `done`.
- `codex-app-server-transport.test.ts` — the watchdog under fake timers: `onSignal` fires **before** each escalation step (SIGTERM, then SIGKILL), and stays silent when the app-server exits on EOF by itself.

Both new assertions were mutation-checked: disabling the runner's termination branch reproduces the original `codex app-server exited with code 143`, and dropping the transport's `onSignal` call fails the watchdog test.

## Validation

`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package` — see the comments below for the run logs (one per push).

Labels I would apply if I had write access: `bug`, `priority:medium`, `review`. Risk is the runner seam, so parity across backends is the thing to check hardest in review.

