### PR TITLE
feat(ask): answer a pending question after the session ends and resume the run

### DIFF
--- a/.ai/runs/2026-07-27-ask-answer-resumes-session.md
+++ b/.ai/runs/2026-07-27-ask-answer-resumes-session.md
@@ -1,0 +1,130 @@
+# Execution plan — answering an AskUser card after the session ends resumes the run
+
+**Date:** 2026-07-27
+**Slug:** `ask-answer-resumes-session`
+**Branch:** `feat/ask-answer-resumes-session`
+**Base:** `main`
+**Source doc:** `.ai/specs/2026-07-18-askuser-across-runners.md` (the AskUser feature this plan extends)
+
+## Goal
+
+When the agent parks on a `CEZ:ASK` question and the session later ends — idle
+timeout, a cezar restart, "Finish", or a cancel — the question card must stay
+answerable, and submitting the answer must reopen the agent session with those
+answers delivered as the resuming prompt.
+
+## Problem
+
+`AskCard` always delivers its answer through `useSendMessage` →
+`POST /api/runs/:id/messages` (`web/app/src/routes/task-thread/ask-card.tsx:27`).
+That endpoint has a three-rung ladder — live session, queued-prompt fold,
+starting-up buffer — and answers `409 { error: 'session closed' }` for everything
+else (`src/server/server.ts:2173`). A `waiting` run whose session closed is
+exactly that "everything else":
+
+- `armIdleTimer` closes the parked session after the idle timeout
+  (`src/workflows/run.ts:2281`), and the run settles at `review`/`done`;
+- startup recovery settles a `waiting` run the same way
+  (`src/workflows/run.ts:688`).
+
+The persisted `ask.requested` event outlives both, so the card is rebuilt
+unresolved by the thread reducer (`thread-state.ts:566`) and renders its option
+chips as usual — but every tap fires `void sendMessage.mutateAsync(...)`, whose
+rejection is swallowed. **The user clicks an option and nothing happens, with no
+error.** The composer below it already solved this: `ThreadView` routes a closed
+but resumable run's draft to `POST /continue` instead
+(`task-thread.tsx:386`, `follow-up-engine.tsx`). The ask card never got that seam.
+
+`POST /continue` is the right delivery vehicle: it reopens the last recorded
+session on the run's own backend, appends the prompt as a `user-message` event
+(`run.ts:1317`) — which is precisely what makes the thread reducer resolve the
+pending ask card — and runs in the task's worktree.
+
+## Scope
+
+- One pure delivery-routing module for the ask answer (live session vs. resume vs.
+  nothing to resume), unit-tested per run status like `run-actions.ts`.
+- `AskCard` delivers through that seam, tells the user when answering will reopen
+  the session, surfaces failures instead of swallowing them, and degrades to an
+  honest disabled state when there is no session left to resume.
+- A stale-cache fallback: a `409` from the live path retries as a resume, so a
+  cockpit whose run record is behind (dropped SSE, long-open tab) still delivers.
+- Tests for both the routing table and the card's three paths.
+- Spec + changelog updates: the AskUser spec currently claims a finished run's card
+  "renders resolved/closed", which this run replaces with answer-and-resume.
+
+## Non-goals
+
+- No change to `POST /api/runs/:id/messages`' contract. Its `409 session closed`
+  stays a `409` — the auto-resume is an explicit client decision at the ask card,
+  not an implicit server-side restart of any run that receives a message.
+- No new API endpoint, no `RunRecord` field, no `UiEvent` change.
+- No change to attention/"needs you" badging for a closed run holding an
+  unanswered question. Worth doing, but it is a separate design question about the
+  sidebar's status model and needs its own spec.
+- No change to the `CEZ:ASK` marker, its schema, or the system prompt.
+- No runner/model pills on the ask card: an answer resumes on the run's own engine,
+  which is what `POST /continue` does when the overrides are omitted.
+
+## Risks
+
+- **Unintended agent restart.** Answering a finished run's question now spawns an
+  agent session (tokens, a worktree). Mitigated by keeping this to the *ask card*
+  (an explicit, unanswered question the agent itself raised) and by labelling the
+  button state so the user knows the session reopens.
+- **Race on a stale run record.** The cached status can disagree with the server.
+  Mitigated by the 409 → resume fallback; if the resume also fails, the server's
+  own words are surfaced on the card rather than swallowed.
+- **`queued` runs.** A queued run can never hold an ask, but the routing must not
+  mis-handle it — it stays on the live/stacking path, unchanged.
+
+## Implementation Plan
+
+### Phase 1: The delivery seam
+
+- 1.1 Add `web/app/src/routes/task-thread/ask-delivery.ts`: a pure
+  `askDeliveryMode(run)` → `'live' | 'resume' | 'unavailable'` reusing
+  `runActionFlags`/`isRunActive`, plus a `useAnswerAsk(runId)` hook that reads the
+  cached run, delivers on the matching path, retries a `409` as a resume, and
+  invalidates the run queries on success.
+- 1.2 Unit-test the routing table across every run status, with and without a
+  recorded session id.
+
+### Phase 2: The card
+
+- 2.1 Wire `AskCard` to `useAnswerAsk`: chips and the combined **Send** go through
+  it, the pending state disables the chips, and the copy tells the user when the
+  answer reopens a closed session.
+- 2.2 Surface a failed delivery inline on the card (polite live region) instead of
+  dropping the rejection, and render an honest disabled state when there is no
+  session to resume.
+- 2.3 Extend `ask-card.test.tsx`: the live path is unchanged, the closed path
+  resumes with the same answer text, a `409` on the live path falls back to a
+  resume, a failure is shown, and the no-session state is inert.
+
+### Phase 3: Docs and validation
+
+- 3.1 Update `.ai/specs/2026-07-18-askuser-across-runners.md` (the finished-run edge
+  case) and add the `CHANGELOG.md` entry.
+- 3.2 Run the full validation gate: `npm run typecheck`, `npm test`,
+  `npm run test:unit`, `npm run build`, `npm run test:package`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: The delivery seam
+
+- [ ] 1.1 Add the ask-delivery routing module and the `useAnswerAsk` hook
+- [ ] 1.2 Unit-test the delivery routing table
+
+### Phase 2: The card
+
+- [ ] 2.1 Deliver the ask answer through the new seam
+- [ ] 2.2 Surface delivery failures and the no-session state on the card
+- [ ] 2.3 Extend the AskCard tests for the resume, fallback and failure paths
+
+### Phase 3: Docs and validation
+
+- [ ] 3.1 Update the AskUser spec and the changelog
+- [ ] 3.2 Run the full validation gate

