### PR TITLE
fix(web): reclaim mobile task history space

### DIFF
--- a/.ai/runs/2026-08-01-mobile-task-reading-mode.md
+++ b/.ai/runs/2026-08-01-mobile-task-reading-mode.md
@@ -3,6 +3,7 @@
 **Branch:** `fix/mobile-task-reading-mode`
 **Base:** `main`
 **Skill:** `om-auto-create-pr`
+**PR:** [#763](https://github.com/open-mercato/cezar/pull/763)
 
 ## Goal
 
@@ -61,13 +62,13 @@ leave roughly half of a 320×568 viewport for the agent transcript.
 
 ### Phase 1: Reclaim mobile viewport height
 
-- [ ] 1.1 Reduce the global mobile bar to 44px
-- [ ] 1.2 Make the run header sticky only on desktop and tighten phone spacing
-- [ ] 1.3 Compact workflow, transcript and bottom composer surfaces on phones
+- [x] 1.1 Reduce the global mobile bar to 44px
+- [x] 1.2 Make the run header sticky only on desktop and tighten phone spacing
+- [x] 1.3 Compact workflow, transcript and bottom composer surfaces on phones
 
 ### Phase 2: Regression coverage
 
-- [ ] 2.1 Add focused responsive component tests
+- [x] 2.1 Add focused responsive component tests
 - [ ] 2.2 Verify 320×568, 360×640, and 390×844 in a real browser
 
 ### Phase 3: Validation and review

--- a/.ai/runs/2026-08-01-mobile-task-reading-mode.md
+++ b/.ai/runs/2026-08-01-mobile-task-reading-mode.md
@@ -1,0 +1,77 @@
+# Execution plan — mobile task reading mode
+
+**Branch:** `fix/mobile-task-reading-mode`
+**Base:** `main`
+**Skill:** `om-auto-create-pr`
+
+## Goal
+
+Give the task history substantially more usable height on small phones. The global mobile bar,
+run header, workflow rail, plan dock, and composer currently stack into persistent chrome that can
+leave roughly half of a 320×568 viewport for the agent transcript.
+
+## Scope
+
+- `packages/web/src/components/app-shell.tsx` — reduce the mobile top bar to the 44px touch-target
+  baseline.
+- `packages/web/src/routes/task-thread/run-header.tsx` and `step-rail.tsx` — let run details scroll
+  away on phones while retaining the sticky desktop header, and tighten mobile-only spacing.
+- `packages/web/src/routes/task-thread/task-thread.tsx` and `plan-dock.tsx` — compact the persistent
+  bottom dock without changing its behavior.
+- `packages/web/src/components/composer/composer.tsx` — use a one-row, 44px minimum prompt input on
+  phones while retaining the current desktop dimensions and iOS-safe 16px text.
+- Focused component tests plus mobile browser verification at 320×568, 360×640, and 390×844.
+
+## Non-goals
+
+- Redesigning the task thread, changing its information architecture, or hiding run metadata.
+- Changing desktop layout, run status behavior, workflow semantics, or composer actions.
+- Adding new persistence, settings, API contracts, or responsive JavaScript state.
+
+## Implementation plan
+
+### Phase 1 — reclaim mobile viewport height
+
+- **1.1** Reduce the global mobile bar from 52px to 44px without shrinking the menu touch target.
+- **1.2** Make the run header sticky only from the desktop breakpoint and tighten phone spacing.
+- **1.3** Compact the workflow summary, transcript padding, plan dock, and composer on phones.
+
+### Phase 2 — regression coverage
+
+- **2.1** Lock the responsive class contract and one-row composer behavior in focused unit tests.
+- **2.2** Verify the task thread in a real browser at 320×568, 360×640, and 390×844.
+
+### Phase 3 — validation and review
+
+- **3.1** Run the full repository validation gate.
+- **3.2** Attach mobile before/after evidence to the pull request.
+- **3.3** Review the complete diff and resolve all blocking findings.
+
+## Risks
+
+- **Low.** The change is limited to responsive Tailwind classes and one textarea `rows` default.
+- The main regression risk is accidentally changing desktop behavior. Every mobile override therefore
+  carries an explicit `md:` restoration, covered by focused assertions and browser checks.
+- A shorter composer must still grow for multi-line text and keep every 44px touch target; existing
+  auto-grow logic and controls remain unchanged.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Reclaim mobile viewport height
+
+- [ ] 1.1 Reduce the global mobile bar to 44px
+- [ ] 1.2 Make the run header sticky only on desktop and tighten phone spacing
+- [ ] 1.3 Compact workflow, transcript and bottom composer surfaces on phones
+
+### Phase 2: Regression coverage
+
+- [ ] 2.1 Add focused responsive component tests
+- [ ] 2.2 Verify 320×568, 360×640, and 390×844 in a real browser
+
+### Phase 3: Validation and review
+
+- [ ] 3.1 Full validation gate green
+- [ ] 3.2 Mobile before/after evidence attached to the PR
+- [ ] 3.3 Complete diff review clean

--- a/packages/web/e2e/task-thread.e2e.ts
+++ b/packages/web/e2e/task-thread.e2e.ts
@@ -416,24 +416,29 @@ describe('task thread', () => {
     )
   })
 
