### PR TITLE
fix(tasks): allow queued prompt follow-ups without provider auth

### DIFF
--- a/.ai/runs/2026-07-28-queued-followup-provider-routing.md
+++ b/.ai/runs/2026-07-28-queued-followup-provider-routing.md
@@ -1,0 +1,51 @@
+# Fix queued follow-up provider routing
+
+## Goal
+
+Allow users to append prompt messages to an already-queued run without requiring an unrelated provider to be authorized, while preserving provider authorization gates for live messages and session continuations.
+
+Source doc: `.ai/specs/2026-07-22-provider-authentication.md`
+
+## Scope
+
+- Treat queued prompt stacking as a mutation of an existing task, not as a new provider-starting action.
+- Keep the server and cockpit gates aligned: queued messages bypass provider discovery, while running/waiting messages remain gated against the active backend.
+- Add regression coverage for the reported Codex-queued/Claude-disconnected scenario at both API and UI boundaries.
+- Validate against the queued prompt behavior documented in `.ai/specs/2026-07-21-queued-session-prompt-stacking.md`.
+
+## Non-goals
+
+- Do not change provider discovery, authorization commands, or enablement preferences.
+- Do not change runner/model selection for new runs or continuations.
+- Do not alter queue scheduling, prompt folding, or live-session delivery semantics.
+
+## Implementation Plan
+
+### Phase 1: Correct queued-message gating
+
+1. Update the message API to skip provider authorization only while the run record is queued, and add a regression test proving prompt stacking does not probe or require provider credentials.
+2. Update the task-thread composer to keep queued prompt authoring enabled regardless of provider state, with a regression test matching a Codex-capable host where Claude is disconnected.
+
+### Phase 2: Verify and finalize
+
+1. Run focused server and cockpit tests, then the configured validation commands in order.
+2. Run the authoritative PR review/autofix pass, capture verification evidence on the PR, and finalize the PR for review.
+
+## Risks
+
+- The dequeue-to-session-open race can still present a queued record while the manager has moved into its starting state. Allowing that message is intentional: the engine's existing three-rung ladder buffers it so the message is not lost.
+- A too-broad bypass could weaken live-session authentication enforcement. Regression tests retain the existing assertion that live messages are blocked when their active provider is unavailable.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Correct queued-message gating
+
+- [ ] 1.1 Update the message API to skip provider authorization only while the run record is queued, and add a regression test proving prompt stacking does not probe or require provider credentials.
+- [ ] 1.2 Update the task-thread composer to keep queued prompt authoring enabled regardless of provider state, with a regression test matching a Codex-capable host where Claude is disconnected.
+
+### Phase 2: Verify and finalize
+
+- [ ] 2.1 Run focused server and cockpit tests, then the configured validation commands in order.
+- [ ] 2.2 Run the authoritative PR review/autofix pass, capture verification evidence on the PR, and finalize the PR for review.

--- a/.ai/runs/2026-07-28-queued-followup-provider-routing.md
+++ b/.ai/runs/2026-07-28-queued-followup-provider-routing.md
@@ -43,7 +43,7 @@ Source doc: `.ai/specs/2026-07-22-provider-authentication.md`
 ### Phase 1: Correct queued-message gating
 
 - [x] 1.1 Update the message API to skip provider authorization only while the run record is queued, and add a regression test proving prompt stacking does not probe or require provider credentials. — 6c4b91c0
-- [ ] 1.2 Update the task-thread composer to keep queued prompt authoring enabled regardless of provider state, with a regression test matching a Codex-capable host where Claude is disconnected.
+- [x] 1.2 Update the task-thread composer to keep queued prompt authoring enabled regardless of provider state, with a regression test matching a Codex-capable host where Claude is disconnected. — ce7a5a55
 
 ### Phase 2: Verify and finalize
 

--- a/.ai/runs/2026-07-28-queued-followup-provider-routing.md
+++ b/.ai/runs/2026-07-28-queued-followup-provider-routing.md
@@ -42,7 +42,7 @@ Source doc: `.ai/specs/2026-07-22-provider-authentication.md`
 
 ### Phase 1: Correct queued-message gating
 
-- [ ] 1.1 Update the message API to skip provider authorization only while the run record is queued, and add a regression test proving prompt stacking does not probe or require provider credentials.
+- [x] 1.1 Update the message API to skip provider authorization only while the run record is queued, and add a regression test proving prompt stacking does not probe or require provider credentials. — 6c4b91c0
 - [ ] 1.2 Update the task-thread composer to keep queued prompt authoring enabled regardless of provider state, with a regression test matching a Codex-capable host where Claude is disconnected.
 
 ### Phase 2: Verify and finalize