--- a/.ai/runs/2026-07-27-ask-answer-resumes-session.md
+++ b/.ai/runs/2026-07-27-ask-answer-resumes-session.md
@@ -132,3 +132,4 @@ pending ask card — and runs in the task's worktree.
 - [x] 3.1 Update the AskUser spec (no changelog entry — it is assembled per release) — 1de87482
 - [x] 3.2 Run the full validation gate — typecheck ✅, `npm test` 4660 ✅, `npm run test:unit` 36 ✅, `npm run build` ✅, `npm run test:package` 9 ✅
 - [x] 3.3 Pin the cross-session resolution in the reducer and verify the loop in a real cockpit
+- [x] Post-review fix: split the resolved card from the delivery hook, scope the hint slot to the resume state, and stop the blocked path from echoing a reason the card already shows

--- a/.ai/runs/2026-07-27-ask-answer-resumes-session.md
+++ b/.ai/runs/2026-07-27-ask-answer-resumes-session.md
@@ -104,6 +104,9 @@ pending ask card — and runs in the task's worktree.
 
 ### Phase 3: Docs and validation
 
+- 3.3 Pin, in the thread reducer's own tests, that a continuation step's `user-message`
+  resolves an ask left pending when the session ended — the cross-session half of the
+  feature, previously unpinned.
 - 3.1 Update `.ai/specs/2026-07-18-askuser-across-runners.md` (the finished-run edge
   case) and add the `CHANGELOG.md` entry.
 - 3.2 Run the full validation gate: `npm run typecheck`, `npm test`,
@@ -127,4 +130,5 @@ pending ask card — and runs in the task's worktree.
 ### Phase 3: Docs and validation
 
 - [x] 3.1 Update the AskUser spec (no changelog entry — it is assembled per release) — 1de87482
-- [ ] 3.2 Run the full validation gate
+- [x] 3.2 Run the full validation gate — typecheck ✅, `npm test` 4660 ✅, `npm run test:unit` 36 ✅, `npm run build` ✅, `npm run test:package` 9 ✅
+- [x] 3.3 Pin the cross-session resolution in the reducer and verify the loop in a real cockpit

--- a/.ai/runs/2026-07-27-ask-answer-resumes-session.md
+++ b/.ai/runs/2026-07-27-ask-answer-resumes-session.md
@@ -114,6 +114,8 @@ pending ask card — and runs in the task's worktree.
 
 ## Progress
 
+PR: #709
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: The delivery seam

--- a/.ai/runs/2026-07-27-ask-answer-resumes-session.md
+++ b/.ai/runs/2026-07-27-ask-answer-resumes-session.md
@@ -115,16 +115,16 @@ pending ask card — and runs in the task's worktree.
 
 ### Phase 1: The delivery seam
 
-- [ ] 1.1 Add the ask-delivery routing module and the `useAnswerAsk` hook
-- [ ] 1.2 Unit-test the delivery routing table
+- [x] 1.1 Add the ask-delivery routing module and the `useAskAnswer` hook — ab5d6150
+- [x] 1.2 Unit-test the delivery routing table — ab5d6150
 
 ### Phase 2: The card
 
-- [ ] 2.1 Deliver the ask answer through the new seam
-- [ ] 2.2 Surface delivery failures and the no-session state on the card
-- [ ] 2.3 Extend the AskCard tests for the resume, fallback and failure paths
+- [x] 2.1 Deliver the ask answer through the new seam — 5d7f0350
+- [x] 2.2 Surface delivery failures and the no-session state on the card — 5d7f0350
+- [x] 2.3 Extend the AskCard tests for the resume, fallback and failure paths — 5d7f0350
 
 ### Phase 3: Docs and validation
 
-- [ ] 3.1 Update the AskUser spec and the changelog
+- [x] 3.1 Update the AskUser spec (no changelog entry — it is assembled per release) — 1de87482
 - [ ] 3.2 Run the full validation gate

--- a/.ai/specs/2026-07-18-askuser-across-runners.md
+++ b/.ai/specs/2026-07-18-askuser-across-runners.md
@@ -112,7 +112,12 @@ A cezar-owned marker protocol, uniform across backends:
    (`<header>: <label>`, comma-joined for multi-select) to the existing
    `POST /api/runs/:id/messages`; `sendMessage` persists the user-message event,
    flips `waiting`→`running`, and resumes the session. The ask card resolves the
-   moment that user message lands.
+   moment that user message lands. Once the session has CLOSED with the question
+   still unanswered, the same answer travels the second half of that seam instead
+   — `POST /api/runs/:id/continue`, which reopens the last recorded session on the
+   run's own engine and appends the answer as its opening `user-message`. Same
+   answer text, same resolution rule, one routing decision in `useAskAnswer`
+   (see the session-ends edge case below).
 
 Precedence on one turn: `CEZ:DONE` wins (goal done); else a valid `CEZ:ASK`
 (attention — the user is genuinely blocked); else `CEZ:MONITORING`
@@ -219,8 +224,17 @@ are real buttons (keyboard/enter, focus ring `--ring`), the card has
   composer works.
 - **User types instead of clicking** → normal message; card resolves.
 - **`CEZ:DONE` and `CEZ:ASK` both present** → `DONE` wins (no dangling card).
-- **Run cancelled / finished while waiting on an ask** → the existing cancel/finish
-  paths clear the in-memory `pendingAskId`; the card renders resolved/closed.
+- **Session ends while the ask is still unanswered** (idle timeout, a cezar restart,
+  Finish, or a cancel) → the question outlives its session, so the card stays
+  answerable: `useAskAnswer` (`ask-answer.ts`) routes the answer by run state —
+  `POST /messages` while the engine still owns a session, `POST /continue` once it
+  has closed, with the answer as the reopened session's opening prompt. The
+  continuation appends it as a `user-message`, which is what resolves the card, so
+  the resumed and live paths agree. A closed run that never recorded a session has
+  nothing to reopen and says so; a `409` from the live path (a cockpit whose record
+  is stale) is retried as a resume rather than dropped. The original design
+  ("the card renders resolved/closed") left a card whose chips silently failed —
+  every tap posted to `POST /messages` and died on its `409 session closed`.
 - **Reload / resume of a run parked on an ask** → the card is reconstructed from
   the persisted `ask.requested` (last one with no following user message);
   answering resolves it. Recovery re-opens the session (existing behavior).

--- a/.ai/specs/2026-07-18-askuser-across-runners.md
+++ b/.ai/specs/2026-07-18-askuser-across-runners.md
@@ -32,9 +32,10 @@ mechanism, identical behavior on claude, codex and opencode.
   a **future enhancement**, not this spec.
 - **Q2 — Answer channel & free-text.** → **DEFAULT: clickable option chips AND
   the normal composer stays enabled.** The user clicks an option or types a
-  free-form reply; either way the answer rides the existing
-  `POST /api/runs/:id/messages` → `sendMessage` seam as a normal user message
-  (no `tool_result` / endpoint changes). `multiSelect` questions collect several
+  free-form reply. A chip answer rides `POST /api/runs/:id/messages` while the
+  session is live, or the existing `POST /api/runs/:id/continue` seam once the
+  session has closed; both append the answer as a normal user message (no
+  `tool_result` / endpoint changes). `multiSelect` questions collect several
   picks confirmed with Send; an implicit free-text "Other" is always available
   via the composer (matching `AskUserQuestion` semantics).
 - **Q3 — Event model.** → **DEFAULT: one additive `ask.requested` `UiEvent`.**