-  it('reflows at iPhone width with no horizontal overflow', () => {
-    browser.setViewport(390, 844)
-    browser.goto(`${baseUrl}${scoped(`/tasks/${RUN_ID}`)}`)
-    browser.waitForFunction(`document.querySelectorAll('[data-slot="user-bubble"]').length >= 2`)
-    browser.waitForFunction(`document.querySelector('[data-streamdown="code-block"]') !== null`)
+  it('reflows across small phone widths with no horizontal overflow', () => {
+    for (const [width, height] of [[320, 568], [360, 640], [390, 844]] as const) {
+      browser.setViewport(width, height)
+      browser.goto(`${baseUrl}${scoped(`/tasks/${RUN_ID}`)}`)
+      browser.waitForFunction(`document.querySelectorAll('[data-slot="user-bubble"]').length >= 2`)
+      browser.waitForFunction(`document.querySelector('[data-streamdown="code-block"]') !== null`)
 
-    expect(browser.evaluate(`document.documentElement.scrollWidth <= window.innerWidth`)).toBe(true)
-    // The wide fixture table/code scroll inside their own boxes, not the page.
-    expect(
-      browser.evaluate(`(() => {
-        const main = document.querySelector('[data-slot="main"]')
-        return main.scrollWidth <= main.clientWidth
-      })()`),
-    ).toBe(true)
+      expect(browser.evaluate(`document.documentElement.scrollWidth <= window.innerWidth`)).toBe(true)
+      // The wide fixture table/code scroll inside their own boxes, not the page.
+      expect(
+        browser.evaluate(`(() => {
+          const main = document.querySelector('[data-slot="main"]')
+          return main.scrollWidth <= main.clientWidth
+        })()`),
+      ).toBe(true)
+      expect(browser.evaluate(`document.querySelector('[data-slot="mobile-top-bar"] > div').getBoundingClientRect().height`)).toBe(44)
+      expect(browser.evaluate(`getComputedStyle(document.querySelector('[data-slot="run-header"]')).position`)).toBe('relative')
+      expect(browser.evaluate(`document.querySelector('[aria-label="Reply to the agent"]').rows`)).toBe(1)
 
-    // Phone default: the dock collapses to the odometer (the mockup's mobile reflow).
-    expect(browser.evaluate(`document.querySelector('[data-slot="plan-dock"]').dataset.state`)).toBe('collapsed')
-    expect(browser.evaluate(`document.querySelector('[data-slot="plan-count"]').textContent`)).toBe('· 2/4')
+      // Phone default: the dock collapses to the odometer (the mockup's mobile reflow).
+      expect(browser.evaluate(`document.querySelector('[data-slot="plan-dock"]').dataset.state`)).toBe('collapsed')
+      expect(browser.evaluate(`document.querySelector('[data-slot="plan-count"]').textContent`)).toBe('· 2/4')
+    }
 
     browser.screenshot(`${artifactsDir}/thread-mobile.png`)
     browser.setViewport(1440, 900)
@@ -461,5 +466,8 @@ describe('task thread', () => {
 
     browser.screenshot(`${artifactsDir}/thread-header-mobile.png`)
     browser.setViewport(1440, 900)
+    browser.goto(`${baseUrl}${scoped(`/tasks/${RUN_ID}`)}`)
+    browser.waitForFunction(`document.querySelector('[data-slot="run-header"]') !== null`)
+    expect(browser.evaluate(`getComputedStyle(document.querySelector('[data-slot="run-header"]')).position`)).toBe('sticky')
   })
 })

--- a/packages/web/src/components/app-shell.test.tsx
+++ b/packages/web/src/components/app-shell.test.tsx
@@ -348,6 +348,9 @@ describe('AppShell', () => {
       const bar = document.querySelector('[data-slot="mobile-top-bar"]') as HTMLElement
       expect(bar).not.toBeNull()
       expect(bar.className).toContain('md:hidden')
+      // The row is exactly the 44px touch baseline; its menu button keeps that same target.
+      expect(bar.firstElementChild?.className).toContain('h-11')
+      expect(within(bar).getByRole('button', { name: 'Open menu' }).className).toContain('size-11')
     })
 
     it('titles the mobile bar from the active route', () => {

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -622,7 +622,7 @@ function MobileTopBar({ title }: { title: string }) {
       data-slot="mobile-top-bar"
       className="row-start-1 border-b border-border bg-card pt-[env(safe-area-inset-top)] md:hidden"
     >
-      <div className="flex h-[52px] items-center gap-2.5 px-3">
+      <div className="flex h-11 items-center gap-2.5 px-3">
         {/* A real SheetTrigger rather than an onClick that flips our state: it is what registers
             the button as the dialog's trigger, which is what Radix restores focus to on close —
             with a bare onClick, closing the drawer drops focus on <body>. It also carries the

--- a/packages/web/src/components/composer/composer.test.tsx
+++ b/packages/web/src/components/composer/composer.test.tsx
@@ -95,6 +95,17 @@ const paste = (textarea: HTMLTextAreaElement, files: File[]) =>
   })
 
 describe('submit shortcuts', () => {
+  it('starts as a compact one-row phone input and restores the desktop minimum at md', () => {
+    const { textarea } = renderComposer()
+    const classes = textarea.className.split(/\s+/)
+
+    expect(textarea.rows).toBe(1)
+    expect(classes).toContain('min-h-11')
+    expect(classes).toContain('md:min-h-[54px]')
+    expect(classes).toContain('text-base')
+    expect(classes).toContain('md:text-sm')
+  })
+
   it('Enter sends the trimmed text and clears optimistically', async () => {
     const { onSubmit, textarea } = renderComposer()
     type(textarea, '  hello agent  ')

--- a/packages/web/src/components/composer/composer.tsx
+++ b/packages/web/src/components/composer/composer.tsx
@@ -258,7 +258,7 @@ export function Composer({
     }
   }, [text])
 
-  // ---- sizing (mockup: min 54px, grows with content, never past ~1/3 screen) ----------------
+  // ---- sizing (44px phone baseline / 54px desktop, grows with content, max ~1/3 screen) ------
 
   useLayoutEffect(() => {
     const el = textareaRef.current
@@ -457,13 +457,13 @@ export function Composer({
 
           <textarea
             ref={textareaRef}
-            rows={2}
+            rows={1}
             value={text}
             disabled={disabled}
             aria-label={ariaLabel}
             placeholder={disabled ? disabledReason : placeholder}
             // 16px on touch widths — iOS zooms any focused input below 16px (spec mobile rule).
-            className="block max-h-[220px] min-h-[54px] w-full resize-none bg-transparent px-4 pt-3 pb-1 text-base leading-normal outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed md:text-sm"
+            className="block max-h-[220px] min-h-11 w-full resize-none bg-transparent px-3 pt-2.5 pb-1 text-base leading-normal outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed md:min-h-[54px] md:px-4 md:pt-3 md:text-sm"
             onChange={(event) => {
               setText(event.target.value)
               syncTrigger()
@@ -484,7 +484,7 @@ export function Composer({
           ) : (
             // The footer may WRAP (the /new pill row on narrow widths), but the trailing
             // controls stay one unbreakable group so the send button never strands alone.
-            <div className="flex flex-wrap items-center gap-1 gap-y-1.5 px-2 pt-1.5 pb-2">
+            <div className="flex flex-wrap items-center gap-1 gap-y-1 px-1.5 pt-1 pb-1.5 md:gap-y-1.5 md:px-2 md:pt-1.5 md:pb-2">
               {/* The paperclip shares ONE wrapping row with the footer pills — otherwise the
                   pill group is a single flex item that wraps as a block, stranding the
                   paperclip alone on the line above it (#composer-attach-line). */}

--- a/packages/web/src/routes/task-thread/plan-dock.test.tsx
+++ b/packages/web/src/routes/task-thread/plan-dock.test.tsx
@@ -90,6 +90,11 @@ describe('PlanDock', () => {
     expect(rows[2]!.querySelector('[data-slot="plan-tag"]')).toBeNull()
     // Expanded: the current-item line belongs to the collapsed head only.
     expect(document.querySelector('[data-slot="plan-current"]')).toBeNull()
+    // Phone spacing is compact, with the current desktop dimensions restored at md.
+    expect(document.querySelector('[data-slot="grad-edge"]')?.className).toContain('h-0.5')
+    expect(document.querySelector('[data-slot="grad-edge"]')?.className).toContain('md:h-[3px]')
+    expect(head().className).toContain('pt-1.5')
+    expect(head().className).toContain('md:pt-2')
   })
 
   // Regression: an opencode `cancelled` todo used to be dropped by the mapper and
@@ -126,6 +131,8 @@ describe('PlanDock', () => {
     expect(document.querySelector('[data-slot="plan-list"]')).toBeNull()
     // The in-progress entry, spelled with its present-continuous activeForm.
     expect(document.querySelector('[data-slot="plan-current"]')?.textContent).toBe('— Running tests')
+    expect(head().className).toContain('py-1.5')
+    expect(head().className).toContain('md:py-2')
   })
 
   it('falls back to the entry content when the current item has no activeForm', () => {

--- a/packages/web/src/routes/task-thread/plan-dock.test.tsx
+++ b/packages/web/src/routes/task-thread/plan-dock.test.tsx
@@ -90,11 +90,9 @@ describe('PlanDock', () => {
     expect(rows[2]!.querySelector('[data-slot="plan-tag"]')).toBeNull()
     // Expanded: the current-item line belongs to the collapsed head only.
     expect(document.querySelector('[data-slot="plan-current"]')).toBeNull()
-    // Phone spacing is compact, with the current desktop dimensions restored at md.
+    // The decorative edge is slimmer on phones, with its current desktop height restored at md.
     expect(document.querySelector('[data-slot="grad-edge"]')?.className).toContain('h-0.5')
     expect(document.querySelector('[data-slot="grad-edge"]')?.className).toContain('md:h-[3px]')
-    expect(head().className).toContain('pt-1.5')
-    expect(head().className).toContain('md:pt-2')
   })
 
   // Regression: an opencode `cancelled` todo used to be dropped by the mapper and
@@ -131,8 +129,6 @@ describe('PlanDock', () => {
     expect(document.querySelector('[data-slot="plan-list"]')).toBeNull()
     // The in-progress entry, spelled with its present-continuous activeForm.
     expect(document.querySelector('[data-slot="plan-current"]')?.textContent).toBe('— Running tests')
-    expect(head().className).toContain('py-1.5')
-    expect(head().className).toContain('md:py-2')
   })
 
   it('falls back to the entry content when the current item has no activeForm', () => {

--- a/packages/web/src/routes/task-thread/plan-dock.tsx
+++ b/packages/web/src/routes/task-thread/plan-dock.tsx
@@ -62,12 +62,15 @@ export function PlanDock({ runId, entries }: { runId: string; entries: PlanEntry
       className="min-w-0 overflow-hidden rounded-lg border border-border bg-card shadow-xs"
     >
       {/* The mockup's `.grad-edge` — the brand gradient as a hairline top edge. */}
-      <div aria-hidden data-slot="grad-edge" className="h-[3px]" style={{ background: 'var(--grad)' }} />
+      <div aria-hidden data-slot="grad-edge" className="h-0.5 md:h-[3px]" style={{ background: 'var(--grad)' }} />
       <button
         type="button"
         onClick={toggle}
         aria-expanded={open}
-        className={cn('flex w-full items-center gap-2 px-3.5 text-left text-[13px]', open ? 'pt-2 pb-1.5' : 'py-2')}
+        className={cn(
+          'flex w-full items-center gap-2 px-3 text-left text-[13px] md:px-3.5',
+          open ? 'pt-1.5 pb-1 md:pt-2 md:pb-1.5' : 'py-1.5 md:py-2',
+        )}
       >
         <span className="shrink-0 font-semibold">Plan</span>
         <span data-slot="plan-count" className="shrink-0 text-muted-foreground tabular-nums">

--- a/packages/web/src/routes/task-thread/plan-dock.tsx
+++ b/packages/web/src/routes/task-thread/plan-dock.tsx
@@ -67,10 +67,7 @@ export function PlanDock({ runId, entries }: { runId: string; entries: PlanEntry
         type="button"
         onClick={toggle}
         aria-expanded={open}
-        className={cn(
-          'flex w-full items-center gap-2 px-3 text-left text-[13px] md:px-3.5',
-          open ? 'pt-1.5 pb-1 md:pt-2 md:pb-1.5' : 'py-1.5 md:py-2',
-        )}
+        className={cn('flex w-full items-center gap-2 px-3.5 text-left text-[13px]', open ? 'pt-2 pb-1.5' : 'py-2')}
       >
         <span className="shrink-0 font-semibold">Plan</span>
         <span data-slot="plan-count" className="shrink-0 text-muted-foreground tabular-nums">

--- a/packages/web/src/routes/task-thread/run-header.test.tsx
+++ b/packages/web/src/routes/task-thread/run-header.test.tsx
@@ -597,6 +597,21 @@ describe('notes panel', () => {
 })
 
 describe('meta line, tabs, pill and resume hint', () => {
+  it('scrolls the run header on phones but restores sticky context on desktop', () => {
+    stubFetch()
+    renderHeader(run('done'))
+
+    const header = document.querySelector('[data-slot="run-header"]') as HTMLElement
+    const classes = header.className.split(/\s+/)
+    expect(classes).toContain('relative')
+    expect(classes).not.toContain('sticky')
+    expect(classes).not.toContain('top-0')
+    expect(classes).toContain('md:sticky')
+    expect(classes).toContain('md:top-0')
+    expect(classes).toContain('px-3')
+    expect(classes).toContain('md:px-6')
+  })
+
   it('meta shows workflow · branch chip · ± · input/output · cost, with runner/model tucked into the agent badge', () => {
     stubFetch()
     renderHeader(

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -91,7 +91,9 @@ import { useFinishRun } from './use-finish-run'
 /**
  * The run header (spec §"Task thread" → Header): editable title + status pill, the meta line,
  * the Session | Changes | Files tabs with the action bar, the workflow step rail and the plan
- * mirror — the whole sticky region above the thread.
+ * mirror — the whole header region above the thread. It scrolls away on phones so the transcript
+ * owns the small viewport, and stays sticky from `md` upward where there is room for persistent
+ * run context.
  *
  * Two deliberate omissions, both seams rather than gaps:
  *  - **VS Code** (spec: `POST /api/runs/:id/open-in-editor`) — the endpoint does not exist yet;
@@ -132,7 +134,7 @@ export function RunHeader({
   return (
     <header
       data-slot="run-header"
-      className="sticky top-0 z-20 border-b border-border bg-background/95 px-4 pt-3 backdrop-blur md:px-6"
+      className="relative z-20 border-b border-border bg-background/95 px-3 pt-2 backdrop-blur md:sticky md:top-0 md:px-6 md:pt-3"
     >
       <div className="mx-auto w-full max-w-[var(--measure)]">
         <div className="flex min-w-0 items-center gap-2">
@@ -141,7 +143,7 @@ export function RunHeader({
             {planTally ? (
               // The plan dock's compact mirror (spec: "mirrored as a compact progress line in
               // the run header").
-              <span data-slot="plan-mirror" className="text-[11px] text-soft-foreground tabular-nums">
+              <span data-slot="plan-mirror" className="hidden text-[11px] text-soft-foreground tabular-nums sm:inline">
                 Plan {planTally.done}/{planTally.total}
               </span>
             ) : null}
@@ -160,7 +162,7 @@ export function RunHeader({
         />
         <MonitoringSchedule run={run} />
 
-        <div data-slot="run-tabs" className="mt-2.5 flex items-end gap-1">
+        <div data-slot="run-tabs" className="mt-1.5 flex items-end gap-1 md:mt-2.5">
           <TabLink to={`/tasks/${run.id}`} active={tab === 'session'}>
             Session
           </TabLink>
@@ -227,7 +229,7 @@ export function RunHeader({
         </div>
 
         {run.steps.length > 0 ? (
-          <div className="border-t border-border pt-2 pb-1">
+          <div className="border-t border-border pt-1 pb-0 md:pt-2 md:pb-1">
             <WorkflowSteps runId={run.id} steps={run.steps} />
           </div>
         ) : null}
@@ -571,7 +573,7 @@ function MetaRow({
   return (
     <div
       data-slot="run-meta"
-      className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
+      className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground md:mt-1.5 md:gap-y-1"
     >
       {parts.map((part, index) => (
         <Fragment key={index}>

--- a/packages/web/src/routes/task-thread/step-rail.test.tsx
+++ b/packages/web/src/routes/task-thread/step-rail.test.tsx
@@ -126,8 +126,11 @@ describe('WorkflowSteps — the collapsible header summary', () => {
   it('collapsed by default: names the active step, one dot per step, and hides the full rows', () => {
     render(<WorkflowSteps runId={freshRun()} steps={steps} />)
     const summary = document.querySelector('[data-slot="workflow-steps"]')!
+    const trigger = screen.getByRole('button')
     expect(summary.textContent).toContain('Verify')
     expect(summary.textContent).toContain('step 2 of 3')
+    expect(trigger.className).toContain('min-h-7')
+    expect(trigger.className).toContain('md:min-h-[30px]')
     const dots = [...document.querySelectorAll('[data-slot="step-dot"]')]
     expect(dots.map((dot) => dot.getAttribute('data-visual'))).toEqual(['done', 'active', 'pending'])
     // The full rows are not mounted until the user expands.

--- a/packages/web/src/routes/task-thread/step-rail.tsx
+++ b/packages/web/src/routes/task-thread/step-rail.tsx
@@ -142,8 +142,8 @@ const openByRun = new Map<string, boolean>()
 
 /**
  * The step rail as it sits in the run header: a ONE-LINE summary by default — a dot per step,
- * the current step's name, its position, and the progress bar — so the sticky header stays
- * shallow and the thread gets the vertical room. Clicking it expands the full `StepRail`.
+ * the current step's name, its position, and the progress bar — so the header stays shallow and
+ * the thread gets the vertical room. Clicking it expands the full `StepRail`.
  * Collapsed by default because the summary already answers "where is this run?" at a glance;
  * an explicit expand is remembered for that run across tab switches.
  */
@@ -161,7 +161,7 @@ export function WorkflowSteps({ runId, steps }: { runId: string; steps: StepStat
     <Collapsible data-slot="workflow-steps" open={open} onOpenChange={toggle} className="min-w-0">
       <CollapsibleTrigger
         aria-label={`Workflow: ${current.name}, step ${index + 1} of ${steps.length}`}
-        className="group flex min-h-[30px] w-full items-center gap-2.5 text-left text-xs text-muted-foreground hover:text-foreground"
+        className="group flex min-h-7 w-full items-center gap-2 text-left text-xs text-muted-foreground hover:text-foreground md:min-h-[30px] md:gap-2.5"
       >
         <span data-slot="step-dots" className="flex shrink-0 items-center gap-1">
           {steps.map((step) => (

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -290,7 +290,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
 
       {/* Row spacing lives on each thread row (pb-2.5, both render modes measure alike);
           this gap only separates the sections — rows, empty state, footer, review panel. */}
-      <div className="mx-auto flex w-full max-w-[var(--measure)] flex-1 flex-col gap-3.5 px-4 py-5 md:px-6">
+      <div className="mx-auto flex w-full max-w-[var(--measure)] flex-1 flex-col gap-2.5 px-3 py-3 md:gap-3.5 md:px-6 md:py-5">
         <ThreadCardCache runId={run.id}>
           <ThreadRows runId={run.id} rows={rows} mode={mode} controls={scroll} />
         </ThreadCardCache>
@@ -376,7 +376,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
           publishes an inset. */}
       <div
         data-slot="thread-dock"
-        className="sticky bottom-[var(--kb,0px)] z-10 bg-background px-4 pt-1.5 pb-3 max-md:border-t max-md:border-border md:px-6 md:pb-4"
+        className="sticky bottom-[var(--kb,0px)] z-10 bg-background px-3 pt-1 pb-2 max-md:border-t max-md:border-border md:px-6 md:pt-1.5 md:pb-4"
       >
         {/* The jump pill floats over the thread, just above the dock, centered. */}
         {scroll.pillVisible ? (
@@ -384,7 +384,7 @@ export function ThreadView({ run, thread }: { run: ApiRun; thread: ThreadState }
             <JumpToLatestPill onJump={scroll.jumpToLatest} />
           </div>
         ) : null}
-        <div className="mx-auto flex w-full max-w-[var(--measure)] flex-col gap-2.5">
+        <div className="mx-auto flex w-full max-w-[var(--measure)] flex-col gap-1.5 md:gap-2.5">
           {/* Agents above the plan: the fan-out is the more urgent "what is happening now",
               and it is transient — the plan outlives it. Keyed by run id like the plan dock. */}
           <AgentsDock key={`agents:${run.id}`} runId={run.id} agents={agents} onSelect={setOpenAgentId} />


### PR DESCRIPTION
## Summary

- reclaim mobile viewport height for the agent transcript
- keep the full run metadata available while allowing it to scroll away on phones
- compact mobile-only header, workflow, plan, and composer spacing without changing desktop layout

## Motivation

On small phones, persistent status bars and input surfaces can consume roughly half of the task
thread viewport. This makes the agent history—the primary content of the screen—hard to follow.

## Plan

Execution progress is tracked in
`.ai/runs/2026-08-01-mobile-task-reading-mode.md`.

## Testing

- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:package`
- [ ] Browser verification at 320×568, 360×640, and 390×844

## Screenshots

Mobile before/after evidence will be attached before this draft is marked ready.
