### PR TITLE
fix(ui): share session rendering with subagents

### DIFF
--- a/.ai/runs/2026-07-31-shared-session-renderer.md
+++ b/.ai/runs/2026-07-31-shared-session-renderer.md
@@ -50,6 +50,7 @@ Replace the sub-agent pane's reduced transcript path with the same backend-neutr
 - Recursive rendering can introduce circular imports; orchestration stays in the session renderer and leaf cards receive a callback.
 - Two active transcript surfaces can corrupt one another's scroll state; every viewport key is namespaced by run and view.
 - User-facing panel behavior needs manual QA after code review; this run requests `needs-qa` and leaves QA approval to the parent workflow.
+- `npm run test:e2e` was invoked during implementation but returned the repository's explicit `TEST_E2E_STATUS=skipped` outcome because the browser provider could not launch; manual/browser evidence remains for the parent QA workflow.
 
 ## Progress
 
@@ -72,5 +73,5 @@ Replace the sub-agent pane's reduced transcript path with the same backend-neutr
 ### Phase 3: Backend and scale verification
 
 - [x] 3.1 Add backend-neutral reducer-to-component coverage — 7aeacec7
-- [ ] 3.2 Add long transcript and image regression coverage
-- [ ] 3.3 Complete full validation and verification preparation
+- [x] 3.2 Add long transcript and image regression coverage — 9f2ec330
+- [x] 3.3 Complete full validation and verification preparation — 9f2ec330

--- a/.ai/runs/2026-07-31-shared-session-renderer.md
+++ b/.ai/runs/2026-07-31-shared-session-renderer.md
@@ -57,20 +57,20 @@ Replace the sub-agent pane's reduced transcript path with the same backend-neutr
 
 ### Phase 1: Extract and stabilize the shared renderer
 
-- [ ] 1.1 Add regression coverage for current main transcript behavior
-- [ ] 1.2 Add transcript view models, adapters, and pure row building
-- [ ] 1.3 Centralize exhaustive rendering and add the nested callback seam
-- [ ] 1.4 Extract the shared viewport and view-scoped scrolling
-- [ ] 1.5 Migrate the main thread to SessionTranscript
+- [x] 1.1 Add regression coverage for current main transcript behavior — 7aeacec7
+- [x] 1.2 Add transcript view models, adapters, and pure row building — 7aeacec7
+- [x] 1.3 Centralize exhaustive rendering and add the nested callback seam — 7aeacec7
+- [x] 1.4 Extract the shared viewport and view-scoped scrolling — 7aeacec7
+- [x] 1.5 Migrate the main thread to SessionTranscript — 7aeacec7
 
 ### Phase 2: Reuse the renderer in the agent pane
 
-- [ ] 2.1 Migrate SubagentSheet to SessionTranscript panel mode
-- [ ] 2.2 Remove duplicate agent scrolling and fix the bounded panel viewport
-- [ ] 2.3 Remove NestedEntry and prove canonical nested rendering
+- [x] 2.1 Migrate SubagentSheet to SessionTranscript panel mode — 7aeacec7
+- [x] 2.2 Remove duplicate agent scrolling and fix the bounded panel viewport — 7aeacec7
+- [x] 2.3 Remove NestedEntry and prove canonical nested rendering — 7aeacec7
 
 ### Phase 3: Backend and scale verification
 
-- [ ] 3.1 Add backend-neutral reducer-to-component coverage
+- [x] 3.1 Add backend-neutral reducer-to-component coverage — 7aeacec7
 - [ ] 3.2 Add long transcript and image regression coverage
 - [ ] 3.3 Complete full validation and verification preparation

--- a/.ai/runs/2026-07-31-shared-session-renderer.md
+++ b/.ai/runs/2026-07-31-shared-session-renderer.md
@@ -54,6 +54,8 @@ Replace the sub-agent pane's reduced transcript path with the same backend-neutr
 
 ## Progress
 
+PR: #756
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Extract and stabilize the shared renderer

--- a/.ai/runs/2026-07-31-shared-session-renderer.md
+++ b/.ai/runs/2026-07-31-shared-session-renderer.md
@@ -63,6 +63,7 @@ Replace the sub-agent pane's reduced transcript path with the same backend-neutr
 - [x] 1.3 Centralize exhaustive rendering and add the nested callback seam — 7aeacec7
 - [x] 1.4 Extract the shared viewport and view-scoped scrolling — 7aeacec7
 - [x] 1.5 Migrate the main thread to SessionTranscript — 7aeacec7
+- [x] Post-review fix: decouple the renderer from run state, remove the legacy row-builder seam, and stabilize its injected ask renderer — 8c035689, 5eeaa678
 
 ### Phase 2: Reuse the renderer in the agent pane
 

--- a/.ai/runs/2026-07-31-shared-session-renderer.md
+++ b/.ai/runs/2026-07-31-shared-session-renderer.md
@@ -1,0 +1,76 @@
+# Shared Session Renderer Execution Plan
+
+Source doc: .ai/specs/2026-07-21-shared-session-renderer.md
+
+## Overview
+
+### Goal
+
+Replace the sub-agent pane's reduced transcript path with the same backend-neutral session renderer used by the main task thread, preserving main-session behavior while adding canonical grouping, tool results, attachments, scrolling, and accessibility to agent sessions.
+
+### Scope
+
+- Extract presentation-ready transcript sections and a single exhaustive renderer for normalized thread entries and grouped blocks.
+- Share viewport, virtualization, follow-tail, jump-to-latest, card-cache, and scrollbar behavior across document and panel layouts.
+- Migrate the main task thread and sub-agent sheet to the shared component without changing APIs, persisted state, event schemas, or backend mappers.
+- Add regression, component, parity, and scale coverage for the reusable renderer.
+
+### Non-goals
+
+- No runner, mapper, `UiEvent`, SSE, API, NDJSON, or `RunRecord` changes.
+- No backend-specific React presentation or speculative Codex child attribution.
+- No redesign of headers, docks, composer, footer, review panel, or nested-agent navigation.
+- No persisted scroll state or new configuration.
+
+## Implementation Plan
+
+### Phase 1: Extract and stabilize the shared renderer
+
+1. Add regression coverage for current row keys, main transcript slots, flat/virtual switching, card cache, scrolling, and initial attachments.
+2. Add the transcript section view model, main/agent adapters, and pure row builder with unit tests.
+3. Centralize exhaustive `ThreadEntry` and `ThreadBlock` dispatch and add the nested-render callback seam to `ToolCard`.
+4. Extract a surface-neutral transcript viewport with view-scoped scroll state and document/panel modes.
+5. Migrate the main thread body to `SessionTranscript` while retaining its surrounding route composition and layout behavior.
+
+### Phase 2: Reuse the renderer in the agent pane
+
+6. Pass `runId` into `SubagentSheet` and render attributed entries through `SessionTranscript` in panel mode.
+7. Remove the duplicate sub-agent streaming/scroll implementation and add the bounded flex layout, scrollbar gutter, jump pill, and accessible transcript label.
+8. Remove `NestedEntry`, route nested tool children through the canonical renderer, and cover grouping, results, errors, diffs, images, asks, and cache namespaces.
+
+### Phase 3: Backend and scale verification
+
+9. Add representative Claude, Codex, and OpenCode reducer-to-component coverage proving backend-neutral rendering and the honest Codex empty state.
+10. Extend dry-run/sub-agent coverage for long output and image events, including overflow, detachment, and jump-to-latest behavior.
+11. Run the full repository validation gate plus E2E/manual verification preparation and update only comments that still describe the retired renderer boundary.
+
+## Risks
+
+- Main-thread compatibility can regress through row keys, spacing, open-card namespaces, or virtualizer measurements; focused tests preserve the existing shape before and after migration.
+- Recursive rendering can introduce circular imports; orchestration stays in the session renderer and leaf cards receive a callback.
+- Two active transcript surfaces can corrupt one another's scroll state; every viewport key is namespaced by run and view.
+- User-facing panel behavior needs manual QA after code review; this run requests `needs-qa` and leaves QA approval to the parent workflow.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Extract and stabilize the shared renderer
+
+- [ ] 1.1 Add regression coverage for current main transcript behavior
+- [ ] 1.2 Add transcript view models, adapters, and pure row building
+- [ ] 1.3 Centralize exhaustive rendering and add the nested callback seam
+- [ ] 1.4 Extract the shared viewport and view-scoped scrolling
+- [ ] 1.5 Migrate the main thread to SessionTranscript
+
+### Phase 2: Reuse the renderer in the agent pane
+
+- [ ] 2.1 Migrate SubagentSheet to SessionTranscript panel mode
+- [ ] 2.2 Remove duplicate agent scrolling and fix the bounded panel viewport
+- [ ] 2.3 Remove NestedEntry and prove canonical nested rendering
+
+### Phase 3: Backend and scale verification
+
+- [ ] 3.1 Add backend-neutral reducer-to-component coverage
+- [ ] 3.2 Add long transcript and image regression coverage
+- [ ] 3.3 Complete full validation and verification preparation

