### PR TITLE
fix(git): support session views without worktrees (#728)

### DIFF
--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -169,7 +169,7 @@ const runRecordSchema = z.object({
   worktreePath: z.string().optional(),
   /** The task's own branch (`cez/<id8>`), created off `baseBranch`. */
   branch: z.string().optional(),
-  /** Branch (or commit, when HEAD was detached) the worktree was forked from. */
+  /** Stable baseline for session git views: a worktree's fork ref, or an in-place run's starting commit. */
   baseBranch: z.string().optional(),
   /** Set when count-based retention (#483) reclaimed this run's worktree
    *  *directory* (the `cez/<id8>` branch is kept). Presence means "materialized

--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -165,7 +165,10 @@ const runRecordSchema = z.object({
   /** Distinct issue URLs spotted so far — the referenced-issue working set,
    *  persisted like `referencedPrCandidates`. Capped. */
   referencedIssueCandidates: z.array(z.string()).optional(),
-  /** Task worktree (spec 006) — absent when the run executed in the repo root. */
+  /** Explicit execution policy. `false` means the run intentionally uses the repo root;
+   *  absent on older runs and for the default isolated-worktree mode. */
+  worktree: z.literal(false).optional(),
+  /** Task worktree (spec 006) — absent for in-place runs and after explicit cleanup. */
   worktreePath: z.string().optional(),
   /** The task's own branch (`cez/<id8>`), created off `baseBranch`. */
   branch: z.string().optional(),
@@ -415,6 +418,7 @@ export class RunStore extends EventEmitter {
     runner?: 'claude' | 'codex' | 'opencode';
     generateFollowups?: boolean;
     autonomous?: boolean;
+    worktree?: false;
     groupId?: string;
     variant?: string;
     steps: Array<Pick<StepState, 'id' | 'name' | 'kind'>>;
@@ -434,6 +438,7 @@ export class RunStore extends EventEmitter {
       runner: input.runner,
       generateFollowups: input.generateFollowups,
       autonomous: input.autonomous,
+      worktree: input.worktree,
       groupId: input.groupId,
       variant: input.variant,
       status: 'queued',

--- a/packages/cezar/src/server/git-changes.test.ts
+++ b/packages/cezar/src/server/git-changes.test.ts
@@ -434,9 +434,16 @@ describe('session git API routes', () => {
   let store: RunStore;
   let app: Hono;
   let run: RunRecord;
+  let repoBaseSha: string;
 
   beforeEach(() => {
     repoRoot = mkdtempSync(join(tmpdir(), 'cez-gitapi-'));
+    initRepo(repoRoot);
+    writeFileSync(join(repoRoot, '.gitignore'), '.ai/\nwt/\n');
+    writeFileSync(join(repoRoot, 'root-base.txt'), 'base\n');
+    g(repoRoot, 'add', '-A');
+    g(repoRoot, 'commit', '-m', 'root base');
+    repoBaseSha = g(repoRoot, 'rev-parse', 'HEAD').trim();
     store = RunStore.open(join(repoRoot, '.ai/cezar'));
     app = createApp({
       repoRoot,
@@ -495,12 +502,41 @@ describe('session git API routes', () => {
     expect(body.repointedHead).toEqual({ headBranch: 'review/pr-42', taskBranch: 'task' });
   });
 
-  it('runs without a worktree get 409 + reason (JSON, never HTML) on every session-git route', async () => {
+  it('runs without a worktree read Changes, Files and Commits from the current checkout', async () => {
     const bare = store.createRun({ title: 'b', workflow: 'quick-task', task: 'b', steps: [] });
+    store.updateRun(bare.id, { baseBranch: repoBaseSha });
+
+    writeFileSync(join(repoRoot, 'committed.txt'), 'session commit\n');
+    g(repoRoot, 'add', 'committed.txt');
+    g(repoRoot, 'commit', '-m', 'session commit');
+    writeFileSync(join(repoRoot, 'untracked.txt'), 'working copy\n');
+
+    const changes = await apiRequest(app, `/api/v1/runs/${bare.id}/changes`);
+    expect(changes.status).toBe(200);
+    const changed = (await changes.json()) as ChangesPayload;
+    expect(changed.files.map((file) => file.path)).toEqual(['committed.txt', 'untracked.txt']);
+    // The read uses a scratch index, so surfacing an untracked file never stages it.
+    expect(g(repoRoot, 'status', '--porcelain', 'untracked.txt').startsWith('??')).toBe(true);
+
+    const files = await apiRequest(app, `/api/v1/runs/${bare.id}/files?path=untracked.txt`);
+    expect(files.status).toBe(200);
+    expect((await files.json()) as object).toMatchObject({ type: 'file', content: 'working copy\n' });
+
+    const commits = await apiRequest(app, `/api/v1/runs/${bare.id}/commits`);
+    expect(commits.status).toBe(200);
+    const commitList = (await commits.json()) as { commits: Array<{ sha: string; subject: string }> };
+    expect(commitList.commits).toHaveLength(1);
+    expect(commitList.commits[0]?.subject).toBe('session commit');
+
+    const detail = await apiRequest(app, `/api/v1/runs/${bare.id}/commit/${commitList.commits[0]!.sha}`);
+    expect(detail.status).toBe(200);
+    expect((await detail.json()) as object).toMatchObject({
+      subject: 'session commit',
+      files: [{ path: 'committed.txt', status: 'added' }],
+    });
+
+    // Mutations still require an isolated worktree/branch.
     for (const req of [
-      apiRequest(app, `/api/v1/runs/${bare.id}/changes`),
-      apiRequest(app, `/api/v1/runs/${bare.id}/files`),
-      apiRequest(app, `/api/v1/runs/${bare.id}/commits`),
       commit(bare.id, { message: 'x' }),
       apiRequest(app, `/api/v1/runs/${bare.id}/git/push`, { method: 'POST' }),
     ]) {

--- a/packages/cezar/src/server/git-changes.test.ts
+++ b/packages/cezar/src/server/git-changes.test.ts
@@ -503,7 +503,13 @@ describe('session git API routes', () => {
   });
 
   it('runs without a worktree read Changes, Files and Commits from the current checkout', async () => {
-    const bare = store.createRun({ title: 'b', workflow: 'quick-task', task: 'b', steps: [] });
+    const bare = store.createRun({
+      title: 'b',
+      workflow: 'quick-task',
+      task: 'b',
+      worktree: false,
+      steps: [],
+    });
     store.updateRun(bare.id, { baseBranch: repoBaseSha });
 
     writeFileSync(join(repoRoot, 'committed.txt'), 'session commit\n');
@@ -526,9 +532,11 @@ describe('session git API routes', () => {
     expect(commits.status).toBe(200);
     const commitList = (await commits.json()) as { commits: Array<{ sha: string; subject: string }> };
     expect(commitList.commits).toHaveLength(1);
-    expect(commitList.commits[0]?.subject).toBe('session commit');
+    const sessionCommit = commitList.commits[0];
+    expect(sessionCommit?.subject).toBe('session commit');
+    if (!sessionCommit) throw new Error('expected the session commit');
 
-    const detail = await apiRequest(app, `/api/v1/runs/${bare.id}/commit/${commitList.commits[0]!.sha}`);
+    const detail = await apiRequest(app, `/api/v1/runs/${bare.id}/commit/${sessionCommit.sha}`);
     expect(detail.status).toBe(200);
     expect((await detail.json()) as object).toMatchObject({
       subject: 'session commit',
@@ -539,6 +547,27 @@ describe('session git API routes', () => {
     for (const req of [
       commit(bare.id, { message: 'x' }),
       apiRequest(app, `/api/v1/runs/${bare.id}/git/push`, { method: 'POST' }),
+    ]) {
+      const res = await req;
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as { error: string }).error).toContain('no worktree');
+    }
+  });
+
+  it('runs whose isolated worktree was removed never fall through to the current checkout', async () => {
+    const removed = store.createRun({ title: 'removed', workflow: 'quick-task', task: 'removed', steps: [] });
+    store.updateRun(removed.id, {
+      worktreePath: join(repoRoot, 'removed-worktree'),
+      branch: 'cez/removed',
+      baseBranch: repoBaseSha,
+    });
+    store.updateRun(removed.id, { worktreePath: undefined, branch: undefined });
+
+    for (const req of [
+      apiRequest(app, `/api/v1/runs/${removed.id}/changes`),
+      apiRequest(app, `/api/v1/runs/${removed.id}/files`),
+      apiRequest(app, `/api/v1/runs/${removed.id}/commits`),
+      apiRequest(app, `/api/v1/runs/${removed.id}/commit/${repoBaseSha}`),
     ]) {
       const res = await req;
       expect(res.status).toBe(409);

--- a/packages/cezar/src/server/git.test.ts
+++ b/packages/cezar/src/server/git.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getRepoInfo } from './git.ts';
+import { getHeadCommit, getRepoInfo } from './git.ts';
 
 /**
  * getRepoInfo remote discovery: the forge seam (and so the GitHub tab) hangs
@@ -60,10 +60,15 @@ describe('getRepoInfo — remote discovery', () => {
     expect(info?.remote).toBeUndefined();
   });
 
+  it('pins the current commit as a full SHA', async () => {
+    expect(await getHeadCommit(dir)).toBe(g(dir, 'rev-parse', 'HEAD').trim());
+  });
+
   it('returns null outside a git repository', async () => {
     const bare = mkdtempSync(join(tmpdir(), 'cez-nogit-'));
     try {
       expect(await getRepoInfo(bare)).toBeNull();
+      expect(await getHeadCommit(bare)).toBeNull();
     } finally {
       rmSync(bare, { recursive: true, force: true });
     }

--- a/packages/cezar/src/server/git.ts
+++ b/packages/cezar/src/server/git.ts
@@ -53,6 +53,15 @@ export async function getRepoInfo(dir: string): Promise<RepoInfo | null> {
   }
 }
 
+/** The current commit, pinned as a full SHA. Null outside a repository or before its first commit. */
+export async function getHeadCommit(root: string): Promise<string | null> {
+  try {
+    return (await git(root, ['rev-parse', '--verify', 'HEAD^{commit}'])).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function getStatus(root: string): Promise<StatusEntry[]> {
   const out = await git(root, ['status', '--porcelain']);
   return out

--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -3465,7 +3465,7 @@ export function createApp(deps: ServerDeps) {
   const worktreeOf = (run: RunRecord): string | null =>
     run.worktreePath && existsSync(run.worktreePath) ? run.worktreePath : null;
   const workingDirectoryOf = (run: RunRecord, repoRoot: string): string | null =>
-    run.worktreePath === undefined
+    run.worktree === false
       ? repoRoot
       : worktreeOf(run);
   const NO_WORKTREE = 'no worktree — this task ran directly in the repo working tree';

--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -3157,36 +3157,40 @@ export function createApp(deps: ServerDeps) {
     })
 
     .get('/runs/:id/changes', async (c) => {
-      const { store } = c.get('project');
+      const { root: repoRoot, store } = c.get('project');
       const run = store.getRun(c.req.param('id'));
       if (!run) return c.json({ error: 'not found' }, 404);
-      const worktree = worktreeOf(run);
-      if (!worktree) return c.json({ error: NO_WORKTREE }, 409);
-      const result = await collectChanges(worktree, run.baseBranch ?? 'HEAD', { taskBranch: run.branch });
+      const workingDirectory = workingDirectoryOf(run, repoRoot);
+      if (!workingDirectory) return c.json({ error: NO_WORKTREE }, 409);
+      const result = await collectChanges(workingDirectory, run.baseBranch ?? 'HEAD', {
+        taskBranch: run.branch,
+        // A read-only GET against the user's real checkout must never modify its index.
+        intentToAdd: run.worktreePath ? undefined : false,
+      });
       if (!result.ok) return c.json({ error: result.error }, 409);
       return c.json(result.changes);
     })
 
     // The run's own commits (<base>..HEAD on the worktree branch) — the Commits tab.
     .get('/runs/:id/commits', async (c) => {
-      const { store } = c.get('project');
+      const { root: repoRoot, store } = c.get('project');
       const run = store.getRun(c.req.param('id'));
       if (!run) return c.json({ error: 'not found' }, 404);
-      const worktree = worktreeOf(run);
-      if (!worktree) return c.json({ error: NO_WORKTREE }, 409);
-      const result = await collectRunCommits(worktree, run.baseBranch ?? 'HEAD');
+      const workingDirectory = workingDirectoryOf(run, repoRoot);
+      if (!workingDirectory) return c.json({ error: NO_WORKTREE }, 409);
+      const result = await collectRunCommits(workingDirectory, run.baseBranch ?? 'HEAD');
       if (!result.ok) return c.json({ error: result.error }, 409);
       return c.json({ commits: result.commits });
     })
 
     // One of the run's commits, structured like the Changes tab (reuses collectCommitChanges).
     .get('/runs/:id/commit/:sha', async (c) => {
-      const { store } = c.get('project');
+      const { root: repoRoot, store } = c.get('project');
       const run = store.getRun(c.req.param('id'));
       if (!run) return c.json({ error: 'not found' }, 404);
-      const worktree = worktreeOf(run);
-      if (!worktree) return c.json({ error: NO_WORKTREE }, 409);
-      const result = await collectCommitChanges(worktree, c.req.param('sha'));
+      const workingDirectory = workingDirectoryOf(run, repoRoot);
+      if (!workingDirectory) return c.json({ error: NO_WORKTREE }, 409);
+      const result = await collectCommitChanges(workingDirectory, c.req.param('sha'));
       if (!result.ok) return c.json({ error: result.error }, 409);
       return c.json(result.commit);
     })
@@ -3202,7 +3206,7 @@ export function createApp(deps: ServerDeps) {
     // what an `<img>` sends — while the flag still wins whenever it is present and `*<slash>*`
     // (every `fetch`) still gets the JSON listing. See `negotiate`.
     .get('/runs/:id/files', queryZodValidator(z.object({ path: queryValue, raw: queryValue })), async (c) => {
-      const { store } = c.get('project');
+      const { root: repoRoot, store } = c.get('project');
       const query = c.req.valid('query');
       c.header('vary', 'Accept');
       const wantsRaw =
@@ -3211,9 +3215,9 @@ export function createApp(deps: ServerDeps) {
           : negotiate(c.req.header('accept'), FILE_FORMATS) === 'image/*';
       const run = store.getRun(c.req.param('id'));
       if (!run) return c.json({ error: 'not found' }, 404);
-      const worktree = worktreeOf(run);
-      if (!worktree) return c.json({ error: NO_WORKTREE }, 409);
-      const result = await readWorktreePath(worktree, query.path ?? '');
+      const workingDirectory = workingDirectoryOf(run, repoRoot);
+      if (!workingDirectory) return c.json({ error: NO_WORKTREE }, 409);
+      const result = await readWorktreePath(workingDirectory, query.path ?? '');
       if (result.kind === 'invalid' || result.kind === 'missing') {
         return c.json({ error: result.error }, 409);
       }
@@ -3242,7 +3246,7 @@ export function createApp(deps: ServerDeps) {
             return c.json({ error }, 409);
           }
         } else {
-          const bytes = await readFile(join(worktree, result.path));
+          const bytes = await readFile(join(workingDirectory, result.path));
           return c.body(new Uint8Array(bytes).buffer as ArrayBuffer, 200, {
             'content-type': mime,
             'x-content-type-options': 'nosniff',
@@ -3455,10 +3459,15 @@ export function createApp(deps: ServerDeps) {
   };
   // ---- session git view (redesign R5 Step 1.2 — §"Git/session API additions").
   // Structured sibling of the text-blob /diff above (which stays untouched —
-  // protected surface). Same worktree/base resolution; every predictable git
-  // failure degrades to 409 + human-readable reason, 404 only for unknown ids.
+  // protected surface). Isolated runs read their worktree; worktree-off runs
+  // read the repo checkout they executed in. Every predictable git failure
+  // degrades to 409 + human-readable reason, 404 only for unknown ids.
   const worktreeOf = (run: RunRecord): string | null =>
     run.worktreePath && existsSync(run.worktreePath) ? run.worktreePath : null;
+  const workingDirectoryOf = (run: RunRecord, repoRoot: string): string | null =>
+    run.worktreePath === undefined
+      ? repoRoot
+      : worktreeOf(run);
   const NO_WORKTREE = 'no worktree — this task ran directly in the repo working tree';
 
   // ---- chained family: worktrees (project-scoped) ----

--- a/packages/cezar/src/workflows/run.test.ts
+++ b/packages/cezar/src/workflows/run.test.ts
@@ -491,6 +491,8 @@ describe('a chain of 2 selected skills runs BOTH steps, in order (#410)', () => 
     }
 
     const finished = store.getRun(record.id);
+    expect(finished?.worktreePath).toBeUndefined();
+    expect(finished?.baseBranch).toMatch(/^[0-9a-f]{40}$/);
     // Neither step failed or was skipped — the reported bug looked exactly
     // like this from the RunRecord's point of view (both `done`) while the
     // second step's session had done nothing; the assertion below on

--- a/packages/cezar/src/workflows/run.test.ts
+++ b/packages/cezar/src/workflows/run.test.ts
@@ -48,6 +48,31 @@ describe('appendTurnText', () => {
   });
 });
 
+it('parallel variants ignore a worktree opt-out and retain isolated mode', () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'cez-variant-isolation-'));
+  const store = RunStore.open(join(repoRoot, '.ai/cezar'));
+  try {
+    const manager = new RunManager(store, repoRoot, {
+      semaphore: new WorkspaceSemaphore({ initial: { maxParallel: 0 } }),
+    });
+    const records = manager.startVariants(
+      {
+        name: 'quick-task',
+        description: 'x',
+        source: 'built-in',
+        steps: [{ id: 'work', name: 'Work', prompt: '{{task}}' }],
+      },
+      { task: 'compare approaches', worktree: false },
+      2,
+    );
+
+    expect(records.map((record) => record.worktree)).toEqual([undefined, undefined]);
+  } finally {
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
 /**
  * Turn-end bookkeeping (#389, task auto-naming spec) against a REAL fixture
  * repo: `recordTurnEnd` is the exact method both agent-event paths fire on
@@ -491,6 +516,7 @@ describe('a chain of 2 selected skills runs BOTH steps, in order (#410)', () => 
     }
 
     const finished = store.getRun(record.id);
+    expect(finished?.worktree).toBe(false);
     expect(finished?.worktreePath).toBeUndefined();
     expect(finished?.baseBranch).toMatch(/^[0-9a-f]{40}$/);
     // Neither step failed or was skipped — the reported bug looked exactly

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -28,7 +28,7 @@ import { materializeSkillDir } from '../skills-remote.ts';
 import { seedAgentConfigLocalLayer } from '../agent-config/seed.ts';
 import { loadConfig, resolveWorktreeRetention } from '../config.ts';
 import { autosaveCommit, createWorktree, resolveBaseRef, worktreeDiff, worktreeShortstat } from '../git-worktree.ts';
-import { getRepoInfo } from '../server/git.ts';
+import { getHeadCommit, getRepoInfo } from '../server/git.ts';
 import { loadWorkflows } from './load.ts';
 import type { QueuedMessage, RunRecord, RunStore } from '../runs/store.ts';
 import { reclaimWorktrees, rematerializeReclaimedWorktree } from '../runs/retention.ts';
@@ -1767,6 +1767,10 @@ export class RunManager {
     if (repo && input.worktree === false) {
       // Composer opt-out: run in the repo working tree, no branch/worktree. The
       // repository-root lease serializes these runs so workflows cannot overlap.
+      // Pin the starting commit: the session's Changes and Commits views use it
+      // as their stable lower bound while reading the current working copy.
+      const startingCommit = await getHeadCommit(repo.root);
+      if (startingCommit) this.store.updateRun(runId, { baseBranch: startingCommit });
       emit({ type: 'note', message: 'worktree off — running in the repo working tree' });
     } else if (repo) {
       emit({

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -489,6 +489,9 @@ export class RunManager {
       // auto-nudge reads `input.autonomous` (`execute`), but the record is the
       // only source those after-the-fact consumers have.
       autonomous: input.autonomous === true,
+      // Persist the explicit opt-out so queued-run restart recovery and the
+      // session Git routes can distinguish it from a removed isolated worktree.
+      worktree: !group && input.worktree === false ? false : undefined,
       groupId: group?.groupId,
       variant: group?.variant,
       steps: workflow.steps.map((s) => ({ id: s.id, name: s.name ?? s.id, kind: stepKind(s) })),
@@ -542,7 +545,7 @@ export class RunManager {
       (variant) => {
         const hint = VARIANT_HINTS[variant];
         const task = hint ? `${input.task}\n\n${hint}` : input.task;
-        return this.startRun(workflow, { ...input, task }, { groupId, variant });
+        return this.startRun(workflow, { ...input, task, worktree: undefined }, { groupId, variant });
       },
     );
   }
@@ -757,6 +760,9 @@ export class RunManager {
               // recovered queued autonomous run would run non-autonomously (no
               // auto-nudge) and later wrongly park at `review`.
               autonomous: run.autonomous,
+              // Preserve an explicit worktree opt-out across a queued restart.
+              // Missing on older records means the default isolated mode.
+              worktree: run.worktree,
             }),
           });
           this.queue.push(run.id);

--- a/packages/contract/src/repo.ts
+++ b/packages/contract/src/repo.ts
@@ -91,7 +91,7 @@ export const changedFileSchema = z.object({
 export type ChangedFile = z.infer<typeof changedFileSchema>;
 
 /** `GET /api/v1/runs/:id/changes` and `GET /api/v1/repo/changes` — the structured diff.
- *  409 (+ reason) when there is no worktree or git itself refuses; never HTML. */
+ *  409 (+ reason) when the run's backing directory is unavailable or git itself refuses; never HTML. */
 export const changesPayloadSchema = z.object({
   files: z.array(changedFileSchema),
   stat: diffStatSchema,

--- a/packages/contract/src/runs.ts
+++ b/packages/contract/src/runs.ts
@@ -187,7 +187,10 @@ export const runRecordSchema = z.object({
   referencedIssueUrl: z.string().optional(),
   /** The referenced-issue working set, persisted like `referencedPrCandidates`. Capped. */
   referencedIssueCandidates: z.array(z.string()).optional(),
-  /** Absent when the run executed in the repo working tree rather than its own worktree. */
+  /** Explicit execution policy. `false` means the run intentionally uses the repo root;
+   *  absent on older runs and for the default isolated-worktree mode. */
+  worktree: z.literal(false).optional(),
+  /** Absent for in-place runs and after an isolated worktree is removed. */
   worktreePath: z.string().optional(),
   branch: z.string().optional(),
   /** Stable baseline for session git views: a worktree's fork ref, or an in-place run's starting commit. */

--- a/packages/contract/src/runs.ts
+++ b/packages/contract/src/runs.ts
@@ -190,6 +190,7 @@ export const runRecordSchema = z.object({
   /** Absent when the run executed in the repo working tree rather than its own worktree. */
   worktreePath: z.string().optional(),
   branch: z.string().optional(),
+  /** Stable baseline for session git views: a worktree's fork ref, or an in-place run's starting commit. */
   baseBranch: z.string().optional(),
   /** Set when count-based retention (#483) reclaimed the worktree DIRECTORY (the branch is
    *  kept): the dir is gone but recoverable. */

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -730,8 +730,8 @@ export function getRunHandoff(id: string, opts?: ReadOptions): Promise<string> {
   return requestText(runPath(id, '/handoff'), { method: 'GET', signal: opts?.signal })
 }
 
-/** The run's structured worktree-vs-base diff (R5): per-file status/±/patch + the aggregate
- *  stat. 409 (as an ApiError with the server's reason) when the run has no worktree. */
+/** The run's structured working-directory-vs-base diff (R5): per-file status/±/patch + the
+ *  aggregate stat. Worktree-off runs read the repo checkout they executed in. */
 export async function getRunChanges(id: string, opts?: ReadOptions): Promise<ChangesPayload> {
   return unwrap(
     await cez.api.v1.p[':projectId'].runs[':id'].changes.$get(

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -480,9 +480,9 @@ export function useRunDiff(id: string | undefined) {
   })
 }
 
-/** The structured worktree diff behind the Changes tab (R5). A 409 ("no worktree — …") is a
- *  real answer here, not a network hiccup — retrying cannot change it, so retries are off and
- *  the view renders the server's own reason. */
+/** The structured session diff behind the Changes tab (R5). A 409 (for example, a reclaimed
+ *  worktree whose directory is unavailable) is a real answer, not a network hiccup — retrying
+ *  cannot change it, so retries are off and the view renders the server's own reason. */
 export function useRunChanges(id: string | undefined, live = false) {
   return useQuery({
     queryKey: queryKeys.runs.changes(id ?? ''),
@@ -528,7 +528,7 @@ export function useGroup(groupId: string | undefined) {
 }
 
 /** A run's commit list (Commits tab). Polls while active so new commits appear as the agent
- *  autosaves. A 409 ("no worktree") is a real answer retries can't change. */
+ *  works. A 409 from an unavailable backing directory is a real answer retries can't change. */
 export function useRunCommits(id: string | undefined, live = false) {
   return useQuery({
     queryKey: queryKeys.runs.commits(id ?? ''),


### PR DESCRIPTION
Closes #728

## 🎯 Goal
Let tasks that run directly in the checked-out repository use their session Changes, Files, and Commits views instead of seeing a no-worktree refusal.

## 🔍 Problem
Runs started with worktree isolation disabled execute in the repository root, but their session-git tabs returned 409 because the API accepted only a materialized task worktree.

## 🔍 Root Cause
The run lifecycle left both `worktreePath` and a stable Git baseline unset for in-place runs. The read-only session-git handlers then treated the absent `worktreePath` as an unavailable working directory, even though the run had executed in the project root.

## What Changed
- Pin the checkout's starting commit when a worktree-off run begins, giving its Changes and Commits views a stable lower bound.
- Resolve read-only session Changes, Files, Commits, and commit details against the repository root for in-place runs while preserving the worktree-only guard for commit and push mutations.
- Use a scratch Git index when collecting checkout changes so a GET request never stages untracked files in the user's real index.
- Add server and workflow regressions covering committed and untracked changes, Files reads, per-session commits, commit details, the pinned baseline, and mutation refusal.

## 🧪 Tests
- `npm run typecheck` — passed across contract, API client, server, and web workspaces.
- `npm test` — 4,801 tests passed across 275 files.
- `npm run test:unit` — 36 tests passed.
- `npm run build` — server/web builds and package-content checks passed.
- `npm run test:package` — 12 packaged CLI/release tests passed.
- Focused regression run — 142 server/workflow tests passed.

## 💥 Breaking Changes
- None. Route URLs and response schemas are unchanged; the previously rejected valid in-place-run read path now succeeds by design, while worktree-dependent mutation actions still return 409.

🤖 Generated by autofix.