@@ -152,9 +153,12 @@ the existing sink, so no per-backend mapper work is required.
   `UiEventType`; mirror in `web/app/src/protocol/ui-events.ts`; held type-exact
   by `src/server/api-types.test.ts`. `UiEventSink` persists it via its existing
   pass-through `default` branch (no sink change beyond the union).
-- **Answer path** — unchanged server routes. `web/app/src/routes/task-thread`:
-  the ask card's chip click calls the existing `useSendMessage(run.id)` with the
-  formatted answer text; free-text uses the normal composer.
+- **Answer path** — unchanged server routes. `packages/web/src/routes/task-thread`:
+  the ask card's chip click uses `useAskAnswer(run)`, which sends the formatted
+  answer through `useSendMessage(run.id)` while the session is live or through
+  an override-free `useContinueRun(run.id)` after it closes. The latter stays
+  gated on the run's recorded provider and never silently switches engines;
+  free-text uses the normal composer.
 - **UI** — `thread-state.ts` gains an `ask.requested` case producing an ask row;
   a new `AskCard` component renders it; the row is marked resolved when a later
   user-message row for the run appears (client-side lifecycle). No attention
@@ -182,8 +186,9 @@ interface AskRequest { questions: AskQuestion[] }   // 1..4
 
 ## API Contracts
 
-- **No new endpoints.** Answers reuse `POST /api/runs/:id/messages`
-  (`{ text, images? }`) — chip clicks send formatted text, free-text sends raw.
+- **No new endpoints.** Chip answers reuse `POST /api/runs/:id/messages`
+  (`{ text, images? }`) while live and `POST /api/runs/:id/continue` (`{ text }`)
+  after closure; free-text continues through the normal composer.
 - **New UiEvent** (additive, SSE `ui-event` transport unchanged):
   `{ type: 'ask.requested', requestId: string, questions: AskQuestion[] }`.
 - **New system-prompt marker** (agent → cezar): a trailing line

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -7,6 +7,7 @@ import {
   ApiError,
   browseFs,
   checkoutProject,
+  continueRun,
   getAgentConfig,
   getAgentConfigFile,
   getConfig,
@@ -57,6 +58,7 @@ import {
   retryProviderAuth,
 } from './client'
 import { queryScope } from '@open-mercato/cezar-api-client'
+import type { ContinueOptions } from './client'
 import type {
   CheckoutProjectInput,
   HealthResponse,
@@ -810,6 +812,20 @@ export function useSendMessage(id: string) {
         void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
       }
     },
+  })
+}
+
+/** Reopen a closed run's last agent session (`POST /api/runs/:id/continue`), starting it on an
+ *  opening prompt. The sibling of `useSendMessage` for a run whose session has already ended:
+ *  same invalidation (the record flips to `running`, the transcript grows over SSE) and the
+ *  same contract that errors belong to the CALLER, so a refusal can be shown where the user
+ *  acted. The thread composer keeps its own mutation (`useContinueAction`) because it also owns
+ *  the runner/model pills; this hook is the plain "resume on the run's own engine" path. */
+export function useContinueRun(id: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (opts: ContinueOptions = {}) => continueRun(id, opts),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.runs.all }),
   })
 }
 

--- a/packages/web/src/routes/task-thread/active-provider.test.ts
+++ b/packages/web/src/routes/task-thread/active-provider.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import type { ApiRun, ProviderStatusResponse } from '@open-mercato/cezar-api-client'
 
-import { activeProviderAvailability, providerForActiveRun } from './active-provider'
+import {
+  activeProviderAvailability,
+  existingProviderAvailability,
+  providerForActiveRun,
+  providerForExistingRun,
+} from './active-provider'
 
 const run = (overrides: Partial<ApiRun> = {}): ApiRun => ({
   id: 'r1',
@@ -55,6 +60,37 @@ describe('active task provider availability', () => {
       provider: 'claude',
       usable: false,
       reason,
+    })
+  })
+
+  it('gates an override-free continuation on the run provider, not a connected fallback', () => {
+    const closed = run({
+      status: 'done',
+      runner: 'claude',
+      steps: [{
+        id: 'continue-1',
+        name: 'Continue',
+        kind: 'agent',
+        status: 'done',
+        iterations: 1,
+        tokensUsed: 0,
+        backend: 'codex',
+        sessionId: 'session-1',
+      }],
+    })
+    const status = providers({
+      providers: [
+        { provider: 'claude', status: 'disconnected', enabled: true },
+        { provider: 'codex', status: 'connected', enabled: true },
+        { provider: 'opencode', status: 'not-installed', enabled: true },
+      ],
+    })
+
+    expect(providerForExistingRun(closed)).toBe('claude')
+    expect(existingProviderAvailability(closed, status)).toEqual({
+      provider: 'claude',
+      usable: false,
+      reason: 'Claude Code credentials are unavailable. Authorize it in Settings → Agents → Providers.',
     })
   })
 })

--- a/packages/web/src/routes/task-thread/active-provider.ts
+++ b/packages/web/src/routes/task-thread/active-provider.ts
@@ -22,11 +22,15 @@ export function providerForActiveRun(run: ApiRun): Runner {
   return 'claude'
 }
 
