### PR TITLE
feat(cockpit): compact session chrome + reading-width setting

### DIFF
--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -499,13 +499,24 @@ const SKILL_USAGE_MAX_ENTRIES = 200;
 // BOTH ui-state routes (per-repo and workspace) via `parseUiStateBody`.
 const UI_STATE_MAX_KEYS = 200;
 
-/** Settings → Appearance (redesign R6): accent + density. ONE schema for both
- *  ui-state files — per-repo (the legacy home, kept so an older cezar in the
- *  same repo still honours it) and workspace (`~/.cezar/ui-state.json`, its
- *  post-migration home — multi-project spec, Data Model). */
+/** Settings → Appearance (redesign R6): accent + density + reading width. ONE
+ *  schema for both ui-state files — per-repo (the legacy home, kept so an older
+ *  cezar in the same repo still honours it) and workspace
+ *  (`~/.cezar/ui-state.json`, its post-migration home — multi-project spec,
+ *  Data Model).
+ *
+ *  Every key is `.optional()` so an older ui-state.json parses unchanged, but
+ *  each one must be listed HERE: the enclosing `workspaceUiStateSchema` is
+ *  `.passthrough()` at the top level only, so an unlisted key inside
+ *  `appearance` is stripped by zod and then wiped from the file by the shallow
+ *  merge-on-write. The cockpit adopts the PUT response as authoritative, so a
+ *  stripped key does not merely fail to persist — it visibly reverts the
+ *  control the user just touched. Adding an appearance preference means adding
+ *  it here in the same change. */
 const appearanceSchema = z.object({
   accent: z.enum(['lime', 'violet']).optional(),
   density: z.enum(['comfortable', 'compact', 'ultra']).optional(),
+  width: z.enum(['narrow', 'wide']).optional(),
 });
 
 const providerAuthDismissalsSchema = z

--- a/packages/cezar/src/server/workspace-api.test.ts
+++ b/packages/cezar/src/server/workspace-api.test.ts
@@ -342,6 +342,29 @@ describe('the workspace settings API (step 2.7)', () => {
     expect(await (await apiRequest(app, '/api/ui-state')).json()).toEqual({});
   });
 