--- a/packages/web/e2e/agents-dock.e2e.ts
+++ b/packages/web/e2e/agents-dock.e2e.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -64,16 +64,61 @@ beforeAll(async () => {
   dataRoot = mkdtempSync(join(tmpdir(), 'cezar-e2e-agents-'))
   mkdirSync(join(dataRoot, '.ai/cezar/runs'), { recursive: true })
   writeFileSync(join(dataRoot, '.ai/cezar/runs.json'), JSON.stringify([RUN], null, 2), 'utf8')
-  copyFileSync(
+  // Derive a long attributed child stream from the real `mock:subagents` recording. The
+  // source fixture stays verbatim; this test adds scale without pretending the runner emitted
+  // data it cannot currently attribute (notably images, whose persisted v1 line has no parent).
+  const recorded = readFileSync(
     resolve(import.meta.dirname, 'fixtures/subagents-run.ndjson'),
-    join(dataRoot, '.ai/cezar/runs', `${RUN_ID}.ndjson`),
+    'utf8',
   )
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+  const taskCompletion = recorded.findIndex(
+    (event) =>
+      event.type === 'item.completed' &&
+      (event.item as { id?: string } | undefined)?.id === 'toolu_task_a_1',
+  )
+  const longChildren = Array.from({ length: 34 }, (_, index) => ({
+    type: 'item.completed',
+    item: {
+      kind: 'tool',
+      id: `toolu_sub_long_${index}`,
+      name: 'Bash',
+      toolKind: 'execute',
+      title: `Ran long check ${index + 1}`,
+      status: 'completed',
+      output: `long check ${index + 1} passed`,
+      exitCode: 0,
+      parentItemId: 'toolu_task_a_1',
+    },
+    stepId: 'task',
+  }))
+  recorded.splice(taskCompletion, 0, ...longChildren)
+  const scaled = recorded
+    .map((event, index) =>
+      JSON.stringify({
+        ...event,
+        seq: index + 1,
+        ts: new Date(Date.UTC(2026, 6, 21, 10, 0, index)).toISOString(),
+      }),
+    )
+    .join('\n')
+  writeFileSync(join(dataRoot, '.ai/cezar/runs', `${RUN_ID}.ndjson`), `${scaled}\n`, 'utf8')
 
   const port = await freePort()
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [
+      join(repoRoot, 'packages/cezar/dist/index.js'),
+      'serve',
+      '--repo',
+      dataRoot,
+      '--port',
+      String(port),
+      '--no-open',
+    ],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)
@@ -110,7 +155,7 @@ describe('the Agents dock against a replayed fan-out', () => {
 
     expect(rows[0]!.text).toContain('Audit the auth flow')
     expect(rows[0]!.type).toBe('general-purpose')
-    expect(rows[0]!.tools).toBe('2 tools')
+    expect(rows[0]!.tools).toBe('36 tools')
     expect(rows[1]!.text).toContain('Review the store layer')
     expect(rows[1]!.type).toBe('code-reviewer')
     expect(rows[1]!.tools).toBe('1 tool')
@@ -150,6 +195,39 @@ describe('the Agents dock against a replayed fan-out', () => {
     browser.press('Escape')
     browser.waitForFunction(`document.querySelector('[data-slot="subagent-sheet"]') === null`)
     expect(browser.evaluate(`document.querySelector('${DOCK}') !== null`)).toBe(true)
+  }, 120_000)
+
+  it('the long agent panel scrolls, detaches from follow-tail, and exposes the jump pill', () => {
+    browser.goto(`${baseUrl}/tasks/${RUN_ID}`)
+    browser.waitForFunction(`document.querySelectorAll('${ROW}').length === 2`)
+    browser.click(`${ROW}:nth-of-type(1) button`)
+    browser.waitForFunction(`document.querySelector('[data-slot="transcript-viewport"]') !== null`)
+
+    const metrics = JSON.parse(
+      browser.evaluate(`JSON.stringify((() => {
+        const el = document.querySelector('[data-slot="transcript-viewport"]')
+        const style = getComputedStyle(el)
+        return {
+          overflowY: style.overflowY,
+          scrollbarGutter: style.scrollbarGutter,
+          scrollHeight: el.scrollHeight,
+          clientHeight: el.clientHeight,
+        }
+      })())`) as string,
+    ) as { overflowY: string; scrollbarGutter: string; scrollHeight: number; clientHeight: number }
+    expect(metrics.overflowY).toBe('auto')
+    expect(metrics.scrollbarGutter).toContain('stable')
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight)
+
+    browser.evaluate(`(() => {
+      const el = document.querySelector('[data-slot="transcript-viewport"]')
+      el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }))
+      el.scrollTop = 0
+      el.dispatchEvent(new Event('scroll', { bubbles: true }))
+    })()`)
+    browser.waitForFunction(`document.querySelector('[data-slot="jump-to-latest"]') !== null`)
+    browser.screenshot(join(artifactsDir, 'agents-dock-long-transcript.png'))
+    browser.click('[data-slot="jump-to-latest"]')
   }, 120_000)
 
   it('collapses to a one-line odometer', () => {

--- a/packages/web/src/routes/task-thread/session-transcript.test.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.test.tsx
@@ -1,0 +1,283 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ApiRun, RunEvent, UiToolItem } from '@open-mercato/cezar-api-client'
+
+import claudeSubagent from '../../../../cezar/src/core/__fixtures__/claude/subagent-task.expected.json'
+import codexReview from '../../../../cezar/src/core/__fixtures__/codex/review-mode.expected.json'
+import opencodeSubtask from '../../../../cezar/src/core/__fixtures__/opencode/subtask-nested.expected.json'
+
+import {
+  SessionTranscript,
+  agentTranscriptSections,
+  buildTranscriptRows,
+  mainTranscriptSections,
+  type TranscriptSection,
+} from './session-transcript'
+import { clearThreadScrollCaches } from './thread-scroll'
+import { collectSubagents, subagentChildren } from './subagent-dock'
+import { reduceThread, type ThreadEntry, type ThreadState } from './thread-state'
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  clearThreadScrollCaches()
+})
+
+const tool = (id: string, overrides: Partial<UiToolItem> = {}): UiToolItem => ({
+  kind: 'tool',
+  id,
+  name: 'Read',
+  toolKind: 'read',
+  title: `Read ${id}.ts`,
+  status: 'completed',
+  ...overrides,
+})
+
+const run = (overrides: Partial<ApiRun> = {}): ApiRun => ({
+  id: 'r1',
+  title: 'Shared transcript',
+  workflow: 'quick-task',
+  task: 'Initial prompt',
+  status: 'running',
+  createdAt: '2026-07-31T00:00:00.000Z',
+  tokensUsed: 0,
+  archived: false,
+  steps: [],
+  ...overrides,
+}) as ApiRun
+
+const asRunEvents = (events: object[]): RunEvent[] =>
+  events.map((event, index) => ({
+    seq: index + 1,
+    ts: '2026-07-31T00:00:00.000Z',
+    ...event,
+  })) as RunEvent[]
+
+describe('transcript adapters and row building', () => {
+  it('preserves initial images, queued messages, turn messages, and established row keys', () => {
+    const state: ThreadState = {
+      turns: [
+        {
+          id: 'turn-1',
+          userMessage: { text: 'Follow up', imageCount: 1, images: ['/turn.png'] },
+          items: [{ kind: 'message', id: 'answer', role: 'assistant', text: 'Done' }],
+        },
+      ],
+    }
+    const sections = mainTranscriptSections(
+      run({
+        taskImages: ['/task.png'],
+        queuedMessages: [
+          { id: 'm1', text: 'Queued note', images: ['/queued.png'], createdAt: '2026-07-31T00:00:01.000Z' },
+        ],
+      }),
+      state,
+    )
+
+    expect(sections.map((section) => section.id)).toEqual(['task', 'queued:m1', 'turn-1'])
+    expect(sections[0]?.userMessage?.images).toEqual(['/task.png'])
+    expect(sections[2]?.userMessage).toMatchObject({ text: 'Follow up', imageCount: 1 })
+    expect(buildTranscriptRows(sections, 'r1').map((row) => row.key)).toEqual([
+      'task',
+      'queued:m1',
+      'turn-1:user',
+      'turn-1:answer',
+    ])
+  })
+
+  it('groups the same normalized entries for an agent section', () => {
+    const entries = [tool('read-1'), tool('read-2')]
+    const rows = buildTranscriptRows(agentTranscriptSections('agent-1', entries), 'r1')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.key).toBe('agent:agent-1:group:read-1')
+    expect(rows[0]?.content).toMatchObject({ kind: 'block', block: { kind: 'context-group' } })
+  })
+})
+
+describe('SessionTranscript', () => {
+  const entries: ThreadEntry[] = [
+    { kind: 'message', id: 'm1', role: 'assistant', text: 'Shared prose' },
+    { kind: 'reasoning', id: 'r1', text: 'Shared reasoning' },
+    tool('exec', {
+      name: 'Bash',
+      toolKind: 'execute',
+      title: 'Ran npm test',
+      output: 'all green',
+      exitCode: 0,
+    }),
+    { kind: 'note', id: 'n1', text: 'Lifecycle note', tone: 'dim' },
+    { kind: 'image', id: 'i1', url: '/shot.png', name: 'agent screenshot' },
+  ]
+  const sections: TranscriptSection[] = [{ id: 'shared', entries }]
+
+  it.each(['document', 'panel'] as const)(
+    'renders the canonical entry primitives in %s mode',
+    (mode) => {
+      render(
+        <SessionTranscript runId="r1" viewId={mode} sections={sections} mode={mode} />,
+      )
+      expect(document.querySelector('[data-slot="assistant-message"]')?.textContent).toContain('Shared prose')
+      expect(document.querySelector('[data-slot="reasoning"]')?.textContent).toContain('Shared reasoning')
+      expect(document.querySelector('[data-slot="tool-card"]')?.textContent).toContain('npm test')
+      expect(document.querySelector('[data-slot="note-line"]')?.textContent).toContain('Lifecycle note')
+      expect(document.querySelector('img[alt="agent screenshot"]')).not.toBeNull()
+    },
+  )
+
+  it('uses one recursive renderer for task-card children', () => {
+    const parent = tool('task', {
+      name: 'Task',
+      toolKind: 'task',
+      title: 'Task: audit auth',
+    })
+    const child = tool('child', {
+      parentItemId: 'task',
+      name: 'Bash',
+      toolKind: 'execute',
+      title: 'Ran npm test',
+      output: 'passed',
+    })
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId="agent:one"
+        sections={[{ id: 'agent:one', entries: [parent, child] }]}
+        mode="panel"
+      />,
+    )
+    fireEvent.click(document.querySelector('[data-slot="tool-card"] button')!)
+    expect(document.querySelector('[data-slot="tool-nested"]')?.textContent).toContain('npm test')
+  })
+
+  it('keeps canonical output, errors, diffs, and exit codes in the agent panel', () => {
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId="agent:details"
+        sections={agentTranscriptSections('details', [
+          tool('failed-command', {
+            name: 'Bash',
+            toolKind: 'execute',
+            title: 'Ran npm test',
+            status: 'failed',
+            output: '1 test passed',
+            error: '1 test failed',
+            exitCode: 1,
+            diffs: [{ path: 'src/session.ts', oldText: 'old\n', newText: 'new\n' }],
+          }),
+        ])}
+        mode="panel"
+      />,
+    )
+    const trigger = document.querySelector('[data-slot="tool-card"] button')!
+    expect(trigger.textContent).toContain('1')
+    fireEvent.click(trigger)
+    const card = document.querySelector('[data-slot="tool-card"]')!
+    expect(card.textContent).toContain('1 test passed')
+    expect(card.textContent).toContain('1 test failed')
+    expect(card.textContent).toContain('src/session.ts')
+  })
+
+  it('renders an attributed ask instead of silently dropping the entry', () => {
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId="agent:ask"
+        sections={agentTranscriptSections('ask', [
+          {
+            kind: 'ask',
+            id: 'ask-1',
+            resolved: false,
+            questions: [
+              {
+                id: 'q1',
+                header: 'Choice',
+                question: 'Continue?',
+                options: [{ label: 'Yes', description: 'Keep going' }],
+              },
+            ],
+          },
+        ])}
+        mode="panel"
+      />,
+    )
+    expect(document.querySelector('[data-slot="ask-card"]')?.textContent).toContain(
+      'Open the main session',
+    )
+  })
+
+  it('provides a bounded, keyboard-scrollable panel with a stable scrollbar gutter', () => {
+    render(<SessionTranscript runId="r1" viewId="agent:one" sections={sections} mode="panel" />)
+    const viewport = document.querySelector('[data-slot="transcript-viewport"]')!
+    expect(viewport.getAttribute('aria-label')).toBe('Agent transcript')
+    expect(viewport.getAttribute('tabindex')).toBe('0')
+    expect(viewport.className).toContain('overflow-y-auto')
+    expect(viewport.className).toContain('[scrollbar-gutter:stable]')
+  })
+
+  it('switches a long agent transcript to the shared virtualized rows', () => {
+    const longEntries = Array.from({ length: 301 }, (_, index): ThreadEntry => ({
+      kind: 'message',
+      id: `message-${index}`,
+      role: 'assistant',
+      text: `message ${index}`,
+    }))
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId="agent:long"
+        sections={agentTranscriptSections('long', longEntries)}
+        mode="panel"
+      />,
+    )
+    expect(document.querySelector('[data-slot="thread-rows"]')?.getAttribute('data-virtualized')).toBe('true')
+  })
+
+  it.each([
+    ['Claude', claudeSubagent as object[], 'Scanning the auth middleware.'],
+    ['OpenCode', opencodeSubtask as object[], 'Two callers: router.ts and session.ts.'],
+  ])('renders %s attributed fixture output through the same component', (_backend, fixture, expected) => {
+    const thread = reduceThread(asRunEvents(fixture))
+    const selected = collectSubagents(thread.turns)[0]
+    expect(selected).toBeDefined()
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId={`agent:${selected!.id}`}
+        sections={agentTranscriptSections(selected!.id, subagentChildren(thread.turns, selected!.id))}
+        mode="panel"
+      />,
+    )
+    expect(document.querySelector('[data-slot="subagent-stream"]')?.textContent).toContain(expected)
+  })
+
+  it('keeps the Codex review fixture honest when it has no attributed children', () => {
+    const thread = reduceThread(asRunEvents(codexReview as object[]))
+    const selected = collectSubagents(thread.turns)[0]
+    expect(selected).toBeDefined()
+    const entries = subagentChildren(thread.turns, selected!.id)
+    expect(entries).toEqual([])
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId={`agent:${selected!.id}`}
+        sections={agentTranscriptSections(selected!.id, entries)}
+        mode="panel"
+        empty={<p data-slot="codex-empty">No attributed output</p>}
+      />,
+    )
+    expect(document.querySelector('[data-slot="codex-empty"]')?.textContent).toBe('No attributed output')
+  })
+})

