### PR TITLE
feat(web): ghost-code typing backdrop on the new-task hero

### DIFF
--- a/packages/web/src/components/ghost-code-backdrop.test.tsx
+++ b/packages/web/src/components/ghost-code-backdrop.test.tsx
@@ -1,0 +1,142 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { GhostCodeBackdrop } from './ghost-code-backdrop'
+
+/**
+ * The ghost-code backdrop is decorative, so the things worth pinning are not the animation
+ * (CSS timing is not unit-testable) but the two contracts a refactor could silently break:
+ * the decorative-safety one — `aria-hidden` + pointer-transparency, or the fake code becomes
+ * readable to screen readers and starts eating clicks meant for the composer — and the
+ * component↔stylesheet one, where `styles/index.css` §ghost code drives every reveal from
+ * `--n`/`--t`/`--d`/`--cycle`. A missing custom property does not throw; it renders zero-width
+ * lines, i.e. nothing at all, which no human notices on a backdrop.
+ *
+ * Plus the motion contract: under `prefers-reduced-motion: reduce` (and wherever `matchMedia`
+ * is missing, which is jsdom's default and this suite's baseline) the loop timer must never be
+ * scheduled, and toggling the OS setting at runtime must start/stop it live.
+ */
+
+/** jsdom ships no `matchMedia` at all, so stub rather than spy (same convention as theme.test). */
+function stubMatchMedia(reduce: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>()
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(
+      (media: string) =>
+        ({
+          media,
+          matches: reduce,
+          addEventListener: (_: string, listener: (event: MediaQueryListEvent) => void) =>
+            listeners.add(listener),
+          removeEventListener: (_: string, listener: (event: MediaQueryListEvent) => void) =>
+            listeners.delete(listener),
+        }) as unknown as MediaQueryList,
+    ),
+  )
+  /** Fire an OS-level change of the preference at every subscribed listener. */
+  return (matches: boolean) => {
+    for (const listener of listeners) listener({ matches } as MediaQueryListEvent)
+  }
+}
+
+const blocksOf = (container: HTMLElement) => [
+  ...container.querySelectorAll<HTMLElement>('.ghost-code-block'),
+]
+const cycleMsOf = (container: HTMLElement) =>
+  Number.parseInt(blocksOf(container)[0]?.style.getPropertyValue('--cycle') ?? '', 10)
+/** Did the component schedule its own loop timer? Keyed on the exact cycle length so React's
+ *  own internal timers can never be mistaken for it. */
+const scheduledLoop = (calls: readonly unknown[][], cycleMs: number) =>
+  calls.some((call) => call[1] === cycleMs)
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('GhostCodeBackdrop', () => {
+  it('renders as a decorative layer: aria-hidden, pointer-transparent, behind everything', () => {
+    const { container } = render(<GhostCodeBackdrop />)
+    const backdrop = container.querySelector<HTMLElement>('[data-slot="ghost-code-backdrop"]')
+    expect(backdrop).not.toBeNull()
+    expect(backdrop?.getAttribute('aria-hidden')).toBe('true')
+    expect(backdrop?.className).toContain('pointer-events-none')
+    expect(backdrop?.className).toContain('-z-10')
+    // Below xl the side margins would collide with the composer column, so the layer is hidden.
+    expect(backdrop?.className).toContain('max-xl:hidden')
+  })
+
+  it('lays out one snippet panel per screen zone, each with typed lines', () => {
+    const { container } = render(<GhostCodeBackdrop />)
+    const blocks = blocksOf(container)
+    expect(blocks).toHaveLength(3)
+    for (const block of blocks) {
+      expect(block.querySelectorAll('.ghost-code-line').length).toBeGreaterThan(0)
+      // Every panel lands in a positioned slot, so no two of them stack in the same corner.
+      expect(block.className).toMatch(/(left|right)-\[\d+%\]/)
+      expect(block.className).toMatch(/top-\[\d+%\]/)
+    }
+  })
+
+  it('drives the stylesheet through the --n/--t/--d/--cycle contract', () => {
+    const { container } = render(<GhostCodeBackdrop />)
+    const cycleMs = cycleMsOf(container)
+    expect(cycleMs).toBeGreaterThan(0)
+    for (const block of blocksOf(container)) {
+      // One shared cycle length per scene: every panel fades on the same clock.
+      expect(block.style.getPropertyValue('--cycle')).toBe(`${cycleMs}ms`)
+      for (const line of block.querySelectorAll<HTMLElement>('.ghost-code-line')) {
+        const chars = Number(line.style.getPropertyValue('--n'))
+        expect(chars).toBe(line.textContent?.length)
+        expect(chars).toBeGreaterThan(0)
+        // `--t` is the steps() duration and `--d` the start delay; both must reach CSS as time.
+        expect(line.style.getPropertyValue('--t')).toMatch(/^\d+ms$/)
+        expect(line.style.getPropertyValue('--d')).toMatch(/^\d+ms$/)
+      }
+    }
+  })
+
+  it('types every panel in sequence — one author, never two carets at once', () => {
+    const { container } = render(<GhostCodeBackdrop />)
+    let previousEnd = -1
+    for (const block of blocksOf(container)) {
+      for (const line of block.querySelectorAll<HTMLElement>('.ghost-code-line')) {
+        const delay = Number.parseInt(line.style.getPropertyValue('--d'), 10)
+        const duration = Number.parseInt(line.style.getPropertyValue('--t'), 10)
+        expect(delay).toBeGreaterThanOrEqual(previousEnd)
+        previousEnd = delay + duration
+      }
+    }
+    // The loop must outlast the last keystroke, or the scene would restart mid-typing.
+    expect(cycleMsOf(container)).toBeGreaterThan(previousEnd)
+  })
+
+  it('schedules no loop timer where matchMedia is missing (jsdom, SSR)', () => {
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const { container } = render(<GhostCodeBackdrop />)
+    expect(scheduledLoop(setTimeoutSpy.mock.calls, cycleMsOf(container))).toBe(false)
+  })
+
+  it('schedules no loop timer under prefers-reduced-motion: reduce', () => {
+    stubMatchMedia(true)
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const { container } = render(<GhostCodeBackdrop />)
+    expect(scheduledLoop(setTimeoutSpy.mock.calls, cycleMsOf(container))).toBe(false)
+  })
+
+  it('loops on the scene length when motion is allowed, and stops live when it is revoked', () => {
+    const emitPreferenceChange = stubMatchMedia(false)
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+    const { container } = render(<GhostCodeBackdrop />)
+    expect(scheduledLoop(setTimeoutSpy.mock.calls, cycleMsOf(container))).toBe(true)
+
+    // The CSS half re-evaluates on an OS toggle, so the timer has to unwind with it.
+    setTimeoutSpy.mockClear()
+    act(() => emitPreferenceChange(true))
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    expect(scheduledLoop(setTimeoutSpy.mock.calls, cycleMsOf(container))).toBe(false)
+  })
+})