--- a/.ai/runs/2026-07-28-queued-followup-provider-routing.md
+++ b/.ai/runs/2026-07-28-queued-followup-provider-routing.md
@@ -38,6 +38,8 @@ Source doc: `.ai/specs/2026-07-22-provider-authentication.md`
 
 ## Progress
 
+PR: #712
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Correct queued-message gating
@@ -48,4 +50,4 @@ Source doc: `.ai/specs/2026-07-22-provider-authentication.md`
 ### Phase 2: Verify and finalize
 
 - [x] 2.1 Run focused server and cockpit tests, then the configured validation commands in order. — ce7a5a55
-- [ ] 2.2 Run the authoritative PR review/autofix pass, capture verification evidence on the PR, and finalize the PR for review.
+- [x] 2.2 Run the authoritative PR review/autofix pass, capture verification evidence on the PR, and finalize the PR for review. — 5588b878

--- a/.ai/runs/2026-07-28-queued-followup-provider-routing.md
+++ b/.ai/runs/2026-07-28-queued-followup-provider-routing.md
@@ -47,5 +47,5 @@ Source doc: `.ai/specs/2026-07-22-provider-authentication.md`
 
 ### Phase 2: Verify and finalize
 
-- [ ] 2.1 Run focused server and cockpit tests, then the configured validation commands in order.
+- [x] 2.1 Run focused server and cockpit tests, then the configured validation commands in order. — ce7a5a55
 - [ ] 2.2 Run the authoritative PR review/autofix pass, capture verification evidence on the PR, and finalize the PR for review.

--- a/packages/cezar/src/server/provider-action-gating.test.ts
+++ b/packages/cezar/src/server/provider-action-gating.test.ts
@@ -65,7 +65,10 @@ describe('provider action gating', () => {
       steps: [{ id: 'task', name: 'Task', kind: 'agent' }],
     });
     if (backend) {
-      store.updateRun(run.id, { currentStepId: 'task' });
+      // A persisted active backend belongs to a live run. Keeping the record queued would
+      // model the prompt-authoring window, where provider availability deliberately does not
+      // gate mutations of the existing task.
+      store.updateRun(run.id, { status: 'running', currentStepId: 'task' });
       store.updateStep(run.id, 'task', { backend, status: 'running' });
     }
     return run;

--- a/packages/cezar/src/server/queued-messages.test.ts
+++ b/packages/cezar/src/server/queued-messages.test.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Hono } from 'hono';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderAuthService } from '../core/provider-auth.js';
 import { RunStore, type QueuedMessage, type RunRecord } from '../runs/store.js';
 import type { RunManager } from '../workflows/run.js';
 import { apiRequest } from './loopback-request.testkit.js';
