### PR TITLE
fix(ui): keep commit links project-scoped (#713)

### DIFF
--- a/packages/web/src/routes/task-git/commit-list.test.tsx
+++ b/packages/web/src/routes/task-git/commit-list.test.tsx
@@ -66,10 +66,23 @@ describe('CommitList', () => {
   })
 
   it('keeps task and repo commit links inside the active project', () => {
-    const repoCommit = commits(1)[0]!
-    const scopedCommits = [
-      repoCommit,
-      { ...repoCommit, sha: 'task-sha', href: '/tasks/run-1/commits/task-sha' },
+    const scopedCommits: CommitListItem[] = [
+      {
+        sha: 'repo-sha',
+        shaLabel: 'repo-sha',
+        subject: 'repo commit',
+        author: 'ada',
+        when: '2h ago',
+        href: '/git/commits/repo-sha',
+      },
+      {
+        sha: 'task-sha',
+        shaLabel: 'task-sha',
+        subject: 'task commit',
+        author: 'ada',
+        when: '2h ago',
+        href: '/tasks/run-1/commits/task-sha',
+      },
     ]
 
     render(
@@ -79,7 +92,7 @@ describe('CommitList', () => {
     )
 
     const links = document.querySelectorAll<HTMLAnchorElement>('[data-slot="commit-row"]')
-    expect(links.item(0).getAttribute('href')).toBe('/p/secondary/git/commits/sha0')
+    expect(links.item(0).getAttribute('href')).toBe('/p/secondary/git/commits/repo-sha')
     expect(links.item(1).getAttribute('href')).toBe('/p/secondary/tasks/run-1/commits/task-sha')
   })
 

--- a/packages/web/src/routes/task-git/commit-list.test.tsx
+++ b/packages/web/src/routes/task-git/commit-list.test.tsx
@@ -37,9 +37,9 @@ const commits = (count: number): CommitListItem[] =>
     href: `/git/commits/sha${index}`,
   }))
 
-function renderList(count: number) {
+function renderList(count: number, route = '/') {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[route]}>
       <CommitList slot="repo-commits" commits={commits(count)} />
     </MemoryRouter>,
   )
@@ -63,6 +63,24 @@ describe('CommitList', () => {
     expect(first.dataset.sha).toBe('sha0')
     expect(first.textContent).toContain('commit 0')
     expect(first.textContent).toContain('ada')
+  })
+
+  it('keeps task and repo commit links inside the active project', () => {
+    const repoCommit = commits(1)[0]!
+    const scopedCommits = [
+      repoCommit,
+      { ...repoCommit, sha: 'task-sha', href: '/tasks/run-1/commits/task-sha' },
+    ]
+
+    render(
+      <MemoryRouter initialEntries={['/p/secondary/tasks/run-1/commits']}>
+        <CommitList slot="task-commits" commits={scopedCommits} />
+      </MemoryRouter>,
+    )
+
+    const links = document.querySelectorAll<HTMLAnchorElement>('[data-slot="commit-row"]')
+    expect(links.item(0).getAttribute('href')).toBe('/p/secondary/git/commits/sha0')
+    expect(links.item(1).getAttribute('href')).toBe('/p/secondary/tasks/run-1/commits/task-sha')
   })
 
   it('switches to virtua past the threshold, bounding the DOM', () => {

--- a/packages/web/src/routes/task-git/commit-list.tsx
+++ b/packages/web/src/routes/task-git/commit-list.tsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react'
-import { Link } from 'react-router'
 import { Virtualizer } from 'virtua'
 
+import { Link } from '@/lib/project-router'
 import { cn } from '@/lib/utils'
 
 /**


### PR DESCRIPTION
Closes #713

## 🎯 Goal
- Keep session and repository commit navigation inside the active project so selecting a commit opens its structured diff instead of redirecting to the boot project and showing “Task not found.”

## 🔍 Problem
Commit rows generated flat `/tasks/...` and `/git/...` targets with React Router's unscoped `Link`. From a non-boot project, the flat target passed through the legacy redirect and resolved against the boot project, where the task could not be found.

## 🔍 Root Cause
`CommitRow` in `packages/web/src/routes/task-git/commit-list.tsx` bypassed the repository's scope-aware navigation seam even though both surrounding commit-detail routes already use it. The generic React Router link therefore omitted the active `/p/:projectId` prefix.

## What Changed
- Switched the shared commit-row renderer to `@/lib/project-router` so both task and repository commit targets inherit the active project scope.
- Added focused regression coverage proving both target shapes gain `/p/secondary` under a scoped route while the existing flat-path assertion continues to protect legacy behavior.

## 🧪 Tests
- `npm run typecheck` — passed.
- `npm test` — 4,801 tests passed across 275 files.
- `npm run test:unit` — 36 tests passed.
- `npm run build` — server, cockpit, and package-content checks passed.
- `npm run test:package` — 12 packed-release/CLI tests passed.
- `commit-list.test.tsx` now verifies scoped task and repository commit links, and its existing test continues to verify flat URLs remain unchanged without an active project scope.

## 💥 Breaking Changes
- None. Legacy flat URLs and server/API contracts are unchanged.