--- a/packages/web/src/routes/task-thread/session-transcript.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.tsx
@@ -2,7 +2,6 @@ import { useMemo, type ReactNode } from 'react'
 
 import type { ApiRun } from '@open-mercato/cezar-api-client'
 
-import { AskCard } from './ask-card'
 import { groupThreadItems, type ThreadBlock } from './thread-groups'
 import {
   AssistantMessage,
@@ -24,7 +23,7 @@ import {
   type ThreadRow,
   type ThreadScrollControls,
 } from './thread-scroller'
-import type { ThreadEntry, ThreadState } from './thread-state'
+import type { ThreadAsk, ThreadEntry, ThreadState } from './thread-state'
 
 export interface TranscriptUserMessage {
   text: string
@@ -61,8 +60,8 @@ export interface SessionTranscriptProps {
   sections: readonly TranscriptSection[]
   mode: 'document' | 'panel'
   empty?: ReactNode
-  /** Needed only by interactive Ask cards; the renderer remains backend-neutral. */
-  run?: ApiRun
+  /** Injects the run-aware reply behavior without coupling this view to run data or stores. */
+  renderAsk?: (ask: ThreadAsk) => ReactNode
   messageActions?: Readonly<Record<string, TranscriptMessageActions>>
   /** Main-document integration preserves the shell's existing dock-owned jump pill. */
   scrollControls?: ThreadScrollControls
@@ -146,7 +145,7 @@ export function SessionTranscript({
   sections,
   mode,
   empty,
-  run,
+  renderAsk,
   messageActions,
   scrollControls,
   renderMode,
@@ -165,10 +164,10 @@ export function SessionTranscript({
               actions={messageActions?.[row.key]}
             />
           ) : (
-            <ThreadBlockRenderer block={row.content.block} scope={row.scope} run={run} />
+            <ThreadBlockRenderer block={row.content.block} scope={row.scope} renderAsk={renderAsk} />
           ),
       })),
-    [messageActions, rowModels, run],
+    [messageActions, renderAsk, rowModels],
   )
   const rowMode = renderMode ?? threadRenderMode('', rows.length)
 
@@ -228,15 +227,15 @@ function TranscriptUserBubble({
 function ThreadBlockRenderer({
   block,
   scope,
-  run,
+  renderAsk,
 }: {
   block: ThreadBlock
   scope: string
-  run?: ApiRun
+  renderAsk?: (ask: ThreadAsk) => ReactNode
 }): ReactNode {
   switch (block.kind) {
     case 'entry':
-      return <ThreadEntryRenderer entry={block.entry} scope={scope} run={run} />
+      return <ThreadEntryRenderer entry={block.entry} scope={scope} renderAsk={renderAsk} />
     case 'tool-card':
       return (
         <ToolCard
@@ -244,7 +243,7 @@ function ThreadBlockRenderer({
           nested={block.children}
           cacheKey={`${scope}:${block.id}`}
           renderNested={(entries, nestedScope) => (
-            <GroupedEntries entries={entries} scope={nestedScope} run={run} />
+            <GroupedEntries entries={entries} scope={nestedScope} renderAsk={renderAsk} />
           )}
         />
       )
@@ -254,7 +253,7 @@ function ThreadBlockRenderer({
       return (
         <ToolStreak count={block.count}>
           {block.blocks.map((inner) => (
-            <ThreadBlockRenderer key={inner.id} block={inner} scope={scope} run={run} />
+            <ThreadBlockRenderer key={inner.id} block={inner} scope={scope} renderAsk={renderAsk} />
           ))}
         </ToolStreak>
       )
@@ -266,25 +265,25 @@ function ThreadBlockRenderer({
 function GroupedEntries({
   entries,
   scope,
-  run,
+  renderAsk,
 }: {
   entries: readonly ThreadEntry[]
   scope: string
-  run?: ApiRun
+  renderAsk?: (ask: ThreadAsk) => ReactNode
 }) {
   return groupThreadItems([...entries]).map((block) => (
-    <ThreadBlockRenderer key={block.id} block={block} scope={scope} run={run} />
+    <ThreadBlockRenderer key={block.id} block={block} scope={scope} renderAsk={renderAsk} />
   ))
 }
 
 function ThreadEntryRenderer({
   entry,
   scope,
-  run,
+  renderAsk,
 }: {
   entry: ThreadEntry
   scope: string
-  run?: ApiRun
+  renderAsk?: (ask: ThreadAsk) => ReactNode
 }): ReactNode {
   switch (entry.kind) {
     case 'message':
@@ -302,8 +301,8 @@ function ThreadEntryRenderer({
     case 'image':
       return <ImageItem image={entry} />
     case 'ask':
-      return run !== undefined ? (
-        <AskCard ask={entry} run={run} />
+      return renderAsk !== undefined ? (
+        renderAsk(entry)
       ) : (
         <div data-slot="ask-card" className="rounded-lg border border-border bg-card px-4 py-3 text-sm">
           The agent asked a question. Open the main session to answer it.

--- a/packages/web/src/routes/task-thread/session-transcript.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.tsx
@@ -1,0 +1,321 @@
+import { useMemo, type ReactNode } from 'react'
+
+import type { ApiRun } from '@open-mercato/cezar-api-client'
+
+import { AskCard } from './ask-card'
+import { groupThreadItems, type ThreadBlock } from './thread-groups'
+import {
+  AssistantMessage,
+  ContextGroup,
+  ImageItem,
+  NoteLine,
+  ProviderAuthRequiredCard,
+  ReasoningItem,
+  ToolCard,
+  ToolStreak,
+  UserBubble,
+} from './thread-items'
+import { ThreadCardCache } from './thread-open-cards'
+import { threadRenderMode } from './thread-scroll'
+import {
+  JumpToLatestPill,
+  ThreadRows,
+  useThreadScroll,
+  type ThreadRow,
+  type ThreadScrollControls,
+} from './thread-scroller'
+import type { ThreadEntry, ThreadState } from './thread-state'
+
+export interface TranscriptUserMessage {
+  text: string
+  imageCount?: number
+  images?: readonly string[]
+}
+
+export interface TranscriptSection {
+  id: string
+  userMessage?: TranscriptUserMessage
+  /** Keeps the main renderer's established keys while allowing generic section ids. */
+  userMessageKey?: string
+  entries: readonly ThreadEntry[]
+}
+
+export interface TranscriptMessageActions {
+  onEdit?: (text: string) => Promise<void>
+  onRemove?: () => Promise<void>
+  editLabel?: string
+  removeLabel?: string
+}
+
+export interface TranscriptRowModel {
+  key: string
+  scope: string
+  content:
+    | { kind: 'user-message'; message: TranscriptUserMessage }
+    | { kind: 'block'; block: ThreadBlock }
+}
+
+export interface SessionTranscriptProps {
+  runId: string
+  viewId: string
+  sections: readonly TranscriptSection[]
+  mode: 'document' | 'panel'
+  empty?: ReactNode
+  /** Needed only by interactive Ask cards; the renderer remains backend-neutral. */
+  run?: ApiRun
+  messageActions?: Readonly<Record<string, TranscriptMessageActions>>
+  /** Main-document integration preserves the shell's existing dock-owned jump pill. */
+  scrollControls?: ThreadScrollControls
+  renderMode?: 'flat' | 'virtual'
+}
+
+/** The main run record plus reduced turns, without rendering or backend inspection. */
+export function mainTranscriptSections(run: ApiRun, thread: ThreadState): TranscriptSection[] {
+  const sections: TranscriptSection[] = []
+  if (run.task) {
+    sections.push({
+      id: 'task',
+      userMessageKey: 'task',
+      userMessage: { text: run.task, images: run.taskImages ?? [] },
+      entries: [],
+    })
+  }
+  for (const message of run.queuedMessages ?? []) {
+    sections.push({
+      id: `queued:${message.id}`,
+      userMessageKey: `queued:${message.id}`,
+      userMessage: { text: message.text, images: message.images ?? [] },
+      entries: [],
+    })
+  }
+  for (const turn of thread.turns) {
+    sections.push({
+      id: turn.id,
+      userMessageKey: `${turn.id}:user`,
+      ...(turn.userMessage !== undefined
+        ? {
+            userMessage: {
+              text: turn.userMessage.text,
+              imageCount: turn.userMessage.imageCount,
+              images: turn.userMessage.images,
+            },
+          }
+        : {}),
+      entries: turn.items,
+    })
+  }
+  return sections
+}
+
+/** One attributed agent stream becomes one ordinary transcript section. */
+export function agentTranscriptSections(
+  agentId: string,
+  entries: readonly ThreadEntry[],
+): TranscriptSection[] {
+  return [{ id: `agent:${agentId}`, entries }]
+}
+
+/** Pure flattening and grouping shared by document and panel surfaces. */
+export function buildTranscriptRows(
+  sections: readonly TranscriptSection[],
+  _runId: string,
+): TranscriptRowModel[] {
+  const rows: TranscriptRowModel[] = []
+  for (const section of sections) {
+    if (section.userMessage !== undefined) {
+      rows.push({
+        key: section.userMessageKey ?? `${section.id}:user`,
+        scope: section.id,
+        content: { kind: 'user-message', message: section.userMessage },
+      })
+    }
+    for (const block of groupThreadItems([...section.entries])) {
+      rows.push({
+        key: `${section.id}:${block.id}`,
+        scope: section.id,
+        content: { kind: 'block', block },
+      })
+    }
+  }
+  return rows
+}
+
+export function SessionTranscript({
+  runId,
+  viewId,
+  sections,
+  mode,
+  empty,
+  run,
+  messageActions,
+  scrollControls,
+  renderMode,
+}: SessionTranscriptProps) {
+  const rowModels = useMemo(() => buildTranscriptRows(sections, runId), [sections, runId])
+  const internalScroll = useThreadScroll(`${runId}:${viewId}`, mode)
+  const controls = scrollControls ?? internalScroll
+  const rows = useMemo<ThreadRow[]>(
+    () =>
+      rowModels.map((row) => ({
+        key: row.key,
+        node:
+          row.content.kind === 'user-message' ? (
+            <TranscriptUserBubble
+              message={row.content.message}
+              actions={messageActions?.[row.key]}
+            />
+          ) : (
+            <ThreadBlockRenderer block={row.content.block} scope={row.scope} run={run} />
+          ),
+      })),
+    [messageActions, rowModels, run],
+  )
+  const rowMode = renderMode ?? threadRenderMode('', rows.length)
+
+  const transcript =
+    rows.length === 0 ? (
+      empty ?? null
+    ) : (
+      <ThreadRows runId={`${runId}:${viewId}`} rows={rows} mode={rowMode} controls={controls} />
+    )
+
+  return (
+    <ThreadCardCache runId={runId}>
+      {mode === 'panel' ? (
+        <div
+          data-slot="transcript-viewport"
+          aria-label="Agent transcript"
+          role="region"
+          tabIndex={0}
+          className="relative flex min-h-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]"
+        >
+          <div data-slot="subagent-stream" className="flex flex-col px-5 py-4">
+            {transcript}
+          </div>
+          {controls.pillVisible ? (
+            <div className="pointer-events-none sticky inset-x-0 bottom-4 flex justify-center">
+              <JumpToLatestPill onJump={controls.jumpToLatest} />
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        transcript
+      )}
+    </ThreadCardCache>
+  )
+}
+
+function TranscriptUserBubble({
+  message,
+  actions,
+}: {
+  message: TranscriptUserMessage
+  actions?: TranscriptMessageActions
+}) {
+  return (
+    <UserBubble
+      text={message.text}
+      imageCount={message.imageCount}
+      images={message.images}
+      onEdit={actions?.onEdit}
+      onRemove={actions?.onRemove}
+      editLabel={actions?.editLabel}
+      removeLabel={actions?.removeLabel}
+    />
+  )
+}
+
+function ThreadBlockRenderer({
+  block,
+  scope,
+  run,
+}: {
+  block: ThreadBlock
+  scope: string
+  run?: ApiRun
+}): ReactNode {
+  switch (block.kind) {
+    case 'entry':
+      return <ThreadEntryRenderer entry={block.entry} scope={scope} run={run} />
+    case 'tool-card':
+      return (
+        <ToolCard
+          item={block.item}
+          nested={block.children}
+          cacheKey={`${scope}:${block.id}`}
+          renderNested={(entries, nestedScope) => (
+            <GroupedEntries entries={entries} scope={nestedScope} run={run} />
+          )}
+        />
+      )
+    case 'context-group':
+      return <ContextGroup group={block} scope={scope} />
+    case 'streak':
+      return (
+        <ToolStreak count={block.count}>
+          {block.blocks.map((inner) => (
+            <ThreadBlockRenderer key={inner.id} block={inner} scope={scope} run={run} />
+          ))}
+        </ToolStreak>
+      )
+    default:
+      return assertNever(block)
+  }
+}
+
+function GroupedEntries({
+  entries,
+  scope,
+  run,
+}: {
+  entries: readonly ThreadEntry[]
+  scope: string
+  run?: ApiRun
+}) {
+  return groupThreadItems([...entries]).map((block) => (
+    <ThreadBlockRenderer key={block.id} block={block} scope={scope} run={run} />
+  ))
+}
+
+function ThreadEntryRenderer({
+  entry,
+  scope,
+  run,
+}: {
+  entry: ThreadEntry
+  scope: string
+  run?: ApiRun
+}): ReactNode {
+  switch (entry.kind) {
+    case 'message':
+      return entry.role === 'assistant' ? (
+        <AssistantMessage text={entry.text} />
+      ) : (
+        <UserBubble text={entry.text} />
+      )
+    case 'reasoning':
+      return <ReasoningItem text={entry.text} />
+    case 'tool':
+      return <ToolCard item={entry} cacheKey={`${scope}:${entry.id}`} />
+    case 'note':
+      return <NoteLine note={entry} />
+    case 'image':
+      return <ImageItem image={entry} />
+    case 'ask':
+      return run !== undefined ? (
+        <AskCard ask={entry} run={run} />
+      ) : (
+        <div data-slot="ask-card" className="rounded-lg border border-border bg-card px-4 py-3 text-sm">
+          The agent asked a question. Open the main session to answer it.
+        </div>
+      )
+    case 'provider-auth-required':
+      return <ProviderAuthRequiredCard incident={entry} />
+    default:
+      return assertNever(entry)
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled transcript variant: ${JSON.stringify(value)}`)
+}

--- a/packages/web/src/routes/task-thread/subagent-replay.test.tsx
+++ b/packages/web/src/routes/task-thread/subagent-replay.test.tsx
@@ -54,7 +54,9 @@ describe('replayed run — the sheet', () => {
       // Exactly the fixture's parented items, deduplicated by the reducer's id-keyed upsert.
       expect(children.map((child) => child.id)).toEqual(['item_1', 'toolu_sub_01'])
 
-      const { unmount } = render(<SubagentSheet agent={agent} entries={children} onClose={() => {}} />)
+      const { unmount } = render(
+        <SubagentSheet runId="r1" agent={agent} entries={children} onClose={() => {}} />,
+      )
       const stream = document.querySelector('[data-slot="subagent-stream"]')!
       expect(stream.textContent).toContain('Scanning the auth middleware.')
       expect(stream.textContent).toContain('session') // "Search session", split verb/detail

--- a/packages/web/src/routes/task-thread/subagent-sheet.test.tsx
+++ b/packages/web/src/routes/task-thread/subagent-sheet.test.tsx
@@ -40,12 +40,12 @@ const stream = () => document.querySelector('[data-slot="subagent-stream"]')
 
 describe('SubagentSheet — open/close', () => {
   it('renders nothing while no agent is selected', () => {
-    render(<SubagentSheet agent={undefined} entries={[]} onClose={() => {}} />)
+    render(<SubagentSheet runId="r1" agent={undefined} entries={[]} onClose={() => {}} />)
     expect(sheet()).toBeNull()
   })
 
   it('opens as a labeled dialog for the selected agent', () => {
-    render(<SubagentSheet agent={agent()} entries={[]} onClose={() => {}} />)
+    render(<SubagentSheet runId="r1" agent={agent()} entries={[]} onClose={() => {}} />)
     expect(sheet()).not.toBeNull()
     expect(sheet()!.getAttribute('role')).toBe('dialog')
     expect(sheet()!.textContent).toContain('Audit the auth flow')
@@ -53,14 +53,14 @@ describe('SubagentSheet — open/close', () => {
 
   it('asks to close on Escape', () => {
     let closed = 0
-    render(<SubagentSheet agent={agent()} entries={[]} onClose={() => { closed += 1 }} />)
+    render(<SubagentSheet runId="r1" agent={agent()} entries={[]} onClose={() => { closed += 1 }} />)
     fireEvent.keyDown(document.body, { key: 'Escape' })
     expect(closed).toBe(1)
   })
 
   it('asks to close from the close button', () => {
     let closed = 0
-    render(<SubagentSheet agent={agent()} entries={[]} onClose={() => { closed += 1 }} />)
+    render(<SubagentSheet runId="r1" agent={agent()} entries={[]} onClose={() => { closed += 1 }} />)
     // `data-slot="subagent-sheet"` replaces the primitive's own slot name, so the sheet's
     // close button is simply the only button in an otherwise empty panel.
     fireEvent.click(document.querySelector('[data-slot="subagent-sheet"] button')!)
@@ -72,6 +72,7 @@ describe('SubagentSheet — header', () => {
   it('shows the type badge, a status word and the tool-call count', () => {
     render(
       <SubagentSheet
+        runId="r1"
         agent={agent({ agentType: 'general-purpose', status: 'running', toolCalls: 3 })}
         entries={[]}
         onClose={() => {}}
@@ -84,12 +85,12 @@ describe('SubagentSheet — header', () => {
   })
 
   it('says "1 tool call", not "1 tool calls"', () => {
-    render(<SubagentSheet agent={agent({ toolCalls: 1 })} entries={[]} onClose={() => {}} />)
+    render(<SubagentSheet runId="r1" agent={agent({ toolCalls: 1 })} entries={[]} onClose={() => {}} />)
     expect(document.querySelector('[data-slot="subagent-meta"]')!.textContent).toContain('1 tool call')
   })
 
   it('omits the type badge for a backend that declares none (codex)', () => {
-    render(<SubagentSheet agent={agent({ agentType: undefined })} entries={[]} onClose={() => {}} />)
+    render(<SubagentSheet runId="r1" agent={agent({ agentType: undefined })} entries={[]} onClose={() => {}} />)
     expect(document.querySelector('[data-slot="agent-type"]')).toBeNull()
   })
 
@@ -99,7 +100,7 @@ describe('SubagentSheet — header', () => {
     ['declined', 'Declined'],
     ['pending', 'Pending'],
   ] as const)('renders %s as the word %s', (status, label) => {
-    render(<SubagentSheet agent={agent({ status })} entries={[]} onClose={() => {}} />)
+    render(<SubagentSheet runId="r1" agent={agent({ status })} entries={[]} onClose={() => {}} />)
     expect(document.querySelector('[data-slot="subagent-status"]')!.textContent).toBe(label)
   })
 })
@@ -108,6 +109,7 @@ describe('SubagentSheet — the child stream', () => {
   it('renders exactly that agent’s children, in stream order', () => {
     render(
       <SubagentSheet
+        runId="r1"
         agent={agent()}
         entries={[textChild('c1', 'Scanning the auth middleware.'), toolChild('c2', 'Ran npm test')]}
         onClose={() => {}}
@@ -122,8 +124,8 @@ describe('SubagentSheet — the child stream', () => {
   })
 
   it('shows the empty state for an agent with no attributed output (a codex review row)', () => {
-    render(<SubagentSheet agent={agent({ toolCalls: 0 })} entries={[]} onClose={() => {}} />)
-    expect(stream()).toBeNull()
+    render(<SubagentSheet runId="r1" agent={agent({ toolCalls: 0 })} entries={[]} onClose={() => {}} />)
+    expect(stream()).not.toBeNull()
     expect(document.querySelector('[data-slot="subagent-empty"]')!.textContent).toContain(
       'No attributed output',
     )
@@ -131,11 +133,12 @@ describe('SubagentSheet — the child stream', () => {
 
   it('renders output appended while the sheet is open', () => {
     const { rerender } = render(
-      <SubagentSheet agent={agent()} entries={[toolChild('c1', 'Ran npm test')]} onClose={() => {}} />,
+      <SubagentSheet runId="r1" agent={agent()} entries={[toolChild('c1', 'Ran npm test')]} onClose={() => {}} />,
     )
     expect(stream()!.textContent).not.toContain('npm run build')
     rerender(
       <SubagentSheet
+        runId="r1"
         agent={agent()}
         entries={[toolChild('c1', 'Ran npm test'), toolChild('c2', 'Ran npm run build')]}
         onClose={() => {}}
@@ -147,10 +150,10 @@ describe('SubagentSheet — the child stream', () => {
   it('an agent completing while inspected flips the status pill and keeps the sheet open', () => {
     const entries = [toolChild('c1', 'Ran npm test')]
     const { rerender } = render(
-      <SubagentSheet agent={agent({ status: 'running' })} entries={entries} onClose={() => {}} />,
+      <SubagentSheet runId="r1" agent={agent({ status: 'running' })} entries={entries} onClose={() => {}} />,
     )
     expect(document.querySelector('[data-slot="subagent-status"]')!.textContent).toBe('Running')
-    rerender(<SubagentSheet agent={agent({ status: 'completed' })} entries={entries} onClose={() => {}} />)
+    rerender(<SubagentSheet runId="r1" agent={agent({ status: 'completed' })} entries={entries} onClose={() => {}} />)
     expect(sheet()).not.toBeNull()
     expect(document.querySelector('[data-slot="subagent-status"]')!.textContent).toBe('Completed')
     expect(stream()!.textContent).toContain('npm test')

--- a/packages/web/src/routes/task-thread/subagent-sheet.tsx
+++ b/packages/web/src/routes/task-thread/subagent-sheet.tsx
@@ -1,27 +1,30 @@
-import { useEffect, useRef } from 'react'
-
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import type { ApiRun } from '@open-mercato/cezar-api-client'
 import { cn } from '@/lib/utils'
 
 import type { SubagentSummary } from './subagent-dock'
 import type { ThreadEntry } from './thread-state'
-import { NestedEntry } from './thread-items'
+import { SessionTranscript, agentTranscriptSections } from './session-transcript'
 
 /**
  * The sub-agent drill-down (spec `.ai/specs/2026-07-20-grouped-subagent-display.md`
  * §"Drill-down sheet", issue #474; mockup `mockup-02-subagent-sheet.png`): one agent's full
  * child stream in a focused right-side panel, entered from an Agents-dock row.
  *
- * It reads the same reducer state the thread does and renders it with the same `NestedEntry`
- * components, so it live-updates for free and a replayed (finished) run shows byte-identical
- * content. No new persistence, no route, no deep link — the selection is one id in component
- * state (spec Q2/Q5).
+ * It reads the same reducer state the thread does and hands it to `SessionTranscript`, so
+ * grouping, cards, attachments, virtualization, and follow-tail behavior cannot drift from
+ * the main session. No new persistence, route, or deep link — the selection is one id in
+ * component state (spec Q2/Q5).
  */
 export function SubagentSheet({
+  runId,
+  run,
   agent,
   entries,
   onClose,
 }: {
+  runId: string
+  run?: ApiRun
   /** The selected agent, or `undefined` when the sheet is closed. */
   agent: SubagentSummary | undefined
   /** That agent's child entries, in stream order (`subagentChildren`). */
@@ -35,15 +38,27 @@ export function SubagentSheet({
         side="right"
         // Wider than the default `sm:max-w-sm`: this panel carries tool cards and diffs,
         // not a settings form.
-        className="w-full gap-0 p-0 sm:max-w-xl"
+        className="flex min-h-0 w-full gap-0 p-0 sm:max-w-xl"
       >
-        {agent !== undefined ? <SheetBody agent={agent} entries={entries} /> : null}
+        {agent !== undefined ? (
+          <SheetBody runId={runId} run={run} agent={agent} entries={entries} />
+        ) : null}
       </SheetContent>
     </Sheet>
   )
 }
 
-function SheetBody({ agent, entries }: { agent: SubagentSummary; entries: ThreadEntry[] }) {
+function SheetBody({
+  runId,
+  run,
+  agent,
+  entries,
+}: {
+  runId: string
+  run?: ApiRun
+  agent: SubagentSummary
+  entries: ThreadEntry[]
+}) {
   return (
     <>
       <SheetHeader className="gap-1.5 border-b border-border px-5 py-4">
@@ -65,65 +80,19 @@ function SheetBody({ agent, entries }: { agent: SubagentSummary; entries: Thread
           </span>
         </SheetDescription>
       </SheetHeader>
-      <SubagentStream entries={entries} scope={agent.id} />
+      <SessionTranscript
+        runId={runId}
+        viewId={`agent:${agent.id}`}
+        sections={agentTranscriptSections(agent.id, entries)}
+        mode="panel"
+        run={run}
+        empty={
+          <div data-slot="subagent-empty" className="py-2 text-[13px] text-muted-foreground">
+            No attributed output — see the thread card for this agent&apos;s result.
+          </div>
+        }
+      />
     </>
-  )
-}
-
-/**
- * The agent's children, tailing live output the way the thread does: pinned to the bottom
- * unless the reader scrolled up, so a long-running agent does not yank the panel out from
- * under someone reading an earlier tool call.
- */
-function SubagentStream({ entries, scope }: { entries: ThreadEntry[]; scope: string }) {
-  const ref = useRef<HTMLDivElement>(null)
-  const stuck = useRef(true)
-
-  // Keyed on CONTENT, not entry count: `item.delta` grows the existing last entry in place,
-  // so a length-only dep would never fire during the streaming this affordance exists for.
-  // `thread-state` applies deltas TWO ways — `item.text += delta` for message/reasoning and
-  // `item.output += delta` for tools — so both have to be in the signature. Counting only text
-  // would leave the panel pinned to a stale offset while a sub-agent streams command output,
-  // which is exactly the long-running case this affordance exists for.
-  const signature = entries.reduce(
-    (sum, entry) =>
-      sum +
-      (entry.kind === 'message' || entry.kind === 'reasoning'
-        ? entry.text.length
-        : entry.kind === 'tool'
-          ? (entry.output?.length ?? 0) + (entry.error?.length ?? 0)
-          : 0),
-    entries.length,
-  )
-  useEffect(() => {
-    const node = ref.current
-    if (node === null || !stuck.current) return
-    node.scrollTop = node.scrollHeight
-  }, [signature])
-
-  if (entries.length === 0) {
-    return (
-      <div data-slot="subagent-empty" className="px-5 py-6 text-[13px] text-muted-foreground">
-        No attributed output — see the thread card for this agent&apos;s result.
-      </div>
-    )
-  }
-
-  return (
-    <div
-      ref={ref}
-      data-slot="subagent-stream"
-      onScroll={(event) => {
-        const node = event.currentTarget
-        // 24px of slack: "close enough to the bottom" survives sub-pixel scroll heights.
-        stuck.current = node.scrollHeight - node.scrollTop - node.clientHeight < 24
-      }}
-      className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-5 py-4"
-    >
-      {entries.map((entry) => (
-        <NestedEntry key={entry.id} entry={entry} scope={`subagent:${scope}`} />
-      ))}
-    </div>
   )
 }
 

--- a/packages/web/src/routes/task-thread/subagent-sheet.tsx
+++ b/packages/web/src/routes/task-thread/subagent-sheet.tsx
@@ -1,9 +1,9 @@
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
-import type { ApiRun } from '@open-mercato/cezar-api-client'
+import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
 import type { SubagentSummary } from './subagent-dock'
-import type { ThreadEntry } from './thread-state'
+import type { ThreadAsk, ThreadEntry } from './thread-state'
 import { SessionTranscript, agentTranscriptSections } from './session-transcript'
 
 /**
@@ -18,13 +18,13 @@ import { SessionTranscript, agentTranscriptSections } from './session-transcript
  */
 export function SubagentSheet({
   runId,
-  run,
+  renderAsk,
   agent,
   entries,
   onClose,
 }: {
   runId: string
-  run?: ApiRun
+  renderAsk?: (ask: ThreadAsk) => ReactNode
   /** The selected agent, or `undefined` when the sheet is closed. */
   agent: SubagentSummary | undefined
   /** That agent's child entries, in stream order (`subagentChildren`). */
@@ -41,7 +41,7 @@ export function SubagentSheet({
         className="flex min-h-0 w-full gap-0 p-0 sm:max-w-xl"
       >
         {agent !== undefined ? (
-          <SheetBody runId={runId} run={run} agent={agent} entries={entries} />
+          <SheetBody runId={runId} renderAsk={renderAsk} agent={agent} entries={entries} />
         ) : null}
       </SheetContent>
     </Sheet>
@@ -50,12 +50,12 @@ export function SubagentSheet({
 
 function SheetBody({
   runId,
-  run,
+  renderAsk,
   agent,
   entries,
 }: {
   runId: string
-  run?: ApiRun
+  renderAsk?: (ask: ThreadAsk) => ReactNode
   agent: SubagentSummary
   entries: ThreadEntry[]
 }) {
@@ -85,7 +85,7 @@ function SheetBody({
         viewId={`agent:${agent.id}`}
         sections={agentTranscriptSections(agent.id, entries)}
         mode="panel"
-        run={run}
+        renderAsk={renderAsk}
         empty={
           <div data-slot="subagent-empty" className="py-2 text-[13px] text-muted-foreground">
             No attributed output — see the thread card for this agent&apos;s result.

--- a/packages/web/src/routes/task-thread/task-thread.test.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.test.tsx
@@ -15,7 +15,8 @@ import type {
   RunStatus,
 } from '@open-mercato/cezar-api-client'
 
-import { buildThreadRows, TaskThreadRoute, ThreadView } from './task-thread'
+import { TaskThreadRoute, ThreadView } from './task-thread'
+import { buildTranscriptRows, mainTranscriptSections } from './session-transcript'
 import { reduceThread } from './thread-state'
 
 afterEach(() => {
@@ -101,6 +102,9 @@ const EVENTS: RunEvent[] = [
   line(6, 'item.completed', { item: { kind: 'reasoning', id: 'item_2', text: 'Considering the layout…' } }),
   line(7, 'user-message', { text: 'Thanks!', imageCount: 2 }),
 ]
+
+const transcriptRows = (fixture: ApiRun, thread = reduceThread(EVENTS)) =>
+  buildTranscriptRows(mainTranscriptSections(fixture, thread), fixture.id)
 
 describe('ThreadView', () => {
   it('keeps provider authorization recovery visible after the run reaches done', () => {
@@ -319,12 +323,12 @@ describe('ThreadView', () => {
   /**
    * The no-regression assertion, at the row-builder level rather than the DOM:
    * an absent stack and an empty one must produce the same rows, and a run with
-   * no stack must produce exactly today's rows. Asserting on `buildThreadRows`
+   * no stack must produce exactly today's rows. Asserting on the shared row builder's
    * keys keeps this free of Radix's per-render generated ids.
    */
   it('builds the same rows whether the stack is absent or empty', () => {
     const keys = (extra: Partial<ApiRun>) =>
-      buildThreadRows(run('queued', extra), reduceThread(EVENTS)).map((r) => r.key)
+      transcriptRows(run('queued', extra)).map((r) => r.key)
 
     const absent = keys({})
     expect(absent[0]).toBe('task')
@@ -334,20 +338,19 @@ describe('ThreadView', () => {
   })
 
   it('inserts the stacked rows directly after the task row, in order', () => {
-    const keys = buildThreadRows(
+    const keys = transcriptRows(
       run('queued', {
         queuedMessages: [
           { id: 'm1', text: 'one', createdAt: '2026-07-21T10:00:00.000Z' },
           { id: 'm2', text: 'two', createdAt: '2026-07-21T10:01:00.000Z' },
         ],
       }),
-      reduceThread(EVENTS),
     ).map((r) => r.key)
 
     expect(keys.slice(0, 3)).toEqual(['task', 'queued:m1', 'queued:m2'])
     // …and the rest of the transcript is untouched behind them.
     expect(keys.slice(3)).toEqual(
-      buildThreadRows(run('queued'), reduceThread(EVENTS)).map((r) => r.key).slice(1),
+      transcriptRows(run('queued')).map((r) => r.key).slice(1),
     )
   })
 
@@ -367,8 +370,8 @@ describe('ThreadView', () => {
     const thread = reduceThread(EVENTS)
 
     // The row builder is pure: same inputs, same rows.
-    expect(buildThreadRows(fixture, thread).map((r) => r.key)).toEqual(
-      buildThreadRows(fixture, thread).map((r) => r.key),
+    expect(transcriptRows(fixture, thread).map((r) => r.key)).toEqual(
+      transcriptRows(fixture, thread).map((r) => r.key),
     )
 
     const { rerender } = renderView(<ThreadView run={fixture} thread={thread} />)

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -24,9 +24,7 @@ import { useKeyboardInsetVar } from '@/lib/keyboard-inset'
 import { taskIssueUrl, taskPrUrl } from '@/lib/tasks-table'
 import { cn, isHttpUrl } from '@/lib/utils'
 
-import {
-  WorkingIndicator,
-} from './thread-items'
+import { WorkingIndicator } from './thread-items'
 import { useContinueAction } from './follow-up-engine'
 import { AgentsDock } from './agents-dock'
 import { PlanDock, planCounts } from './plan-dock'
@@ -35,6 +33,7 @@ import { SubagentSheet } from './subagent-sheet'
 import { AcceptCelebration, ReviewPanel } from './review-panel'
 import { queuePosition } from './run-actions'
 import { RunHeader } from './run-header'
+import { AskCard } from './ask-card'
 import { useRunRecordReconcile } from './run-reconcile'
 import { useActiveProviderAvailability } from './active-provider'
 import { ThreadLoading } from './thread-loading'
@@ -45,7 +44,6 @@ import {
   buildTranscriptRows,
   mainTranscriptSections,
   type TranscriptMessageActions,
-  type TranscriptRowModel,
 } from './session-transcript'
 import {
   latestPlanEntries,
@@ -109,21 +107,6 @@ export function TaskThreadRoute() {
  * (thread-scroll.ts owns the rule). Row keys are turn-scoped — the same keys the open-card
  * cache uses, because v2 item ids repeat across sessions.
  */
-export function buildThreadRows(
-  run: ApiRun,
-  thread: ThreadState,
-  /** Queued-run affordances (#472). Omitted (the default) renders every bubble read-only,
-   *  which is what every caller outside the live thread view wants. */
-  edit?: {
-    onEditTask: (text: string) => Promise<void>
-    onEditMessage: (msgId: string, text: string) => Promise<void>
-    onRemoveMessage: (msgId: string) => Promise<void>
-  },
-): TranscriptRowModel[] {
-  void edit
-  return buildTranscriptRows(mainTranscriptSections(run, thread), run.id)
-}
-
 /** The loaded thread. The header owns its own data hooks (mutations, the runs list); the
  *  thread body stays presentational — tests drive it with reduced fixture states directly. */
 export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }) {
@@ -251,7 +234,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
           viewId="main"
           sections={sections}
           mode="document"
-          run={run}
+          renderAsk={(ask) => <AskCard ask={ask} run={run} />}
           messageActions={messageActions}
           scrollControls={scroll}
           renderMode={mode}
@@ -327,7 +310,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
           uses), or tool cards expanded in the sheet would forget that on reopen. */}
       <SubagentSheet
         runId={run.id}
-        run={run}
+        renderAsk={(ask) => <AskCard ask={ask} run={run} />}
         agent={openAgent}
         entries={openAgentChildren}
         onClose={() => setOpenAgentId(undefined)}

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -1,5 +1,5 @@
 import { MessageSquareTextIcon, SearchXIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router'
 
 import { Link } from '@/lib/project-router'
@@ -50,6 +50,7 @@ import {
   reduceThread,
   threadFilePaths,
   threadFooter,
+  type ThreadAsk,
   type ThreadState,
 } from './thread-state'
 
@@ -102,11 +103,6 @@ export function TaskThreadRoute() {
   return <ThreadView run={run.data} thread={thread} />
 }
 
-/**
- * The run's task + every turn, flattened to keyed rows for the threshold-switched scroller
- * (thread-scroll.ts owns the rule). Row keys are turn-scoped — the same keys the open-card
- * cache uses, because v2 item ids repeat across sessions.
- */
 /** The loaded thread. The header owns its own data hooks (mutations, the runs list); the
  *  thread body stays presentational — tests drive it with reduced fixture states directly. */
 export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }) {
@@ -199,6 +195,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
 
   const sections = useMemo(() => mainTranscriptSections(run, thread), [run, thread])
   const rows = useMemo(() => buildTranscriptRows(sections, run.id), [sections, run.id])
+  const renderAsk = useCallback((ask: ThreadAsk) => <AskCard ask={ask} run={run} />, [run])
   const messageActions = useMemo<Readonly<Record<string, TranscriptMessageActions>> | undefined>(() => {
     if (edit === undefined) return undefined
     const actions: Record<string, TranscriptMessageActions> = {
@@ -234,7 +231,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
           viewId="main"
           sections={sections}
           mode="document"
-          renderAsk={(ask) => <AskCard ask={ask} run={run} />}
+          renderAsk={renderAsk}
           messageActions={messageActions}
           scrollControls={scroll}
           renderMode={mode}
@@ -305,12 +302,11 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
       <AcceptCelebration status={run.status} />
 
       {/* The drill-down for whichever Agents-dock row was clicked. Rendered outside the dock
-          so the sheet's portal is not affected by the dock's collapse state — but inside its
-          own card cache (module-level and run-keyed, so this is the SAME store the thread
-          uses), or tool cards expanded in the sheet would forget that on reopen. */}
+          so the sheet's portal is not affected by the dock's collapse state. SessionTranscript
+          owns the shared run-keyed card cache, so expanded sheet cards survive a reopen. */}
       <SubagentSheet
         runId={run.id}
-        renderAsk={(ask) => <AskCard ask={ask} run={run} />}
+        renderAsk={renderAsk}
         agent={openAgent}
         entries={openAgentChildren}
         onClose={() => setOpenAgentId(undefined)}

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -25,15 +25,6 @@ import { taskIssueUrl, taskPrUrl } from '@/lib/tasks-table'
 import { cn, isHttpUrl } from '@/lib/utils'
 
 import {
-  AssistantMessage,
-  ContextGroup,
-  ImageItem,
-  NoteLine,
-  ProviderAuthRequiredCard,
-  ReasoningItem,
-  ToolCard,
-  ToolStreak,
-  UserBubble,
   WorkingIndicator,
 } from './thread-items'
 import { useContinueAction } from './follow-up-engine'
@@ -44,20 +35,23 @@ import { SubagentSheet } from './subagent-sheet'
 import { AcceptCelebration, ReviewPanel } from './review-panel'
 import { queuePosition } from './run-actions'
 import { RunHeader } from './run-header'
-import { AskCard } from './ask-card'
 import { useRunRecordReconcile } from './run-reconcile'
 import { useActiveProviderAvailability } from './active-provider'
-import { groupThreadItems, type ThreadBlock } from './thread-groups'
 import { ThreadLoading } from './thread-loading'
-import { ThreadCardCache } from './thread-open-cards'
 import { threadRenderMode } from './thread-scroll'
-import { JumpToLatestPill, ThreadRows, useThreadScroll, type ThreadRow } from './thread-scroller'
+import { JumpToLatestPill, useThreadScroll } from './thread-scroller'
+import {
+  SessionTranscript,
+  buildTranscriptRows,
+  mainTranscriptSections,
+  type TranscriptMessageActions,
+  type TranscriptRowModel,
+} from './session-transcript'
 import {
   latestPlanEntries,
   reduceThread,
   threadFilePaths,
   threadFooter,
-  type ThreadEntry,
   type ThreadState,
 } from './thread-state'
 
@@ -125,62 +119,9 @@ export function buildThreadRows(
     onEditMessage: (msgId: string, text: string) => Promise<void>
     onRemoveMessage: (msgId: string) => Promise<void>
   },
-): ThreadRow[] {
-  const rows: ThreadRow[] = []
-  // The initial prompt: the engine writes no v1 `user-message` line for it — the task on
-  // the run record IS that message, so it renders from there, not from an invented event.
-  if (run.task)
-    rows.push({
-      key: 'task',
-      node: (
-        <UserBubble
-          text={run.task}
-          images={run.taskImages ?? []}
-          // Editable but never removable: a run with no prompt is not a run.
-          onEdit={edit ? edit.onEditTask : undefined}
-          editLabel="Edit the prompt"
-        />
-      ),
-    })
-  // Messages stacked onto the run while it waits for a slot (#472). Same provenance as the
-  // task bubble — they live on the record, not in the event stream, and the engine writes no
-  // `user-message` line for them (they are folded into the prompt, not sent as turns). So
-  // rendering them here is what keeps the thread showing exactly one bubble per authored
-  // message, before the run starts and after.
-  for (const message of run.queuedMessages ?? []) {
-    rows.push({
-      key: `queued:${message.id}`,
-      node: (
-        <UserBubble
-          text={message.text}
-          images={message.images ?? []}
-          onEdit={edit ? (text) => edit.onEditMessage(message.id, text) : undefined}
-          onRemove={edit ? () => edit.onRemoveMessage(message.id) : undefined}
-        />
-      ),
-    })
-  }
-  for (const turn of thread.turns) {
-    if (turn.userMessage) {
-      rows.push({
-        key: `${turn.id}:user`,
-        node: (
-          <UserBubble
-            text={turn.userMessage.text}
-            imageCount={turn.userMessage.imageCount}
-            images={turn.userMessage.images}
-          />
-        ),
-      })
-    }
-    for (const block of groupThreadItems(turn.items)) {
-      rows.push({
-        key: `${turn.id}:${block.id}`,
-        node: <ThreadBlockView block={block} scope={turn.id} run={run} />,
-      })
-    }
-  }
-  return rows
+): TranscriptRowModel[] {
+  void edit
+  return buildTranscriptRows(mainTranscriptSections(run, thread), run.id)
 }
 
 /** The loaded thread. The header owns its own data hooks (mutations, the runs list); the
@@ -273,13 +214,27 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
     [queued, patchRunAsync, editQueuedAsync, removeQueuedAsync],
   )
 
-  const rows = useMemo(() => buildThreadRows(run, thread, edit), [run, thread, edit])
+  const sections = useMemo(() => mainTranscriptSections(run, thread), [run, thread])
+  const rows = useMemo(() => buildTranscriptRows(sections, run.id), [sections, run.id])
+  const messageActions = useMemo<Readonly<Record<string, TranscriptMessageActions>> | undefined>(() => {
+    if (edit === undefined) return undefined
+    const actions: Record<string, TranscriptMessageActions> = {
+      task: { onEdit: edit.onEditTask, editLabel: 'Edit the prompt' },
+    }
+    for (const message of run.queuedMessages ?? []) {
+      actions[`queued:${message.id}`] = {
+        onEdit: (text) => edit.onEditMessage(message.id, text),
+        onRemove: () => edit.onRemoveMessage(message.id),
+      }
+    }
+    return actions
+  }, [edit, run.queuedMessages])
   // #526: the footer's issue link may be synthesized from the CEZ:ISSUE marker, and the only
   // repository it may ever name is the one on screen — never the transcript's.
   const issueUrl = taskIssueUrl(run, useProjectRepoBase())
   const { search } = useLocation()
   const mode = threadRenderMode(search, rows.length)
-  const scroll = useThreadScroll(run.id)
+  const scroll = useThreadScroll(`${run.id}:main`)
   // The iOS keyboard lifts the dock via `--kb`; once it settles, a pinned reader re-pins
   // (research §7: re-run scrollToEnd after the viewport settles).
   useKeyboardInsetVar(scroll.restickIfStuck)
@@ -291,9 +246,16 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
       {/* Row spacing lives on each thread row (pb-2.5, both render modes measure alike);
           this gap only separates the sections — rows, empty state, footer, review panel. */}
       <div className="mx-auto flex w-full max-w-[var(--measure)] flex-1 flex-col gap-3.5 px-4 py-5 md:px-6">
-        <ThreadCardCache runId={run.id}>
-          <ThreadRows runId={run.id} rows={rows} mode={mode} controls={scroll} />
-        </ThreadCardCache>
+        <SessionTranscript
+          runId={run.id}
+          viewId="main"
+          sections={sections}
+          mode="document"
+          run={run}
+          messageActions={messageActions}
+          scrollControls={scroll}
+          renderMode={mode}
+        />
 
         {thread.turns.length === 0 ? (
           run.status === 'queued' ? (
@@ -363,13 +325,13 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
           so the sheet's portal is not affected by the dock's collapse state — but inside its
           own card cache (module-level and run-keyed, so this is the SAME store the thread
           uses), or tool cards expanded in the sheet would forget that on reopen. */}
-      <ThreadCardCache runId={run.id}>
-        <SubagentSheet
-          agent={openAgent}
-          entries={openAgentChildren}
-          onClose={() => setOpenAgentId(undefined)}
-        />
-      </ThreadCardCache>
+      <SubagentSheet
+        runId={run.id}
+        run={run}
+        agent={openAgent}
+        entries={openAgentChildren}
+        onClose={() => setOpenAgentId(undefined)}
+      />
 
       {/* The dock region (mockup `.dock`): plan dock, paused hint, then the composer.
           `bottom: var(--kb)` is the iOS keyboard lift — 0 until the visualViewport watcher
@@ -473,51 +435,4 @@ function QueuedPlaceholder({ run }: { run: ApiRun }) {
       </p>
     </div>
   )
-}
-
-/** One grouped block → its surface. Grouping (context groups, streaks, sub-agent nesting) is
- *  `groupThreadItems`'s — this only maps block kinds to components. `scope` (the turn's render
- *  key) namespaces the open-card cache keys, because item ids repeat across sessions. */
-function ThreadBlockView({ block, scope, run }: { block: ThreadBlock; scope: string; run: ApiRun }) {
-  switch (block.kind) {
-    case 'entry':
-      return <ThreadEntryView entry={block.entry} scope={scope} run={run} />
-    case 'tool-card':
-      return <ToolCard item={block.item} nested={block.children} cacheKey={`${scope}:${block.id}`} />
-    case 'context-group':
-      return <ContextGroup group={block} scope={scope} />
-    case 'streak':
-      return (
-        <ToolStreak count={block.count}>
-          {block.blocks.map((inner) => (
-            <ThreadBlockView key={inner.id} block={inner} scope={scope} run={run} />
-          ))}
-        </ToolStreak>
-      )
-  }
-}
-
-/** One reducer entry → its block (non-tool entries; tools always arrive as tool-card blocks). */
-function ThreadEntryView({ entry, scope, run }: { entry: ThreadEntry; scope: string; run: ApiRun }) {
-  switch (entry.kind) {
-    case 'message':
-      // Agent-side user echoes (some backends emit them) read as user bubbles too.
-      return entry.role === 'assistant' ? (
-        <AssistantMessage text={entry.text} />
-      ) : (
-        <UserBubble text={entry.text} />
-      )
-    case 'reasoning':
-      return <ReasoningItem text={entry.text} />
-    case 'tool':
-      return <ToolCard item={entry} cacheKey={`${scope}:${entry.id}`} />
-    case 'note':
-      return <NoteLine note={entry} />
-    case 'image':
-      return <ImageItem image={entry} />
-    case 'ask':
-      return <AskCard ask={entry} run={run} />
-    case 'provider-auth-required':
-      return <ProviderAuthRequiredCard incident={entry} />
-  }
 }

--- a/packages/web/src/routes/task-thread/thread-items.test.tsx
+++ b/packages/web/src/routes/task-thread/thread-items.test.tsx
@@ -21,6 +21,7 @@ import {
   ToolStreak,
 } from './thread-items'
 import { reduceThread } from './thread-state'
+import { SessionTranscript } from './session-transcript'
 
 afterEach(cleanup)
 
@@ -286,7 +287,14 @@ describe('sub-agent nesting (golden subagent-task fixture, end to end through th
     const blocks = groupThreadItems(turns[0]!.items)
     const task = blocks.find((b) => b.kind === 'tool-card')
     if (task?.kind !== 'tool-card') throw new Error('expected the Task card')
-    render(<ToolCard item={task.item} nested={task.children} />)
+    render(
+      <SessionTranscript
+        runId="r1"
+        viewId="main"
+        sections={[{ id: 'turn-1', entries: turns[0]!.items }]}
+        mode="document"
+      />,
+    )
 
     const button = screen.getByRole('button', { name: /Task/ })
     expect((button as HTMLButtonElement).disabled).toBe(false) // nested children ARE detail — the card is not locked

--- a/packages/web/src/routes/task-thread/thread-items.tsx
+++ b/packages/web/src/routes/task-thread/thread-items.tsx
@@ -490,10 +490,12 @@ export function ToolCard({
   item,
   nested = [],
   cacheKey,
+  renderNested,
 }: {
   item: UiToolItem
-  nested?: ThreadEntry[]
+  nested?: readonly ThreadEntry[]
   cacheKey?: string
+  renderNested?: (entries: readonly ThreadEntry[], scope: string) => ReactNode
 }) {
   const cache = useThreadCardCache()
   const [userOpen, setUserOpenState] = useState<boolean | null>(
@@ -583,40 +585,13 @@ export function ToolCard({
           ) : null}
           {nested.length > 0 ? (
             <div data-slot="tool-nested" className="flex flex-col gap-2 border-l-2 border-border py-2.5 pr-3 pl-3 ml-4 my-2">
-              {nested.map((entry) => (
-                <NestedEntry key={entry.id} entry={entry} scope={cacheKey} />
-              ))}
+              {renderNested?.(nested, cacheKey ?? item.id)}
             </div>
           ) : null}
         </div>
       </CollapsibleContent>
     </Collapsible>
   )
-}
-
-/** A sub-agent entry inside a Task card — one level deep by design, so nested tools render
- *  without their own children. `scope` is the parent card's cache key, extended per child.
- *
- *  Exported for the sub-agent sheet (#474), which renders the SAME child entries in a focused
- *  panel: the drill-down must look like the inline nesting, not like a second renderer that
- *  drifts from it. */
-export function NestedEntry({ entry, scope }: { entry: ThreadEntry; scope?: string }) {
-  switch (entry.kind) {
-    case 'message':
-      return <AssistantMessage text={entry.text} />
-    case 'reasoning':
-      return <ReasoningItem text={entry.text} />
-    case 'tool':
-      return <ToolCard item={entry} cacheKey={scope !== undefined ? `${scope}:${entry.id}` : undefined} />
-    case 'note':
-      return <NoteLine note={entry} />
-    case 'image':
-      return <ImageItem image={entry} />
-    case 'ask':
-      // AskUser cards are always top-level turn entries (#473) — they never nest
-      // under a tool group, so there is nothing to render here.
-      return null
-  }
 }
 
 /** "Explored N files · M searches" — consecutive finished read/search tools, one row,

--- a/packages/web/src/routes/task-thread/thread-scroll.ts
+++ b/packages/web/src/routes/task-thread/thread-scroll.ts
@@ -51,7 +51,7 @@ export interface ScrollMemory {
   atBottom: boolean
 }
 
-/** Scroll positions per run id — module-level on purpose (the PlanDock collapse-memory
+/** Scroll positions per run/view key — module-level on purpose (the PlanDock collapse-memory
  *  pattern): survives route changes for the browser session, gone on reload, no server state. */
 const scrollByRun = new Map<string, ScrollMemory>()
 
@@ -64,7 +64,7 @@ export function readThreadScroll(runId: string): ScrollMemory | undefined {
 }
 
 /** virtua's per-session measurement cache (research §5: "per-session measurement cache"),
- *  keyed by run id: revisiting a virtualized thread restores measured row heights instead of
+ *  keyed by run/view: revisiting a virtualized thread restores measured row heights instead of
  *  re-estimating, so the restored scroll offset lands on the same content. The snapshot is
  *  opaque, so the row count it was taken at rides along — virtua's documented caveat is that
  *  a snapshot only fits the same item count, and a mid-replay remount must degrade to

--- a/packages/web/src/routes/task-thread/thread-scroller.tsx
+++ b/packages/web/src/routes/task-thread/thread-scroller.tsx
@@ -53,7 +53,7 @@ export interface ThreadScrollControls {
 }
 
 /**
- * Stick-to-bottom, the jump pill, and the per-run scroll cache (spec §"Task thread").
+ * Stick-to-bottom, the jump pill, and the per-view scroll cache (spec §"Task thread").
  *
  *  - While content grows, stay pinned to the bottom ONLY while the reader is within
  *    {@link NEAR_BOTTOM_SLACK_PX} of it; the moment they scroll up, growth stops moving them
@@ -62,7 +62,10 @@ export interface ThreadScrollControls {
  *    including through the SSE replay, which re-grows the content after mount: the desired
  *    offset is re-applied on every growth until it is reachable or the user scrolls.
  */
-export function useThreadScroll(runId: string): ThreadScrollControls {
+export function useThreadScroll(
+  viewKey: string,
+  surface: 'document' | 'panel' = 'document',
+): ThreadScrollControls {
   const scrollElRef = useRef<HTMLElement | null>(null)
   // State, not a ref: crossing the virtualization threshold mid-replay REPLACES the rows
   // container, and the observers below must re-subscribe to the new element.
@@ -72,15 +75,19 @@ export function useThreadScroll(runId: string): ThreadScrollControls {
   const stuckRef = useRef(true)
   /** A cached offset not yet reachable (content still replaying). Cleared by user intent. */
   const pendingRestoreRef = useRef<number | null>(null)
-  /** Arrival (cache restore / land at tail) happens once per run, not once per container. */
+  /** Arrival (cache restore / land at tail) happens once per view, not once per container. */
   const arrivedForRef = useRef<string | null>(null)
   /** virtua's handle while virtualized (VirtualRows fills it), null in flat mode. */
   const virtualizerRef = useRef<VirtualizerHandle | null>(null)
 
   const attachContent = useCallback((el: HTMLElement | null) => {
     setContentEl(el)
-    if (el) scrollElRef.current = el.closest<HTMLElement>('[data-slot="main"]')
-  }, [])
+    if (el) {
+      scrollElRef.current = el.closest<HTMLElement>(
+        surface === 'panel' ? '[data-slot="transcript-viewport"]' : '[data-slot="main"]',
+      )
+    }
+  }, [surface])
 
   // EVERY programmatic scroll goes through virtua's handle when virtualized. A raw
   // `scrollTop` write races virtua's own jump compensation (it also writes scrollTop, from
@@ -118,9 +125,9 @@ export function useThreadScroll(runId: string): ThreadScrollControls {
 
     // Arrival: cached position if the reader had one away from the tail, else the tail.
     // Once per run — a container swap (threshold crossing) re-subscribes without re-arriving.
-    if (arrivedForRef.current !== runId) {
-      arrivedForRef.current = runId
-      const memory = readThreadScroll(runId)
+    if (arrivedForRef.current !== viewKey) {
+      arrivedForRef.current = viewKey
+      const memory = readThreadScroll(viewKey)
       if (memory && !memory.atBottom) {
         stuckRef.current = false
         pendingRestoreRef.current = memory.top
@@ -191,7 +198,7 @@ export function useThreadScroll(runId: string): ThreadScrollControls {
       // …and no overwriting the memory being restored, either — leaving again mid-restore
       // must find the parked position, not a replay artifact.
       if (pendingRestoreRef.current === null) {
-        saveThreadScroll(runId, { top: scroller.scrollTop, atBottom: near })
+        saveThreadScroll(viewKey, { top: scroller.scrollTop, atBottom: near })
       }
     }
     scroller.addEventListener('scroll', onScroll, { passive: true })
@@ -228,7 +235,7 @@ export function useThreadScroll(runId: string): ThreadScrollControls {
       scroller.removeEventListener('keydown', onKey)
       observer?.disconnect()
     }
-  }, [runId, contentEl, setOffset, toBottom])
+  }, [viewKey, contentEl, setOffset, toBottom])
 
   return { attachContent, scrollElRef, virtualizerRef, pillVisible, jumpToLatest, restickIfStuck }
 }

--- a/packages/web/src/routes/task-thread/thread-scroller.tsx
+++ b/packages/web/src/routes/task-thread/thread-scroller.tsx
@@ -124,7 +124,7 @@ export function useThreadScroll(
     if (!scroller || !content) return
 
     // Arrival: cached position if the reader had one away from the tail, else the tail.
-    // Once per run — a container swap (threshold crossing) re-subscribes without re-arriving.
+    // Once per view — a container swap (threshold crossing) re-subscribes without re-arriving.
     if (arrivedForRef.current !== viewKey) {
       arrivedForRef.current = viewKey
       const memory = readThreadScroll(viewKey)


### PR DESCRIPTION
## Summary

- extract a backend-neutral `SessionTranscript` with one exhaustive renderer for main and sub-agent sessions
- migrate the task thread and sub-agent sheet onto the shared viewport, grouping, card-cache, scrolling, and virtualization behavior
- add reducer/component parity coverage plus long-panel overflow, detachment, and jump-to-latest regression coverage

## Validation

- `npm run typecheck`
- `npm test` — 283 files, 4979 tests
- `npm run test:unit` — 36 tests
- `npm run build` — package check: 433 files, 88 web assets
- `npm run test:package` — 12 tests
- `npm run test:e2e` — repository harness reported `TEST_E2E_STATUS=skipped` because the browser provider could not launch; manual UI evidence remains required

Tracking plan: .ai/runs/2026-07-31-shared-session-renderer.md
Source doc: .ai/specs/2026-07-21-shared-session-renderer.md

Refs #580
Closes #557

Status: complete
