### PR TITLE
fix(ask): resume answers through idle teardown

### DIFF
--- a/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
+++ b/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
@@ -41,8 +41,8 @@ Make a structured question's option chips reliably resume an agent session after
 
 ### Phase 1: Reliable answer delivery
 
-- [ ] 1.1 Synchronize with idle-session teardown.
-- [ ] 1.2 Lock in the race behavior.
+- [x] 1.1 Synchronize with idle-session teardown. — bc25262c
+- [x] 1.2 Lock in the race behavior. — bc25262c
 
 ### Phase 2: Behavioral documentation
 

--- a/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
+++ b/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
@@ -37,12 +37,14 @@ Make a structured question's option chips reliably resume an agent session after
 
 ## Progress
 
+PR: #758
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Reliable answer delivery
 
-- [x] 1.1 Synchronize with idle-session teardown. — bc25262c
-- [x] 1.2 Lock in the race behavior. — bc25262c
+- [x] 1.1 Synchronize with idle-session teardown. — bc25262c, ed987425
+- [x] 1.2 Lock in the race behavior. — bc25262c, ed987425
 
 ### Phase 2: Behavioral documentation
 

--- a/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
+++ b/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
@@ -46,4 +46,4 @@ Make a structured question's option chips reliably resume an agent session after
 
 ### Phase 2: Behavioral documentation
 
-- [ ] 2.1 Document the teardown transition.
+- [x] 2.1 Document the teardown transition. — 29d4b2fa

--- a/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
+++ b/.ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
@@ -1,0 +1,49 @@
+# Resume interactive answers after inactivity
+
+## Goal
+
+Make a structured question's option chips reliably resume an agent session after the inactivity timer closes it, including the short teardown interval where the cockpit still has a `waiting` record and the server still considers the old run active.
+
+## Scope
+
+- Keep the existing live-message and closed-session continuation seams.
+- Add bounded synchronization for the specific `409 run is still active` teardown response before retrying the same continuation.
+- Keep one answer delivery in flight across that retry window so repeated clicks cannot start duplicate continuations.
+- Add focused cockpit regression coverage and update the AskUser behavior specification.
+
+## Non-goals
+
+- No HTTP route, contract, persisted run schema, or agent protocol changes.
+- No generic retry policy for mutations or unrelated `409` responses.
+- No provider fallback or runner-switch behavior changes.
+- No changes to the inactivity timeout duration or server session lifecycle.
+
+## Implementation Plan
+
+### Phase 1: Reliable answer delivery
+
+- **Step 1.1 — Synchronize with idle-session teardown.** Update the AskUser delivery hook to retry only a continuation refused because the previous run is still active, use a bounded delay, surface every other error unchanged, and hold a single-flight guard across the complete operation.
+- **Step 1.2 — Lock in the race behavior.** Extend focused AskUser tests to reproduce `POST /messages` returning `session closed`, the first `POST /continue` returning `run is still active`, and the later continuation succeeding without duplicate delivery; also pin the bounded/non-retry cases.
+
+### Phase 2: Behavioral documentation
+
+- **Step 2.1 — Document the teardown transition.** Amend the AskUser specification's closed-session edge case to explain that the client briefly waits and retries only while the old engine is settling.
+
+## Risks
+
+- A broad `409` retry could hide real provider or session errors. Mitigation: match the existing `ApiError` status and exact transient server message, and test that other refusals pass through immediately.
+- The retry delay creates a window for duplicate clicks. Mitigation: keep a hook-owned single-flight flag from the first message attempt through the final continuation result.
+- Teardown could exceed the bounded retry window on an unusually slow worktree. Mitigation: retain the last server error visibly on the card so the action is recoverable instead of silently dropped.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Reliable answer delivery
+
+- [ ] 1.1 Synchronize with idle-session teardown.
+- [ ] 1.2 Lock in the race behavior.
+
+### Phase 2: Behavioral documentation
+
+- [ ] 2.1 Document the teardown transition.