@@ -22,6 +23,7 @@ describe('queued prompt stack routes (#472)', () => {
   let repoRoot: string;
   let store: RunStore;
   let app: Hono;
+  let manager: RunManager;
   let record: RunRecord;
   /** Which rung the fake engine answers on. */
   let rung: 'live' | 'queued' | 'starting' | 'closed';
@@ -35,7 +37,7 @@ describe('queued prompt stack routes (#472)', () => {
     store.updateRun(record.id, { status: 'queued' });
     rung = 'queued';
 
-    const manager = {
+    manager = {
       sendMessage: () => rung === 'live',
       enqueueMessage: (id: string, content: Array<{ type: string; text?: string }>): QueuedMessage | null => {
         if (rung !== 'queued') return null;
@@ -120,6 +122,23 @@ describe('queued prompt stack routes (#472)', () => {
     expect(body.queued).toBe(true);
     expect(body.message.text).toBe('stack me');
     expect(store.getRun(record.id)?.queuedMessages?.map((m) => m.text)).toEqual(['stack me']);
+  });
+
+  it('does not probe or require provider credentials to amend a queued prompt', async () => {
+    const status = vi.fn(() => Promise.reject(new Error('provider status must not be read')));
+    app = createApp({
+      repoRoot,
+      store,
+      manager,
+      version: '0.0.0-test',
+      providerAuth: { status } as unknown as ProviderAuthService,
+    });
+
+    const res = await post({ text: 'keep this queued Codex task moving' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ queued: true });
+    expect(status).not.toHaveBeenCalled();
   });
 
   /** The rung that exists so a message in the dequeue → session-open gap is

--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -2467,8 +2467,15 @@ export function createApp(deps: ServerDeps) {
     if (!parsed.success) {
       return c.json({ error: parsed.error.issues.map((i) => i.message).join('; ') }, 400);
     }
-    const blocked = await providerActionError([providerForActiveRun(run)]);
-    if (blocked) return c.json({ error: blocked }, 409);
+    // Stacking onto a queued prompt mutates an existing task and invokes no provider.
+    // Provider availability still gates live delivery after the record leaves `queued`, but
+    // must not strand prompt authoring just because an unrelated fallback provider is
+    // disconnected (provider-auth spec: disabling never blocks existing-task mutations).
+    // In the dequeue race, the ladder below safely turns this into a starting-state buffer.
+    if (run.status !== 'queued') {
+      const blocked = await providerActionError([providerForActiveRun(run)]);
+      if (blocked) return c.json({ error: blocked }, 409);
+    }
     const content: ContentBlock[] = [
       ...parsed.data.images.map((img): ContentBlock => ({
         type: 'image',

--- a/packages/web/src/routes/task-thread/task-thread.test.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.test.tsx
@@ -175,11 +175,14 @@ describe('ThreadView', () => {
   })
 
   it.each([
-    ['disabled', { provider: 'claude', status: 'connected', enabled: false }, 'Claude Code is disabled. Enable it in Settings → Agents → Providers.'],
-    ['disconnected', { provider: 'claude', status: 'disconnected', enabled: true }, 'Claude Code credentials are unavailable. Authorize it in Settings → Agents → Providers.'],
-  ] as const)('disables a queued composer when its active provider is %s', async (_case, claude, reason) => {
+    ['disabled', { provider: 'claude', status: 'connected', enabled: false }],
+    ['disconnected', { provider: 'claude', status: 'disconnected', enabled: true }],
+  ] as const)('keeps a queued Codex prompt authorable when fallback Claude is %s', async (_case, claude) => {
     renderView(
-      <ThreadView run={run('queued', { runner: 'claude' })} thread={reduceThread([])} />,
+      // Before the run starts, an omitted runner means the server will use its configured
+      // default (Codex in the reported case). The active-provider helper used to guess Claude
+      // here and block a mutation that invokes no provider at all.
+      <ThreadView run={run('queued', { runner: undefined })} thread={reduceThread([])} />,
       {
         providers: [
           claude,
@@ -190,11 +193,9 @@ describe('ThreadView', () => {
     )
 
     const textarea = screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement
-    await waitFor(() => expect(textarea.disabled).toBe(true))
-    expect(textarea.placeholder).toBe(reason)
-    expect(screen.getByRole('link', { name: 'Configure providers' }).getAttribute('href')).toBe(
-      '/settings/agents#providers',
-    )
+    await waitFor(() => expect(textarea.disabled).toBe(false))
+    expect(textarea.placeholder).toBe('Add to the prompt — sent when the run starts…')
+    expect(screen.queryByRole('link', { name: 'Configure providers' })).toBeNull()
   })
 
   it('keeps a waiting composer enabled when a retrying current step uses a usable provider', async () => {

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -241,7 +241,10 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
   )
   const sendMessage = useSendMessage(run.id)
   const activeProvider = useActiveProviderAvailability(run)
-  const activeProviderBlocked = (sessionOpen || queued) && !activeProvider.usable
+  // A queued send only amends the persisted prompt; it invokes no provider and therefore
+  // remains available even when provider discovery cannot authorize a live session. Once the
+  // session is open, mirror the server's active-backend gate as before.
+  const activeProviderBlocked = sessionOpen && !activeProvider.usable
   const continuationProviderBlocked = hasContinuation && !continueAction.canContinue
   const providerBlocked = activeProviderBlocked || continuationProviderBlocked
   const providerReason = activeProviderBlocked ? activeProvider.reason : continueAction.reason


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-28-queued-followup-provider-routing.md
Status: complete

## 🎯 Goal
- Allow users to amend an already-queued run's prompt without requiring an unrelated provider to be authorized. Provider gates remain intact for live messages and actual session continuations.

## What Changed
- `packages/cezar/src/server/server.ts` now treats queued prompt stacking as an existing-task mutation and skips provider discovery only while the run record remains queued.
- `packages/web/src/routes/task-thread/task-thread.tsx` keeps the queued composer enabled regardless of provider state, while still mirroring the active-provider gate for running and waiting sessions.
- Server and cockpit regression tests cover a queued default-runner/Codex scenario where fallback Claude is disabled or disconnected, plus the retained live-message gate.

## 🧪 Tests
- `npm run typecheck` — passed.
- `npm test` — 4,621 passed across 256 files.
- `npm run test:unit` — 36 passed.
- `npm run build` — passed, including `check:pack`.
- `npm run test:package` — 9 passed.
- Isolated `queued-stack.e2e.ts` browser flow — 5 passed with screenshots attached to this PR.
- The full E2E sweep exposed an unrelated baseline fixture-path defect: 17 suites launch the nonexistent `<repo>/dist/index.js` instead of `packages/cezar/dist/index.js`. The affected queued-stack spec passed after a temporary untracked compatibility symlink; no harness workaround is included in this product diff.

## 💥 Breaking Changes
- None. The change removes an erroneous 409 for queued prompt mutations and leaves live-session and continuation authorization contracts unchanged.

## 📋 Progress
See the Progress section in the tracking plan.
