### PR TITLE
fix(codex): keep an active run under Working when a sub-agent turn ends (#600)

### DIFF
--- a/packages/cezar/src/core/__fixtures__/codex/mock-codex-app-server.mjs
+++ b/packages/cezar/src/core/__fixtures__/codex/mock-codex-app-server.mjs
@@ -55,6 +55,20 @@ rl.on('line', (line) => {
       emit({ method: 'turn/completed', params: { turn: { id: 'turn_mock_1', status: 'completed' } } });
       return;
     }
+    if (turnText.includes('mock:child-turn')) {
+      // A spawned sub-agent runs in its OWN child thread that emits a full turn
+      // lifecycle over the shared connection. Its turn/completed must not end the
+      // parent turn (#600): the parent is still working after the child finishes.
+      emit({ method: 'turn/started', params: { threadId: 'th_child', turn: { id: 'turn_child', status: 'inProgress', items: [] } } });
+      emit({ method: 'item/started', params: { threadId: 'th_child', turnId: 'turn_child', item: { type: 'commandExecution', id: 'item_child', command: ['rg', 'requestUserInput'], cwd: '/repo', status: 'inProgress' } } });
+      emit({ method: 'turn/completed', params: { threadId: 'th_child', turn: { id: 'turn_child', status: 'completed' } } });
+      // Parent keeps streaming after the child's turn ended.
+      emit({ method: 'item/started', params: { threadId: 'th_mock_1', turnId: 'turn_mock_1', item: { type: 'agentMessage', id: 'item_p1', text: '' } } });
+      emit({ method: 'item/agentMessage/delta', params: { threadId: 'th_mock_1', turnId: 'turn_mock_1', itemId: 'item_p1', delta: 'Still working after the sub-agent.' } });
+      emit({ method: 'item/completed', params: { threadId: 'th_mock_1', turnId: 'turn_mock_1', item: { type: 'agentMessage', id: 'item_p1', text: 'Still working after the sub-agent.' } } });
+      emit({ method: 'turn/completed', params: { threadId: 'th_mock_1', turn: { id: 'turn_mock_1', status: 'completed' } } });
+      return;
+    }
     if (process.env.MOCK_CODEX_ASK === '1' || turnText.includes('mock:native-codex-ask')) {
       const questions = turnText.includes('multi free text')
         ? [{ id: 'first', header: 'First', question: 'First choice?', isOther: true, isSecret: false,

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -384,9 +384,20 @@ class CodexSession implements AgentSession {
     this.rpc.respond({ id: pending.rpcId, error: { code: -32000, message } });
   }
 
+  /** True when a turn notification belongs to a sub-agent CHILD thread rather than this run's
+   *  own main thread — its lifecycle must not start or end the parent turn (#600). The app-server
+   *  multiplexes every thread over one connection, so a spawned skill's child `turn/completed`
+   *  would otherwise emit a `turn-end` and park the actively-working run under "Needs you".
+   *  Fail-open: an absent `threadId` (the single-thread wire shape) or our own id counts as ours. */
+  private isForeignThreadTurn(params: Record<string, unknown>): boolean {
+    const eventThreadId = stringField(params, 'threadId');
+    return !!eventThreadId && !!this.threadId && eventThreadId !== this.threadId;
+  }
+
   private handleNotification(method: string, params: Record<string, unknown>): void {
     switch (method) {
       case 'turn/started': {
+        if (this.isForeignThreadTurn(params)) break; // sub-agent child thread — not our turn (#600)
         this.activeTurnId = turnIdOf(params) ?? this.activeTurnId;
         break;
       }
@@ -434,6 +445,7 @@ class CodexSession implements AgentSession {
       }
       case 'turn/completed':
       case 'turn/failed': {
+        if (this.isForeignThreadTurn(params)) break; // don't end the parent turn on a child turn (#600)
         this.pendingUserInput = undefined;
         this.activeTurnId = undefined;
         // An interrupted/failed item never sees item/completed — surface its

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -179,6 +179,12 @@ class CodexSession implements AgentSession {
             } catch {
               continue; // not JSON-RPC — skip
             }
+            // A sub-agent child thread's turn lifecycle must reach neither channel (#600):
+            // v1 would emit a bogus `turn-end`, and the v2 mapper — which carries no thread
+            // identity — would record the child turn as the parent's, clearing its turn-scoped
+            // plan/reasoning state and resetting the current turn id. Child ITEM events still
+            // flow, so nested sub-agent activity keeps rendering.
+            if (this.isForeignTurnLifecycle(msg)) continue;
             this.emitUi((state) => mapCodexNotification(msg, state));
             this.dispatch(msg);
           }
@@ -394,6 +400,15 @@ class CodexSession implements AgentSession {
     return !!eventThreadId && !!this.threadId && eventThreadId !== this.threadId;
   }
 
+  /** A `turn/started|completed|failed` notification for a sub-agent child thread — dropped
+   *  before either channel processes it (#600). Only turn lifecycle is filtered; child item
+   *  events still map, so nested sub-agent activity keeps rendering. */
+  private isForeignTurnLifecycle(msg: CodexAppServerMessage): boolean {
+    const method = typeof msg.method === 'string' ? msg.method : undefined;
+    if (!method || !TURN_LIFECYCLE_METHODS.has(method)) return false;
+    return this.isForeignThreadTurn((msg.params ?? {}) as Record<string, unknown>);
+  }
+
   private handleNotification(method: string, params: Record<string, unknown>): void {
     switch (method) {
       case 'turn/started': {
@@ -524,6 +539,10 @@ function userInputAnswers(questions: AskQuestion[], text: string): Record<string
 
 /** ThreadItem `type`s that are conversation text, not tool activity. */
 const NON_TOOL_ITEMS = new Set(['agentMessage', 'userMessage', 'reasoning', 'plan']);
+
+/** Turn-lifecycle notification methods — the only frames whose child-thread copies must be
+ *  dropped so a sub-agent turn can't be mistaken for the parent's (#600). */
+const TURN_LIFECYCLE_METHODS = new Set(['turn/started', 'turn/completed', 'turn/failed']);
 
 const REASONING_SUMMARIES = new Set(['auto', 'concise', 'detailed', 'none']);
 

--- a/packages/cezar/src/core/codex-ui-mapper.test.ts
+++ b/packages/cezar/src/core/codex-ui-mapper.test.ts
@@ -762,6 +762,26 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
     expect(v2.filter((event) => event.type === 'item.started' && event.item.kind === 'tool' && event.item.toolKind === 'task')).toHaveLength(1);
   }, 30_000);
 
+  it('does not end the parent turn when a sub-agent child thread completes its turn (#600)', async () => {
+    const runner = new CodexAppServerRunner({ bin: mockBin, timeoutMs: 60_000 });
+    const v1: AgentEvent[] = [];
+    const session = runner.startSession(
+      { userPrompt: 'mock:child-turn', cwd: process.cwd() },
+      (event) => v1.push(event),
+      { autoEndAfterFirstTurn: true },
+    );
+    await session.result;
+
+    // The child thread (th_child) emits its own turn/completed, but only the run's
+    // own main thread (th_mock_1) may produce a turn-end — otherwise the run parks
+    // under "Needs you" while it is visibly still working.
+    const turnEnds = v1.filter((event) => event.type === 'turn-end');
+    expect(turnEnds).toHaveLength(1);
+    // The parent's post-child activity still streamed through.
+    const text = v1.flatMap((event) => (event.type === 'text' ? [event.text] : [])).join('');
+    expect(text).toContain('Still working after the sub-agent.');
+  }, 30_000);
+
   it('keeps autonomous full-access permissions when resuming a thread', async () => {
     const runner = new CodexAppServerRunner({ bin: mockBin, timeoutMs: 60_000 });
     const session = runner.startSession(

--- a/packages/cezar/src/core/codex-ui-mapper.test.ts
+++ b/packages/cezar/src/core/codex-ui-mapper.test.ts
@@ -765,14 +765,15 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
   it('does not end the parent turn when a sub-agent child thread completes its turn (#600)', async () => {
     const runner = new CodexAppServerRunner({ bin: mockBin, timeoutMs: 60_000 });
     const v1: AgentEvent[] = [];
+    const v2: UiEvent[] = [];
     const session = runner.startSession(
       { userPrompt: 'mock:child-turn', cwd: process.cwd() },
       (event) => v1.push(event),
-      { autoEndAfterFirstTurn: true },
+      { autoEndAfterFirstTurn: true, onUiEvent: (event) => v2.push(event) },
     );
     await session.result;
 
-    // The child thread (th_child) emits its own turn/completed, but only the run's
+    // v1: the child thread (th_child) emits its own turn/completed, but only the run's
     // own main thread (th_mock_1) may produce a turn-end — otherwise the run parks
     // under "Needs you" while it is visibly still working.
     const turnEnds = v1.filter((event) => event.type === 'turn-end');
@@ -780,6 +781,13 @@ describe('CodexAppServerRunner v2 wiring (against the bundled mock app-server)',
     // The parent's post-child activity still streamed through.
     const text = v1.flatMap((event) => (event.type === 'text' ? [event.text] : [])).join('');
     expect(text).toContain('Still working after the sub-agent.');
+
+    // v2: the child turn must not corrupt the parent's normalized stream either — exactly
+    // one turn.started and one turn.completed, both for the parent turn (turn_mock_1).
+    const v2Started = v2.filter((event) => event.type === 'turn.started');
+    const v2Completed = v2.filter((event) => event.type === 'turn.completed');
+    expect(v2Started).toEqual([{ type: 'turn.started', turnId: 'turn_mock_1' }]);
+    expect(v2Completed).toEqual([{ type: 'turn.completed', turnId: 'turn_mock_1', stopReason: 'end_turn' }]);
   }, 30_000);
 
   it('keeps autonomous full-access permissions when resuming a thread', async () => {


### PR DESCRIPTION
Fixes #600.

## Problem
A Codex run actively running a skill (e.g. `om-auto-fix-issue`) — spinner, live tool calls — was simultaneously grouped under **NEEDS YOU** in the sidebar. A false attention signal on an actively-working run.

## Cause
The Codex app-server multiplexes every thread over one connection, so a spawned skill runs in a **child thread** that emits its own `turn/started` and `turn/completed`. `handleNotification` acted on those unconditionally: the child's `turn/completed` emitted a `turn-end`, which `run.ts` parks as `status: 'waiting'` → "Needs you". Subsequent parent-thread item events never reset the status back, so the run stayed parked while visibly working.

## Fix
Guard the turn-lifecycle handlers with `isForeignThreadTurn()`: ignore `turn/started` / `turn/completed` / `turn/failed` whose `threadId` differs from the run's own main thread. **Fail-open** — an absent `threadId` (the single-thread wire shape, the common case) is treated as ours, so existing runs are unaffected. Item events are untouched, so nested sub-agent tool calls still render under the parent (#598/#687 preserved).

## Test
New wiring test drives the mock app-server through a child-thread `turn/completed` interleaved with parent activity and asserts exactly one `turn-end` (the parent's) and that parent output kept streaming. Full runner suite (67) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)