--- a/.ai/specs/2026-07-18-askuser-across-runners.md
+++ b/.ai/specs/2026-07-18-askuser-across-runners.md
@@ -237,7 +237,12 @@ are real buttons (keyboard/enter, focus ring `--ring`), the card has
   continuation appends it as a `user-message`, which is what resolves the card, so
   the resumed and live paths agree. A closed run that never recorded a session has
   nothing to reopen and says so; a `409` from the live path (a cockpit whose record
-  is stale) is retried as a resume rather than dropped. The original design
+  is stale) is retried as a resume rather than dropped. Idle shutdown has a brief
+  teardown interval where `/messages` already reports `session closed` but the old
+  run still occupies the RunManager's active map; during that interval the ask card
+  keeps the answer single-flight and retries only the exact transient
+  `409 run is still active` continuation refusal for a bounded period. Other
+  continuation failures surface immediately on the card. The original design
   ("the card renders resolved/closed") left a card whose chips silently failed —
   every tap posted to `POST /messages` and died on its `409 session closed`.
 - **Reload / resume of a run parked on an ask** → the card is reconstructed from

--- a/.ai/specs/2026-07-18-askuser-across-runners.md
+++ b/.ai/specs/2026-07-18-askuser-across-runners.md
@@ -241,7 +241,8 @@ are real buttons (keyboard/enter, focus ring `--ring`), the card has
   teardown interval where `/messages` already reports `session closed` but the old
   run still occupies the RunManager's active map; during that interval the ask card
   keeps the answer single-flight and retries only the exact transient
-  `409 run is still active` continuation refusal for a bounded period. Other
+  `409 run is still active` continuation refusal with bounded, capped exponential
+  backoff for roughly five seconds. Other
   continuation failures surface immediately on the card. The original design
   ("the card renders resolved/closed") left a card whose chips silently failed —
   every tap posted to `POST /messages` and died on its `409 session closed`.

--- a/packages/web/src/routes/task-thread/ask-answer.test.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { RunRecord, RunStatus, StepState } from '@open-mercato/cezar-api-client'
 