--- a/packages/web/src/components/ghost-code-backdrop.tsx
+++ b/packages/web/src/components/ghost-code-backdrop.tsx
@@ -201,18 +201,38 @@ function GhostBlock({ block, cycleMs }: { block: SceneBlock; cycleMs: number }) 
   )
 }
 
+const REDUCE_MOTION = '(prefers-reduced-motion: reduce)'
+
+/** Live `prefers-reduced-motion`, inverted: the CSS half re-evaluates the moment the OS setting
+ *  flips, so the loop timer has to follow it rather than read it once at mount — same
+ *  subscription shape as `lib/use-desktop.ts`. Where `matchMedia` is missing (jsdom, SSR) the
+ *  answer is "don't animate", so the suites never schedule a timer. */
+function useMotionSafe(): boolean {
+  const [motionSafe, setMotionSafe] = useState(
+    () => typeof window.matchMedia === 'function' && !window.matchMedia(REDUCE_MOTION).matches,
+  )
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return
+    const query = window.matchMedia(REDUCE_MOTION)
+    const onChange = (event: MediaQueryListEvent) => setMotionSafe(!event.matches)
+    query.addEventListener('change', onChange)
+    return () => query.removeEventListener('change', onChange)
+  }, [])
+  return motionSafe
+}
+
 export function GhostCodeBackdrop() {
   const [cycle, setCycle] = useState(0)
+  const motionSafe = useMotionSafe()
   // A fresh random scene each loop — `cycle` is the retrigger, not data the scene reads.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const scene = useMemo(() => buildScene(), [cycle])
   useEffect(() => {
-    // Under reduced motion the CSS renders the scene static — re-rolling it would be churn
-    // (and the jsdom tests ship no matchMedia at all, which counts as "don't animate").
-    if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches !== false) return
+    // Under reduced motion the CSS renders the scene static — re-rolling it would be churn.
+    if (!motionSafe) return
     const id = window.setTimeout(() => setCycle((current) => current + 1), scene.cycleMs)
     return () => window.clearTimeout(id)
-  }, [cycle, scene.cycleMs])
+  }, [cycle, motionSafe, scene.cycleMs])
   return (
     <div
       data-slot="ghost-code-backdrop"

--- a/packages/web/src/components/ghost-code-backdrop.tsx
+++ b/packages/web/src/components/ghost-code-backdrop.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/**
+ * GhostCodeBackdrop — the `/new` hero's second texture layer, behind the twinkles: faint
+ * pseudo-code panels typed out character by character, as if an agent were quietly working in
+ * the margins. Strictly decorative (aria-hidden, pointer-transparent, -z-10) and strictly
+ * delicate: theme syntax tokens at ~0.3 opacity, masked out toward the bottom, and hidden
+ * below `xl` where the side margins would collide with the composer column.
+ *
+ * Every loop composes a fresh scene: three snippets drawn from a multi-language pool
+ * (TypeScript, Python, Rust, Go, SQL, CSS, a run log), each dropped into a random slot of a
+ * different screen zone — the zones guarantee the picks never overlap each other or the
+ * composer column. One author, so the blocks type strictly in sequence.
+ *
+ * The reveal itself is CSS (styles/index.css §ghost code) — this component only lays out the
+ * lines and computes the typing schedule. The loop is a remount: at each scene's end the
+ * `key` bumps, re-rolling the scene and restarting every animation after the CSS fade-out
+ * has landed. Reduced motion renders one finished scene static and never schedules the timer.
+ */
+
+type GhostTone = 'key' | 'str' | 'fn' | 'com' | 'num'
+type GhostToken = { text: string; tone?: GhostTone }
+type GhostLine = GhostToken[]
+
+const CHAR_MS = 38 // per-character typing speed
+const LINE_PAUSE_MS = 280 // breath between lines, like a human reaching for the next thought
+const BLOCK_PAUSE_MS = 900 // one author: each panel starts after the previous one finishes
+const FIRST_KEYSTROKE_MS = 600
+const HOLD_MS = 5500 // finished work lingers before the fade
+const FADE_MS = 1400 // matches the tail of the CSS ghost-block-fade curve
+
+const k = (text: string): GhostToken => ({ text, tone: 'key' })
+const s = (text: string): GhostToken => ({ text, tone: 'str' })
+const f = (text: string): GhostToken => ({ text, tone: 'fn' })
+const c = (text: string): GhostToken => ({ text, tone: 'com' })
+const n = (text: string): GhostToken => ({ text, tone: 'num' })
+const p = (text: string): GhostToken => ({ text })
+
+/** The snippet pool the imaginary agent writes from — one entry per language, all of them
+ *  about the work this screen is about to start. Lines stay under ~46ch so every slot fits. */
+const SNIPPETS: GhostLine[][] = [
+  // TypeScript — the run loop itself
+  [
+    [c('// task accepted — isolating a worktree')],
+    [k('const'), p(' tree = '), k('await'), p(' git.'), f('worktree'), p('(task.branch)')],
+    [k('const'), p(' agent = '), f('spawn'), p('(runner, { tree, skills })')],
+    [k('for await'), p(' ('), k('const'), p(' event '), k('of'), p(' agent.'), f('stream'), p('()) {')],
+    [p('  cockpit.'), f('render'), p('(event)')],
+    [p('}')],
+  ],
+  // the run log answering it
+  [
+    [p('$ cezar run '), s('--worktree --autonomous')],
+    [s('✓'), p(' worktree ready · base '), s('main')],
+    [s('✓'), p(' agent started')],
+    [c('… editing src/routes/new-task.tsx')],
+    [s('✓'), p(' tests green · '), n('+42 −7')],
+    [s('✓'), p(' pull request opened')],
+  ],
+  // Python — taming a flaky test
+  [
+    [c('# flaky: replay before touching code')],
+    [k('def'), p(' '), f('stabilize'), p('(test):')],
+    [p('    '), k('for'), p(' attempt '), k('in'), p(' '), f('range'), p('('), n('3'), p('):')],
+    [p('        '), k('if'), p(' '), f('run'), p('(test).ok:')],
+    [p('            '), k('return'), p(' '), s("'green'")],
+    [p('    '), k('return'), p(' '), f('quarantine'), p('(test)')],
+  ],
+  // Rust — applying the reviewed plan
+  [
+    [c('// apply the reviewed plan, step by step')],
+    [k('let'), p(' diff = worktree.'), f('diff'), p('()?;')],
+    [k('match'), p(' '), f('review'), p('(diff) {')],
+    [p('    Ok(pr) => gh::'), f('open'), p('(pr),')],
+    [p('    Err(e) => '), f('retry'), p('(e, backoff),')],
+    [p('}')],
+  ],
+  // Go — merging once checks are green
+  [
+    [c('// merge when every check is green')],
+    [k('func'), p(' '), f('merge'), p('(pr *PullRequest) '), k('error'), p(' {')],
+    [p('    '), k('if'), p(' err := ci.'), f('Wait'), p('(pr); err != '), k('nil'), p(' {')],
+    [p('        '), k('return'), p(' err')],
+    [p('    }')],
+    [p('    '), k('return'), p(' gh.'), f('Merge'), p('(pr)')],
+    [p('}')],
+  ],
+  // SQL — the cockpit asking itself questions
+  [
+    [c('-- which branches ship the most?')],
+    [k('select'), p(' branch, '), f('count'), p('(*) '), k('as'), p(' runs')],
+    [k('from'), p(' tasks')],
+    [k('where'), p(' status = '), s("'green'")],
+    [k('group by'), p(' branch')],
+    [k('order by'), p(' runs '), k('desc'), p(';')],
+  ],
+  // CSS — the composer's own glow
+  [
+    [c('/* the composer glow, one token deep */')],
+    [p('.composer'), k(':focus-within'), p(' {')],
+    [p('  border-color: '), f('var'), p('(--primary);')],
+    [p('  box-shadow: '), n('0 0 0 3px'), p(' '), f('var'), p('(--ring);')],
+    [p('  transition: box-shadow '), n('120ms'), p(' ease;')],
+    [p('}')],
+  ],
+]
+
+/** Position slots, grouped into non-overlapping screen zones: the left margin, the right
+ *  margin, and the empty band under the suggestion chips. One slot is drawn per zone, so no
+ *  two panels of a scene can collide — and none of them can touch the composer column. */
+const ZONES: string[][] = [
+  ['left-[3%] top-[12%]', 'left-[5%] top-[36%]', 'left-[8%] top-[58%]'],
+  ['right-[3%] top-[14%]', 'right-[6%] top-[40%]', 'right-[4%] top-[62%]'],
+  ['left-[28%] top-[66%]', 'left-[45%] top-[72%]', 'right-[26%] top-[70%]'],
+]
+
+const toneColor: Record<GhostTone, string> = {
+  key: 'var(--syn-key)',
+  str: 'var(--syn-str)',
+  fn: 'var(--syn-fn)',
+  com: 'var(--syn-com)',
+  num: 'var(--syn-num)',
+}
+
+const lineLength = (line: GhostLine) =>
+  line.reduce((total, token) => total + token.text.length, 0)
+
+const blockTypeMs = (lines: GhostLine[]) =>
+  lines.reduce((total, line) => total + lineLength(line) * CHAR_MS + LINE_PAUSE_MS, 0)
+
+function shuffle<T>(items: readonly T[]): T[] {
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    const a = out[i] as T
+    out[i] = out[j] as T
+    out[j] = a
+  }
+  return out
+}
+
+type SceneBlock = { lines: GhostLine[]; slot: string; startMs: number }
+type Scene = { blocks: SceneBlock[]; cycleMs: number }
+
+/** Roll one loop's worth of panels: a random snippet per zone, random slot within the zone,
+ *  typed in shuffled order — so consecutive loops feel like different corners of the work. */
+function buildScene(): Scene {
+  const snippets = shuffle(SNIPPETS).slice(0, ZONES.length)
+  const slots = shuffle(
+    ZONES.map((zone) => zone[Math.floor(Math.random() * zone.length)] ?? ''),
+  )
+  let at = FIRST_KEYSTROKE_MS
+  const blocks = snippets.map((lines, index) => {
+    const startMs = at
+    at += blockTypeMs(lines) + BLOCK_PAUSE_MS
+    return { lines, slot: slots[index] ?? '', startMs }
+  })
+  return { blocks, cycleMs: at - BLOCK_PAUSE_MS + HOLD_MS + FADE_MS }
+}
+
+function GhostBlock({ block, cycleMs }: { block: SceneBlock; cycleMs: number }) {
+  let at = block.startMs
+  return (
+    <div
+      className={cn(
+        'ghost-code-block absolute font-mono text-[11.5px] leading-[1.9] text-soft-foreground',
+        block.slot,
+      )}
+      style={{ '--cycle': `${cycleMs}ms` } as CSSProperties}
+    >
+      {block.lines.map((line, index) => {
+        const chars = lineLength(line)
+        const delay = at
+        at += chars * CHAR_MS + LINE_PAUSE_MS
+        return (
+          <div
+            key={index}
+            className="ghost-code-line"
+            style={
+              {
+                '--n': chars,
+                '--t': `${chars * CHAR_MS}ms`,
+                '--d': `${delay}ms`,
+              } as CSSProperties
+            }
+          >
+            {line.map((token, tokenIndex) => (
+              <span
+                key={tokenIndex}
+                style={token.tone ? { color: toneColor[token.tone] } : undefined}
+              >
+                {token.text}
+              </span>
+            ))}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function GhostCodeBackdrop() {
+  const [cycle, setCycle] = useState(0)
+  // A fresh random scene each loop — `cycle` is the retrigger, not data the scene reads.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const scene = useMemo(() => buildScene(), [cycle])
+  useEffect(() => {
+    // Under reduced motion the CSS renders the scene static — re-rolling it would be churn
+    // (and the jsdom tests ship no matchMedia at all, which counts as "don't animate").
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches !== false) return
+    const id = window.setTimeout(() => setCycle((current) => current + 1), scene.cycleMs)
+    return () => window.clearTimeout(id)
+  }, [cycle, scene.cycleMs])
+  return (
+    <div
+      data-slot="ghost-code-backdrop"
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 -z-10 overflow-hidden max-xl:hidden [mask-image:linear-gradient(to_bottom,black_30%,transparent_96%)]"
+    >
+      {/* Remount wrapper: bumping the key restarts every CSS animation for the next loop. */}
+      <div key={cycle} className="contents">
+        {scene.blocks.map((block, index) => (
+          <GhostBlock key={index} block={block} cycleMs={scene.cycleMs} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/src/routes/new-task.tsx
+++ b/packages/web/src/routes/new-task.tsx
@@ -38,6 +38,7 @@ import type {
 } from '@open-mercato/cezar-api-client'
 import { TwinkleBackdrop } from '@/components/centered-state'
 import { Composer, type ComposerHandle } from '@/components/composer/composer'
+import { GhostCodeBackdrop } from '@/components/ghost-code-backdrop'
 import { PickerPill, RunnerPill, chevron, chipClass } from '@/components/picker-pill'
 import { PromptTemplateMenu } from '@/components/prompt-template-menu'
 import { SkillPreviewDialog } from '@/components/skill-detail'
@@ -523,6 +524,7 @@ export function NewTaskRoute() {
       className="relative isolate flex min-h-full flex-col items-center overflow-x-clip px-6 pt-[clamp(32px,7vh,84px)] pb-16 max-md:px-3.5 max-md:pt-7"
     >
       <TwinkleBackdrop />
+      <GhostCodeBackdrop />
 
       <div className="w-full max-w-[720px]">
         <header className="mb-6 text-center max-md:mb-4">

--- a/packages/web/src/styles/index.css
+++ b/packages/web/src/styles/index.css
@@ -366,6 +366,67 @@
   }
 }
 
+/* ---------- ghost code (new-task hero backdrop) ----------
+ * The `/new` hero's "someone is quietly writing code" texture (ghost-code-backdrop.tsx).
+ * Character-by-character reveal is the classic CSS typewriter: the line clips at `width`,
+ * animated 0 → n·1ch in `steps(n)`, so glyphs appear whole; the reveal edge carries a 1px
+ * border that reads as the caret and a second animation blanks it shortly after the line
+ * lands. Everything is driven by per-line vars the component sets (`--n` chars, `--t` type
+ * duration, `--d` start delay, `--cycle` full loop length).
+ * Reduced motion: the base rules render every line fully typed, static, at the block's
+ * resting opacity — the animations only exist inside the motion-safe media block. */
+
+.ghost-code-line {
+  width: calc(var(--n) * 1ch);
+  overflow: hidden;
+  white-space: pre;
+}
+.ghost-code-block {
+  opacity: 0.3;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .ghost-code-block {
+    opacity: 0;
+    animation: ghost-block-fade var(--cycle) linear forwards;
+  }
+  .ghost-code-line {
+    width: 0;
+    border-right: 1px solid transparent;
+    animation:
+      ghost-type var(--t) steps(var(--n)) var(--d) forwards,
+      ghost-caret-off 1ms linear calc(var(--d) + var(--t) + 700ms) forwards;
+  }
+}
+@keyframes ghost-type {
+  from {
+    width: 0;
+    border-right-color: var(--primary);
+  }
+  to {
+    width: calc(var(--n) * 1ch);
+    border-right-color: var(--primary);
+  }
+}
+@keyframes ghost-caret-off {
+  to {
+    border-right-color: transparent;
+  }
+}
+@keyframes ghost-block-fade {
+  0% {
+    opacity: 0;
+  }
+  4% {
+    opacity: 0.3;
+  }
+  93% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 /* ---------- thread markdown (mockup `.msg-assist`) ----------
  * Chat-scale typography for assistant messages. Streamdown ships document-scale utility
  * classes on its elements (text-2xl headings, prose paddings); these rules are deliberately


### PR DESCRIPTION
## What

A delicate "someone is quietly writing code" animation behind the `/new` hero — the demo wow-effect. Faint pseudo-code panels type out character by character in the empty margins, with a caret riding the reveal edge, then hold, fade, and start over.

## How it behaves

- **Fresh scene every loop (~35s):** three snippets drawn from a seven-language pool (the TypeScript run loop, a `$ cezar run` log, Python, Rust, Go, SQL, CSS — all vignettes of the work this screen starts) land in random slots of three non-overlapping screen zones and type strictly in sequence, one author, one caret.
- **Delicate by construction:** theme shiki syntax tokens (`--syn-*`) + `--primary` for the caret at ~0.3 opacity, masked toward the bottom, `aria-hidden`, pointer-transparent, `-z-10` behind the twinkles, hidden below `xl` where it would collide with the composer column.
- **Reduced motion:** renders one finished scene static — no animation, no timer.

## How it works

The reveal is the classic CSS typewriter (styles/index.css §ghost code): each line clips at `width`, animated `0 → n·1ch` in `steps(n)` so glyphs appear whole; the reveal edge carries a 1px border that reads as the caret and blanks shortly after the line lands. The component only lays out tokenized lines and computes the per-line schedule (`--n`/`--t`/`--d`/`--cycle`); the loop is a `key` remount that re-rolls the scene.

## Testing

- `tsc --noEmit`, full web suite (2534 tests incl. the design guardian) green.
- Verified live in the running cockpit across multiple cycles and reloads: typing + caret render, scenes differ per loop, loop restarts cleanly, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)