### PR TITLE
chore(release): bump alias-cezar to 0.9.2

### DIFF
--- a/alias-cezar/package.json
+++ b/alias-cezar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cezar-cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Alias for @open-mercato/cezar — so `npx cezar-cli` just works. Local cockpit for running and tracking AI agent tasks in your repo.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Finish the 0.9.2 version sync on `main`. `#777` bumped `cezar` / `api-client` / `contract` / `web` to `0.9.2` but left **`alias-cezar`** at `0.9.1` — and it's part of the published release set (`contract` / `api-client` / `cezar` / `alias-cezar`).

`scripts/release.mjs` re-stamps every manifest to the base version at publish, so npm is correct regardless; this just keeps the committed manifest honest so `main` doesn't show a split version.

One line, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)