+  // Every Settings → Appearance preference has to be listed in `appearanceSchema`: the top-level
+  // `.passthrough()` does NOT reach inside `appearance`, so an unlisted key is stripped here and
+  // then wiped from the file by the shallow merge. The cockpit adopts this response as
+  // authoritative, so a stripped key visibly reverts the control the user just touched — which is
+  // exactly what happened to `width` before it was added. The client-side settings test stubs
+  // `fetch` with an echo, so this route-level round-trip is the only place that can catch it.
+  it('round-trips every appearance preference — accent, density AND reading width', async () => {
+    const res = await putUiState({ appearance: { accent: 'violet', density: 'compact', width: 'wide' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      appearance: { accent: 'violet', density: 'compact', width: 'wide' },
+    });
+    expect(rawUiState()).toEqual({
+      appearance: { accent: 'violet', density: 'compact', width: 'wide' },
+    });
+  });
+
+  it('rejects an out-of-enum reading width instead of silently dropping it', async () => {
+    const res = await putUiState({ appearance: { width: 'ultrawide' } });
+    expect(res.status).toBe(400);
+    expect(() => readFileSync(workspaceUiStatePath(), 'utf8')).toThrow();
+  });
+
   it('accepts bounded provider auth failure dismissals', async () => {
     const response = await putUiState({
       dismissedProviderAuthFailures: {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -36,6 +36,8 @@
           var density = localStorage.getItem('cez-density')
           if (density === 'compact' || density === 'ultra')
             document.documentElement.dataset.density = density
+          if (localStorage.getItem('cez-width') === 'wide')
+            document.documentElement.dataset.width = 'wide'
         } catch (e) {
           // Storage unavailable — lime/comfortable defaults already apply.
         }

--- a/packages/web/src/components/appearance-provider.tsx
+++ b/packages/web/src/components/appearance-provider.tsx
@@ -12,13 +12,16 @@ import {
   type Accent,
   type Appearance,
   type Density,
+  type Width,
 } from '@/lib/appearance'
 
 type AppearanceContextValue = {
   accent: Accent
   density: Density
+  width: Width
   setAccent: (accent: Accent) => void
   setDensity: (density: Density) => void
+  setWidth: (width: Width) => void
 }
 
 const AppearanceContext = React.createContext<AppearanceContextValue | null>(null)
@@ -79,17 +82,28 @@ export function AppearanceProvider({ children }: { children: React.ReactNode }) 
   )
 
   const setAccent = React.useCallback(
-    (accent: Accent) => save({ accent, density: appearance.density }),
-    [save, appearance.density],
+    (accent: Accent) => save({ ...appearance, accent }),
+    [save, appearance],
   )
   const setDensity = React.useCallback(
-    (density: Density) => save({ accent: appearance.accent, density }),
-    [save, appearance.accent],
+    (density: Density) => save({ ...appearance, density }),
+    [save, appearance],
+  )
+  const setWidth = React.useCallback(
+    (width: Width) => save({ ...appearance, width }),
+    [save, appearance],
   )
 
   const value = React.useMemo<AppearanceContextValue>(
-    () => ({ accent: appearance.accent, density: appearance.density, setAccent, setDensity }),
-    [appearance, setAccent, setDensity],
+    () => ({
+      accent: appearance.accent,
+      density: appearance.density,
+      width: appearance.width,
+      setAccent,
+      setDensity,
+      setWidth,
+    }),
+    [appearance, setAccent, setDensity, setWidth],
   )
 
   return <AppearanceContext.Provider value={value}>{children}</AppearanceContext.Provider>

--- a/packages/web/src/lib/appearance.test.ts
+++ b/packages/web/src/lib/appearance.test.ts
@@ -3,10 +3,12 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   ACCENT_STORAGE_KEY,
   DENSITY_STORAGE_KEY,
+  WIDTH_STORAGE_KEY,
   applyAppearance,
   normalizeAccent,
   normalizeAppearance,
   normalizeDensity,
+  normalizeWidth,
   readStoredAppearance,
   writeStoredAppearance,
 } from './appearance'
@@ -15,6 +17,7 @@ afterEach(() => {
   localStorage.clear()
   delete document.documentElement.dataset.accent
   delete document.documentElement.dataset.density
+  delete document.documentElement.dataset.width
 })
 
 describe('normalize', () => {
@@ -25,49 +28,65 @@ describe('normalize', () => {
     for (const raw of [null, undefined, 'magenta', 42, {}]) {
       expect(normalizeAccent(raw)).toBe('lime')
       expect(normalizeDensity(raw)).toBe('comfortable')
+      expect(normalizeWidth(raw)).toBe('narrow')
     }
     expect(normalizeDensity('compact')).toBe('compact')
     expect(normalizeDensity('ultra')).toBe('ultra')
+    expect(normalizeWidth('wide')).toBe('wide')
+    expect(normalizeWidth('narrow')).toBe('narrow')
   })
 
   it('normalizeAppearance survives any ui-state shape', () => {
-    expect(normalizeAppearance(undefined)).toEqual({ accent: 'lime', density: 'comfortable' })
-    expect(normalizeAppearance('not-an-object')).toEqual({ accent: 'lime', density: 'comfortable' })
+    expect(normalizeAppearance(undefined)).toEqual({
+      accent: 'lime',
+      density: 'comfortable',
+      width: 'narrow',
+    })
+    expect(normalizeAppearance('not-an-object')).toEqual({
+      accent: 'lime',
+      density: 'comfortable',
+      width: 'narrow',
+    })
     expect(normalizeAppearance({ accent: 'violet' })).toEqual({
       accent: 'violet',
       density: 'comfortable',
+      width: 'narrow',
     })
-    expect(normalizeAppearance({ accent: 'nope', density: 'compact' })).toEqual({
+    expect(normalizeAppearance({ accent: 'nope', density: 'compact', width: 'wide' })).toEqual({
       accent: 'lime',
       density: 'compact',
+      width: 'wide',
     })
   })
 })
 
 describe('the localStorage mirror', () => {
   it('round-trips through the same keys the index.html pre-paint script reads', () => {
-    writeStoredAppearance({ accent: 'violet', density: 'compact' })
+    writeStoredAppearance({ accent: 'violet', density: 'compact', width: 'wide' })
     expect(localStorage.getItem(ACCENT_STORAGE_KEY)).toBe('violet')
     expect(localStorage.getItem(DENSITY_STORAGE_KEY)).toBe('compact')
-    expect(readStoredAppearance()).toEqual({ accent: 'violet', density: 'compact' })
+    expect(localStorage.getItem(WIDTH_STORAGE_KEY)).toBe('wide')
+    expect(readStoredAppearance()).toEqual({ accent: 'violet', density: 'compact', width: 'wide' })
   })
 
   it('defaults when the mirror is empty', () => {
-    expect(readStoredAppearance()).toEqual({ accent: 'lime', density: 'comfortable' })
+    expect(readStoredAppearance()).toEqual({ accent: 'lime', density: 'comfortable', width: 'narrow' })
   })
 })
 
 describe('applyAppearance', () => {
   it('stamps only the non-default choices, exactly like the pre-paint script', () => {
     const root = document.documentElement
-    applyAppearance(root, { accent: 'violet', density: 'compact' })
+    applyAppearance(root, { accent: 'violet', density: 'compact', width: 'wide' })
     expect(root.dataset.accent).toBe('violet')
     expect(root.dataset.density).toBe('compact')
+    expect(root.dataset.width).toBe('wide')
 
     // Back to defaults: the attributes must come OFF (the stock token sheet is the default),
     // not be written as data-accent="lime".
-    applyAppearance(root, { accent: 'lime', density: 'comfortable' })
+    applyAppearance(root, { accent: 'lime', density: 'comfortable', width: 'narrow' })
     expect(root.hasAttribute('data-accent')).toBe(false)
     expect(root.hasAttribute('data-density')).toBe(false)
+    expect(root.hasAttribute('data-width')).toBe(false)
   })
 })

--- a/packages/web/src/lib/appearance.ts
+++ b/packages/web/src/lib/appearance.ts
@@ -13,6 +13,7 @@
 
 export const ACCENT_STORAGE_KEY = 'cez-accent'
 export const DENSITY_STORAGE_KEY = 'cez-density'
+export const WIDTH_STORAGE_KEY = 'cez-width'
 
 /** The two accents the token sheet can express today: `lime` is `--primary` as shipped;
  *  `violet` swaps the `--primary` family onto the existing `--violet` tokens (index.css
@@ -24,12 +25,19 @@ export type Accent = 'lime' | 'violet'
  *  `ultra` ("Compact for real") → 3px (~25%). See the `:root[data-density]` blocks in index.css. */
 export type Density = 'comfortable' | 'compact' | 'ultra'
 
+/** Reading width flips the one `--measure` token that caps the task-view column (index.css
+ *  `:root[data-width="wide"]`): `narrow` is the shipped 820px reading column; `wide` opens it
+ *  to 1180px so long transcripts use more of the screen. Type size and spacing stay untouched. */
+export type Width = 'narrow' | 'wide'
+
 export const DEFAULT_ACCENT: Accent = 'lime'
 export const DEFAULT_DENSITY: Density = 'comfortable'
+export const DEFAULT_WIDTH: Width = 'narrow'
 
 export interface Appearance {
   accent: Accent
   density: Density
+  width: Width
 }
 
 /** Coerce anything (missing key, a future value, garbage) into an Accent. */
@@ -41,11 +49,19 @@ export function normalizeDensity(raw: unknown): Density {
   return raw === 'comfortable' || raw === 'compact' || raw === 'ultra' ? raw : DEFAULT_DENSITY
 }
 
+export function normalizeWidth(raw: unknown): Width {
+  return raw === 'narrow' || raw === 'wide' ? raw : DEFAULT_WIDTH
+}
+
 /** The `appearance` key of a ui-state payload, defaults filled in. Defensive about shape —
  *  the server passes unknown keys through, so this can meet anything. */
 export function normalizeAppearance(raw: unknown): Appearance {
   const obj = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
-  return { accent: normalizeAccent(obj.accent), density: normalizeDensity(obj.density) }
+  return {
+    accent: normalizeAccent(obj.accent),
+    density: normalizeDensity(obj.density),
+    width: normalizeWidth(obj.width),
+  }
 }
 
 /** The mirrored preference, or the default when storage is empty/unreadable (private mode). */
@@ -54,9 +70,10 @@ export function readStoredAppearance(): Appearance {
     return {
       accent: normalizeAccent(localStorage.getItem(ACCENT_STORAGE_KEY)),
       density: normalizeDensity(localStorage.getItem(DENSITY_STORAGE_KEY)),
+      width: normalizeWidth(localStorage.getItem(WIDTH_STORAGE_KEY)),
     }
   } catch {
-    return { accent: DEFAULT_ACCENT, density: DEFAULT_DENSITY }
+    return { accent: DEFAULT_ACCENT, density: DEFAULT_DENSITY, width: DEFAULT_WIDTH }
   }
 }
 
@@ -64,6 +81,7 @@ export function writeStoredAppearance(appearance: Appearance): void {
   try {
     localStorage.setItem(ACCENT_STORAGE_KEY, appearance.accent)
     localStorage.setItem(DENSITY_STORAGE_KEY, appearance.density)
+    localStorage.setItem(WIDTH_STORAGE_KEY, appearance.width)
   } catch {
     // Private mode / storage disabled — the appearance still applies for this page.
   }
@@ -76,4 +94,6 @@ export function applyAppearance(root: HTMLElement, appearance: Appearance): void
   else root.dataset.accent = appearance.accent
   if (appearance.density === DEFAULT_DENSITY) delete root.dataset.density
   else root.dataset.density = appearance.density
+  if (appearance.width === DEFAULT_WIDTH) delete root.dataset.width
+  else root.dataset.width = appearance.width
 }

--- a/packages/web/src/routes/settings/appearance.tsx
+++ b/packages/web/src/routes/settings/appearance.tsx
@@ -4,7 +4,7 @@ import type { ComponentType, ReactNode, SVGProps } from 'react'
 import { useAppearance } from '@/components/appearance-provider'
 import { useTheme } from '@/components/theme-provider'
 import { cn } from '@/lib/utils'
-import type { Accent, Density } from '@/lib/appearance'
+import type { Accent, Density, Width } from '@/lib/appearance'
 import type { Theme } from '@/lib/theme'
 
 /**
@@ -37,6 +37,11 @@ const DENSITY_OPTIONS: Array<{ value: Density; label: string }> = [
   { value: 'comfortable', label: 'Comfortable' },
   { value: 'compact', label: 'Compact' },
   { value: 'ultra', label: 'Compact for real' },
+]
+
+const WIDTH_OPTIONS: Array<{ value: Width; label: string }> = [
+  { value: 'narrow', label: 'Narrow' },
+  { value: 'wide', label: 'Wide' },
 ]
 
 /** One segmented radio group — the shared chassis of all three controls. */
@@ -107,7 +112,7 @@ function Field({ title, hint, children }: { title: string; hint: string; childre
 
 export function AppearanceSection() {
   const { theme, setTheme } = useTheme()
-  const { accent, density, setAccent, setDensity } = useAppearance()
+  const { accent, density, width, setAccent, setDensity, setWidth } = useAppearance()
 
   return (
     <div
@@ -127,6 +132,13 @@ export function AppearanceSection() {
         hint="Compact tightens spacing across the cockpit — text stays the same size."
       >
         <Segmented slot="appearance-density" label="Density" value={density} options={DENSITY_OPTIONS} onChange={setDensity} />
+      </Field>
+
+      <Field
+        title="Reading width"
+        hint="Wide lets a task's session, changes and commits use more of the screen. Narrow keeps a comfortable reading column."
+      >
+        <Segmented slot="appearance-width" label="Reading width" value={width} options={WIDTH_OPTIONS} onChange={setWidth} />
       </Field>
     </div>
   )

--- a/packages/web/src/routes/settings/appearance.tsx
+++ b/packages/web/src/routes/settings/appearance.tsx
@@ -136,7 +136,7 @@ export function AppearanceSection() {
 
       <Field
         title="Reading width"
-        hint="Wide lets a task's session, changes and commits use more of the screen. Narrow keeps a comfortable reading column."
+        hint="Wide lets a task's session and commits use more of the screen. Narrow keeps a comfortable reading column. The Changes tab is always full-width."
       >
         <Segmented slot="appearance-width" label="Reading width" value={width} options={WIDTH_OPTIONS} onChange={setWidth} />
       </Field>

--- a/packages/web/src/routes/settings/settings.test.tsx
+++ b/packages/web/src/routes/settings/settings.test.tsx
@@ -113,6 +113,7 @@ afterEach(() => {
   localStorage.clear()
   delete document.documentElement.dataset.accent
   delete document.documentElement.dataset.density
+  delete document.documentElement.dataset.width
   document.documentElement.classList.remove('light')
 })
 
@@ -258,7 +259,7 @@ describe('the appearance section (global scope)', () => {
     // `{ accent }` would silently drop the stored density.
     await waitFor(() => {
       expect(requests.find((r) => r.method === 'PUT' && r.url === '/api/workspace/ui-state')?.body).toEqual({
-        appearance: { accent: 'violet', density: 'compact' },
+        appearance: { accent: 'violet', density: 'compact', width: 'narrow' },
       })
     })
     expect(localStorage.getItem('cez-accent')).toBe('violet')
@@ -275,8 +276,34 @@ describe('the appearance section (global scope)', () => {
     expect(document.documentElement.hasAttribute('data-density')).toBe(false)
     await waitFor(() => {
       expect(requests.find((r) => r.method === 'PUT' && r.url === '/api/workspace/ui-state')?.body).toEqual({
-        appearance: { accent: 'lime', density: 'comfortable' },
+        appearance: { accent: 'lime', density: 'comfortable', width: 'narrow' },
       })
+    })
+  })
+
+  it('reading width round-trip: Wide stamps the root and PUTs the full object; back to Narrow clears it', async () => {
+    serve({ appearance: { accent: 'violet' } })
+    renderAt('/settings/global/appearance')
+    // Wait for the server value to settle (Violet is server-provided; Narrow is the default and
+    // would report "checked" from the mirror before the GET even lands), so the pending load
+    // can't clobber the width write we're about to make.
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'Violet' }).getAttribute('aria-checked')).toBe('true')
+    })
+    expect(screen.getByRole('radio', { name: 'Narrow' }).getAttribute('aria-checked')).toBe('true')
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Wide' }))
+    expect(document.documentElement.dataset.width).toBe('wide')
+    await waitFor(() => {
+      expect(requests.find((r) => r.method === 'PUT' && r.url === '/api/workspace/ui-state')?.body).toEqual({
+        appearance: { accent: 'violet', density: 'comfortable', width: 'wide' },
+      })
+    })
+
+    // Narrow is the default — the attribute must come OFF the root, not be written as data-width="narrow".
+    fireEvent.click(screen.getByRole('radio', { name: 'Narrow' }))
+    await waitFor(() => {
+      expect(document.documentElement.hasAttribute('data-width')).toBe(false)
     })
   })
 
@@ -317,7 +344,7 @@ describe('the settings split writes the right store', () => {
 
     await waitFor(() => expect(putsTo('/api/workspace/ui-state')).toHaveLength(1))
     expect(putsTo('/api/workspace/ui-state')[0]?.body).toEqual({
-      appearance: { accent: 'violet', density: 'comfortable' },
+      appearance: { accent: 'violet', density: 'comfortable', width: 'narrow' },
     })
     expect(putsTo('/api/ui-state')).toHaveLength(0)
   })

--- a/packages/web/src/routes/task-git/task-commits.tsx
+++ b/packages/web/src/routes/task-git/task-commits.tsx
@@ -69,7 +69,7 @@ function CommitsView({ run }: { run: ApiRun }) {
       ) : (
         <CommitList
           slot="task-commits"
-          className="mx-auto w-full max-w-[820px]"
+          className="mx-auto w-full max-w-[var(--measure)]"
           commits={commits.data.commits.map((commit: RunCommit) => ({
             ...commit,
             shaLabel: commit.sha.slice(0, 8),
@@ -92,7 +92,7 @@ function CommitDiffView({ runId, sha }: { runId: string; sha: string }) {
   const effectiveWrap = desktop ? wrap : true
 
   return (
-    <section data-slot="task-commit" data-sha={sha} className="mx-auto flex min-h-0 w-full max-w-[820px] flex-1 flex-col">
+    <section data-slot="task-commit" data-sha={sha} className="mx-auto flex min-h-0 w-full max-w-[var(--measure)] flex-1 flex-col">
       <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b border-border px-4 py-2 md:px-6">
         <Button asChild variant="ghost" size="sm" data-slot="commit-back">
           <Link to={`/tasks/${runId}/commits`}>

--- a/packages/web/src/routes/task-thread/agents-dock.test.tsx
+++ b/packages/web/src/routes/task-thread/agents-dock.test.tsx
@@ -23,6 +23,8 @@ const dock = () => document.querySelector('[data-slot="agents-dock"]')
 const head = () => document.querySelector<HTMLButtonElement>('[data-slot="agents-dock"] > button')!
 const rows = () => Array.from(document.querySelectorAll('[data-slot="agent-item"]'))
 const glyph = (row: Element) => row.querySelector('[data-slot="agent-glyph"]')!
+/** The dock is collapsed by default now — open it to inspect the per-agent rows. */
+const expand = () => fireEvent.click(head())
 
 describe('AgentsDock — visibility', () => {
   it('renders nothing at all when there is no fan-out', () => {
@@ -37,7 +39,7 @@ describe('AgentsDock — visibility', () => {
 })
 
 describe('AgentsDock — the collapsed head', () => {
-  it('shows the odometer and the first working agent’s activity', () => {
+  it('is collapsed by default: the slim head carries the odometer and the working agent’s activity', () => {
     render(
       <AgentsDock
         runId={freshRun()}
@@ -48,7 +50,10 @@ describe('AgentsDock — the collapsed head', () => {
         ]}
       />,
     )
-    fireEvent.click(head()) // jsdom defaults to expanded (desktop) — collapse it
+    // No click — the dock opens collapsed, so the rows are not mounted…
+    expect(head().getAttribute('aria-expanded')).toBe('false')
+    expect(rows()).toHaveLength(0)
+    // …but the one-line head still answers "what's running right now?".
     expect(document.querySelector('[data-slot="agents-count"]')!.textContent).toContain('1/3')
     expect(document.querySelector('[data-slot="agents-current"]')!.textContent).toContain('Reviewing store layer')
   })
@@ -69,6 +74,9 @@ describe('AgentsDock — the collapsed head', () => {
 
   it('toggles expanded/collapsed and reports it to assistive tech', () => {
     render(<AgentsDock runId="run-toggle" agents={[agent()]} />)
+    expect(head().getAttribute('aria-expanded')).toBe('false')
+    expect(rows()).toHaveLength(0)
+    fireEvent.click(head())
     expect(head().getAttribute('aria-expanded')).toBe('true')
     expect(rows()).toHaveLength(1)
     fireEvent.click(head())
@@ -88,6 +96,7 @@ describe('AgentsDock — expanded rows', () => {
         ]}
       />,
     )
+    expand()
     const [first, second] = rows()
     expect(first!.textContent).toContain('Audit the auth flow')
     expect(first!.querySelector('[data-slot="agent-type"]')!.textContent).toBe('general-purpose')
@@ -100,11 +109,13 @@ describe('AgentsDock — expanded rows', () => {
 
   it('renders "starting…" for an agent with no attributed output yet', () => {
     render(<AgentsDock runId={freshRun()} agents={[agent({ activity: undefined })]} />)
+    expand()
     expect(document.querySelector('[data-slot="agent-activity"]')!.textContent).toBe('starting…')
   })
 
   it('omits the type badge when the backend declares none (codex)', () => {
     render(<AgentsDock runId={freshRun()} agents={[agent({ agentType: undefined })]} />)
+    expand()
     expect(document.querySelector('[data-slot="agent-type"]')).toBeNull()
   })
 
@@ -119,6 +130,7 @@ describe('AgentsDock — expanded rows', () => {
         ]}
       />,
     )
+    expand()
     const [running, completed, failed] = rows().map(glyph)
     // The running glyph is the pulsing half-disc; the other two are stroked paths.
     expect(running!.querySelector('.fill-pending')).not.toBeNull()
@@ -134,6 +146,7 @@ describe('AgentsDock — expanded rows', () => {
 
   it('renders a stalled agent as interrupted — not pulsing, not a checkmark', () => {
     render(<AgentsDock runId={freshRun()} agents={[agent({ status: 'running', stalled: true })]} />)
+    expand()
     const svg = glyph(rows()[0]!)
     expect(svg.getAttribute('data-stalled')).toBe('true')
     // Not the live glyph: no pulse, no amber fill — the run ended, nothing is working.
@@ -148,11 +161,13 @@ describe('AgentsDock — expanded rows', () => {
     render(
       <AgentsDock runId={freshRun()} agents={[agent({ status: 'running', stalled: true, activity: 'Ran npm test' })]} />,
     )
+    expand()
     expect(document.querySelector('[data-slot="agent-activity"]')!.textContent).toBe('Ran npm test')
   })
 
   it('exposes each status on the row for styling and tests', () => {
     render(<AgentsDock runId={freshRun()} agents={[agent({ status: 'declined' })]} />)
+    expand()
     expect(rows()[0]!.getAttribute('data-status')).toBe('declined')
   })
 })
@@ -160,12 +175,14 @@ describe('AgentsDock — expanded rows', () => {
 describe('AgentsDock — row interaction', () => {
   it('rows are static display when no handler is passed (Phase 1)', () => {
     render(<AgentsDock runId={freshRun()} agents={[agent()]} />)
+    expand()
     expect(rows()[0]!.querySelector('button')).toBeNull()
   })
 
   it('rows become dialog-opening buttons once a handler is passed (Phase 2)', () => {
     const opened: string[] = []
     render(<AgentsDock runId={freshRun()} agents={[agent({ id: 'agent-42' })]} onSelect={(id) => opened.push(id)} />)
+    expand()
     const button = rows()[0]!.querySelector('button')!
     expect(button.getAttribute('aria-haspopup')).toBe('dialog')
     fireEvent.click(button)
@@ -174,16 +191,16 @@ describe('AgentsDock — row interaction', () => {
 })
 
 describe('AgentsDock — collapse memory', () => {
-  it('remembers the collapse choice per run across remounts', () => {
+  it('remembers an explicit expand per run across remounts', () => {
     const { unmount } = render(<AgentsDock runId="run-memory" agents={[agent()]} />)
-    fireEvent.click(head()) // collapse
+    fireEvent.click(head()) // expand (default is collapsed)
     unmount()
     render(<AgentsDock runId="run-memory" agents={[agent()]} />)
-    expect(head().getAttribute('aria-expanded')).toBe('false')
+    expect(head().getAttribute('aria-expanded')).toBe('true')
   })
 
-  it('does not leak that choice to a different run', () => {
+  it('does not leak that choice to a different run — a fresh run opens collapsed', () => {
     render(<AgentsDock runId="run-other" agents={[agent()]} />)
-    expect(head().getAttribute('aria-expanded')).toBe('true')
+    expect(head().getAttribute('aria-expanded')).toBe('false')
   })
 })

--- a/packages/web/src/routes/task-thread/agents-dock.tsx
+++ b/packages/web/src/routes/task-thread/agents-dock.tsx
@@ -25,10 +25,10 @@ import { activeSubagent, subagentActivityText, subagentCounts, type SubagentSumm
  *  the choice survives route changes for the session without inventing server persistence. */
 const openByRun = new Map<string, boolean>()
 
-/** Desktop starts expanded, phones collapsed. jsdom has no matchMedia — that counts as desktop. */
-function defaultOpen(): boolean {
-  return typeof window.matchMedia !== 'function' || window.matchMedia('(min-width: 768px)').matches
-}
+/** Collapsed by default (redesign): the slim one-line head already answers "what's running now?"
+ *  — `Agents · 1/3 — Reviewing store layer…` — so the dock stays out of the thread's way until
+ *  the reader wants the per-agent breakdown. Their explicit expand is remembered per run. */
+const DEFAULT_OPEN = false
 
 export function AgentsDock({
   runId,
@@ -40,7 +40,7 @@ export function AgentsDock({
   /** Phase 2: opens the drill-down sheet. Absent ⇒ rows are static display. */
   onSelect?: (id: string) => void
 }) {
-  const [open, setOpen] = useState(() => openByRun.get(runId) ?? defaultOpen())
+  const [open, setOpen] = useState(() => openByRun.get(runId) ?? DEFAULT_OPEN)
   // No fan-out to show — the overwhelming majority of runs never mount this at all.
   if (agents.length === 0) return null
 

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -74,7 +74,7 @@ import { isHttpUrl } from '@/lib/utils'
 import { Markdown } from './markdown'
 import { useContinuationProvider } from './continuation-provider'
 import { cliTargetResumes, cliTargetRunner, finishTitle, resumeHint, runActionFlags } from './run-actions'
-import { StepRail } from './step-rail'
+import { WorkflowSteps } from './step-rail'
 import { useFinishRun } from './use-finish-run'
 
 /**
@@ -121,7 +121,7 @@ export function RunHeader({
       data-slot="run-header"
       className="sticky top-0 z-20 border-b border-border bg-background/95 px-4 pt-3 backdrop-blur md:px-6"
     >
-      <div className="mx-auto w-full max-w-[820px]">
+      <div className="mx-auto w-full max-w-[var(--measure)]">
         <div className="flex min-w-0 items-center gap-2">
           <EditableTitle run={run} />
           <span className="ml-auto flex shrink-0 items-center gap-2.5">
@@ -210,8 +210,8 @@ export function RunHeader({
         </div>
 
         {run.steps.length > 0 ? (
-          <div className="border-t border-border pt-2.5 pb-1">
-            <StepRail steps={run.steps} />
+          <div className="border-t border-border pt-2 pb-1">
+            <WorkflowSteps steps={run.steps} />
           </div>
         ) : null}
 

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -211,7 +211,7 @@ export function RunHeader({
 
         {run.steps.length > 0 ? (
           <div className="border-t border-border pt-2 pb-1">
-            <WorkflowSteps steps={run.steps} />
+            <WorkflowSteps runId={run.id} steps={run.steps} />
           </div>
         ) : null}
 

--- a/packages/web/src/routes/task-thread/step-rail.test.tsx
+++ b/packages/web/src/routes/task-thread/step-rail.test.tsx
@@ -1,9 +1,9 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type { StepState, StepStatus } from '@open-mercato/cezar-api-client'
 
-import { railProgress, railVisual, StepRail, type RailVisual } from './step-rail'
+import { activeStepIndex, railProgress, railVisual, StepRail, WorkflowSteps, type RailVisual } from './step-rail'
 
 afterEach(cleanup)
 
@@ -94,5 +94,45 @@ describe('StepRail', () => {
     render(<StepRail steps={[step('a', 'done'), step('b', 'running'), step('c', 'pending'), step('d', 'pending')]} />)
     const bar = document.querySelector<HTMLElement>('[data-slot="step-progress"] > div')!
     expect(bar.style.width).toBe('37.5%') // (1 + 0.5) / 4
+  })
+})
+
+describe('activeStepIndex — who the summary speaks for', () => {
+  it('points at the first in-flight step, else the last (a finished run reads "N of N")', () => {
+    expect(activeStepIndex([step('a', 'done'), step('b', 'running'), step('c', 'pending')])).toBe(1)
+    expect(activeStepIndex([step('a', 'done'), step('b', 'done')])).toBe(1)
+    expect(activeStepIndex([step('a', 'pending'), step('b', 'pending')])).toBe(0)
+  })
+})
+
+describe('WorkflowSteps — the collapsible header summary', () => {
+  const steps = [
+    step('implement', 'done', { name: 'Do the task' }),
+    step('verify', 'running', { name: 'Verify', kind: 'check' }),
+    step('review', 'pending', { name: 'Review' }),
+  ]
+
+  it('renders nothing without steps', () => {
+    render(<WorkflowSteps steps={[]} />)
+    expect(document.querySelector('[data-slot="workflow-steps"]')).toBeNull()
+  })
+
+  it('collapsed by default: names the active step, one dot per step, and hides the full rows', () => {
+    render(<WorkflowSteps steps={steps} />)
+    const summary = document.querySelector('[data-slot="workflow-steps"]')!
+    expect(summary.textContent).toContain('Verify')
+    expect(summary.textContent).toContain('step 2 of 3')
+    const dots = [...document.querySelectorAll('[data-slot="step-dot"]')]
+    expect(dots.map((dot) => dot.getAttribute('data-visual'))).toEqual(['done', 'active', 'pending'])
+    // The full rows are not mounted until the user expands.
+    expect(document.querySelector('[data-slot="step-row"]')).toBeNull()
+  })
+
+  it('expands to the full rail on click', () => {
+    render(<WorkflowSteps steps={steps} />)
+    fireEvent.click(screen.getByRole('button'))
+    const rows = [...document.querySelectorAll('[data-slot="step-row"]')]
+    expect(rows.map((row) => row.getAttribute('data-visual'))).toEqual(['done', 'active', 'pending'])
+    expect(rows[1]!.textContent).toContain('check · step 2 of 3')
   })
 })

--- a/packages/web/src/routes/task-thread/step-rail.test.tsx
+++ b/packages/web/src/routes/task-thread/step-rail.test.tsx
@@ -102,6 +102,9 @@ describe('activeStepIndex — who the summary speaks for', () => {
     expect(activeStepIndex([step('a', 'done'), step('b', 'running'), step('c', 'pending')])).toBe(1)
     expect(activeStepIndex([step('a', 'done'), step('b', 'done')])).toBe(1)
     expect(activeStepIndex([step('a', 'pending'), step('b', 'pending')])).toBe(0)
+    // An empty list has no index to point at; 0 keeps `steps[index]` undefined rather than
+    // handing back a -1 that would silently address the wrong element.
+    expect(activeStepIndex([])).toBe(0)
   })
 })
 
@@ -111,14 +114,17 @@ describe('WorkflowSteps — the collapsible header summary', () => {
     step('verify', 'running', { name: 'Verify', kind: 'check' }),
     step('review', 'pending', { name: 'Review' }),
   ]
+  /** Unique per test — the expand memory below is module-level and keyed by run id. */
+  let seq = 0
+  const freshRun = () => `run-steps-${(seq += 1)}`
 
   it('renders nothing without steps', () => {
-    render(<WorkflowSteps steps={[]} />)
+    render(<WorkflowSteps runId={freshRun()} steps={[]} />)
     expect(document.querySelector('[data-slot="workflow-steps"]')).toBeNull()
   })
 
   it('collapsed by default: names the active step, one dot per step, and hides the full rows', () => {
-    render(<WorkflowSteps steps={steps} />)
+    render(<WorkflowSteps runId={freshRun()} steps={steps} />)
     const summary = document.querySelector('[data-slot="workflow-steps"]')!
     expect(summary.textContent).toContain('Verify')
     expect(summary.textContent).toContain('step 2 of 3')
@@ -129,10 +135,31 @@ describe('WorkflowSteps — the collapsible header summary', () => {
   })
 
   it('expands to the full rail on click', () => {
-    render(<WorkflowSteps steps={steps} />)
+    render(<WorkflowSteps runId={freshRun()} steps={steps} />)
     fireEvent.click(screen.getByRole('button'))
     const rows = [...document.querySelectorAll('[data-slot="step-row"]')]
     expect(rows.map((row) => row.getAttribute('data-visual'))).toEqual(['done', 'active', 'pending'])
     expect(rows[1]!.textContent).toContain('check · step 2 of 3')
+  })
+
+  it('remembers an explicit expand per run across remounts — a tab switch must not collapse it', () => {
+    const runId = freshRun()
+    const first = render(<WorkflowSteps runId={runId} steps={steps} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(document.querySelector('[data-slot="step-row"]')).not.toBeNull()
+    first.unmount()
+
+    // Same run, remounted by another task route's RunHeader: still expanded.
+    render(<WorkflowSteps runId={runId} steps={steps} />)
+    expect(document.querySelector('[data-slot="step-row"]')).not.toBeNull()
+  })
+
+  it('does not leak that choice to a different run — a fresh run opens collapsed', () => {
+    const first = render(<WorkflowSteps runId={freshRun()} steps={steps} />)
+    fireEvent.click(screen.getByRole('button'))
+    first.unmount()
+
+    render(<WorkflowSteps runId={freshRun()} steps={steps} />)
+    expect(document.querySelector('[data-slot="step-row"]')).toBeNull()
   })
 })

--- a/packages/web/src/routes/task-thread/step-rail.tsx
+++ b/packages/web/src/routes/task-thread/step-rail.tsx
@@ -108,7 +108,9 @@ export function activeStepIndex(steps: ReadonlyArray<Pick<StepState, 'status'>>)
   if (active >= 0) return active
   const pending = steps.findIndex((step) => railVisual(step.status) === 'pending')
   if (pending >= 0) return pending
-  return steps.length - 1
+  // `steps.length - 1` would hand an empty list back a -1 that indexes nothing; 0 keeps every
+  // caller's `steps[index]` honest (undefined for an empty list, never a silent wrong element).
+  return Math.max(0, steps.length - 1)
 }
 
 /** One status dot in the collapsed summary — the rail's four glyphs compressed to a color.
@@ -132,20 +134,31 @@ function StepDot({ visual }: { visual: RailVisual }) {
   )
 }
 
+/** Expand memory per run id — the same module-level map the Agents dock keeps (`openByRun` in
+ *  agents-dock.tsx), for the same reason: `RunHeader` is rendered separately by each of the four
+ *  task routes, so without it a Session → Changes → Commits hop would throw the reader's explicit
+ *  expand away every time. Session-lifetime only; no server persistence invented for it. */
+const openByRun = new Map<string, boolean>()
+
 /**
  * The step rail as it sits in the run header: a ONE-LINE summary by default — a dot per step,
  * the current step's name, its position, and the progress bar — so the sticky header stays
  * shallow and the thread gets the vertical room. Clicking it expands the full `StepRail`.
- * Collapsed by default because the summary already answers "where is this run?" at a glance.
+ * Collapsed by default because the summary already answers "where is this run?" at a glance;
+ * an explicit expand is remembered for that run across tab switches.
  */
-export function WorkflowSteps({ steps }: { steps: StepState[] }) {
-  const [open, setOpen] = useState(false)
+export function WorkflowSteps({ runId, steps }: { runId: string; steps: StepState[] }) {
+  const [open, setOpen] = useState(() => openByRun.get(runId) ?? false)
   if (steps.length === 0) return null
+  const toggle = (next: boolean) => {
+    openByRun.set(runId, next)
+    setOpen(next)
+  }
   const index = activeStepIndex(steps)
   const current = steps[index]!
   const pct = railProgress(steps) * 100
   return (
-    <Collapsible data-slot="workflow-steps" open={open} onOpenChange={setOpen} className="min-w-0">
+    <Collapsible data-slot="workflow-steps" open={open} onOpenChange={toggle} className="min-w-0">
       <CollapsibleTrigger
         aria-label={`Workflow: ${current.name}, step ${index + 1} of ${steps.length}`}
         className="group flex min-h-[30px] w-full items-center gap-2.5 text-left text-xs text-muted-foreground hover:text-foreground"

--- a/packages/web/src/routes/task-thread/step-rail.tsx
+++ b/packages/web/src/routes/task-thread/step-rail.tsx
@@ -1,6 +1,8 @@
-import { CircleCheckIcon, CircleIcon, CircleXIcon, LoaderCircleIcon } from 'lucide-react'
+import { ChevronDownIcon, CircleCheckIcon, CircleIcon, CircleXIcon, LoaderCircleIcon } from 'lucide-react'
+import { useState } from 'react'
 
 import type { StepState, StepStatus } from '@open-mercato/cezar-api-client'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
 
 /**
@@ -96,4 +98,80 @@ function RailIcon({ visual }: { visual: RailVisual }) {
     case 'pending':
       return <CircleIcon aria-hidden className={cn(base, 'text-soft-foreground')} />
   }
+}
+
+/** The step the summary line speaks for: the first ACTIVE step (running/waiting/review); else the
+ *  next step still to run (first pending), so a not-yet-started or between-steps run reads honestly;
+ *  else the last step, so a finished workflow reads "step N of N". */
+export function activeStepIndex(steps: ReadonlyArray<Pick<StepState, 'status'>>): number {
+  const active = steps.findIndex((step) => railVisual(step.status) === 'active')
+  if (active >= 0) return active
+  const pending = steps.findIndex((step) => railVisual(step.status) === 'pending')
+  if (pending >= 0) return pending
+  return steps.length - 1
+}
+
+/** One status dot in the collapsed summary — the rail's four glyphs compressed to a color.
+ *  Amber (`bg-pending`) stays a dot-only color per the guardian rule. */
+function StepDot({ visual }: { visual: RailVisual }) {
+  const tone =
+    visual === 'done'
+      ? 'bg-success'
+      : visual === 'failed'
+        ? 'bg-danger'
+        : visual === 'active'
+          ? 'bg-pending'
+          : 'bg-soft-foreground'
+  return (
+    <span
+      aria-hidden
+      data-slot="step-dot"
+      data-visual={visual}
+      className={cn('size-1.5 rounded-full', tone, visual === 'active' && 'animate-pulse motion-reduce:animate-none')}
+    />
+  )
+}
+
+/**
+ * The step rail as it sits in the run header: a ONE-LINE summary by default — a dot per step,
+ * the current step's name, its position, and the progress bar — so the sticky header stays
+ * shallow and the thread gets the vertical room. Clicking it expands the full `StepRail`.
+ * Collapsed by default because the summary already answers "where is this run?" at a glance.
+ */
+export function WorkflowSteps({ steps }: { steps: StepState[] }) {
+  const [open, setOpen] = useState(false)
+  if (steps.length === 0) return null
+  const index = activeStepIndex(steps)
+  const current = steps[index]!
+  const pct = railProgress(steps) * 100
+  return (
+    <Collapsible data-slot="workflow-steps" open={open} onOpenChange={setOpen} className="min-w-0">
+      <CollapsibleTrigger
+        aria-label={`Workflow: ${current.name}, step ${index + 1} of ${steps.length}`}
+        className="group flex min-h-[30px] w-full items-center gap-2.5 text-left text-xs text-muted-foreground hover:text-foreground"
+      >
+        <span data-slot="step-dots" className="flex shrink-0 items-center gap-1">
+          {steps.map((step) => (
+            <StepDot key={step.id} visual={railVisual(step.status)} />
+          ))}
+        </span>
+        <span className="min-w-0 max-w-[45%] shrink truncate font-semibold text-foreground">{current.name}</span>
+        <span className="shrink-0 text-soft-foreground tabular-nums">
+          step {index + 1} of {steps.length}
+        </span>
+        <span data-slot="step-summary-progress" className="h-0.5 min-w-[36px] flex-1 overflow-hidden rounded-full bg-muted">
+          <span className="block h-full rounded-full bg-pending" style={{ width: `${pct}%` }} />
+        </span>
+        <ChevronDownIcon
+          aria-hidden
+          className="size-4 shrink-0 text-soft-foreground transition-transform group-data-[state=open]:rotate-180"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="pt-2">
+          <StepRail steps={steps} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
 }

--- a/packages/web/src/routes/task-thread/task-thread.test.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.test.tsx
@@ -586,9 +586,15 @@ describe('ThreadView', () => {
     )
     expect(document.querySelector('[data-slot="plan-dock"]')).toBeNull()
     expect(document.querySelector('[data-slot="plan-mirror"]')).toBeNull()
-    const rows = [...document.querySelectorAll('[data-slot="step-row"]')]
-    expect(rows.map((row) => row.getAttribute('data-visual'))).toEqual(['active', 'pending'])
-    expect(rows[0]!.textContent).toContain('Do the task')
+    // The header shows the compact one-line summary (collapsed by default): a dot per step and
+    // the active step's name + position. The full rows only mount once it's expanded.
+    const summary = document.querySelector('[data-slot="workflow-steps"]')
+    expect(summary).not.toBeNull()
+    expect(summary!.textContent).toContain('Do the task')
+    expect(summary!.textContent).toContain('step 1 of 2')
+    const dots = [...document.querySelectorAll('[data-slot="step-dot"]')]
+    expect(dots.map((dot) => dot.getAttribute('data-visual'))).toEqual(['active', 'pending'])
+    expect(document.querySelector('[data-slot="step-row"]')).toBeNull()
   })
 
   it('a plan in the stream → the dock above the composer area + the compact header mirror', () => {

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -283,7 +283,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
 
       {/* Row spacing lives on each thread row (pb-2.5, both render modes measure alike);
           this gap only separates the sections — rows, empty state, footer, review panel. */}
-      <div className="mx-auto flex w-full max-w-[820px] flex-1 flex-col gap-3.5 px-4 py-5 md:px-6">
+      <div className="mx-auto flex w-full max-w-[var(--measure)] flex-1 flex-col gap-3.5 px-4 py-5 md:px-6">
         <ThreadCardCache runId={run.id}>
           <ThreadRows runId={run.id} rows={rows} mode={mode} controls={scroll} />
         </ThreadCardCache>
@@ -364,7 +364,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
             <JumpToLatestPill onJump={scroll.jumpToLatest} />
           </div>
         ) : null}
-        <div className="mx-auto flex w-full max-w-[820px] flex-col gap-2.5">
+        <div className="mx-auto flex w-full max-w-[var(--measure)] flex-col gap-2.5">
           {/* Agents above the plan: the fan-out is the more urgent "what is happening now",
               and it is transient — the plan outlives it. Keyed by run id like the plan dock. */}
           <AgentsDock key={`agents:${run.id}`} runId={run.id} agents={agents} onSelect={setOpenAgentId} />

--- a/packages/web/src/routes/task-thread/thread-items.test.tsx
+++ b/packages/web/src/routes/task-thread/thread-items.test.tsx
@@ -105,12 +105,16 @@ describe('ToolCard — states', () => {
     expect(document.querySelector('[data-slot="tool-output"] pre')?.textContent).toContain('npm warn deprecated')
   })
 
-  it('failed: open by default, danger tint, the error string rendered in danger tone', () => {
+  it('failed: closed by default with a faint tint; expands to the danger-toned error', () => {
     const item = goldenItem(failedAndDenied, 'toolu_fail_01', 'failed')
     render(<ToolCard item={item} />)
     expect(card().getAttribute('data-status')).toBe('failed')
+    // A faint danger tint still identifies it, but the loud outline and auto-open are gone.
     expect(card().className).toContain('border-danger')
     expect(screen.getByText('failed')).toBeTruthy()
+    // Calm by default: the red error body only appears once the reader opens the card.
+    expect(document.querySelector('[data-slot="tool-error"]')).toBeNull()
+    fireEvent.click(trigger(/failed/))
     const error = document.querySelector('[data-slot="tool-error"]')
     expect(error?.textContent).toContain('npm ERR! Missing script: "lint"')
     expect(error?.className).toContain('text-danger')

--- a/packages/web/src/routes/task-thread/thread-items.tsx
+++ b/packages/web/src/routes/task-thread/thread-items.tsx
@@ -468,11 +468,12 @@ function DiffLine({ text }: { text: string }) {
   )
 }
 
-/** Default-open policy (opencode research §4): failed opens itself; a running command opens
- *  to show its live tail; everything else — including edits and finished commands — starts
- *  closed but prominent. The user's own toggle always wins once they touch the card. */
+/** Default-open policy: a running command opens to show its live tail; everything else —
+ *  including edits, finished commands AND failures — starts closed but prominent. A failed step
+ *  no longer springs its red error body open on its own (it reads as calmer that way, and a
+ *  recovered failure is not an emergency); its collapsed row still carries the `failed` label and
+ *  exit code. The user's own toggle always wins once they touch the card. */
 function defaultOpen(item: UiToolItem): boolean {
-  if (item.status === 'failed') return true
   return item.toolKind === 'execute' && item.status === 'running' && item.output !== undefined
 }
 
@@ -520,8 +521,10 @@ export function ToolCard({
       open={open}
       onOpenChange={setUserOpen}
       className={cn(
+        // A failed card wears a FAINT danger tint so it reads at a glance, not the loud outline it
+        // used to — the exit code and `failed` label carry the signal, the red stays in the body.
         'min-w-0 overflow-hidden rounded-md border bg-card',
-        item.status === 'failed' ? 'border-danger/40' : 'border-border',
+        item.status === 'failed' ? 'border-danger/25' : 'border-border',
       )}
     >
       <CollapsibleTrigger
@@ -535,12 +538,11 @@ export function ToolCard({
             !hasDetail && 'invisible',
           )}
         />
-        <Icon aria-hidden className={cn('size-3.5 shrink-0', item.status === 'failed' ? 'text-danger' : 'text-muted-foreground')} />
+        <Icon aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
         <span
           className={cn(
             'shrink-0 font-semibold',
             busy && 'shimmer',
-            item.status === 'failed' && 'text-danger',
             item.status === 'declined' && 'text-muted-foreground',
           )}
         >
@@ -553,7 +555,7 @@ export function ToolCard({
           {busy ? (
             <LoaderCircleIcon role="status" aria-label="Running" className="size-3.5 animate-spin text-soft-foreground" />
           ) : null}
-          {item.status === 'failed' ? <span className="text-xs text-danger">failed</span> : null}
+          {item.status === 'failed' ? <span className="text-xs text-muted-foreground">failed</span> : null}
           {item.status === 'declined' ? <span className="text-xs text-soft-foreground">declined</span> : null}
           {item.toolKind === 'execute' && typeof item.exitCode === 'number' ? (
             <span

--- a/packages/web/src/routes/task-thread/thread-open-cards.test.tsx
+++ b/packages/web/src/routes/task-thread/thread-open-cards.test.tsx
@@ -49,14 +49,16 @@ describe('the per-run open-card cache', () => {
   })
 
   it('a user-closed card beats a would-be default-open on revisit', () => {
-    const failed = item({ status: 'failed', error: 'boom' }) // failed opens itself by default
-    const first = render(card('r1', failed))
+    // A running execute WITH output opens itself by default (the live tail) — the one default-open
+    // case left now that failures start closed.
+    const streaming = item({ status: 'running', output: 'installing…' })
+    const first = render(card('r1', streaming))
     expect(state()).toBe('open')
     fireEvent.click(trigger())
     expect(state()).toBe('closed')
     first.unmount()
 
-    render(card('r1', failed))
+    render(card('r1', streaming))
     expect(state()).toBe('closed')
   })
 

--- a/packages/web/src/styles/index.css
+++ b/packages/web/src/styles/index.css
@@ -122,6 +122,12 @@
   --sans: 'Inter Variable', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
   --mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, 'SF Mono', 'Menlo', monospace;
 
+  /* reading measure — the max width of the task view's column (header, thread, changes,
+   * commits). The default is the shipped 820px reading column; Settings → Appearance → Reading
+   * width flips it to `wide` (see the `:root[data-width]` block). Consumed as
+   * `max-w-[var(--measure)]` so one token moves every column together. */
+  --measure: 820px;
+
   /* shiki syntax highlighting (dark) */
   --syn-key: #c4b5fd;
   --syn-str: #86efac;
@@ -207,6 +213,13 @@
  * lever as compact, just smaller; the type scale still stays untouched. */
 :root[data-density='ultra'] {
   --spacing: 0.1875rem;
+}
+
+/* Wide reading width (Settings → Appearance → Reading width): open the task-view column from the
+ * default 820px to 1180px so long transcripts, diffs and command output use more of the screen.
+ * One token, same `:root[…]` (unlayered) lever as density; narrow is the absence of the attribute. */
+:root[data-width='wide'] {
+  --measure: 1180px;
 }
 
 /* ---------- tokens: radius + shadow ----------


### PR DESCRIPTION
## Why

The task/session view spent a lot of vertical and horizontal room on persistent chrome — a multi-row workflow step rail and an expanded Agents dock — which squeezed the conversation. This frees that space for the thread and adds a **Reading width** control so long transcripts can use more of the screen.

## What changed

**Compact workflow steps** — the run header's step rail collapses to a one-line summary (a dot per step, the active step's name + position, and the progress bar), expanding to the full rail on click. New `WorkflowSteps` wrapper in `step-rail.tsx`; `StepRail` itself is unchanged (so its contract/tests stay put). Saves ~60–90px of sticky-header height.

**Slim Agents dock, collapsed by default** — the dock's one-line head already answers *what's running right now* (`Agents · 1/3 — Reviewing store layer…`), so it opens collapsed; the per-agent rows are one click away and the explicit expand is still remembered per run.

**Calmer failed tool cards** — a failed step no longer springs its red error body open on its own. It starts closed and reads calmly: a faint tint instead of the loud outline, muted verb/icon, with the exit code and `failed` label carrying the signal. The red returns in the body once you open it. (A recovered failure isn't an emergency.)

**Reading width setting** — new **Settings → Appearance → Reading width** (Narrow | Wide). Wide opens the task view's column from the shipped 820px to 1180px so session, changes and commits use more of the screen. Implemented as one `--measure` token flipped by `:root[data-width='wide']`, wired through the exact same `appearance` store + localStorage-mirror + `index.html` pre-paint pattern as accent/density (no-flash on cold load).

## Screens affected
Task view header (steps), the Agents dock above the composer, tool cards in the thread, and the Appearance settings section. The Session/Changes/Commits columns all follow the width token together.

## Tests
- Full web suite green: **2540 passed**, and `tsc --noEmit -p packages/web/tsconfig.json` clean.
- New/updated coverage: width normalize + storage + apply + settings round-trip; `WorkflowSteps` collapsed/expand + `activeStepIndex`; Agents dock collapsed-by-default + collapse memory; failed card collapsed-by-default; open-card cache.
- No raw hex / off-token utilities — the design-guardian test passes.

## Notes
This is the compact-chrome + width slice of the broader "Claude Code style" session redesign; the full narration-timeline restructure of the thread is intentionally left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)