### PR TITLE
fix(skills): filter the Most used tier in the template skill picker (#668)

### DIFF
--- a/packages/web/src/routes/settings/prompt-templates-section.test.tsx
+++ b/packages/web/src/routes/settings/prompt-templates-section.test.tsx
@@ -257,6 +257,28 @@ describe('assigning a template to a skill', () => {
     expect(options.map((o) => o.dataset.skill)).toEqual(['g-review', 'om-fix'])
   })
 
+  it('a query filters the Most used tier too — not just the rest of the catalog (#668)', async () => {
+    // g-review is promoted into Most used by usage; a query for "fix" must still hide it.
+    serve({ skillUsage: { 'g-review': 3 } })
+    renderSection()
+    await waitFor(() => expect(rows()).toHaveLength(DEFAULT_PROMPT_TEMPLATES.length))
+
+    await openPicker(rows()[0]!)
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-slot="prompt-template-skill-option"]')).toHaveLength(2),
+    )
+
+    const searchInput = document.querySelector<HTMLInputElement>('[placeholder="search skills…"]')!
+    fireEvent.change(searchInput, { target: { value: 'fix' } })
+
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-slot="prompt-template-skill-option"]')).toHaveLength(1),
+    )
+    expect(option('om-fix')).not.toBeNull()
+    // The frequently-used g-review must be gone even though it sits in the Most used tier.
+    expect(option('g-review')).toBeNull()
+  })
+
   it('assigning shows a chip and Save PUTs the skills alongside the template', async () => {
     serve()
     renderSection()

--- a/packages/web/src/routes/settings/prompt-templates-section.tsx
+++ b/packages/web/src/routes/settings/prompt-templates-section.tsx
@@ -25,7 +25,7 @@ import {
   normalizePromptTemplates,
   type PromptTemplate,
 } from '@/lib/prompt-templates'
-import { isProjectSkill, multiWordFilter, partitionSkillsForDisplay, skillKeywords } from '@/lib/skills'
+import { isProjectSkill, partitionSkillsForDisplay, searchSkills, skillKeywords } from '@/lib/skills'
 import { cn } from '@/lib/utils'
 
 /**
@@ -290,9 +290,13 @@ function TemplateSkillsPicker({
   onToggle: (name: string) => void
 }) {
   const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const listRef = useRef<HTMLDivElement>(null)
-  // The #519 display tiers — the same most-used → project → global order every picker renders.
-  const { mostUsed, project, global } = partitionSkillsForDisplay(skills, skillUsage)
+  // #668: rank the full catalog in JS first, then split into the #519 tiers — otherwise the
+  // Most used tier is built from the unfiltered set and survives a query (cmdk's own sort is
+  // unreliable here, so we drive the filter ourselves like the other pickers).
+  const matched = searchSkills(skills, search, skillUsage)
+  const { mostUsed, project, global } = partitionSkillsForDisplay(matched, skillUsage)
 
   const skillItem = (skill: Skill, emphasized: boolean) => {
     const isSelected = selected.includes(skill.name)
@@ -323,7 +327,13 @@ function TemplateSkillsPicker({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) setSearch('')
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -342,14 +352,21 @@ function TemplateSkillsPicker({
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={8} className="w-[336px] max-w-[calc(100vw-2rem)] p-0">
-        <Command filter={multiWordFilter}>
-          <CommandInput placeholder="search skills…" onInput={() => listRef.current?.scrollTo(0, 0)} />
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="search skills…"
+            value={search}
+            onValueChange={setSearch}
+            onInput={() => listRef.current?.scrollTo(0, 0)}
+          />
           <CommandList
             ref={listRef}
             data-slot="prompt-template-skill-menu"
             className="max-h-[min(16rem,calc(var(--radix-popover-content-available-height)-3rem))]"
           >
-            <CommandEmpty>Nothing matches.</CommandEmpty>
+            {mostUsed.length === 0 && project.length === 0 && global.length === 0 ? (
+              <CommandEmpty>Nothing matches.</CommandEmpty>
+            ) : null}
             {mostUsed.length > 0 ? (
               <CommandGroup heading="Most used">
                 {mostUsed.map((skill) => skillItem(skill, isProjectSkill(skill)))}


### PR DESCRIPTION
Fixes #668.

## Problem
In the Settings → Prompt templates skill picker, typing a query filtered most of the catalog but left the **Most used** tier unfiltered — unrelated frequently-used skills stayed visible while the rest disappeared.

## Cause
`TemplateSkillsPicker` partitioned the **raw, unfiltered** catalog into display tiers and relied on cmdk's group-local filter. The other two pickers (`SourcePill`, `SkillsPicker`) already do it correctly: rank the full catalog with `searchSkills` first, then tier the matches.

## Fix
Mirror the working pickers — controlled `search` state, `searchSkills(skills, search, usage)` before `partitionSkillsForDisplay`, `Command shouldFilter={false}`, and a manual empty-state check. One file; the other two pickers were already correct.

## Test
Added a regression test: a query for `fix` hides a frequently-used skill even though it sits in the Most used tier. Full suite (16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)