### PR TITLE
fix(composer): honor Worktree opt-out (#714)

### DIFF
--- a/.ai/specs/2026-07-25-configurable-composer-run-defaults.md
+++ b/.ai/specs/2026-07-25-configurable-composer-run-defaults.md
@@ -2,8 +2,8 @@
 
 ## TLDR
 
-Make quick-task the cold New Task default, expose Worktree for every eligible
-single-step run, and let Autonomous/Worktree defaults be seeded by environment
+Make quick-task the cold New Task default, expose Worktree for every ordinary
+run, and let Autonomous/Worktree defaults be seeded by environment
 and overridden in workspace Settings. This is the no-ceremony composer policy
 half of issue #657; per-skill `interactive: true` semantics are specified
 separately in `2026-07-25-interactive-skill-composer-defaults.md`.
@@ -15,7 +15,7 @@ separately in `2026-07-25-interactive-skill-composer-defaults.md`.
 | Q1 | Where do configured defaults live? | Workspace config with nullable stored overrides that inherit environment values. | These are operator preferences shared across projects, and sandboxes need one seed with a per-sandbox override. | ok |
 | Q2 | How much of #650 belongs here? | Only cold selection of quick-task and the truthful Worktree control. Broader source-picker/no-skill redesign stays in #650. | This delivers the issue’s explicit no-ceremony path without expanding into navigation work. | ok |
 | Q3 | What replaces last-used toggle memory? | Stable workspace/env policy. Legacy `lastAutonomous`/`lastWorktree` keys remain parseable but new clients stop reading/writing them. | An unrelated previous run should not silently override an administrator’s or user’s declared default. | ok |
-| Q4 | Which workflows can disable Worktree? | Skills and workflows with exactly one executable step; multi-step workflows and parallel variants remain isolated. | The engine can run one step in place, while multi-step/parallel execution depends on a shared or separate worktree boundary. | ok |
+| Q4 | Which workflows can disable Worktree? | Skills and workflows may run in place; parallel variants remain isolated. | The repository-root lease safely serializes ordinary in-place workflows, while parallel variants require separate worktrees by definition. | ok |
 
 ## Problem Statement
 
@@ -32,8 +32,8 @@ based on whichever task ran last.
 
 1. Cold New Task selects built-in `quick-task` when no draft, deep link, or
    remembered explicit source exists.
-2. Worktree appears for any git-backed single-step skill/workflow. Multi-step
-   workflows and parallel variants show it on and disabled with a reason.
+2. Worktree appears for any ordinary git-backed skill/workflow. Parallel
+   variants show it on and disabled with a reason.
 3. `~/.cezar/config.json` gains optional workspace composer overrides.
 4. `CEZ_AUTONOMOUS_DEFAULT` and `CEZ_WORKTREE_DEFAULT` seed absent overrides.
 5. Global Resources Settings gains a **New task defaults** card with
@@ -86,9 +86,8 @@ The companion interactive-skill spec adds its hint between explicit choice and
 configured policy. Implement one helper with an optional skill recommendation
 input so the two specs cannot create competing ternaries.
 
-Eligibility requires git, variants ≤ 1, and exactly one expanded executable
-step. While sources load, retain the existing readiness guard to prevent control
-flicker.
+Eligibility requires git and variants ≤ 1. While sources load, retain the
+existing readiness guard to prevent control flicker.
 
 Legacy `lastAutonomous`/`lastWorktree` UI-state keys remain accepted by the
 passthrough schema for backward compatibility but no longer participate in
@@ -143,9 +142,9 @@ patterns apply.
 
 - Cold composer selects quick-task only when no explicit draft/deep-link/source
   preference exists.
-- Worktree renders for eligible single-step workflows, including quick-task.
-- Multi-step workflows and parallel variants render Worktree on and disabled
-  with a concise reason.
+- Worktree renders for ordinary workflows, including quick-task and multi-step
+  workflows.
+- Parallel variants render Worktree on and disabled with a concise reason.
 - Explicit user changes survive source switching for the current draft.
 - Starting/clearing creates a fresh draft resolved from current policy.
 
@@ -179,7 +178,7 @@ Visuals live under `assets/configurable-composer-run-defaults/`.
 - No git hides Worktree and runs in place.
 - Raising variants after explicit Worktree off forces on; returning to one
   restores the draft’s explicit off.
-- Multi-step workflow forces Worktree on.
+- Multi-step workflows honor explicit and configured Worktree opt-outs.
 - Workflow shape loading does not flicker controls.
 - Direct incompatible API requests remain subject to server validation.
 
@@ -219,8 +218,7 @@ capability: every checkpoint uses the same resolver and Settings contract.
    tolerant state parsing.
 6. Make quick-task the cold default without overriding deep links, drafts, or
    explicit source memory. Add route tests.
-7. Derive single-step eligibility from expanded workflow data; render Worktree
-   for quick-task and eligible workflows, forced disabled states otherwise,
+7. Render Worktree for ordinary workflows, force it only for parallel variants,
    and verify submitted request bodies.
 8. Document both env vars in `.env.example` and README and update any env drift
    guard.

--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -967,7 +967,7 @@ export interface CreateRunInput {
   /** 1–3. Above 1 the response is `{ runs }` rather than a single record. */
   variants?: number
   images?: ImageInput[]
-  /** false → run in the repo working tree instead of an isolated worktree (read-only skills).
+  /** false → run in the repo working tree instead of an isolated worktree.
    *  Omit for the default. Ignored server-side when variants > 1. */
   worktree?: boolean
   /** true → autonomous run: never parks at "waiting" for the user; auto-continues until done. */

--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -411,7 +411,7 @@ const startRunSchema = z
     // agents in separate worktrees; the user compares diffs and picks one.
     variants: z.number().int().min(1).max(3).optional(),
     // Composer worktree opt-out (#worktree-toggle): false runs in the repo
-    // working tree (read-only skills). Ignored when variants > 1.
+    // working tree. Ignored when variants > 1.
     worktree: z.boolean().optional(),
     // Autonomous mode (#autonomous): the run never parks at `waiting` — it
     // auto-continues until the agent signals done. No "needs you" is raised.

--- a/packages/cezar/src/workflows/run-isolation.test.ts
+++ b/packages/cezar/src/workflows/run-isolation.test.ts
@@ -60,6 +60,8 @@ describe('RunManager repository-root isolation', () => {
     expect(store.getRun(record.id)?.error).toContain('worktree creation failed');
     expect(existsSync(join(root, 'root-was-touched'))).toBe(false);
     const notes = store.readEvents(record.id).filter((event) => event.type === 'note');
+    expect(notes.some((event) => String(event.message).includes('worktree on'))).toBe(true);
+    expect(notes.some((event) => String(event.message).includes('(default)'))).toBe(true);
     expect(notes.some((event) => String(event.message).includes('stopped before workflow execution'))).toBe(true);
     expect(notes.some((event) => String(event.message).includes('exclusive access'))).toBe(false);
   });

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -155,9 +155,8 @@ export interface StartRunInput {
    *  `resolveExtraSystemPrompt` for the precedence contract. */
   systemPrompt?: string;
   /** Composer opt-out (#worktree-toggle): `false` runs the task in the repo
-   *  working tree instead of an isolated worktree — for read-only skills that
-   *  don't need a branch. Undefined/`true` keeps the default per-task worktree.
-   *  Ignored for variants (they always isolate). */
+   *  working tree instead of an isolated worktree. Undefined/`true` keeps the
+   *  default per-task worktree. Ignored for variants (they always isolate). */
   worktree?: boolean;
   /** Autonomous mode (#autonomous): the run never parks at `waiting` for the
    *  user — turn-ends auto-continue until the agent signals done or the safety
@@ -1605,10 +1604,14 @@ export class RunManager {
     // established; only explicit opt-out and non-Git modes run in place.
     const repo = await getRepoInfo(this.repoRoot);
     if (repo && input.worktree === false) {
-      // Composer opt-out: run in the repo working tree, no branch/worktree
-      // (read-only skills — review, summarize — that never need isolation).
+      // Composer opt-out: run in the repo working tree, no branch/worktree. The
+      // repository-root lease serializes these runs so workflows cannot overlap.
       emit({ type: 'note', message: 'worktree off — running in the repo working tree' });
     } else if (repo) {
+      emit({
+        type: 'note',
+        message: `worktree on — using an isolated task worktree (${input.worktree === true ? 'explicit request' : 'default'})`,
+      });
       // Fork from the configured base branch (config.json `baseBranch`, e.g.
       // `develop`) — also the target of the eventual draft PR. Unresolvable
       // (typo, not fetched) → note + the currently checked-out branch.

--- a/packages/web/src/routes/new-task-draft.test.ts
+++ b/packages/web/src/routes/new-task-draft.test.ts
@@ -49,13 +49,12 @@ describe('resolveComposerRunMode', () => {
   it('keeps plan, parallel, and no-git constraints authoritative', () => {
     expect(resolveComposerRunMode({ ...base, planFirst: true, explicitAutonomous: true }).autonomous).toBe(false)
     expect(resolveComposerRunMode({ ...base, variants: 2, explicitWorktree: false }).worktree).toBe(true)
-    expect(resolveComposerRunMode({
-      ...base,
-      forceWorktree: true,
-      explicitWorktree: false,
-      interactive: true,
-    }).worktree).toBe(true)
     expect(resolveComposerRunMode({ ...base, hasGit: false, explicitWorktree: true }).worktree).toBe(false)
+  })
+
+  it('keeps explicit and configured Worktree opt-outs authoritative for ordinary workflows', () => {
+    expect(resolveComposerRunMode({ ...base, explicitWorktree: false }).worktree).toBe(false)
+    expect(resolveComposerRunMode({ ...base, configuredWorktree: false }).worktree).toBe(false)
   })
 })
 

--- a/packages/web/src/routes/new-task-draft.ts
+++ b/packages/web/src/routes/new-task-draft.ts
@@ -35,7 +35,6 @@ export interface NewTaskDraft {
 export interface ComposerRunModeInput {
   hasGit: boolean
   variants: number
-  forceWorktree?: boolean
   planFirst: boolean
   explicitAutonomous: boolean | null
   explicitWorktree: boolean | null
@@ -47,8 +46,10 @@ export interface ComposerRunModeInput {
 
 /** Resolve run-mode values once, in precedence order: hard constraints, explicit draft
  * choices, an interactive-skill recommendation, then the configured (or source-dependent)
- * default. `configuredAutonomous`/`configuredWorktree` carry the workspace run defaults;
- * `'source-dependent'` autonomy means skills default on and everything else off. */
+ * default. Parallel variants are the only hard Worktree constraint; ordinary workflows can
+ * run in place when the user or workspace policy opts out. `configuredAutonomous`/
+ * `configuredWorktree` carry the workspace run defaults; `'source-dependent'` autonomy means
+ * skills default on and everything else off. */
 export function resolveComposerRunMode(input: ComposerRunModeInput): {
   autonomous: boolean
   worktree: boolean
@@ -62,7 +63,7 @@ export function resolveComposerRunMode(input: ComposerRunModeInput): {
     : (input.explicitAutonomous ?? recommended ?? autonomousFallback)
   const worktree = !input.hasGit
     ? false
-    : input.variants > 1 || input.forceWorktree === true
+    : input.variants > 1
       ? true
       : (input.explicitWorktree ?? recommended ?? input.configuredWorktree)
   return { autonomous, worktree }

--- a/packages/web/src/routes/new-task.test.tsx
+++ b/packages/web/src/routes/new-task.test.tsx
@@ -11,6 +11,7 @@ import type {
   ProviderStatusResponse,
   RepoResponse,
   Skill,
+  WorkspaceConfigResponse,
   WorkflowsResponse,
 } from '@open-mercato/cezar-api-client'
 import { resetToasts, Toaster } from '@/components/ui/toaster'
@@ -147,6 +148,24 @@ const CONFIG: ConfigResponse = {
   reviewGate: null,
 }
 
+const WORKSPACE_CONFIG: WorkspaceConfigResponse = {
+  browseRoot: '~/',
+  projectsDir: '~/cezar/projects',
+  skillsAutoUpdate: null,
+  effectiveSkillsAutoUpdate: true,
+  composerDefaults: {
+    autonomous: null,
+    worktree: null,
+    inheritedAutonomous: 'source-dependent',
+    inheritedWorktree: true,
+  },
+  resources: {
+    maxParallel: 2,
+    memoryLimitMb: null,
+    worktreeRetentionDefault: 10,
+  },
+}
+
 /** The shape `POST /api/plan` answers (spec 008) — three steps so reorder/remove are provable. */
 const PLAN = {
   steps: [
@@ -187,6 +206,7 @@ function serve(overrides: {
   health?: HealthResponse | (() => Promise<Response>)
   /** Active project's scoped config; health may describe a different boot project. */
   config?: Partial<ConfigResponse> | (() => Promise<Response>)
+  workspaceConfig?: WorkspaceConfigResponse
   /** Host authentication state, or a delayed answer for pending/refresh tests. */
   providerStatus?: ProviderStatusResponse | (() => Promise<Response>)
   providerStatusStatus?: number
@@ -209,6 +229,7 @@ function serve(overrides: {
   const data = {
     health: HEALTH,
     config: CONFIG,
+    workspaceConfig: WORKSPACE_CONFIG,
     providerStatus: PROVIDERS_CONNECTED,
     providerStatusStatus: 200,
     skills: SKILLS,
@@ -264,6 +285,7 @@ function serve(overrides: {
           : json({ ...CONFIG, ...data.config })
       if (url === '/api/config' && method === 'PUT')
         return json({ baseBranch: (body as { baseBranch: string | null }).baseBranch, defaultRunner: 'claude' })
+      if (url === '/api/workspace/config' && method === 'GET') return json(data.workspaceConfig)
       return json({ error: `unmocked ${method} ${url}` }, 404)
     }),
   )
@@ -735,6 +757,72 @@ describe('submit', () => {
     expect(postedBody()).toEqual({ task: 'Ship it', workflow: 'quick-task' })
   })
 
+  it('posts worktree:false after opt-out for every single-step source shape', async () => {
+    const cases: Array<{
+      label: string
+      overrides: NonNullable<Parameters<typeof serve>[0]>
+      expected: Record<string, unknown>
+    }> = [
+      {
+        label: 'quick-task',
+        overrides: {},
+        expected: { workflow: 'quick-task' },
+      },
+      {
+        label: 'om-fix',
+        overrides: { uiState: { lastTask: { source: 'skill', ref: 'om-fix' } } },
+        expected: { steps: [{ id: 'task', name: 'om-fix', skill: 'om-fix', prompt: '{{task}}' }] },
+      },
+      {
+        label: 'one-step',
+        overrides: {
+          workflows: {
+            workflows: [
+              ...WORKFLOWS.workflows,
+              { name: 'one-step', source: 'file', steps: [{ id: 'task', name: 'Task', prompt: '{{task}}' }] },
+            ],
+            issues: [],
+          },
+          uiState: { lastTask: { source: 'workflow', ref: 'one-step' } },
+        },
+        expected: { workflow: 'one-step' },
+      },
+    ]
+
+    for (const testCase of cases) {
+      cleanup()
+      resetDraft()
+      serve(testCase.overrides)
+      renderNewTask()
+      await pillReady(testCase.label)
+      const worktree = document.querySelector('[data-slot="worktree-toggle"]') as HTMLButtonElement
+      fireEvent.click(worktree)
+      expect(worktree.getAttribute('aria-checked')).toBe('false')
+      fireEvent.change(textarea(), { target: { value: `Run ${testCase.label} in place` } })
+      await startTask()
+      expect(postedBody()).toMatchObject({ ...testCase.expected, worktree: false })
+    }
+  })
+
+  it('carries an inherited Worktree-off policy into the submitted payload', async () => {
+    serve({
+      workspaceConfig: {
+        ...WORKSPACE_CONFIG,
+        composerDefaults: {
+          ...WORKSPACE_CONFIG.composerDefaults!,
+          inheritedWorktree: false,
+        },
+      },
+    })
+    renderNewTask()
+    await pillReady()
+    const worktree = document.querySelector('[data-slot="worktree-toggle"]') as HTMLButtonElement
+    expect(worktree.getAttribute('aria-checked')).toBe('false')
+    fireEvent.change(textarea(), { target: { value: 'Use the environment seed' } })
+    await startTask()
+    expect(postedBody()).toMatchObject({ workflow: 'quick-task', worktree: false })
+  })
+
   it('picking a model and ×2 variants rides along; {runs} answer navigates to the FIRST variant', async () => {
     serve({ createRun: { runs: [{ id: 'v-a' }, { id: 'v-b' }] } })
     renderNewTask()
@@ -855,7 +943,7 @@ describe('submit', () => {
     expect(worktree.getAttribute('aria-checked')).toBe('true')
   })
 
-  it('forces and disables Worktree for a multi-step workflow', async () => {
+  it('lets a multi-step workflow opt out and submits worktree:false', async () => {
     serve({
       workflows: {
         workflows: [
@@ -873,17 +961,16 @@ describe('submit', () => {
       },
       uiState: { lastTask: { source: 'workflow', ref: 'fix-and-verify' } },
     })
-    writeDraft({
-      ...readDraft(),
-      worktree: false,
-    })
     renderNewTask()
     await pillReady('fix-and-verify')
 
     const worktree = document.querySelector('[data-slot="worktree-toggle"]') as HTMLButtonElement
-    expect(worktree.getAttribute('aria-checked')).toBe('true')
-    expect(worktree.disabled).toBe(true)
-    expect(worktree.title).toBe('Multi-step workflows require an isolated worktree')
+    expect(worktree.disabled).toBe(false)
+    fireEvent.click(worktree)
+    expect(worktree.getAttribute('aria-checked')).toBe('false')
+    fireEvent.change(textarea(), { target: { value: 'Run the whole workflow in place' } })
+    await startTask()
+    expect(postedBody()).toMatchObject({ workflow: 'fix-and-verify', worktree: false })
   })
 
   // #471 — the composer must not offer a switch the server overrides anyway.

--- a/packages/web/src/routes/new-task.tsx
+++ b/packages/web/src/routes/new-task.tsx
@@ -177,9 +177,6 @@ export function NewTaskRoute() {
   const sourcesReady =
     skills.data !== undefined && workflows.data !== undefined && !uiState.isPending
   const source = resolveSource([draft.source, uiState.data?.lastTask], skillList, workflowList)
-  const selectedWorkflow = source.source === 'workflow'
-    ? workflowList.find((workflow) => workflow.name === source.ref)
-    : undefined
   const selectedSkill = source.source === 'skill'
     ? skillList.find((skill) => skill.name === source.ref)
     : undefined
@@ -241,14 +238,11 @@ export function NewTaskRoute() {
   const hasGit = health.data === undefined || health.data.repo !== null
   const variants = hasGit ? draft.variants : 1
 
-  // Worktree opt-out (#worktree-toggle): only offered for a single skill run in a git repo —
-  // workflows and variants always isolate, and a non-git repo already runs in place. The choice
-  // is remembered (draft → last-used → default on).
-  const singleStepSource = source.source === 'skill'
-    || source.ref === 'quick-task'
-    || selectedWorkflow?.steps.length === 1
+  // Worktree opt-out (#worktree-toggle): any ordinary run in a git repo may use the current
+  // checkout. Parallel variants are the one hard constraint because each competing run needs
+  // its own tree; a non-git repo already runs in place.
   const worktreeToggleShown = hasGit
-  const worktreeForced = !singleStepSource || variants > 1
+  const worktreeForced = variants > 1
 
   // Autonomous (#autonomous): the run never pauses for the user. An explicit toggle this session
   // wins; then an interactive skill recommends handing the ball back; otherwise the configured
@@ -258,7 +252,6 @@ export function NewTaskRoute() {
   const runMode = resolveComposerRunMode({
     hasGit,
     variants,
-    forceWorktree: !singleStepSource,
     planFirst: draft.planFirst,
     explicitAutonomous: draft.autonomous,
     explicitWorktree: draft.worktree,
@@ -624,9 +617,7 @@ export function NewTaskRoute() {
                 <WorktreeToggle
                   on={worktreeOn}
                   disabled={worktreeForced}
-                  disabledReason={variants > 1
-                    ? 'Parallel variants always use isolated worktrees'
-                    : 'Multi-step workflows require an isolated worktree'}
+                  disabledReason="Parallel variants always use isolated worktrees"
                   onChange={(on) => update({ worktree: on })}
                 />
               ) : null}
@@ -703,7 +694,7 @@ export function NewTaskRoute() {
   )
 }
 
-/** Worktree opt-out toggle (#worktree-toggle): a checkbox-style chip for single skill runs.
+/** Worktree opt-out toggle (#worktree-toggle): a checkbox-style chip for ordinary runs.
  *  Checked = isolated worktree (the default); unchecked = run in the repo working tree. */
 function WorktreeToggle({
   on,


### PR DESCRIPTION
Fixes #714

## Problem
The New Task composer could silently turn an explicit or configured Worktree opt-out back on, causing tasks to run in `.ai/cezar/worktrees/<id>` despite the UI or workspace policy selecting the repository working tree.

## Root Cause
`resolveComposerRunMode` treated every non-single-step workflow as a hard isolation constraint. That `forceWorktree` branch outranked both the draft choice and the effective workspace/environment default, even though only parallel variants require separate worktrees; the API and RunManager already preserve and honor `worktree: false`.

## What Changed
- Make parallel variants the only hard Worktree constraint, leaving explicit and configured opt-outs authoritative for ordinary skill and workflow runs.
- Keep the Worktree control enabled for multi-step workflows and send `worktree: false` on opt-out.
- Emit an isolated-worktree decision note before setup, including whether isolation was explicit or the default.
- Update the governing composer-defaults spec and the API documentation comments.

## Tests
- Added route regressions for quick-task, skill, one-step workflow, multi-step workflow, and inherited `CEZ_WORKTREE_DEFAULT=0` payloads.
- Added resolver precedence coverage and isolated-run decision-note coverage.
- `npm run typecheck` — passed.
- `npm test` — 4,672 tests passed.
- `npm run test:unit` — 36 tests passed.
- `npm run build` — passed, including check:pack.
- `npm run test:package` — 9 tests passed.

## Breaking Changes
None. The protected `POST /api/runs` schema is unchanged; this fixes the documented behavior of its existing optional `worktree` field. Tasks that explicitly opt out now place their edits in the repository working tree as requested.

## QA
This changes user-facing composer behavior, so the PR retains `needs-qa`; the chain will attach browser evidence, and the manual QA gate still owns `qa-approved`.

🤖 Generated by autofix.