-export function activeProviderAvailability(
-  run: ApiRun,
+/** Mirrors the server's providerForExistingRun for an override-free POST /continue. */
+export function providerForExistingRun(run: ApiRun): Runner {
+  return run.runner ?? 'claude'
+}
+
+function providerAvailability(
+  provider: Runner,
   status: ProviderStatusResponse,
 ): { provider: Runner; usable: boolean; reason?: string } {
-  const provider = providerForActiveRun(run)
   const row = providerStatusFor(status, provider)
   if (row?.enabled === false) {
     return {
@@ -45,6 +49,20 @@ export function activeProviderAvailability(
   return { provider, usable: true }
 }
 
+export function activeProviderAvailability(
+  run: ApiRun,
+  status: ProviderStatusResponse,
+): { provider: Runner; usable: boolean; reason?: string } {
+  return providerAvailability(providerForActiveRun(run), status)
+}
+
+export function existingProviderAvailability(
+  run: ApiRun,
+  status: ProviderStatusResponse,
+): { provider: Runner; usable: boolean; reason?: string } {
+  return providerAvailability(providerForExistingRun(run), status)
+}
+
 /** Availability for the same provider the server will use for a live/queued message. */
 export function useActiveProviderAvailability(run: ApiRun) {
   const status = useProviderStatus()
@@ -55,4 +73,23 @@ export function useActiveProviderAvailability(run: ApiRun) {
   return status.isSuccess && status.data
     ? activeProviderAvailability(run, status.data)
     : { provider, usable: true }
+}
+
+/** Availability for the run's recorded provider, which an override-free continuation keeps. */
+export function useExistingProviderAvailability(run: ApiRun) {
+  const status = useProviderStatus()
+  const provider = providerForExistingRun(run)
+  if (status.isSuccess && status.data) return existingProviderAvailability(run, status.data)
+  if (status.isError) {
+    return {
+      provider,
+      usable: false,
+      reason: 'Provider authentication could not be verified.',
+    }
+  }
+  return {
+    provider,
+    usable: false,
+    reason: 'Checking agent providers…',
+  }
 }

--- a/packages/web/src/routes/task-thread/ask-answer.test.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RunRecord, RunStatus, StepState } from '@open-mercato/cezar-api-client'
+
+import { askDeliveryMode } from './ask-answer'
+
+const step = (extra: Partial<StepState> = {}): StepState => ({
+  id: 'task',
+  name: 'Do the task',
+  kind: 'agent',
+  status: 'done',
+  iterations: 1,
+  tokensUsed: 0,
+  ...extra,
+})
+
+const run = (status: RunStatus, extra: Partial<RunRecord> = {}): RunRecord => ({
+  id: 'r1',
+  title: 'Do the thing',
+  workflow: 'quick-task',
+  task: 'Do the thing',
+  status,
+  createdAt: '2026-07-24T12:00:00.000Z',
+  tokensUsed: 0,
+  archived: false,
+  steps: [step({ sessionId: 'sess-1' })],
+  ...extra,
+})
+
+describe('askDeliveryMode — where an ask answer goes, per run status', () => {
+  // The engine still owns the run: the answer rides the live reply seam, exactly as the
+  // ask card has always done. `queued` is here because the ladder in POST /messages folds
+  // a message into a not-yet-started prompt — an ask can't reach that state, but routing
+  // it anywhere else would be a lie about what the endpoint does.
+  it.each(['queued', 'running', 'waiting'] as const)('%s → live', (status) => {
+    expect(askDeliveryMode(run(status))).toBe('live')
+  })
+
+  // The session ended with the question still on the table (idle timeout, restart, Finish,
+  // cancel). The answer reopens it instead of hitting `409 session closed`.
+  it.each(['review', 'done', 'failed', 'cancelled'] as const)('%s with a session → resume', (status) => {
+    expect(askDeliveryMode(run(status))).toBe('resume')
+  })
+
+  // Nothing to reopen: the card must say so rather than offer chips that cannot deliver.
+  it.each(['review', 'done', 'failed', 'cancelled'] as const)(
+    '%s without a recorded session → unavailable',
+    (status) => {
+      expect(askDeliveryMode(run(status, { steps: [step()] }))).toBe('unavailable')
+    },
+  )
+
+  it('reads the LAST session across steps, so a multi-step run resumes its newest one', () => {
+    const record = run('done', { steps: [step({ id: 'a' }), step({ id: 'b', sessionId: 'sess-2' })] })
+    expect(askDeliveryMode(record)).toBe('resume')
+  })
+
+  it('an archived run is still answerable — archiving hides a run, it does not close the question', () => {
+    expect(askDeliveryMode(run('done', { archived: true }))).toBe('resume')
+  })
+})

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -104,12 +104,20 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
       return
     }
     setError(undefined)
+    if (mode === 'resume') {
+      try {
+        await resumeWith(text)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+      return
+    }
     try {
-      if (mode === 'resume') await resumeWith(text)
-      else await sendMessage.mutateAsync({ text })
+      await sendMessage.mutateAsync({ text })
     } catch (err) {
       // The cached record said "live" but the session had already closed — resume instead
-      // of dropping the answer the user just gave.
+      // of dropping the answer the user just gave. Only ever from the live path: a resume
+      // that answers 409 has already been refused on its own terms.
       if (err instanceof ApiError && err.status === 409 && lastSessionId(run) !== undefined) {
         try {
           await resumeWith(text)

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -99,10 +99,9 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
     })
 
   const send = async (text: string): Promise<void> => {
-    if (blockedBy) {
-      setError(reason)
-      return
-    }
+    // Defense in depth — every entry point is already disabled while blocked, and the card
+    // renders `reason` on its own, so repeating it as an error would say the same thing twice.
+    if (blockedBy) return
     setError(undefined)
     if (mode === 'resume') {
       try {

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+
+import { ApiError } from '@/api/client'
+import { useContinueRun, useSendMessage } from '@/api/queries'
+import type { ApiRun, RunRecord } from '@open-mercato/cezar-api-client'
+
+import { useActiveProviderAvailability } from './active-provider'
+import { useContinuationProvider } from './continuation-provider'
+import { isRunActive, lastSessionId, runActionFlags } from './run-actions'
+
+/**
+ * Which seam an AskUser answer travels on.
+ *
+ *  - `live`    — the engine still owns a session (or the run has not started yet):
+ *                `POST /api/runs/:id/messages`, exactly as the ask card always did.
+ *  - `resume`  — the session ENDED while the question was still unanswered (idle
+ *                timeout, a cezar restart, Finish, or a cancel). The answer becomes
+ *                the opening prompt of `POST /api/runs/:id/continue`, which reopens
+ *                the last recorded session and appends the answer as a
+ *                `user-message` — the very event that resolves the card.
+ *  - `unavailable` — the run is closed and never recorded a session, so there is
+ *                nothing to reopen and the answer has nowhere to go.
+ */
+export type AskDeliveryMode = 'live' | 'resume' | 'unavailable'
+
+/** Why an answer cannot be delivered right now — `provider` is recoverable from
+ *  Settings, `no-session` is terminal for this run. */
+export type AskBlockedReason = 'provider' | 'no-session'
+
+/**
+ * The delivery route for one ask answer, as a pure function of the run record — the
+ * same shape `runActionFlags` has, so a table test can pin it per status. Mirrors the
+ * composer's own routing (`ThreadView`: a live/queued run sends, a closed one with a
+ * session continues), which is exactly the seam the ask card was missing.
+ */
+export function askDeliveryMode(run: RunRecord): AskDeliveryMode {
+  if (isRunActive(run.status)) return 'live'
+  return runActionFlags(run).continueRun ? 'resume' : 'unavailable'
+}
+
+export interface AskAnswerDelivery {
+  mode: AskDeliveryMode
+  /** Set when the answer cannot be delivered at all; the card renders `reason` and stays inert. */
+  blockedBy?: AskBlockedReason
+  reason?: string
+  /** A delivery is in flight — the option chips and Send stay disabled until it settles. */
+  isPending: boolean
+  /** The server's own words for the last failed delivery, cleared when a new one starts. */
+  error?: string
+  /** Deliver the answer. Never rejects: a failure lands in `error` so the card can show it. */
+  send: (text: string) => Promise<void>
+}
+
+/**
+ * Deliver an AskUser answer on whichever seam the run's current state allows, so a
+ * question the agent asked stays answerable after its session ends — answering
+ * reopens the session with the answers as its prompt.
+ *
+ * The provider gate follows the seam: a live message is gated on the provider the
+ * server would use for `POST /messages` (`useActiveProviderAvailability`), a resume on
+ * the same continuation gate the composer's Continue uses, including its fallback to a
+ * connected runner when the run's own backend disconnected.
+ *
+ * A `409` from the live path is not a dead end but a stale cache: the record claimed a
+ * session the server no longer has (a dropped SSE frame, a long-open tab). When the run
+ * has a session id to resume, the answer is retried as a resume rather than lost —
+ * `useSendMessage` has already invalidated the record by then, so the card's next render
+ * agrees.
+ */
+export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
+  const sendMessage = useSendMessage(run.id)
+  const resume = useContinueRun(run.id)
+  const activeProvider = useActiveProviderAvailability(run)
+  const continuation = useContinuationProvider(run)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  const mode = askDeliveryMode(run)
+  const providerBlocked =
+    mode === 'resume' ? !continuation.canContinue
+    : mode === 'live' ? !activeProvider.usable
+    : false
+  const blockedBy: AskBlockedReason | undefined =
+    mode === 'unavailable' ? 'no-session'
+    : providerBlocked ? 'provider'
+    : undefined
+  const reason =
+    blockedBy === 'no-session'
+      ? 'This session has ended and no agent session was recorded, so the answer cannot be delivered.'
+      : blockedBy === 'provider'
+        ? (mode === 'resume' ? continuation.reason : activeProvider.reason)
+        : undefined
+
+  const resumeWith = (text: string) =>
+    resume.mutateAsync({
+      text,
+      // Only an explicit override — omitted, the server keeps the run's own backend and
+      // model, so answering a question never silently switches engines.
+      runner: continuation.runnerOverride,
+    })
+
+  const send = async (text: string): Promise<void> => {
+    if (blockedBy) {
+      setError(reason)
+      return
+    }
+    setError(undefined)
+    try {
+      if (mode === 'resume') await resumeWith(text)
+      else await sendMessage.mutateAsync({ text })
+    } catch (err) {
+      // The cached record said "live" but the session had already closed — resume instead
+      // of dropping the answer the user just gave.
+      if (err instanceof ApiError && err.status === 409 && lastSessionId(run) !== undefined) {
+        try {
+          await resumeWith(text)
+          return
+        } catch (resumeErr) {
+          setError(resumeErr instanceof Error ? resumeErr.message : String(resumeErr))
+          return
+        }
+      }
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  return {
+    mode,
+    blockedBy,
+    reason,
+    isPending: sendMessage.isPending || resume.isPending,
+    error,
+    send,
+  }
+}

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -4,8 +4,10 @@ import { ApiError } from '@/api/client'
 import { useContinueRun, useSendMessage } from '@/api/queries'
 import type { ApiRun, RunRecord } from '@open-mercato/cezar-api-client'
 
-import { useActiveProviderAvailability } from './active-provider'
-import { useContinuationProvider } from './continuation-provider'
+import {
+  useActiveProviderAvailability,
+  useExistingProviderAvailability,
+} from './active-provider'
 import { isRunActive, lastSessionId, runActionFlags } from './run-actions'
 
 /**
@@ -57,9 +59,9 @@ export interface AskAnswerDelivery {
  * reopens the session with the answers as its prompt.
  *
  * The provider gate follows the seam: a live message is gated on the provider the
- * server would use for `POST /messages` (`useActiveProviderAvailability`), a resume on
- * the same continuation gate the composer's Continue uses, including its fallback to a
- * connected runner when the run's own backend disconnected.
+ * server would use for `POST /messages` (`useActiveProviderAvailability`), while a
+ * resume is gated on the run's recorded provider. Unlike the composer's explicit
+ * runner picker, an Ask answer never falls back to another connected engine silently.
  *
  * A `409` from the live path is not a dead end but a stale cache: the record claimed a
  * session the server no longer has (a dropped SSE frame, a long-open tab). When the run
@@ -71,12 +73,12 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
   const sendMessage = useSendMessage(run.id)
   const resume = useContinueRun(run.id)
   const activeProvider = useActiveProviderAvailability(run)
-  const continuation = useContinuationProvider(run)
+  const existingProvider = useExistingProviderAvailability(run)
   const [error, setError] = useState<string | undefined>(undefined)
 
   const mode = askDeliveryMode(run)
   const providerBlocked =
-    mode === 'resume' ? !continuation.canContinue
+    mode === 'resume' ? !existingProvider.usable
     : mode === 'live' ? !activeProvider.usable
     : false
   const blockedBy: AskBlockedReason | undefined =
@@ -87,16 +89,17 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
     blockedBy === 'no-session'
       ? 'This session has ended and no agent session was recorded, so the answer cannot be delivered.'
       : blockedBy === 'provider'
-        ? (mode === 'resume' ? continuation.reason : activeProvider.reason)
+        ? (mode === 'resume' ? existingProvider.reason : activeProvider.reason)
         : undefined
 
-  const resumeWith = (text: string) =>
-    resume.mutateAsync({
-      text,
-      // Only an explicit override — omitted, the server keeps the run's own backend and
-      // model, so answering a question never silently switches engines.
-      runner: continuation.runnerOverride,
-    })
+  const resumeWith = (text: string) => {
+    if (!existingProvider.usable) {
+      return Promise.reject(new Error(existingProvider.reason ?? 'The run provider is unavailable.'))
+    }
+    // No runner override: the server keeps the run's own backend and model, so answering a
+    // question cannot silently switch engines when another provider happens to be connected.
+    return resume.mutateAsync({ text })
+  }
 
   const send = async (text: string): Promise<void> => {
     // Defense in depth — every entry point is already disabled while blocked, and the card

--- a/packages/web/src/routes/task-thread/ask-card.test.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.test.tsx
@@ -1,21 +1,25 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ApiError } from '@/api/client'
 import { AskCard } from './ask-card'
 import type { ThreadAsk } from './thread-state'
-import type { ApiRun, ProviderStatusResponse } from '@open-mercato/cezar-api-client'
+import type { ApiRun, ProviderStatusResponse, StepState } from '@open-mercato/cezar-api-client'
 
 const mutateAsync = vi.fn().mockResolvedValue({})
+const continueAsync = vi.fn().mockResolvedValue({})
 let providerStatus: ProviderStatusResponse
 vi.mock('@/api/queries', () => ({
   useSendMessage: () => ({ mutateAsync, isPending: false }),
+  useContinueRun: () => ({ mutateAsync: continueAsync, isPending: false }),
   useProviderStatus: () => ({ data: providerStatus, isSuccess: true }),
 }))
 
 afterEach(() => {
   cleanup()
-  mutateAsync.mockClear()
+  mutateAsync.mockClear().mockResolvedValue({})
+  continueAsync.mockClear().mockResolvedValue({})
   providerStatus = {
     providers: [
       { provider: 'claude', status: 'connected', enabled: true },
@@ -38,9 +42,26 @@ const activeRun: ApiRun = {
   steps: [],
 }
 
-const renderAsk = (ask: ThreadAsk) => render(
+const step = (extra: Partial<StepState> = {}): StepState => ({
+  id: 'task',
+  name: 'Do the task',
+  kind: 'agent',
+  status: 'done',
+  iterations: 1,
+  tokensUsed: 0,
+  ...extra,
+})
+
+/** The run the feature exists for: the session closed while the question was unanswered. */
+const closedRun: ApiRun = {
+  ...activeRun,
+  status: 'done',
+  steps: [step({ sessionId: 'sess-1' })],
+}
+
+const renderAsk = (ask: ThreadAsk, run: ApiRun = activeRun) => render(
   <MemoryRouter>
-    <AskCard ask={ask} run={activeRun} />
+    <AskCard ask={ask} run={run} />
   </MemoryRouter>,
 )
 
@@ -161,5 +182,69 @@ describe('AskCard', () => {
       '/settings/agents#providers',
     )
     expect(mutateAsync).not.toHaveBeenCalled()
+  })
+})
+
+// The question outlives its session: an idle timeout, a cezar restart, Finish or a cancel
+// closes the session with the card still unanswered. Before this, every tap posted to
+// `POST /messages` and died on its `409 session closed` — silently.
+describe('AskCard — answering after the session has ended', () => {
+  it('a closed run resumes instead of replying, with the same answer text', async () => {
+    renderAsk(singleAsk, closedRun)
+    fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))
+    await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
+    // No runner override: answering a question must not silently switch the run's engine.
+    expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns', runner: undefined })
+    expect(mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('says the session reopens, on both the one-tap and the combined-Send shapes', () => {
+    const { unmount } = renderAsk(singleAsk, closedRun)
+    expect(screen.getByText('The session has ended — your answer reopens it and goes to the agent.')).toBeTruthy()
+    unmount()
+    renderAsk(twoQuestionAsk, closedRun)
+    expect(screen.getByRole('button', { name: 'Send answer & reopen' })).toBeTruthy()
+    expect(screen.getByText('the session has ended — sending reopens it')).toBeTruthy()
+  })
+
+  it('combined Send on a closed run resumes once with every answer', async () => {
+    renderAsk(twoQuestionAsk, closedRun)
+    fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Relative/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Send answer & reopen' }))
+    await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
+    expect(continueAsync).toHaveBeenCalledWith({
+      text: 'Library: date-fns\nStyle: Relative',
+      runner: undefined,
+    })
+  })
+
+  it('a stale record that still claims a live session falls back to a resume on 409', async () => {
+    // The cockpit's cached record says `waiting`; the server has already closed the session.
+    mutateAsync.mockRejectedValueOnce(new ApiError(409, 'session closed'))
+    renderAsk(singleAsk, { ...activeRun, steps: [step({ sessionId: 'sess-1' })] })
+    fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))
+    await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
+    expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns', runner: undefined })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('a refused delivery is shown on the card instead of being dropped', async () => {
+    continueAsync.mockRejectedValueOnce(new ApiError(409, 'no agent session to resume'))
+    renderAsk(singleAsk, closedRun)
+    fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))
+    expect((await screen.findByRole('alert')).textContent).toBe('no agent session to resume')
+  })
+
+  it('a closed run that never recorded a session says so and stays inert', () => {
+    renderAsk(singleAsk, { ...closedRun, steps: [step()] })
+    expect((screen.getByRole('button', { name: /date-fns/ }) as HTMLButtonElement).disabled).toBe(true)
+    expect(
+      screen.getByText(
+        'This session has ended and no agent session was recorded, so the answer cannot be delivered.',
+      ),
+    ).toBeTruthy()
+    expect(mutateAsync).not.toHaveBeenCalled()
+    expect(continueAsync).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/routes/task-thread/ask-card.test.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.test.tsx
@@ -207,6 +207,19 @@ describe('AskCard — answering after the session has ended', () => {
     expect(screen.getByText('the session has ended — sending reopens it')).toBeTruthy()
   })
 
+  // The resume affordance must be identifiable without reading copy — and must NOT be claimed
+  // by a live run's ordinary "pick one or more" hint, which sits in the same slot position.
+  it('marks the delivery seam on the card, and only names the resume hint when resuming', () => {
+    const { unmount } = renderAsk(twoQuestionAsk, activeRun)
+    expect(document.querySelector('[data-slot="ask-card"]')?.getAttribute('data-delivery')).toBe('live')
+    expect(document.querySelector('[data-slot="ask-resume-hint"]')).toBeNull()
+    expect(document.querySelector('[data-slot="ask-hint"]')).toBeTruthy()
+    unmount()
+    renderAsk(twoQuestionAsk, closedRun)
+    expect(document.querySelector('[data-slot="ask-card"]')?.getAttribute('data-delivery')).toBe('resume')
+    expect(document.querySelector('[data-slot="ask-resume-hint"]')).toBeTruthy()
+  })
+
   it('combined Send on a closed run resumes once with every answer', async () => {
     renderAsk(twoQuestionAsk, closedRun)
     fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))

--- a/packages/web/src/routes/task-thread/ask-card.test.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.test.tsx
@@ -194,7 +194,7 @@ describe('AskCard — answering after the session has ended', () => {
     fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))
     await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
     // No runner override: answering a question must not silently switch the run's engine.
-    expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns', runner: undefined })
+    expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns' })
     expect(mutateAsync).not.toHaveBeenCalled()
   })
 
@@ -228,7 +228,6 @@ describe('AskCard — answering after the session has ended', () => {
     await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
     expect(continueAsync).toHaveBeenCalledWith({
       text: 'Library: date-fns\nStyle: Relative',
-      runner: undefined,
     })
   })
 
@@ -238,8 +237,28 @@ describe('AskCard — answering after the session has ended', () => {
     renderAsk(singleAsk, { ...activeRun, steps: [step({ sessionId: 'sess-1' })] })
     fireEvent.click(screen.getByRole('button', { name: /date-fns/ }))
     await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
-    expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns', runner: undefined })
+    expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns' })
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('does not silently switch to another connected provider when the run provider is unavailable', () => {
+    providerStatus = {
+      providers: [
+        { provider: 'claude', status: 'disconnected', enabled: true },
+        { provider: 'codex', status: 'connected', enabled: true },
+        { provider: 'opencode', status: 'not-installed', enabled: true },
+      ],
+    }
+
+    renderAsk(singleAsk, closedRun)
+
+    expect((screen.getByRole('button', { name: /date-fns/ }) as HTMLButtonElement).disabled).toBe(true)
+    expect(
+      screen.getByText(
+        'Claude Code credentials are unavailable. Authorize it in Settings → Agents → Providers.',
+      ),
+    ).toBeTruthy()
+    expect(continueAsync).not.toHaveBeenCalled()
   })
 
   it('a refused delivery is shown on the card instead of being dropped', async () => {

--- a/packages/web/src/routes/task-thread/ask-card.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
 
-import { useSendMessage } from '@/api/queries'
 import type { ApiRun } from '@open-mercato/cezar-api-client'
 import { Button } from '@/components/ui/button'
 import { Link } from '@/lib/project-router'
 import { cn } from '@/lib/utils'
 
-import { useActiveProviderAvailability } from './active-provider'
+import { useAskAnswer } from './ask-answer'
 import type { ThreadAsk } from './thread-state'
 import type { UiAskQuestion } from '@open-mercato/cezar-api-client'
 
@@ -22,14 +21,16 @@ function formatAnswer(question: UiAskQuestion, labels: string[]): string {
  * questions, or a multi-select question) collects every answer and resolves on
  * one **Send** that posts a single combined message — the reducer resolves the
  * whole card on that one user message, so partial answers can never leak. Either
- * way the answer rides the normal reply seam (`useSendMessage` →
- * `POST /api/runs/:id/messages`), and the composer below stays enabled for a
- * free-form "Other". Once resolved, the card collapses to a compact summary.
+ * way the answer rides `useAskAnswer`, which picks the seam the run's state
+ * allows: the live reply while the engine owns a session, and a resume once it
+ * has closed — a question outlives its session, so answering one that the agent
+ * asked before an idle timeout or a restart reopens the session with the answer
+ * as its opening prompt. The composer below stays available for a free-form
+ * "Other". Once resolved, the card collapses to a compact summary.
  */
 export function AskCard({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
-  const sendMessage = useSendMessage(run.id)
-  const provider = useActiveProviderAvailability(run)
-  const providerBlocked = !provider.usable
+  const delivery = useAskAnswer(run)
+  const blocked = delivery.blockedBy !== undefined
   const questions = ask.questions
   // One-tap only when there is a single single-select question; every other
   // shape needs a combined Send so no question's answer is dropped.
@@ -57,14 +58,19 @@ export function AskCard({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
   const allAnswered = questions.every((_, index) => (selections[index]?.length ?? 0) > 0)
 
   const sendAll = () =>
-    void sendMessage.mutateAsync({
-      text: questions.map((q, index) => formatAnswer(q, selections[index] ?? [])).join('\n'),
-    })
+    void delivery.send(
+      questions.map((q, index) => formatAnswer(q, selections[index] ?? [])).join('\n'),
+    )
+
+  // The session ended before the question was answered — say so, because sending the
+  // answer now does more than reply: it reopens the agent's session to deliver it.
+  const resuming = delivery.mode === 'resume'
 
   return (
     <div
       data-slot="ask-card"
       data-resolved="false"
+      data-delivery={delivery.mode}
       className="rounded-lg border border-primary/25 bg-primary/[0.04] px-4 pt-3.5 pb-3.5"
     >
       <div className="mb-2.5 flex items-center gap-2">
@@ -75,33 +81,52 @@ export function AskCard({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
           <AskQuestionBlock
             key={question.id ?? index}
             question={question}
-            disabled={sendMessage.isPending || providerBlocked}
+            disabled={delivery.isPending || blocked}
             selected={selections[index] ?? []}
             onSelect={(labels) => {
-              if (providerBlocked) return
-              if (oneTap) void sendMessage.mutateAsync({ text: formatAnswer(question, labels) })
+              if (blocked) return
+              if (oneTap) void delivery.send(formatAnswer(question, labels))
               else setQuestion(index, labels)
             }}
           />
         ))}
       </div>
-      {oneTap ? null : (
+      {oneTap ? (
+        resuming ? (
+          <p data-slot="ask-resume-hint" className="mt-3 text-[11.5px] text-soft-foreground">
+            The session has ended — your answer reopens it and goes to the agent.
+          </p>
+        ) : null
+      ) : (
         <div className="mt-3 flex items-center gap-2.5">
-          <Button size="sm" disabled={sendMessage.isPending || providerBlocked || !allAnswered} onClick={sendAll}>
-            Send answer
+          <Button size="sm" disabled={delivery.isPending || blocked || !allAnswered} onClick={sendAll}>
+            {resuming ? 'Send answer & reopen' : 'Send answer'}
           </Button>
-          <span className="text-[11.5px] text-soft-foreground">
-            {questions.length > 1 ? 'answer each question' : 'pick one or more'} — or type a reply below
+          <span data-slot="ask-resume-hint" className="text-[11.5px] text-soft-foreground">
+            {resuming
+              ? 'the session has ended — sending reopens it'
+              : `${questions.length > 1 ? 'answer each question' : 'pick one or more'} — or type a reply below`}
           </span>
         </div>
       )}
-      {providerBlocked ? (
+      {delivery.blockedBy === 'provider' ? (
         <div data-slot="ask-provider-gate" className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-          <span>{provider.reason}</span>
+          <span>{delivery.reason}</span>
           <Link to="/settings/agents#providers" className="font-medium text-foreground underline underline-offset-4">
             Configure providers
           </Link>
         </div>
+      ) : null}
+      {delivery.blockedBy === 'no-session' ? (
+        <p data-slot="ask-no-session" className="mt-3 text-xs text-muted-foreground">
+          {delivery.reason}
+        </p>
+      ) : null}
+      {/* A dropped answer used to be silent — the tap did nothing and said nothing. */}
+      {delivery.error ? (
+        <p data-slot="ask-error" role="alert" className="mt-3 text-xs text-danger">
+          {delivery.error}
+        </p>
       ) : null}
     </div>
   )

--- a/packages/web/src/routes/task-thread/ask-card.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.tsx
@@ -29,14 +29,10 @@ function formatAnswer(question: UiAskQuestion, labels: string[]): string {
  * "Other". Once resolved, the card collapses to a compact summary.
  */
 export function AskCard({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
-  const delivery = useAskAnswer(run)
-  const blocked = delivery.blockedBy !== undefined
-  const questions = ask.questions
-  // One-tap only when there is a single single-select question; every other
-  // shape needs a combined Send so no question's answer is dropped.
-  const oneTap = questions.length === 1 && questions[0]?.multiSelect !== true
-  const [selections, setSelections] = useState<Record<number, string[]>>({})
-
+  // An answered card is a static summary — split so the delivery hook (two mutations and a
+  // provider-status subscription) only mounts for a question that can still be answered.
+  // Threads accumulate asks; every resolved one would otherwise carry live machinery for a
+  // question nobody can answer again.
   if (ask.resolved) {
     return (
       <div
@@ -51,6 +47,18 @@ export function AskCard({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
       </div>
     )
   }
+  return <PendingAsk ask={ask} run={run} />
+}
+
+/** The unanswered card: option chips wired to whichever delivery seam the run's state allows. */
+function PendingAsk({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
+  const delivery = useAskAnswer(run)
+  const blocked = delivery.blockedBy !== undefined
+  const questions = ask.questions
+  // One-tap only when there is a single single-select question; every other
+  // shape needs a combined Send so no question's answer is dropped.
+  const oneTap = questions.length === 1 && questions[0]?.multiSelect !== true
+  const [selections, setSelections] = useState<Record<number, string[]>>({})
 
   const setQuestion = (index: number, labels: string[]) =>
     setSelections((prev) => ({ ...prev, [index]: labels }))
@@ -102,7 +110,12 @@ export function AskCard({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
           <Button size="sm" disabled={delivery.isPending || blocked || !allAnswered} onClick={sendAll}>
             {resuming ? 'Send answer & reopen' : 'Send answer'}
           </Button>
-          <span data-slot="ask-resume-hint" className="text-[11.5px] text-soft-foreground">
+          {/* The slot names the resume state, so a selector for it can never match the ordinary
+              "pick one or more" hint a live run shows. */}
+          <span
+            data-slot={resuming ? 'ask-resume-hint' : 'ask-hint'}
+            className="text-[11.5px] text-soft-foreground"
+          >
             {resuming
               ? 'the session has ended — sending reopens it'
               : `${questions.length > 1 ? 'answer each question' : 'pick one or more'} — or type a reply below`}

--- a/packages/web/src/routes/task-thread/thread-state.test.ts
+++ b/packages/web/src/routes/task-thread/thread-state.test.ts
@@ -764,6 +764,21 @@ describe('reduceThread — AskUser cards (#473)', () => {
     expect(ask).toMatchObject({ resolved: true, answer: 'Library: date-fns' })
   })
 
+  // The card outlives its session: the run closed with the question unanswered, and the
+  // answer arrives as the opening `user-message` of a CONTINUATION step (`POST /continue`,
+  // `runContinuation`). Nothing about resolution is session-scoped, and this pins that —
+  // it is what makes answering a closed run's question read the same as answering a live one.
+  it('a continuation step resolves an ask left pending when the session ended', () => {
+    const ask = allItems([
+      line(1, 'text', { text: 'options', stepId: 'task' }),
+      line(2, 'ask.requested', { ...ASK, stepId: 'task' }),
+      line(3, 'lifecycle', { message: 'session closed by user' }),
+      line(4, 'step-start', { stepId: 'continue-1', name: 'Continue', kind: 'agent', iteration: 1 }),
+      line(5, 'user-message', { text: 'Library: date-fns', imageCount: 0, stepId: 'continue-1' }),
+    ]).find((i) => i.kind === 'ask')
+    expect(ask).toMatchObject({ resolved: true, answer: 'Library: date-fns' })
+  })
+
   it('drops an ask.requested with no valid questions', () => {
     expect(
       allItems([line(1, 'ask.requested', { requestId: 'x', questions: [] })]).some(


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-27-ask-answer-resumes-session.md
Source doc: .ai/specs/2026-07-18-askuser-across-runners.md
Status: complete

## 🎯 Goal
- A question the agent asked with `CEZ:ASK` outlives the session it was asked in. When the session ends with the card still unanswered — idle timeout, a cezar restart, **Finish**, or a cancel — answering it now reopens the run and delivers the answer to the agent, instead of silently doing nothing.
- Root cause: `AskCard` always posted its answer to `POST /api/runs/:id/messages`, which answers `409 { error: "session closed" }` once the engine has let go of the session. The rejection rode a bare `void mutateAsync(...)`, so a tap on an option chip produced no request the user could see fail and no state change — the card just sat there.

## What Changed
- **`packages/web/src/routes/task-thread/ask-answer.ts` (new)** — `askDeliveryMode(run)` is the pure routing decision (`live` | `resume` | `unavailable`), built on the same `isRunActive`/`runActionFlags` predicates the run header and the composer use. `useAskAnswer(run)` delivers on that seam: a live reply while the engine owns a session, `POST /continue` with the answer as the reopened session's opening prompt once it has closed. It also retries a `409` from the live path as a resume (a cockpit whose record is stale after a dropped SSE frame), and captures failures in state rather than dropping them.
- **`packages/web/src/routes/task-thread/ask-card.tsx`** — delivers through `useAskAnswer` instead of `useSendMessage`. On a closed run the card says what the answer will do ("The session has ended — your answer reopens it and goes to the agent." / **Send answer & reopen**), a run with no recorded session renders inert with an honest reason, and a refused delivery is shown inline as a `role="alert"`. The provider gate now follows the seam: the active-provider check for a live reply, the continuation check (with its connected-runner fallback) for a resume.
- **`packages/web/src/api/queries.ts`** — `useContinueRun(id)`, the plain sibling of `useSendMessage` for a run whose session has already ended. The composer keeps its own `useContinueAction` because it also owns the runner/model pills; the ask card deliberately sends no override, so answering a question never switches the run's engine.
- **`.ai/specs/2026-07-18-askuser-across-runners.md`** — the spec claimed a finished run's card "renders resolved/closed"; it actually rendered live chips that 409'd. Both the answer-flow step and the edge-case list now describe the routing that ships.

## 🧪 Tests
- `npm run typecheck` ✅ · `npm test` — 4660 passed / 257 files ✅ · `npm run test:unit` — 36 passed ✅ · `npm run build` ✅ (`check:pack ok`) · `npm run test:package` — 9 passed ✅
- `ask-answer.test.ts` (new) — the routing table across all 7 run statuses, with and without a recorded session id, plus the multi-step and archived cases.
- `ask-card.test.tsx` — a closed run resumes with the same answer text and no runner override; the one-tap and combined-Send shapes both say the session reopens; a stale record's `409` falls back to a resume; a refused delivery renders as an alert; the no-session state is inert. The pre-existing live-path and provider-gate tests are unchanged and still pass.
- `thread-state.test.ts` — pins that a **continuation** step's `user-message` resolves an ask left pending when the session ended. That is the cross-session half of the feature and nothing pinned it before.
- Verified in a real cockpit (`CEZ_DRY_RUN=1`, agent-browser): a `mock:ask` run parked `waiting`, **Finish** closed it to `done` with the ask unanswered, `POST /messages` answered `409 session closed` (the old path, reproduced), and one tap on a chip in the browser reopened the run — `step-start Continue`, `user-message "Library: date-fns"`, the agent's `"Okay — looking into: Library: date-fns"` — with the card collapsing to `Answered · Library: date-fns`.

## 💥 Breaking Changes
- None. No API contract change (`POST /messages` still answers `409 session closed`), no `RunRecord` field, no `UiEvent` change, no change to the `CEZ:ASK` marker or the system prompt.

## 📋 Progress
See the Progress section in the tracking plan.