-import { askDeliveryMode } from './ask-answer'
+import { ApiError } from '@/api/client'
+import {
+  askDeliveryMode,
+  IDLE_TEARDOWN_RETRY_LIMIT,
+  resumeAfterIdleTeardown,
+} from './ask-answer'
 
 const step = (extra: Partial<StepState> = {}): StepState => ({
   id: 'task',
@@ -57,5 +62,41 @@ describe('askDeliveryMode — where an ask answer goes, per run status', () => {
 
   it('an archived run is still answerable — archiving hides a run, it does not close the question', () => {
     expect(askDeliveryMode(run('done', { archived: true }))).toBe('resume')
+  })
+})
+
+describe('resumeAfterIdleTeardown', () => {
+  it('waits through the exact active-run teardown refusal, then returns the continuation result', async () => {
+    const resume = vi.fn()
+      .mockRejectedValueOnce(new ApiError(409, 'run is still active'))
+      .mockResolvedValueOnce({ continued: true })
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(resumeAfterIdleTeardown(resume, wait)).resolves.toEqual({ continued: true })
+    expect(resume).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    new ApiError(409, 'no agent session to resume'),
+    new ApiError(409, 'cannot continue a waiting run'),
+    new ApiError(0, 'cannot reach the cezar server'),
+  ])('does not retry a non-transitional refusal: %s', async (error) => {
+    const resume = vi.fn().mockRejectedValue(error)
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(resumeAfterIdleTeardown(resume, wait)).rejects.toBe(error)
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(wait).not.toHaveBeenCalled()
+  })
+
+  it('stops after the bounded retry window and preserves the server error', async () => {
+    const error = new ApiError(409, 'run is still active')
+    const resume = vi.fn().mockRejectedValue(error)
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(resumeAfterIdleTeardown(resume, wait)).rejects.toBe(error)
+    expect(resume).toHaveBeenCalledTimes(IDLE_TEARDOWN_RETRY_LIMIT + 1)
+    expect(wait).toHaveBeenCalledTimes(IDLE_TEARDOWN_RETRY_LIMIT)
   })
 })

--- a/packages/web/src/routes/task-thread/ask-answer.test.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.test.ts
@@ -5,7 +5,7 @@ import type { RunRecord, RunStatus, StepState } from '@open-mercato/cezar-api-cl
 import { ApiError } from '@/api/client'
 import {
   askDeliveryMode,
-  IDLE_TEARDOWN_RETRY_LIMIT,
+  IDLE_TEARDOWN_RETRY_DELAYS_MS,
   resumeAfterIdleTeardown,
 } from './ask-answer'
 
@@ -75,6 +75,7 @@ describe('resumeAfterIdleTeardown', () => {
     await expect(resumeAfterIdleTeardown(resume, wait)).resolves.toEqual({ continued: true })
     expect(resume).toHaveBeenCalledTimes(2)
     expect(wait).toHaveBeenCalledTimes(1)
+    expect(wait).toHaveBeenCalledWith(IDLE_TEARDOWN_RETRY_DELAYS_MS[0])
   })
 
   it.each([
@@ -96,7 +97,8 @@ describe('resumeAfterIdleTeardown', () => {
     const wait = vi.fn().mockResolvedValue(undefined)
 
     await expect(resumeAfterIdleTeardown(resume, wait)).rejects.toBe(error)
-    expect(resume).toHaveBeenCalledTimes(IDLE_TEARDOWN_RETRY_LIMIT + 1)
-    expect(wait).toHaveBeenCalledTimes(IDLE_TEARDOWN_RETRY_LIMIT)
+    expect(resume).toHaveBeenCalledTimes(IDLE_TEARDOWN_RETRY_DELAYS_MS.length + 1)
+    expect(wait).toHaveBeenCalledTimes(IDLE_TEARDOWN_RETRY_DELAYS_MS.length)
+    expect(wait.mock.calls.map(([delayMs]) => delayMs)).toEqual(IDLE_TEARDOWN_RETRY_DELAYS_MS)
   })
 })

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -33,11 +33,10 @@ export type AskBlockedReason = 'provider' | 'no-session'
  *  the run record and releasing its active-run entry. A stale ask card can therefore
  *  learn that `/messages` is closed, then reach `/continue` a few milliseconds too
  *  early. Retry only that exact transitional refusal; every other 409 is actionable. */
-export const IDLE_TEARDOWN_RETRY_DELAY_MS = 100
-export const IDLE_TEARDOWN_RETRY_LIMIT = 50
+export const IDLE_TEARDOWN_RETRY_DELAYS_MS = [50, 100, 200, 400, 800, 1_000, 1_000, 1_000, 1_000] as const
 
-const delayIdleTeardownRetry = () =>
-  new Promise<void>((resolve) => setTimeout(resolve, IDLE_TEARDOWN_RETRY_DELAY_MS))
+const delayIdleTeardownRetry = (delayMs: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, delayMs))
 
 function isIdleTeardownRefusal(error: unknown): error is ApiError {
   return error instanceof ApiError && error.status === 409 && error.message === 'run is still active'
@@ -47,14 +46,15 @@ function isIdleTeardownRefusal(error: unknown): error is ApiError {
  *  The injected wait keeps the bounded policy deterministic in unit tests. */
 export async function resumeAfterIdleTeardown<T>(
   resume: () => Promise<T>,
-  wait: () => Promise<void> = delayIdleTeardownRetry,
+  wait: (delayMs: number) => Promise<void> = delayIdleTeardownRetry,
 ): Promise<T> {
   for (let retries = 0; ; retries += 1) {
     try {
       return await resume()
     } catch (error) {
-      if (!isIdleTeardownRefusal(error) || retries >= IDLE_TEARDOWN_RETRY_LIMIT) throw error
-      await wait()
+      const delayMs = IDLE_TEARDOWN_RETRY_DELAYS_MS[retries]
+      if (!isIdleTeardownRefusal(error) || delayMs === undefined) throw error
+      await wait(delayMs)
     }
   }
 }

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { ApiError } from '@/api/client'
 import { useContinueRun, useSendMessage } from '@/api/queries'
@@ -28,6 +28,36 @@ export type AskDeliveryMode = 'live' | 'resume' | 'unavailable'
 /** Why an answer cannot be delivered right now — `provider` is recoverable from
  *  Settings, `no-session` is terminal for this run. */
 export type AskBlockedReason = 'provider' | 'no-session'
+
+/** The idle timer closes the backend before the RunManager has finished settling
+ *  the run record and releasing its active-run entry. A stale ask card can therefore
+ *  learn that `/messages` is closed, then reach `/continue` a few milliseconds too
+ *  early. Retry only that exact transitional refusal; every other 409 is actionable. */
+export const IDLE_TEARDOWN_RETRY_DELAY_MS = 100
+export const IDLE_TEARDOWN_RETRY_LIMIT = 50
+
+const delayIdleTeardownRetry = () =>
+  new Promise<void>((resolve) => setTimeout(resolve, IDLE_TEARDOWN_RETRY_DELAY_MS))
+
+function isIdleTeardownRefusal(error: unknown): error is ApiError {
+  return error instanceof ApiError && error.status === 409 && error.message === 'run is still active'
+}
+
+/** Reopen once the old idle-closed session has left the RunManager's active map.
+ *  The injected wait keeps the bounded policy deterministic in unit tests. */
+export async function resumeAfterIdleTeardown<T>(
+  resume: () => Promise<T>,
+  wait: () => Promise<void> = delayIdleTeardownRetry,
+): Promise<T> {
+  for (let retries = 0; ; retries += 1) {
+    try {
+      return await resume()
+    } catch (error) {
+      if (!isIdleTeardownRefusal(error) || retries >= IDLE_TEARDOWN_RETRY_LIMIT) throw error
+      await wait()
+    }
+  }
+}
 
 /**
  * The delivery route for one ask answer, as a pure function of the run record — the
@@ -75,6 +105,8 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
   const activeProvider = useActiveProviderAvailability(run)
   const existingProvider = useExistingProviderAvailability(run)
   const [error, setError] = useState<string | undefined>(undefined)
+  const [delivering, setDelivering] = useState(false)
+  const deliveringRef = useRef(false)
 
   const mode = askDeliveryMode(run)
   const providerBlocked =
@@ -104,32 +136,36 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
   const send = async (text: string): Promise<void> => {
     // Defense in depth — every entry point is already disabled while blocked, and the card
     // renders `reason` on its own, so repeating it as an error would say the same thing twice.
-    if (blockedBy) return
+    if (blockedBy || deliveringRef.current) return
+    deliveringRef.current = true
+    setDelivering(true)
     setError(undefined)
-    if (mode === 'resume') {
-      try {
-        await resumeWith(text)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
-      }
-      return
-    }
     try {
-      await sendMessage.mutateAsync({ text })
-    } catch (err) {
-      // The cached record said "live" but the session had already closed — resume instead
-      // of dropping the answer the user just gave. Only ever from the live path: a resume
-      // that answers 409 has already been refused on its own terms.
-      if (err instanceof ApiError && err.status === 409 && lastSessionId(run) !== undefined) {
-        try {
-          await resumeWith(text)
-          return
-        } catch (resumeErr) {
-          setError(resumeErr instanceof Error ? resumeErr.message : String(resumeErr))
+      if (mode === 'resume') {
+        await resumeAfterIdleTeardown(() => resumeWith(text))
+        return
+      }
+      try {
+        await sendMessage.mutateAsync({ text })
+      } catch (sendError) {
+        // The cached record said "live" but the session had already closed — resume instead
+        // of dropping the answer the user just gave. The old session can still be settling
+        // after the message 409, so the continuation helper owns that narrow retry window.
+        if (
+          sendError instanceof ApiError &&
+          sendError.status === 409 &&
+          lastSessionId(run) !== undefined
+        ) {
+          await resumeAfterIdleTeardown(() => resumeWith(text))
           return
         }
+        throw sendError
       }
+    } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      deliveringRef.current = false
+      setDelivering(false)
     }
   }
 
@@ -137,7 +173,7 @@ export function useAskAnswer(run: ApiRun): AskAnswerDelivery {
     mode,
     blockedBy,
     reason,
-    isPending: sendMessage.isPending || resume.isPending,
+    isPending: delivering || sendMessage.isPending || resume.isPending,
     error,
     send,
   }

--- a/packages/web/src/routes/task-thread/ask-card.test.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.test.tsx
@@ -243,9 +243,13 @@ describe('AskCard — answering after the session has ended', () => {
 
   it('waits for idle teardown before retrying the continuation, without accepting a duplicate tap', async () => {
     mutateAsync.mockRejectedValueOnce(new ApiError(409, 'session closed'))
+    let resolveContinuation: ((value: { continued: true }) => void) | undefined
+    const continuation = new Promise<{ continued: true }>((resolve) => {
+      resolveContinuation = resolve
+    })
     continueAsync
       .mockRejectedValueOnce(new ApiError(409, 'run is still active'))
-      .mockResolvedValueOnce({ continued: true })
+      .mockReturnValueOnce(continuation)
     renderAsk(singleAsk, { ...activeRun, steps: [step({ sessionId: 'sess-1' })] })
 
     const option = screen.getByRole('button', { name: /date-fns/ })
@@ -258,6 +262,8 @@ describe('AskCard — answering after the session has ended', () => {
     expect(continueAsync).toHaveBeenNthCalledWith(1, { text: 'Library: date-fns' })
     expect(continueAsync).toHaveBeenNthCalledWith(2, { text: 'Library: date-fns' })
     expect(mutateAsync).toHaveBeenCalledTimes(1)
+    resolveContinuation?.({ continued: true })
+    await waitFor(() => expect((option as HTMLButtonElement).disabled).toBe(false))
     expect(screen.queryByRole('alert')).toBeNull()
   })
 

--- a/packages/web/src/routes/task-thread/ask-card.test.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.test.tsx
@@ -241,6 +241,26 @@ describe('AskCard — answering after the session has ended', () => {
     expect(screen.queryByRole('alert')).toBeNull()
   })
 
+  it('waits for idle teardown before retrying the continuation, without accepting a duplicate tap', async () => {
+    mutateAsync.mockRejectedValueOnce(new ApiError(409, 'session closed'))
+    continueAsync
+      .mockRejectedValueOnce(new ApiError(409, 'run is still active'))
+      .mockResolvedValueOnce({ continued: true })
+    renderAsk(singleAsk, { ...activeRun, steps: [step({ sessionId: 'sess-1' })] })
+
+    const option = screen.getByRole('button', { name: /date-fns/ })
+    fireEvent.click(option)
+    await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(1))
+    expect((option as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(option)
+
+    await waitFor(() => expect(continueAsync).toHaveBeenCalledTimes(2))
+    expect(continueAsync).toHaveBeenNthCalledWith(1, { text: 'Library: date-fns' })
+    expect(continueAsync).toHaveBeenNthCalledWith(2, { text: 'Library: date-fns' })
+    expect(mutateAsync).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
   it('does not silently switch to another connected provider when the run provider is unavailable', () => {
     providerStatus = {
       providers: [


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-31-resume-interactive-answers-after-inactivity.md
Status: complete

## 🎯 Goal
- Make structured-question option chips reliably resume the agent after inactivity closes its session, so clicking an answer behaves like typing the same answer into the continuation composer.

## 🔍 Problem
An unanswered `CEZ:ASK` card sometimes remained visible after the inactivity timer closed the underlying session, but clicking an option did not resume the run. Typing a reply into the composer after the same timeout did resume it.

## 🔍 Root Cause
The existing stale-card fallback correctly changed from `POST /messages` to `POST /continue` after receiving `409 session closed`, but it made that continuation request immediately. Idle shutdown closes the backend before the RunManager finishes settling the run record and removing its active-run entry, so the immediate continuation could hit the short teardown window and receive a second `409 run is still active`. Typing into the composer introduced enough delay for teardown to finish, which explains why the symptom was intermittent and why free-form input worked.

## What Changed
- `packages/web/src/routes/task-thread/ask-answer.ts` now retries only the exact transitional `409 run is still active` continuation refusal with bounded capped exponential backoff for roughly five seconds; unrelated provider, session, and network errors still surface immediately.
- The AskUser delivery hook now owns a single-flight flag across the initial message, teardown wait, and final continuation so repeated option taps cannot create duplicate resume requests.
- `ask-answer.test.ts` and `ask-card.test.tsx` reproduce the two-`409` sequence, prove the later continuation succeeds once, pin the backoff schedule and bound, and verify non-transitional errors are not retried.
- `.ai/specs/2026-07-18-askuser-across-runners.md` documents the idle-teardown transition and its exact-error synchronization behavior.

## 🧪 Tests
- `npm run typecheck` — passed across contract, api-client, server, and web workspaces.
- `npm test` — 4,973 passed in 282 files.
- `npm run test:unit` — 36 passed; the rerun used `TMPDIR=/var/tmp` because the shared `/tmp` inode pool was full.
- `npm run build` — passed, including the production cockpit build and `check:pack` (433 files, 88 web assets).
- `npm run test:package` — 12 passed.
- Focused post-review AskUser regression run — 34 passed across the routing/helper and card suites; `npm run typecheck:web` also passed.

## 💥 Breaking Changes
- None. No route, request/response contract, event type, persisted record, marker syntax, provider-selection behavior, or timeout default changed.

## 📋 Progress
See the Progress section in the tracking plan.
