### PR TITLE
feat(cockpit): readable task names in the sidebar quick-list

### DIFF
--- a/.ai/runs/2026-08-05-readable-sidebar-task-names.md
+++ b/.ai/runs/2026-08-05-readable-sidebar-task-names.md
@@ -100,10 +100,10 @@ clamp, persist across a reload and stay absent below `md`.
 
 ### Phase 1: De-duplicate the reference number in the row
 
-- [ ] 1.1 Add `stripRefPrefix` to `lib/task-groups.ts` with table tests
-- [ ] 1.2 Render the leading PR/issue ref chip in `RunRow`, drop the trailing PR chip and the now-dead `ReferenceChip compact` mode
-- [ ] 1.3 Establish the width-priority rule (title floor, droppable metadata) in `RunRow` and the group tile
-- [ ] 1.4 Unit tests for a row under full width contention (title + diff + PR + unread)
+- [x] 1.1 Add `stripRefPrefix` to `lib/task-groups.ts` with table tests — d1a366a66bb028b9ea1527e9b3dffedbc2ccb7bc
+- [x] 1.2 Render the leading PR/issue ref chip in `RunRow`, drop the trailing PR chip and the now-dead `ReferenceChip compact` mode — 5e8010ae6f0576b10bf0bf03d5bb5f8e82153cc4
+- [x] 1.3 Establish the width-priority rule (title floor, droppable metadata) in `RunRow` and the group tile — 5e8010ae6f0576b10bf0bf03d5bb5f8e82153cc4
+- [x] 1.4 Unit tests for a row under full width contention (title + diff + PR + unread) — 5e8010ae6f0576b10bf0bf03d5bb5f8e82153cc4
 
 ### Phase 2: Let the column breathe
 

--- a/.ai/runs/2026-08-05-readable-sidebar-task-names.md
+++ b/.ai/runs/2026-08-05-readable-sidebar-task-names.md
@@ -1,0 +1,117 @@
+# Execution plan — readable task names in the sidebar quick-list (issue #788, option C)
+
+Issue: <https://github.com/open-mercato/cezar/issues/788> — the maintainer picked **option 3 / C**,
+"Structural: de-duplicate the number, let the column breathe". The follow-up comment from
+`@patzick` on the issue ("sidebar should be available for drag to resize on desktop, we can have
+min-width so user can make it a bit bigger for their needs") confirms the resizable-column half is
+wanted, not optional.
+
+## 🎯 Goal
+
+A sidebar quick-list row shows a readable task **name** again. Today a worst-case row spends its
+244px of content on a status dot, an unabbreviated `+59514 −12160` diff pair, a `PR ↗` chip and an
+unread dot — every one of them `shrink-0` — leaving the title, the only `min-w-0 flex-1` element,
+about 68px ≈ 10 characters, five of which are the `775: ` prefix the row *also* shows in its PR
+chip. Option C attacks that on both sides: stop rendering the reference number twice, and stop
+pretending every desktop wants the same 264px column.
+
+## Scope
+
+Two composable halves, both confined to the cockpit bundle (`packages/web`):
+
+1. **Render-only reference de-duplication.** Strip the `NNN: ` prefix at display time and promote
+   the number into a **leading** mono ref chip that is itself the PR/issue link, replacing the
+   separate trailing PR chip. Stored titles are untouched — the Tasks table, the page title and
+   search keep reading the same `titleSummary`/`title` fields byte-for-byte.
+2. **A user-resizable desktop sidebar.** The `md`-and-up column becomes drag-resizable, clamped
+   264–420px, persisted per browser in `localStorage`. The `<md` drawer keeps its fixed 264px.
+
+Plus the priority rule the row never had: the title is the only element allowed to grow, it gets a
+minimum floor, and metadata is what gives way — encoded as a comment so the next element added to
+the row inherits it.
+
+### Non-goals
+
+- **The Tasks table.** It has the column width for full diff numbers and keeps them.
+- **The auto-naming format** (`packages/cezar/src/runs/auto-name.ts`). `postValidateTitle` keeps
+  writing the `NNN: ` prefix; it is useful on every other surface, and per option C this is a
+  *render* concern only.
+- **New data in the row** (branch, runner, cost). The row is already over-subscribed.
+- **Option A's compact diff formatter and option B's two-line row.** The issue keeps them as
+  separate follow-ups; mixing them in would make the chosen option unevaluable.
+- **A density/appearance setting** for the list.
+- **Server-side or `~/.cezar/ui-state.json` persistence** of the width. It is a browser-local
+  preference, like the theme.
+
+## Implementation plan
+
+### Phase 1 — De-duplicate the reference number in the row
+
+`stripRefPrefix` lands beside `runTitle` in `packages/web/src/lib/task-groups.ts` as a pure,
+table-tested helper. It matches exactly the shape `postValidateTitle` writes (`^(\d+):\s`) and
+nothing looser, and it returns both halves so the caller can decide.
+
+The de-duplication is **conditional on the numbers agreeing**: the prefix is dropped only when the
+number it carries is the same number the leading chip is about to show. A task opened on issue
+`#788` whose PR later becomes `#790` keeps its `788: ` prefix, because in that row the two numbers
+are two different facts and hiding one would be a lie, not a saving.
+
+The leading chip is built from `taskReference(run)` (PR wins once one exists, else the issue), so
+the row gains an issue link it never had while losing the duplicated digits. Because an anchor
+inside an anchor is invalid, the chip stays a flex **sibling** of the row `<Link>` — which means
+the status dot moves out of the `<Link>` too, so the visual order can be dot → chip → title rather
+than a chip wedged in front of the dot.
+
+### Phase 2 — Let the column breathe
+
+`packages/web/src/lib/sidebar-width.ts` is the pure half: the clamp, the storage key, and
+defensive read/write that survive private mode and garbage values — modelled on `lib/theme.ts`,
+which is the house pattern for a browser-local preference. Deliberately its **own** module rather
+than an edit to the `sidebar-collapse.ts` that PR #786 is adding, so the two land without a
+conflict and each owns one preference.
+
+`AppShell` holds the width in state, paints it as an inline width on the desktop `<aside>`, and
+renders a `role="separator"` drag handle on its right border: pointer-captured drag, arrow-key
+adjustment, `Home`/`End` to the bounds, double-click back to the default. The drawer is untouched.
+
+### Phase 3 — Prove it
+
+Unit coverage for both pure halves and both components, then e2e at the real 264px column against
+a real browser: a seeded run with a long title, a 5-digit diff stat, a PR and an unread marker all
+at once must still show a readable number of characters of its name — and the resize must drag,
+clamp, persist across a reload and stay absent below `md`.
+
+## Risks
+
+- **The dot leaving the `<Link>`** shrinks the row's click target by ~7px on the left. Accepted:
+  the dot is a status indicator with `role="img"`, the wrapper still owns the hover highlight, and
+  the alternative (a ref chip in front of the status dot) is worse to read.
+- **`stripRefPrefix` over-matching** a title that legitimately begins with a number (`"2026: the
+  year in review"`). Mitigated by the numbers-must-agree rule — an unrelated leading number never
+  equals the reference the chip is showing — and table-tested.
+- **A persisted width that a future layout cannot honor.** Mitigated by clamping on read as well
+  as on write, so a stale or hand-edited value can never paint an unusable column.
+- **Conflict with PR #786** (`sidebar-collapse.ts`, `last-location.ts`). Mitigated by keeping the
+  width in a separate module and not touching the files that PR edits.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: De-duplicate the reference number in the row
+
+- [ ] 1.1 Add `stripRefPrefix` to `lib/task-groups.ts` with table tests
+- [ ] 1.2 Render the leading PR/issue ref chip in `RunRow`, drop the trailing PR chip and the now-dead `ReferenceChip compact` mode
+- [ ] 1.3 Establish the width-priority rule (title floor, droppable metadata) in `RunRow` and the group tile
+- [ ] 1.4 Unit tests for a row under full width contention (title + diff + PR + unread)
+
+### Phase 2: Let the column breathe
+
+- [ ] 2.1 Add `lib/sidebar-width.ts` (clamp 264–420, localStorage, defensive) with unit tests
+- [ ] 2.2 Drive the desktop `<aside>` width from state in `app-shell.tsx` and add the pointer + keyboard resize handle
+- [ ] 2.3 Unit tests for the resize handle in `app-shell.test.tsx`
+
+### Phase 3: Prove it
+
+- [ ] 3.1 e2e: readable title at 264px, and drag/clamp/persist/`<md`-no-op for the resize
+- [ ] 3.2 Full validation gate green

--- a/.ai/runs/2026-08-05-readable-sidebar-task-names.md
+++ b/.ai/runs/2026-08-05-readable-sidebar-task-names.md
@@ -107,9 +107,9 @@ clamp, persist across a reload and stay absent below `md`.
 
 ### Phase 2: Let the column breathe
 
-- [ ] 2.1 Add `lib/sidebar-width.ts` (clamp 264–420, localStorage, defensive) with unit tests
-- [ ] 2.2 Drive the desktop `<aside>` width from state in `app-shell.tsx` and add the pointer + keyboard resize handle
-- [ ] 2.3 Unit tests for the resize handle in `app-shell.test.tsx`
+- [x] 2.1 Add `lib/sidebar-width.ts` (clamp 264–420, localStorage, defensive) with unit tests — eb8a7abe75bb126132b5ae2d243f24cb5299af3a
+- [x] 2.2 Drive the desktop `<aside>` width from state in `app-shell.tsx` and add the pointer + keyboard resize handle — 34d936be48c5efb350271594ff1d71a962706077
+- [x] 2.3 Unit tests for the resize handle in `app-shell.test.tsx` — 34d936be48c5efb350271594ff1d71a962706077
 
 ### Phase 3: Prove it
 

--- a/.ai/runs/2026-08-05-readable-sidebar-task-names.md
+++ b/.ai/runs/2026-08-05-readable-sidebar-task-names.md
@@ -96,6 +96,8 @@ clamp, persist across a reload and stay absent below `md`.
 
 ## Progress
 
+PR: #789
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: De-duplicate the reference number in the row
@@ -113,5 +115,5 @@ clamp, persist across a reload and stay absent below `md`.
 
 ### Phase 3: Prove it
 
-- [ ] 3.1 e2e: readable title at 264px, and drag/clamp/persist/`<md`-no-op for the resize
-- [ ] 3.2 Full validation gate green
+- [x] 3.1 e2e: readable title at 264px, and drag/clamp/persist/`<md`-no-op for the resize — e9d75c0b6f57791229c5b1443adc3d390a533f66, e29cb7608abbb541f80ed9a2c686f8e7b1c53d4d
+- [x] 3.2 Full validation gate green — 62a813d1 (typecheck, npm test 5395 passed, test:unit 36, build + check:pack, test:package 12)

--- a/packages/web/e2e/agent-browser.ts
+++ b/packages/web/e2e/agent-browser.ts
@@ -15,6 +15,16 @@ import { dirname, resolve } from 'node:path'
 const repoRoot = resolve(import.meta.dirname, '../../..')
 const descriptorPath = resolve(repoRoot, '.ai/qa/test-env.json')
 
+/**
+ * The built CLI a spec spawns when it needs its OWN cezar rather than the shared test env
+ * (a pinned `runs.json` fixture, an empty repo, a second project).
+ *
+ * Exported from here rather than re-derived per spec because it is one fact about the build
+ * layout, and it has already moved once: `npm run build` emits the server into the workspace
+ * package (`packages/cezar/dist`), not into a root-level `dist/`.
+ */
+export const cezarCli = resolve(repoRoot, 'packages/cezar/dist/index.js')
+
 type EnvDescriptor = {
   baseUrl: string
   browser: { installed: boolean; command: string; version: string; notes: string }

--- a/packages/web/e2e/agent-browser.ts
+++ b/packages/web/e2e/agent-browser.ts
@@ -173,6 +173,22 @@ export class AgentBrowser {
     this.run(['mouse', 'up'])
   }
 
+  /** operation: interact (`mouse move`/`down`/`up`) — press at one viewport coordinate, move to
+   *  another, release. A real, trusted pointer stream, which is the only kind that can exercise
+   *  a drag built on pointer capture (`setPointerCapture` rejects a pointer id the browser is
+   *  not actually tracking, so a synthetically dispatched PointerEvent cannot test one).
+   *
+   *  The intermediate move exists because a single jump from press to release is indistinguishable
+   *  from a click for anything that samples movement — the sidebar's resize handle reads each
+   *  move, so it needs more than one. */
+  dragTo(from: { x: number; y: number }, to: { x: number; y: number }): void {
+    this.run(['mouse', 'move', String(from.x), String(from.y)])
+    this.run(['mouse', 'down'])
+    this.run(['mouse', 'move', String(Math.round((from.x + to.x) / 2)), String(Math.round((from.y + to.y) / 2))])
+    this.run(['mouse', 'move', String(to.x), String(to.y)])
+    this.run(['mouse', 'up'])
+  }
+
   /** operation: assert (`eval`) — for DOM facts no selector query can express, such as a
    *  computed style resolved from a CSS custom property. */
   evaluate(js: string): unknown {

--- a/packages/web/e2e/agents-dock.e2e.ts
+++ b/packages/web/e2e/agents-dock.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, cezarCli, fixtureServeEnv } from './agent-browser'
 import record from './fixtures/subagents-run.record.json'
 
 /**
@@ -25,7 +25,6 @@ import record from './fixtures/subagents-run.record.json'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-agents-dock-${process.pid}`
 
 const RUN = record
@@ -111,7 +110,7 @@ beforeAll(async () => {
   server = spawn(
     process.execPath,
     [
-      join(repoRoot, 'packages/cezar/dist/index.js'),
+      cezarCli,
       'serve',
       '--repo',
       dataRoot,

--- a/packages/web/e2e/commit-list.e2e.ts
+++ b/packages/web/e2e/commit-list.e2e.ts
@@ -2,10 +2,10 @@ import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, cezarCli, fixtureServeEnv } from './agent-browser'
 import record from './fixtures/thread-run.record.json'
 
 /**
@@ -22,7 +22,6 @@ import record from './fixtures/thread-run.record.json'
  * is not measured. The fixture is generated so the row count is controlled rather than ambient.
  */
 
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-commit-list-${process.pid}`
 
 /** Past COMMIT_VIRTUALIZE_THRESHOLD (150) with room to spare. */
@@ -140,7 +139,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/composer-defaults.e2e.ts
+++ b/packages/web/e2e/composer-defaults.e2e.ts
@@ -5,9 +5,8 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-composer-defaults-${process.pid}`
 
 let browser: AgentBrowser
@@ -79,7 +78,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/composer.e2e.ts
+++ b/packages/web/e2e/composer.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The composer (R3 Step 2.1) end-to-end, against a LIVE dry-run session — not a replayed
@@ -23,7 +23,6 @@ import { AgentBrowser, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-composer-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -89,7 +88,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/diff-scroll.e2e.ts
+++ b/packages/web/e2e/diff-scroll.e2e.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * Diff virtualization in a real browser (`components/diff/diff-scroll.ts` §"THE PERFORMANCE
@@ -30,7 +30,6 @@ import { AgentBrowser, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-diff-scroll-${process.pid}`
 
 /**
@@ -127,7 +126,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', repo, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', repo, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(repo), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/empty-states.e2e.ts
+++ b/packages/web/e2e/empty-states.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The CenteredState surfaces (Step 4.1), in a real browser: the no-tasks hero on the overview
@@ -17,7 +17,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 
 function freePort(): Promise<number> {
   return new Promise((done, fail) => {
@@ -62,7 +61,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' }
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/new-task.e2e.ts
+++ b/packages/web/e2e/new-task.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The full-screen /new composer (R4 Steps 1.1 + 1.3) end-to-end against a LIVE dry-run server:
@@ -18,7 +18,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-new-task-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -84,7 +83,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/plan-mode.e2e.ts
+++ b/packages/web/e2e/plan-mode.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * Plan mode end-to-end (R4 Step 1.2, #383 + spec 008) against a LIVE dry-run server. Under
@@ -17,7 +17,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-plan-mode-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -75,7 +74,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/queued-stack.e2e.ts
+++ b/packages/web/e2e/queued-stack.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser } from './agent-browser'
+import { AgentBrowser, cezarCli } from './agent-browser'
 
 /**
  * Stacking, editing and removing a queued run's prompt (#472), end-to-end against a LIVE
@@ -26,7 +26,6 @@ import { AgentBrowser } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-queued-stack-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -122,7 +121,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: { ...process.env, CEZ_DRY_RUN: '1', CEZ_HOME: cezHome }, stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/quick-list.e2e.ts
+++ b/packages/web/e2e/quick-list.e2e.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The task quick-list, in a real browser, against a real cezar serving real runs.
@@ -30,7 +30,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const runId = `e2e-quick-list-${process.pid}`
 
 const now = Date.now()
@@ -184,7 +183,7 @@ beforeAll(async () => {
 
   const port = await freePort()
   baseUrl = `http://localhost:${port}`
-  server = spawn(process.execPath, [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'], {
+  server = spawn(process.execPath, [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'], {
     // Dry-run + a pinned CEZ_HOME, exactly as the shared test env does — see `fixtureServeEnv`.
     // Nothing in this spec starts a run, but the boot probes the backends.
     env: fixtureServeEnv(dataRoot),
@@ -542,6 +541,26 @@ describe('a row under width contention, in a column the user can widen', () => {
       )
     )
 
+  /** The row title's measured width — how much of the column the NAME actually got. */
+  const titleWidth = () =>
+    Number(
+      browser.evaluate(
+        `document.querySelector('${ROW_ID} [data-slot="task-row-title"]').getBoundingClientRect().width`
+      )
+    )
+
+  /** The diff pair's RESOLVED display — the container query's answer, not a class. */
+  const diffDisplay = () =>
+    String(browser.evaluate(`getComputedStyle(document.querySelector('${ROW_ID} [data-slot="diff-stat"]')).display`))
+
+  /** Set the width through the stored preference and reload — the non-pointer path to a width,
+   *  used where the assertion is about the LAYOUT at that width rather than about dragging. */
+  const setStoredWidth = (width: number) => {
+    browser.evaluate(`localStorage.setItem('cez-sidebar-width', '${width}')`)
+    browser.goto(`${wideUrl}/p/${wideProject}/`)
+    browser.waitForFunction(`document.querySelector('${ROW_ID}') !== null`)
+  }
+
   /** Grab the handle at its middle and pull it `dx` px horizontally. */
   const dragHandle = (dx: number) => {
     const box = browser.evaluate(`(() => {
@@ -585,7 +604,7 @@ describe('a row under width contention, in a column the user can widen', () => {
     wideUrl = `http://localhost:${port}`
     wideServer = spawn(
       process.execPath,
-      [join(repoRoot, 'dist/index.js'), 'serve', '--repo', wideRoot, '--port', String(port), '--no-open'],
+      [cezarCli, 'serve', '--repo', wideRoot, '--port', String(port), '--no-open'],
       { env: fixtureServeEnv(wideRoot), stdio: 'ignore' }
     )
     await waitForHealth(wideUrl)
@@ -654,22 +673,44 @@ describe('a row under width contention, in a column the user can widen', () => {
     browser.screenshot(`${artifactsDir}/quick-list-width-contention-264.png`, { viewport: true })
   })
 
+  it('grows the name as the column grows, without ever shrinking it', () => {
+    // The cliff this guards against: a threshold placed where the diff pair merely *fits* makes
+    // dragging the column WIDER produce a SHORTER name, which is the exact bargain #788 exists
+    // to stop making. At every width the name is at least as long as it was at the default.
+    const baseline = titleWidth()
+    let previousBelowThreshold = baseline
+    for (const width of [280, 320, 360, 368, 400, 420]) {
+      setStoredWidth(width)
+      expect(sidebarWidth()).toBe(width)
+      expect(titleWidth()).toBeGreaterThanOrEqual(baseline)
+      if (diffDisplay() === 'none') {
+        // Below the threshold the name grows monotonically — every px goes to it.
+        expect(titleWidth()).toBeGreaterThanOrEqual(previousBelowThreshold)
+        previousBelowThreshold = titleWidth()
+      }
+    }
+  })
+
   it('drags wider, brings the diff pair back, and remembers the width across a reload', () => {
     dragHandle(100)
     expect(sidebarWidth()).toBe(364)
     expect(browser.evaluate(`document.querySelector('${HANDLE}').getAttribute('aria-valuenow')`)).toBe('364')
-    // Past 21rem of column, the row can afford its diff numbers again — the whole point of making
-    // the metadata droppable rather than deleting it.
-    expect(
-      browser.evaluate(`getComputedStyle(document.querySelector('${ROW_ID} [data-slot="diff-stat"]')).display`)
-    ).toBe('inline')
+    // Still below 23rem: the column is wider, and all of it went to the name.
+    expect(diffDisplay()).toBe('none')
 
-    browser.screenshot(`${artifactsDir}/quick-list-width-contention-364.png`, { viewport: true })
+    dragHandle(56)
+    expect(sidebarWidth()).toBe(420)
+    // Past 23rem the row can afford its diff numbers again — the whole point of making the
+    // metadata droppable rather than deleting it. `block`, not `inline`: the utility says
+    // `inline`, and CSS blockifies the display of a flex item, which this span is.
+    expect(diffDisplay()).not.toBe('none')
 
-    expect(browser.evaluate(`localStorage.getItem('cez-sidebar-width')`)).toBe('364')
+    browser.screenshot(`${artifactsDir}/quick-list-width-contention-420.png`, { viewport: true })
+
+    expect(browser.evaluate(`localStorage.getItem('cez-sidebar-width')`)).toBe('420')
     browser.goto(`${wideUrl}/p/${wideProject}/`)
     browser.waitForFunction(`document.querySelector('${ROW_ID}') !== null`)
-    expect(sidebarWidth()).toBe(364)
+    expect(sidebarWidth()).toBe(420)
   })
 
   it('clamps at both ends — the column can never collapse or swallow the view', () => {
@@ -731,7 +772,7 @@ describe('empty quick-list', () => {
     emptyUrl = `http://localhost:${port}`
     emptyServer = spawn(
       process.execPath,
-      [join(repoRoot, 'dist/index.js'), 'serve', '--repo', emptyRoot, '--port', String(port), '--no-open'],
+      [cezarCli, 'serve', '--repo', emptyRoot, '--port', String(port), '--no-open'],
       { env: fixtureServeEnv(emptyRoot), stdio: 'ignore' }
     )
     await waitForHealth(emptyUrl)

--- a/packages/web/e2e/quick-list.e2e.ts
+++ b/packages/web/e2e/quick-list.e2e.ts
@@ -4,7 +4,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
 
@@ -510,6 +510,211 @@ describe('tasks table overview', () => {
 
     browser.screenshot(`${artifactsDir}/tasks-cards-mobile.png`)
     browser.setViewport(1440, 900)
+  })
+})
+
+/**
+ * A row under width contention, and the column the user can widen (#788, option C).
+ *
+ * Its own fixture server, like the empty case below: this is one deliberately worst-case record —
+ * a long `NNN: `-prefixed title competing with a five-digit diff pair, a PR chip and the unread
+ * marker, all at once — and dropping it into the shared fixture above would rewrite every
+ * ordering, count and screenshot assertion in this file for one row's sake.
+ *
+ * jsdom cannot answer any of this: the whole question is what the REAL CSS does with 264px, so
+ * every assertion below reads a resolved computed style or a measured rectangle.
+ */
+describe('a row under width contention, in a column the user can widen', () => {
+  let wideServer: ChildProcess
+  let wideRoot: string
+  let wideUrl: string
+  let wideProject: string
+
+  const ROW_ID = '[data-slot="task-row"][data-run-id="wide-load"]'
+  const HANDLE = '[data-slot="sidebar-resize-handle"]'
+  const FULL_TITLE = '775: implementing comment threads across the whole thread view'
+
+  /** The `<aside>`'s resolved width in px — the number the drag is actually moving. */
+  const sidebarWidth = () =>
+    Number(
+      browser.evaluate(
+        `document.querySelector('[data-slot="sidebar"]').getBoundingClientRect().width`
+      )
+    )
+
+  /** Grab the handle at its middle and pull it `dx` px horizontally. */
+  const dragHandle = (dx: number) => {
+    const box = browser.evaluate(`(() => {
+      const r = document.querySelector('${HANDLE}').getBoundingClientRect()
+      return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + r.height / 2) }
+    })()`) as { x: number; y: number }
+    browser.dragTo(box, { x: box.x + dx, y: box.y })
+  }
+
+  beforeAll(async () => {
+    wideRoot = mkdtempSync(join(tmpdir(), 'cezar-e2e-wide-'))
+    mkdirSync(join(wideRoot, '.ai/cezar'), { recursive: true })
+    writeFileSync(
+      join(wideRoot, '.ai/cezar/runs.json'),
+      JSON.stringify(
+        [
+          {
+            id: 'wide-load',
+            title: FULL_TITLE,
+            workflow: 'default',
+            task: 'implement comment threads',
+            status: 'done',
+            createdAt: ago(4 * 3_600_000),
+            // Finished and never opened, so the row also wears the unread marker — the fourth
+            // element that used to compete with the name.
+            finishedAt: ago(3_600_000),
+            tokensUsed: 512_000,
+            diffStat: { adds: 59_514, dels: 12_160, files: 208 },
+            pullRequestUrl: 'https://github.com/open-mercato/cezar/pull/775',
+            archived: false,
+            steps: [],
+          },
+        ],
+        null,
+        2
+      ),
+      'utf8'
+    )
+
+    const port = await freePort()
+    wideUrl = `http://localhost:${port}`
+    wideServer = spawn(
+      process.execPath,
+      [join(repoRoot, 'dist/index.js'), 'serve', '--repo', wideRoot, '--port', String(port), '--no-open'],
+      { env: fixtureServeEnv(wideRoot), stdio: 'ignore' }
+    )
+    await waitForHealth(wideUrl)
+    wideProject = await bootProjectId(wideUrl)
+  }, 90_000)
+
+  afterAll(() => {
+    wideServer?.kill()
+    if (wideRoot) rmSync(wideRoot, { recursive: true, force: true })
+  })
+
+  beforeEach(() => {
+    browser.setViewport(1440, 900)
+    browser.goto(`${wideUrl}/p/${wideProject}/`)
+    // A width the last test dragged must not leak into the next one — the preference is real.
+    browser.evaluate(`localStorage.removeItem('cez-sidebar-width')`)
+    browser.goto(`${wideUrl}/p/${wideProject}/`)
+    browser.waitForFunction(`document.querySelector('${ROW_ID}') !== null`)
+  })
+
+  it('names the task instead of its number: the prefix is gone and the chip carries it', () => {
+    const painted = browser.evaluate(`(() => {
+      const row = document.querySelector('${ROW_ID}')
+      const chip = row.querySelector('[data-slot="pr-chip"]')
+      return {
+        title: row.querySelector('[data-slot="task-row-title"]').textContent,
+        chip: chip.textContent,
+        chipHref: chip.href,
+        tooltip: row.querySelector('a[href$="/tasks/wide-load"]').getAttribute('title'),
+      }
+    })()`) as { title: string; chip: string; chipHref: string; tooltip: string }
+
+    expect(painted.title).toBe('implementing comment threads across the whole thread view')
+    expect(painted.chip).toBe('#775')
+    expect(painted.chipHref).toBe('https://github.com/open-mercato/cezar/pull/775')
+    // The number was moved, not deleted — the stored title is still one hover away.
+    expect(painted.tooltip).toBe(FULL_TITLE)
+  })
+
+  it('gives the name real width at the default 264px, and drops the diff pair to do it', () => {
+    expect(sidebarWidth()).toBe(264)
+
+    const measured = browser.evaluate(`(() => {
+      const row = document.querySelector('${ROW_ID}')
+      const title = row.querySelector('[data-slot="task-row-title"]')
+      const diff = row.querySelector('[data-slot="diff-stat"]')
+      const scroller = document.querySelector('[data-slot="task-quick-list"]')
+      return {
+        titleWidth: title.getBoundingClientRect().width,
+        // The real CSS, not the class: this is the container query resolving at 264px.
+        diffDisplay: getComputedStyle(diff).display,
+        diffTooltip: diff.getAttribute('title'),
+        overflows: scroller.scrollWidth > scroller.clientWidth,
+      }
+    })()`) as { titleWidth: number; diffDisplay: string; diffTooltip: string; overflows: boolean }
+
+    // The floor from the width-priority rule, honored by the real layout — before this change the
+    // same row gave its title ~68px.
+    expect(measured.titleWidth).toBeGreaterThanOrEqual(112)
+    expect(measured.diffDisplay).toBe('none')
+    // Dropped from view, not from reach.
+    expect(measured.diffTooltip).toBe('+59514 −12160 across 208 files')
+    // A floor must not buy readability with a horizontal scrollbar.
+    expect(measured.overflows).toBe(false)
+
+    browser.screenshot(`${artifactsDir}/quick-list-width-contention-264.png`, { viewport: true })
+  })
+
+  it('drags wider, brings the diff pair back, and remembers the width across a reload', () => {
+    dragHandle(100)
+    expect(sidebarWidth()).toBe(364)
+    expect(browser.evaluate(`document.querySelector('${HANDLE}').getAttribute('aria-valuenow')`)).toBe('364')
+    // Past 21rem of column, the row can afford its diff numbers again — the whole point of making
+    // the metadata droppable rather than deleting it.
+    expect(
+      browser.evaluate(`getComputedStyle(document.querySelector('${ROW_ID} [data-slot="diff-stat"]')).display`)
+    ).toBe('inline')
+
+    browser.screenshot(`${artifactsDir}/quick-list-width-contention-364.png`, { viewport: true })
+
+    expect(browser.evaluate(`localStorage.getItem('cez-sidebar-width')`)).toBe('364')
+    browser.goto(`${wideUrl}/p/${wideProject}/`)
+    browser.waitForFunction(`document.querySelector('${ROW_ID}') !== null`)
+    expect(sidebarWidth()).toBe(364)
+  })
+
+  it('clamps at both ends — the column can never collapse or swallow the view', () => {
+    dragHandle(4000)
+    expect(sidebarWidth()).toBe(420)
+    dragHandle(-4000)
+    expect(sidebarWidth()).toBe(264)
+  })
+
+  it('resizes from the keyboard and resets on double-click', () => {
+    browser.evaluate(`document.querySelector('${HANDLE}').focus()`)
+    browser.press('End')
+    expect(sidebarWidth()).toBe(420)
+    browser.press('ArrowLeft')
+    expect(sidebarWidth()).toBe(404)
+    browser.press('Home')
+    expect(sidebarWidth()).toBe(264)
+
+    browser.press('ArrowRight')
+    expect(sidebarWidth()).toBe(280)
+    browser.evaluate(`(() => {
+      const el = document.querySelector('${HANDLE}')
+      el.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    })()`)
+    browser.waitForFunction(`document.querySelector('[data-slot="sidebar"]').getBoundingClientRect().width === 264`)
+  })
+
+  it('is a desktop affordance only: below md there is no handle to reach', () => {
+    browser.setViewport(390, 844)
+    browser.goto(`${wideUrl}/p/${wideProject}/`)
+    browser.waitForFunction(`document.querySelector('[data-slot="mobile-top-bar"]') !== null`)
+
+    // The aside is still in the DOM (display:none), so the handle inside it is unreachable
+    // rather than absent — and the drawer that replaces it brings no handle of its own.
+    expect(browser.isVisible(HANDLE)).toBe(false)
+    browser.click('[data-slot="mobile-top-bar"] button[aria-label="Open menu"]')
+    browser.waitForFunction(`document.querySelector('[data-slot="mobile-nav-drawer"]') !== null`)
+    expect(
+      browser.evaluate(`document.querySelectorAll('[data-slot="mobile-nav-drawer"] ${HANDLE}').length`)
+    ).toBe(0)
+    expect(
+      browser.evaluate(
+        `Math.round(document.querySelector('[data-slot="mobile-nav-drawer"]').getBoundingClientRect().width)`
+      )
+    ).toBe(264)
   })
 })
 

--- a/packages/web/e2e/review-gate.e2e.ts
+++ b/packages/web/e2e/review-gate.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The review gate (R3 Step 2.2) end-to-end, against a LIVE dry run — cezar's core promise
@@ -21,7 +21,6 @@ import { AgentBrowser, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-review-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -79,7 +78,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     // CEZ_REVIEW_GATE=1 because this spec is ABOUT the gate: it is opt-in (#489, default OFF),
     // so pinning it here is what makes the parked-at-review fixture reproducible instead of
     // depending on whatever the operator happens to export.

--- a/packages/web/e2e/skill-search-ranking.e2e.ts
+++ b/packages/web/e2e/skill-search-ranking.e2e.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * #484 end-to-end: skill search must rank the (almost-)exact match to the TOP wherever it is
@@ -19,7 +19,6 @@ import { AgentBrowser, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-skill-search-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -87,7 +86,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/task-changes.e2e.ts
+++ b/packages/web/e2e/task-changes.e2e.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The Changes tab (R5 Step 1.5) end-to-end against a LIVE dry run, same doctrine as
@@ -28,7 +28,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-changes-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -94,7 +93,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     // CEZ_REVIEW_GATE=1 because this spec is ABOUT the gate: it is opt-in (#489, default OFF),
     // so pinning it here is what makes the parked-at-review fixture reproducible instead of
     // depending on whatever the operator happens to export.

--- a/packages/web/e2e/task-files.e2e.ts
+++ b/packages/web/e2e/task-files.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The Files tab (R5 Step 1.6) end-to-end against a LIVE dry run, same doctrine as
@@ -22,7 +22,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-files-${process.pid}`
 
 // 1×1 transparent PNG — real bytes so the <img> decode is a real test.
@@ -93,7 +92,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     // CEZ_REVIEW_GATE=1 because this spec is ABOUT the gate: it is opt-in (#489, default OFF),
     // so pinning it here is what makes the parked-at-review fixture reproducible instead of
     // depending on whatever the operator happens to export.

--- a/packages/web/e2e/task-thread.e2e.ts
+++ b/packages/web/e2e/task-thread.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 import record from './fixtures/thread-run.record.json'
 
 /**
@@ -22,7 +22,6 @@ import record from './fixtures/thread-run.record.json'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-thread-${process.pid}`
 
 /** The recorded run (`fixtures/thread-run.record.json`, the store's own zod-checked shape),
@@ -84,7 +83,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/thread-scroll.e2e.ts
+++ b/packages/web/e2e/thread-scroll.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 import { expectedRowCount, largeThreadEvents } from './fixtures/make-large-thread'
 import record from './fixtures/thread-run.record.json'
 
@@ -26,7 +26,6 @@ import record from './fixtures/thread-run.record.json'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-thread-scroll-${process.pid}`
 
 const TURNS = 250
@@ -133,7 +132,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
   )
   await waitForHealth(baseUrl)

--- a/packages/web/e2e/variants-compare.e2e.ts
+++ b/packages/web/e2e/variants-compare.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
 
 /**
  * The variants compare view (R3 Step 2.3) end-to-end, against a LIVE ×2 dry run — spec 010
@@ -19,7 +19,6 @@ import { AgentBrowser, bootProjectId, fixtureServeEnv } from './agent-browser'
  */
 
 const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
-const repoRoot = resolve(import.meta.dirname, '../../..')
 const sessionId = `e2e-variants-${process.pid}`
 
 function freePort(): Promise<number> {
@@ -88,7 +87,7 @@ beforeAll(async () => {
   baseUrl = `http://localhost:${port}`
   server = spawn(
     process.execPath,
-    [join(repoRoot, 'dist/index.js'), 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
     // CEZ_REVIEW_GATE=1 because this spec is ABOUT the gate: it is opt-in (#489, default OFF),
     // so pinning it here is what makes the parked-at-review fixture reproducible instead of
     // depending on whatever the operator happens to export.

--- a/packages/web/src/components/app-shell.test.tsx
+++ b/packages/web/src/components/app-shell.test.tsx
@@ -425,6 +425,21 @@ describe('AppShell', () => {
       expect(sidebar().style.width).toBe('264px')
     })
 
+    it('takes focus on grab, so the arrow keys work right after a mouse drag', () => {
+      // `preventDefault()` on pointerdown (which stops the drag selecting the sidebar's text)
+      // also suppresses the focus a press would otherwise give a tabIndex=0 element.
+      renderShell()
+      drag(264, 320)
+      expect(document.activeElement).toBe(handle())
+      fireEvent.keyDown(handle(), { key: 'ArrowRight' })
+      expect(sidebar().style.width).toBe('336px')
+    })
+
+    it('opts out of browser touch panning, so a touch drag resizes instead of scrolling', () => {
+      renderShell()
+      expect(handle().className).toContain('touch-none')
+    })
+
     it('ignores a non-primary button, so a right-click on the border resizes nothing', () => {
       renderShell()
       const el = handle()

--- a/packages/web/src/components/app-shell.test.tsx
+++ b/packages/web/src/components/app-shell.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, createEvent, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter, useLocation } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,7 +7,12 @@ import { AppShell, type AppShellProps } from './app-shell'
 import { NAV_ITEMS } from './nav-items'
 import { ThemeProvider } from './theme-provider'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  // The sidebar width is a real localStorage preference (#788) — one test's drag must not be the
+  // next test's starting width.
+  localStorage.clear()
+})
 
 // jsdom ships no `matchMedia`; the ThemeProvider wrapping the footer toggle needs one.
 beforeEach(() => {
@@ -356,6 +361,127 @@ describe('AppShell', () => {
       expect(within(bar).getByText('Skills')).toBeTruthy()
     })
 
+  })
+
+  /** The resizable desktop column (#788, option C). jsdom has no layout engine, so these assert
+   *  the state machine and the accessibility contract; the drag itself is exercised for real in
+   *  `e2e/sidebar-resize.e2e.ts`. */
+  describe('resizable sidebar', () => {
+    const handle = () => document.querySelector('[data-slot="sidebar-resize-handle"]') as HTMLElement
+
+    /** jsdom implements neither pointer capture nor `PointerEvent`'s coordinates on the synthetic
+     *  events React dispatches, so the capture calls are stubbed and the moves are fired as the
+     *  mouse events jsdom does construct — React routes `onPointerDown`/`onPointerMove` from
+     *  them, which is exactly what a real pointer produces. */
+    function drag(from: number, to: number) {
+      const el = handle()
+      el.setPointerCapture = vi.fn()
+      el.releasePointerCapture = vi.fn()
+      el.hasPointerCapture = vi.fn(() => true)
+      fireEvent.pointerDown(el, { button: 0, pointerId: 1, clientX: from })
+      fireEvent.pointerMove(el, { pointerId: 1, clientX: to })
+      fireEvent.pointerUp(el, { pointerId: 1, clientX: to })
+    }
+
+    it('starts at the shipped 264px when nothing has been stored', () => {
+      renderShell()
+      expect(sidebar().style.width).toBe('264px')
+      // No Tailwind width class left behind to fight the inline one.
+      expect(sidebar().className).not.toContain('w-[264px]')
+    })
+
+    it('restores the width the browser remembers', () => {
+      localStorage.setItem('cez-sidebar-width', '350')
+      renderShell()
+      // First paint, not an effect: a jump from 264 to 350 would be visible on every load.
+      expect(sidebar().style.width).toBe('350px')
+    })
+
+    it('is a keyboard-operable separator that reports its range', () => {
+      renderShell()
+      const el = handle()
+      expect(el.getAttribute('role')).toBe('separator')
+      expect(el.getAttribute('aria-orientation')).toBe('vertical')
+      expect(el.getAttribute('aria-label')).toBe('Resize the sidebar')
+      expect(el.tabIndex).toBe(0)
+      expect(el.getAttribute('aria-valuenow')).toBe('264')
+      expect(el.getAttribute('aria-valuemin')).toBe('264')
+      expect(el.getAttribute('aria-valuemax')).toBe('420')
+    })
+
+    it('widens on drag and persists what it landed on', () => {
+      renderShell()
+      drag(264, 344)
+      expect(sidebar().style.width).toBe('344px')
+      expect(handle().getAttribute('aria-valuenow')).toBe('344')
+      expect(localStorage.getItem('cez-sidebar-width')).toBe('344')
+    })
+
+    it('clamps a drag at both bounds rather than letting the column collapse or take over', () => {
+      renderShell()
+      drag(264, 3000)
+      expect(sidebar().style.width).toBe('420px')
+      drag(420, -3000)
+      expect(sidebar().style.width).toBe('264px')
+    })
+
+    it('ignores a non-primary button, so a right-click on the border resizes nothing', () => {
+      renderShell()
+      const el = handle()
+      el.setPointerCapture = vi.fn()
+      fireEvent.pointerDown(el, { button: 2, pointerId: 1, clientX: 264 })
+      fireEvent.pointerMove(el, { pointerId: 1, clientX: 400 })
+      expect(sidebar().style.width).toBe('264px')
+      expect(el.setPointerCapture).not.toHaveBeenCalled()
+    })
+
+    it('steps with the arrow keys and jumps to the bounds with Home/End', () => {
+      renderShell()
+      fireEvent.keyDown(handle(), { key: 'ArrowRight' })
+      expect(sidebar().style.width).toBe('280px')
+      fireEvent.keyDown(handle(), { key: 'ArrowLeft' })
+      expect(sidebar().style.width).toBe('264px')
+      fireEvent.keyDown(handle(), { key: 'End' })
+      expect(sidebar().style.width).toBe('420px')
+      fireEvent.keyDown(handle(), { key: 'Home' })
+      expect(sidebar().style.width).toBe('264px')
+      expect(localStorage.getItem('cez-sidebar-width')).toBe('264')
+    })
+
+    it('leaves every other key to the browser — Tab must still move focus', () => {
+      renderShell()
+      const event = createEvent.keyDown(handle(), { key: 'Tab' })
+      fireEvent(handle(), event)
+      expect(event.defaultPrevented).toBe(false)
+      expect(sidebar().style.width).toBe('264px')
+    })
+
+    it('resets to the default on double-click', () => {
+      localStorage.setItem('cez-sidebar-width', '400')
+      renderShell()
+      expect(sidebar().style.width).toBe('400px')
+      fireEvent.doubleClick(handle())
+      expect(sidebar().style.width).toBe('264px')
+      expect(localStorage.getItem('cez-sidebar-width')).toBe('264')
+    })
+
+    it('does not follow the drawer: the `<md` overlay keeps its fixed 264px and no handle', () => {
+      localStorage.setItem('cez-sidebar-width', '400')
+      renderShell('/', { taskQuickList: <p>list</p> })
+      fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+      const drawer = document.querySelector('[data-slot="mobile-nav-drawer"]') as HTMLElement
+      expect(drawer.className).toContain('w-[264px]')
+      expect(drawer.style.width).toBe('')
+      expect(within(drawer).queryByRole('separator', { name: 'Resize the sidebar' })).toBeNull()
+    })
+
+    it('declares the container the rows size their metadata against', () => {
+      // The width-priority rule in `task-quick-list.tsx` drops metadata with an
+      // `@min-[…]/sidebar:` query; without this container it has nothing to query.
+      renderShell()
+      const content = sidebar().querySelector('[data-slot="sidebar-content"]') as HTMLElement
+      expect(content.className).toContain('@container/sidebar')
+    })
   })
 
   /** The layout contract from the spec. These classes are the whole reason the cockpit does not

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -336,7 +336,11 @@ function SidebarContent({
   return (
     <div
       data-slot="sidebar-content"
-      className="flex min-h-0 flex-1 flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+      // `@container/sidebar` (#788): the sidebar is no longer one fixed width, so what its rows
+      // can afford to paint is a question about THIS column, not about the viewport. Everything
+      // inside that is droppable metadata — the quick-list's diff pair today — hides itself with
+      // an `@min-[…]/sidebar:` query and returns when the user drags the column wider.
+      className="@container/sidebar flex min-h-0 flex-1 flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
     >
       <div className="flex items-center gap-[9px] px-3.5 pt-3.5 pb-2.5">
         <BrandTile />

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -332,6 +332,10 @@ function SidebarResizeHandle({ width, onWidthChange }: SidebarResize) {
     event.currentTarget.setPointerCapture(event.pointerId)
     // Without this the drag selects the sidebar's text as it passes over it.
     event.preventDefault()
+    // …but preventing the default also suppresses the focus the press would have given a
+    // `tabIndex=0` element, which would leave someone who grabbed the handle with a mouse unable
+    // to fine-tune with the arrow keys immediately afterwards. Focus it explicitly instead.
+    event.currentTarget.focus()
   }
 
   const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -382,9 +386,10 @@ function SidebarResizeHandle({ width, onWidthChange }: SidebarResize) {
       onKeyDown={onKeyDown}
       onDoubleClick={() => onWidthChange(DEFAULT_SIDEBAR_WIDTH)}
       title="Drag to resize the sidebar — double-click to reset"
-      // A 5px grab strip straddling the border, invisible until you reach for it: the border is
-      // already the visual edge, so a second permanent line would just be a heavier border.
-      className="absolute inset-y-0 -right-[2px] z-20 w-[5px] cursor-col-resize bg-transparent transition-colors hover:bg-violet/40 focus-visible:bg-violet/60 focus-visible:outline-none"
+      // A 5px grab strip straddling the border, invisible until you reach for it. `touch-none`
+      // is load-bearing rather than decorative: without it a touch drag is claimed by the
+      // browser's own panning and scrolls the page instead of resizing the column.
+      className="absolute inset-y-0 -right-[2px] z-20 w-[5px] cursor-col-resize touch-none bg-transparent transition-colors hover:bg-violet/40 focus-visible:bg-violet/60 focus-visible:outline-none"
     />
   )
 }

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -29,6 +29,15 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Sheet, SheetClose, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { activeNavItem, activeNavPath, visibleNavItems, type NavItem } from '@/components/nav-items'
+import {
+  DEFAULT_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_STEP,
+  clampSidebarWidth,
+  readStoredSidebarWidth,
+  writeStoredSidebarWidth,
+} from '@/lib/sidebar-width'
 import { cn } from '@/lib/utils'
 // The Open Mercato brand mark. A `public/` asset, not a bundled import: the service serves the
 // same file at this exact path (`GET /open-mercato.svg` — the favicon index.html points at), so
@@ -149,6 +158,17 @@ export function AppShell({
   const current = activeNavItem(areaPathname)
   const [menuOpen, setMenuOpen] = React.useState(false)
   const mainRef = React.useRef<HTMLElement>(null)
+  // The desktop column's width (#788). Read once, lazily, from `localStorage` — it is a
+  // browser-local preference like the theme, so there is nothing to fetch and nothing to wait
+  // for, and the first paint is already the user's width rather than a default that jumps.
+  const [sidebarWidth, setSidebarWidth] = React.useState(readStoredSidebarWidth)
+  const changeSidebarWidth = React.useCallback((next: number) => {
+    const width = clampSidebarWidth(next)
+    setSidebarWidth(width)
+    // Persist on every change rather than on drag end: a drag is a stream of small writes to one
+    // key, which localStorage is fine with, and it means a tab closed mid-drag still remembers.
+    writeStoredSidebarWidth(width)
+  }, [])
 
   // The scroller PERSISTS across routes (it is the shell's, not the view's), so without this
   // a deep scroll on one page carries into the next — most visibly on mobile, where Tasks or
@@ -204,7 +224,9 @@ export function AppShell({
         data-slot="app-shell"
         className="flex h-dvh overflow-hidden bg-background text-foreground pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
       >
-        <Sidebar {...nav} />
+        <Sidebar {...nav} width={sidebarWidth} onWidthChange={changeSidebarWidth} />
+        {/* The drawer keeps its fixed 264px: it is a full-height overlay on a phone, where
+            there is no second column to trade width with and no pointer to drag a border. */}
         <MobileNavDrawer {...nav} onNavigate={() => setMenuOpen(false)} />
 
         <div className="grid min-w-0 flex-1 grid-rows-[auto_auto_1fr_auto] overflow-hidden">
@@ -251,15 +273,119 @@ type NavProps = {
   singleProject: boolean
 }
 
-/** The desktop frame: a fixed 264px column, from `md` up. */
-function Sidebar(props: NavProps) {
+/**
+ * The desktop frame, from `md` up — 264px by default and draggable up to 420px (#788).
+ *
+ * The width is the user's, not the layout's: the sidebar is the app's primary navigation and its
+ * rows carry task names, so the right column width depends on the screen someone is sitting at.
+ * It lives in `localStorage` rather than in the workspace config for exactly that reason — see
+ * `lib/sidebar-width.ts`.
+ *
+ * An inline `width` rather than a Tailwind class because the value is a number from state, and
+ * the class is left off entirely below `md`, where `hidden` takes the element out of flow and the
+ * drawer (a fixed 264px) is the sidebar instead.
+ */
+function Sidebar({ width, onWidthChange, ...props }: NavProps & SidebarResize) {
   return (
     <aside
       data-slot="sidebar"
-      className="hidden w-[264px] shrink-0 flex-col border-r border-border bg-sidebar md:flex"
+      style={{ width }}
+      className="relative hidden shrink-0 flex-col border-r border-border bg-sidebar md:flex"
     >
       <SidebarContent {...props} />
+      <SidebarResizeHandle width={width} onWidthChange={onWidthChange} />
     </aside>
+  )
+}
+
+type SidebarResize = {
+  width: number
+  onWidthChange: (width: number) => void
+}
+
+/**
+ * The drag handle on the sidebar's right border (#788).
+ *
+ * A `separator` with `aria-orientation="vertical"` — the ARIA window-splitter pattern — which is
+ * the one role that is BOTH focusable and carries a value range, so the same affordance serves a
+ * pointer and a keyboard. Arrow keys step it, Home/End go to the bounds, and a double-click puts
+ * it back to the default, which is the cheap way out of a width you dragged by accident.
+ *
+ * Pointer capture rather than window listeners: the drag must survive the pointer leaving a 5px
+ * hit area (it will, immediately, on any real drag), and capture is how the browser keeps
+ * delivering the moves to this element without us installing and remembering to remove global
+ * handlers. `touch-none` stops a touch-drag from scrolling the page instead of resizing — the
+ * handle is `md`-only, but `md` includes touch laptops and tablets.
+ *
+ * Rendered inside the `<aside>` and absolutely positioned over its border, so it inherits the
+ * column's height without a second element having to track it.
+ */
+function SidebarResizeHandle({ width, onWidthChange }: SidebarResize) {
+  // The width the drag started from, plus the pointer x it started at. Refs, not state: they
+  // change on every pointermove and nothing renders from them.
+  const origin = React.useRef<{ x: number; width: number } | null>(null)
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    // Primary button only — a right-click on the border must not start a resize.
+    if (event.button !== 0) return
+    origin.current = { x: event.clientX, width }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    // Without this the drag selects the sidebar's text as it passes over it.
+    event.preventDefault()
+  }
+
+  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const start = origin.current
+    if (!start) return
+    onWidthChange(clampSidebarWidth(start.width + (event.clientX - start.x)))
+  }
+
+  const endDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!origin.current) return
+    origin.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const next =
+      event.key === 'ArrowLeft'
+        ? width - SIDEBAR_WIDTH_STEP
+        : event.key === 'ArrowRight'
+          ? width + SIDEBAR_WIDTH_STEP
+          : event.key === 'Home'
+            ? MIN_SIDEBAR_WIDTH
+            : event.key === 'End'
+              ? MAX_SIDEBAR_WIDTH
+              : null
+    if (next === null) return
+    // Only for the keys we handled: Tab, Escape and the rest stay the browser's.
+    event.preventDefault()
+    onWidthChange(clampSidebarWidth(next))
+  }
+
+  return (
+    <div
+      data-slot="sidebar-resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize the sidebar"
+      aria-valuenow={width}
+      aria-valuemin={MIN_SIDEBAR_WIDTH}
+      aria-valuemax={MAX_SIDEBAR_WIDTH}
+      tabIndex={0}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={onKeyDown}
+      onDoubleClick={() => onWidthChange(DEFAULT_SIDEBAR_WIDTH)}
+      title="Drag to resize the sidebar — double-click to reset"
+      // A 5px grab strip straddling the border, invisible until you reach for it: the border is
+      // already the visual edge, so a second permanent line would just be a heavier border.
+      className="absolute inset-y-0 -right-[2px] z-20 w-[5px] cursor-col-resize bg-transparent transition-colors hover:bg-violet/40 focus-visible:bg-violet/60 focus-visible:outline-none"
+    />
   )
 }
 

--- a/packages/web/src/components/reference-chip.tsx
+++ b/packages/web/src/components/reference-chip.tsx
@@ -13,7 +13,14 @@ export function ReferenceChip({
   reference: { kind: 'PR' | 'Issue'; number?: number; url?: string }
   taskTitle: string
   className?: string
-  /** The narrow sidebar keeps its established `PR` label instead of spelling out a number. */
+  /**
+   * The narrow sidebar row (#788, option C): the number ALONE — `#402` — with no `Issue ` word
+   * and no `PR` label. There the chip is the row's leading identifier and every glyph it spends
+   * is a glyph the task's name does not get, and which kind of reference it is stays carried by
+   * the accessible name ("Open the pull request for …" / "Open the issue for …"), the `title`
+   * (the URL) and the `data-slot`. Without a number there is nothing shorter to say, so the kind
+   * is the label, exactly as in the full treatment.
+   */
   compact?: boolean
 }) {
   const { kind, number, url } = reference
@@ -21,12 +28,7 @@ export function ReferenceChip({
     'inline-flex h-[22px] items-center gap-1 rounded-full border border-violet/35 px-2 font-mono text-[11px] font-semibold text-violet',
     className,
   )
-  const label =
-    compact && kind === 'PR'
-      ? 'PR'
-      : number
-        ? `${kind === 'Issue' ? 'Issue ' : ''}#${number}`
-        : kind
+  const label = number ? `${!compact && kind === 'Issue' ? 'Issue ' : ''}#${number}` : kind
 
   // href protocol guard (#431): a transcript-scraped non-http URL degrades to inert text.
   if (!url || !isHttpUrl(url)) {

--- a/packages/web/src/components/task-quick-list.test.tsx
+++ b/packages/web/src/components/task-quick-list.test.tsx
@@ -336,9 +336,10 @@ describe('TaskQuickList', () => {
       expect(title.textContent).toBe('implementing comment threads across the whole thread view')
 
       const diff = rowEl.querySelector('[data-slot="diff-stat"]') as HTMLElement
-      // Hidden by default at the 264px column, back once the column is dragged past 21rem.
+      // Hidden by default at the 264px column, back once the column is dragged past 23rem —
+      // the width at which the pair fits without costing the name any of its default budget.
       expect(diff.className).toContain('hidden')
-      expect(diff.className).toContain('@min-[21rem]/sidebar:inline')
+      expect(diff.className).toContain('@min-[23rem]/sidebar:inline')
       // Dropped from view, never from reach — the exact numbers stay in its tooltip.
       expect(diff.getAttribute('title')).toBe('+59514 −12160 across 208 files')
 

--- a/packages/web/src/components/task-quick-list.test.tsx
+++ b/packages/web/src/components/task-quick-list.test.tsx
@@ -225,11 +225,137 @@ describe('TaskQuickList', () => {
       expect(chip.parentElement?.getAttribute('data-slot')).toBe('task-row')
     })
 
-    it('takes the age slot', () => {
+    it('leads the row and takes the age slot, spelling the number rather than the word "PR" (#788)', () => {
       renderList({
         runs: [run({ id: 'x', title: 'Has a PR', status: 'review', pullRequestUrl: 'https://github.com/o/r/pull/7' })],
       })
-      expect(rowsIn('Needs you')).toEqual(['Has a PRPR'])
+      // Chip first, then the name: the number is the row's leading identifier, and the age it
+      // displaces was the weaker of the two signals.
+      expect(rowsIn('Needs you')).toEqual(['#7Has a PR'])
+    })
+
+    it('carries the issue when no PR exists yet — the number the title prefix was about', () => {
+      renderList({
+        runs: [
+          run({
+            id: 'iss',
+            title: '788: implementing readable task names',
+            status: 'running',
+            referencedIssueUrl: 'https://github.com/o/r/issues/788',
+          }),
+        ],
+      })
+      const chip = within(row('iss') as HTMLElement).getByRole('link', {
+        name: 'Open the issue for 788: implementing readable task names',
+      })
+      expect(chip.getAttribute('href')).toBe('https://github.com/o/r/issues/788')
+      // `#788`, not `Issue #788`: in this column the word costs six glyphs the name needs.
+      expect(chip.textContent).toBe('#788')
+    })
+
+    it('still paints a number it cannot link — an inert chip beats losing the reference', () => {
+      // A record that knows its PR number but has no URL (or a non-http one, #431). The title's
+      // prefix is dropped in favour of the chip, so the chip has to exist or the number is gone.
+      renderList({ runs: [run({ id: 'noturl', title: '402: no url for this one', prNumber: 402 })] })
+      const chip = document.querySelector('[data-run-id="noturl"] [data-slot="pr-chip"]') as HTMLElement
+      expect(chip.tagName).toBe('SPAN')
+      expect(chip.textContent).toBe('#402')
+    })
+  })
+
+  describe('the title vs. its metadata (#788, option C)', () => {
+    it('drops the NNN: prefix the chip is already showing, and keeps the full title on hover', () => {
+      renderList({
+        runs: [
+          run({
+            id: 'dedup',
+            title: '775: implementing comment threads',
+            status: 'review',
+            pullRequestUrl: 'https://github.com/o/r/pull/775',
+          }),
+        ],
+      })
+
+      const title = document.querySelector('[data-run-id="dedup"] [data-slot="task-row-title"]')
+      expect(title?.textContent).toBe('implementing comment threads')
+      // Nothing is lost: the number is a chip, and the stored title is still the row's tooltip.
+      expect(document.querySelector('[data-run-id="dedup"] [data-slot="pr-chip"]')?.textContent).toBe('#775')
+      expect(
+        document.querySelector('[data-run-id="dedup"] a[href="/tasks/dedup"]')?.getAttribute('title')
+      ).toBe('775: implementing comment threads')
+    })
+
+    it('keeps the prefix when it is a DIFFERENT number from the chip — two facts, not one', () => {
+      // Opened on issue #788, shipped as PR #790. Stripping `788: ` here would delete the only
+      // place the issue number appears.
+      renderList({
+        runs: [
+          run({
+            id: 'two',
+            title: '788: implementing readable task names',
+            status: 'review',
+            pullRequestUrl: 'https://github.com/o/r/pull/790',
+            referencedIssueUrl: 'https://github.com/o/r/issues/788',
+          }),
+        ],
+      })
+      expect(document.querySelector('[data-run-id="two"] [data-slot="task-row-title"]')?.textContent).toBe(
+        '788: implementing readable task names'
+      )
+      expect(document.querySelector('[data-run-id="two"] [data-slot="pr-chip"]')?.textContent).toBe('#790')
+    })
+
+    it('keeps a leading number that is not a reference at all', () => {
+      renderList({ runs: [run({ id: 'year', title: '2026: the year in review' })] })
+      expect(document.querySelector('[data-run-id="year"] [data-slot="task-row-title"]')?.textContent).toBe(
+        '2026: the year in review'
+      )
+    })
+
+    it('gives the title a floor and makes the diff pair the element that drops', () => {
+      // The worst case from the issue: a title competing with a 5-digit diff pair, a PR chip and
+      // the unread dot all at once. The title must still be the growing element with a floor,
+      // and the diff pair must be the one carrying the container query that drops it.
+      renderList({
+        runs: [
+          run({
+            id: 'worst',
+            title: '775: implementing comment threads across the whole thread view',
+            status: 'done',
+            finishedAt: ago(60_000),
+            diffStat: { adds: 59_514, dels: 12_160, files: 208 },
+            pullRequestUrl: 'https://github.com/o/r/pull/775',
+          }),
+        ],
+      })
+
+      const rowEl = row('worst') as HTMLElement
+      const title = rowEl.querySelector('[data-slot="task-row-title"]') as HTMLElement
+      expect(title.className).toContain('min-w-[7rem]')
+      expect(title.className).toContain('flex-1')
+      expect(title.textContent).toBe('implementing comment threads across the whole thread view')
+
+      const diff = rowEl.querySelector('[data-slot="diff-stat"]') as HTMLElement
+      // Hidden by default at the 264px column, back once the column is dragged past 21rem.
+      expect(diff.className).toContain('hidden')
+      expect(diff.className).toContain('@min-[21rem]/sidebar:inline')
+      // Dropped from view, never from reach — the exact numbers stay in its tooltip.
+      expect(diff.getAttribute('title')).toBe('+59514 −12160 across 208 files')
+
+      // Everything the row paints, in reading order: reference, name, diff, unread marker. No
+      // age — the reference took that slot.
+      expect(rowsIn('Recent')).toEqual(['#775implementing comment threads across the whole thread view+59514 −12160'])
+    })
+
+    it('gives the collapsed variant tile the same floor', () => {
+      renderList({
+        runs: [
+          run({ id: 'ga', title: 'Add skills autocomplete (A)', groupId: 'g', variant: 'A' }),
+          run({ id: 'gb', title: 'Add skills autocomplete (B)', groupId: 'g', variant: 'B' }),
+        ],
+      })
+      const tileTitle = document.querySelector('[data-slot="group-tile"] span') as HTMLElement
+      expect(tileTitle.className).toContain('min-w-[7rem]')
     })
   })
 

--- a/packages/web/src/components/task-quick-list.test.tsx
+++ b/packages/web/src/components/task-quick-list.test.tsx
@@ -388,6 +388,39 @@ describe('TaskQuickList', () => {
       expect(row('q1')?.textContent).toBe('First#1')
       expect(row('q2')?.textContent).toBe('Second#2')
     })
+
+    it('keeps the queue position even when the row has a reference chip', () => {
+      // The chip takes the AGE's slot, never the queue position's: `#1` is where the engine will
+      // pick this run up, it is carried nowhere else in the row, and an issue-driven queued run —
+      // an issue reference, no PR yet — is exactly the shape that would have silently lost it.
+      renderList({
+        runs: [
+          run({
+            id: 'qref',
+            title: '788: queued on an issue',
+            status: 'queued',
+            createdAt: ago(120_000),
+            referencedIssueUrl: 'https://github.com/o/r/issues/788',
+          }),
+        ],
+      })
+      expect(row('qref')?.textContent).toBe('#788queued on an issue#1')
+    })
+
+    it('still drops the age for a referenced row that is not queued', () => {
+      renderList({
+        runs: [
+          run({
+            id: 'aged',
+            title: 'Finished with a PR',
+            status: 'done',
+            finishedAt: ago(2 * 3_600_000),
+            pullRequestUrl: 'https://github.com/o/r/pull/9',
+          }),
+        ],
+      })
+      expect(row('aged')?.textContent).toBe('#9Finished with a PR')
+    })
   })
 
   describe('variant groups', () => {

--- a/packages/web/src/components/task-quick-list.tsx
+++ b/packages/web/src/components/task-quick-list.tsx
@@ -281,8 +281,9 @@ function Row({
  * WIDTH-PRIORITY RULE (#788, option C) — read this before adding anything to this row.
  * The column is 264px by default and the title is the ONLY thing here a person scans for, so:
  *
- *  1. The title is the only element allowed to GROW (`min-w-0 flex-1`) and it has a floor
- *     (`min-w-[7rem]`) that nothing may push it below.
+ *  1. The title is the only element allowed to GROW (`flex-1`) and it has a floor
+ *     (`min-w-[7rem]`, replacing the `min-w-0` that let it be squeezed to nothing) that no other
+ *     element may push it below.
  *  2. Every other element is metadata and must be DROPPABLE beneath that floor. The mechanism is
  *     the `@container/sidebar` the app shell declares: metadata that does not fit a narrow column
  *     is hidden by a container query and comes back when the user drags the column wider.
@@ -409,12 +410,18 @@ function RunRow({
             className="hidden shrink-0 text-[10.5px] @min-[23rem]/sidebar:inline"
           />
         ) : null}
-        {/* The reference chip takes the age's slot when there is one — same as the mockup, and
+        {/* The reference chip takes the AGE's slot when there is one — same as the mockup, and
             the same trade as before: a row that knows its PR or issue number is identified by
-            that, not by how long ago it finished. */}
-        {reference || !age ? null : (
+            that, not by how long ago it finished.
+
+            It never takes the QUEUE POSITION's slot. `#2` is not an age, it is where the engine
+            will pick this run up, it is carried nowhere else in the row, and a queued run is
+            exactly the kind that has an issue reference and no PR yet — so keying this on "has a
+            reference" alone would have silently deleted the queue position from every
+            issue-driven queued row. */}
+        {age && (queuePosition !== null || !reference) ? (
           <span className="shrink-0 text-[11px] text-soft-foreground tabular-nums">{age}</span>
-        )}
+        ) : null}
         {/* The unread marker (#unread-done-items): a trailing violet dot, opposite end and
             different hue from the leading status dot, so the two read as two signals. */}
         {unread ? (

--- a/packages/web/src/components/task-quick-list.tsx
+++ b/packages/web/src/components/task-quick-list.tsx
@@ -395,13 +395,18 @@ function RunRow({
             sidebar row has no column to hold an em dash open for.
 
             Droppable metadata, per the width-priority rule: `+59514 −12160` is ~82px, which a
-            264px column cannot spend and still name the task. It appears once the user has
-            dragged the sidebar wide enough to afford it AND the title's floor (#788), and its
-            exact numbers stay one hover away in the Tasks table's ± column either way. */}
+            264px column cannot spend and still name the task, and its exact numbers stay in the
+            `title` tooltip and in the Tasks table's ± column either way.
+
+            23rem is not the width at which the pair merely *fits* — it is the width at which it
+            fits AND the name is still at least as long as it was in the default 264px column
+            (measured: 146px of title at 23rem vs 132px at 264px). Anything narrower buys the
+            numbers back by making the task names shorter than they were before the drag, which
+            is precisely the bargain this issue exists to stop making. */}
         {run.diffStat ? (
           <DiffStatLabel
             stat={run.diffStat}
-            className="hidden shrink-0 text-[10.5px] @min-[21rem]/sidebar:inline"
+            className="hidden shrink-0 text-[10.5px] @min-[23rem]/sidebar:inline"
           />
         ) : null}
         {/* The reference chip takes the age's slot when there is one — same as the mockup, and

--- a/packages/web/src/components/task-quick-list.tsx
+++ b/packages/web/src/components/task-quick-list.tsx
@@ -14,15 +14,17 @@ import { directionalUsageText } from '@/components/directional-usage'
 import {
   groupRuns,
   listCounts,
+  refPrefixMatches,
   runTitle,
+  splitRefPrefix,
   type ListView,
   type QuickListBucket,
   type QuickListRow,
 } from '@/lib/task-groups'
-import { formatCost, prNumber, taskPrUrl } from '@/lib/tasks-table'
+import { formatCost, taskReference } from '@/lib/tasks-table'
 import { usageMetricVisibility } from '@/lib/token-metrics'
 import { useNow } from '@/lib/use-now'
-import { cn, isHttpUrl } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 
 /**
  * The sidebar's task quick-list (spec, "App shell & navigation"): Active/Archived tabs, then the
@@ -232,7 +234,9 @@ function Row({
             className={cn('size-3 shrink-0 text-soft-foreground transition-transform', !expanded && '-rotate-90')}
             aria-hidden="true"
           />
-          <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{row.title}</span>
+          {/* Same width-priority rule as `RunRow`: the shared title has a floor, and the `×N`
+              badge and the compare link give way before it does. */}
+          <span className="min-w-[7rem] flex-1 truncate text-[13px] font-medium">{row.title}</span>
           <span className="shrink-0 rounded-full bg-muted px-1.5 py-px font-mono text-[10.5px] font-semibold text-muted-foreground">
             ×{row.members.length}
           </span>
@@ -269,8 +273,24 @@ function Row({
 /**
  * One run.
  *
- * The row is a `<Link>` and the PR chip is its flex *sibling*, not its child: an anchor inside an
- * anchor is invalid, and both targets are real — the row opens the task, the chip opens the PR.
+ * The row is a `<Link>` and the reference chip is its flex *sibling*, not its child: an anchor
+ * inside an anchor is invalid, and both targets are real — the row opens the task, the chip opens
+ * the PR or issue. The status dot is a sibling too, so the reading order can be dot → chip →
+ * title rather than a chip wedged in front of the status it is not about.
+ *
+ * WIDTH-PRIORITY RULE (#788, option C) — read this before adding anything to this row.
+ * The column is 264px by default and the title is the ONLY thing here a person scans for, so:
+ *
+ *  1. The title is the only element allowed to GROW (`min-w-0 flex-1`) and it has a floor
+ *     (`min-w-[7rem]`) that nothing may push it below.
+ *  2. Every other element is metadata and must be DROPPABLE beneath that floor. The mechanism is
+ *     the `@container/sidebar` the app shell declares: metadata that does not fit a narrow column
+ *     is hidden by a container query and comes back when the user drags the column wider.
+ *  3. Anything a dropped element was the only carrier of has to survive somewhere reachable —
+ *     the diff numbers keep their `title` tooltip, the reference keeps its own chip.
+ *
+ * Before this rule the title was the sole compressible item in a row of `shrink-0` metadata, so
+ * it absorbed 100% of any deficit — which is how `775: i…` happened.
  */
 function RunRow({
   run,
@@ -296,7 +316,14 @@ function RunRow({
 }) {
   const attention = deriveAttention(run)
   const isActive = run.id === currentRunId
-  const prUrl = taskPrUrl(run)
+  // The strongest tracker reference the run knows about — the PR once one exists, else the issue
+  // it was opened on. It is the row's leading chip AND the reason the title may drop its `NNN: `
+  // prefix (#788, option C): the number is painted once, as a link, instead of twice as digits.
+  const reference = taskReference(run)
+  const title = runTitle(run)
+  // Only when the two numbers are the same number — see `refPrefixMatches`. A run opened on issue
+  // #788 that shipped as PR #790 keeps its prefix, because the chip is no longer saying it.
+  const displayTitle = refPrefixMatches(title, reference?.number) ? splitRefPrefix(title).rest : title
   // Read/unread (#unread-done-items, "Option B"): an unread done item is promoted (bright +
   // semibold) and wears a trailing violet dot; a read one dims so the history steps back. Both
   // are orthogonal to the leading status dot, which keeps saying done/failed.
@@ -314,42 +341,73 @@ function RunRow({
     <div
       data-slot="task-row"
       data-run-id={run.id}
-      // The row's highlight is a wrapper concern (the PR chip sits outside the Link), so the
-      // active state has to be readable here rather than only from the Link's `aria-current`.
+      // The row's highlight is a wrapper concern (the dot and the reference chip sit outside the
+      // Link), so the active state has to be readable here rather than only from the Link's
+      // `aria-current`.
       data-active={isActive ? 'true' : undefined}
       className={cn(
-        'flex items-center rounded-sm hover:bg-muted',
+        'flex items-center gap-2 rounded-sm pl-2.5 hover:bg-muted',
         isActive && 'bg-muted',
-        variant && 'pl-4'
+        // The indent a member row wears under an expanded group tile. One padding declaration,
+        // not two: `cn` is tailwind-merge, so this REPLACES the `pl-2.5` above rather than losing
+        // to it — 26px = the row's own 10px plus the 16px indent.
+        variant && 'pl-[26px]'
       )}
     >
+      {/* Outside the Link so it can lead the reference chip. The dot is a status indicator, not a
+          navigation target, and the wrapper still owns the row's hover surface. */}
+      <StatusDot tone={attention.tone} pulse={attention.pulse} aria-label={attention.label} role="img" />
+      {/* The reference, ONCE (#788, option C): the number that used to be both a `775: ` title
+          prefix and a trailing `PR ↗` chip is now one leading chip that is itself the link. */}
+      {reference ? (
+        <ReferenceChip
+          reference={reference}
+          taskTitle={title}
+          compact
+          className="h-auto shrink-0 gap-[2px] px-1.5 py-px text-[10.5px]"
+        />
+      ) : null}
       <Link
         to={scopeTo(scope, `/tasks/${run.id}`)}
-        // The row's accessible name is the title; `title` gives the full text back when the CSS
-        // truncates it, which for a one-line 264px column is most of the time.
-        title={runTitle(run)}
+        // `title` carries the FULL stored title — including a `NNN: ` prefix the chip let the
+        // visible text drop — so hover always gives back everything the column could not show.
+        title={title}
         aria-current={isActive ? 'page' : undefined}
-        className="flex min-w-0 flex-1 items-center gap-2 px-2.5 py-[7px]"
+        className="flex min-w-0 flex-1 items-center gap-2 py-[7px] pr-2.5"
       >
         {variant ? (
           <span className="inline-flex size-[15px] shrink-0 items-center justify-center rounded-full bg-violet/15 font-mono text-[9.5px] font-semibold text-violet">
             {run.variant ?? '?'}
           </span>
         ) : null}
-        <StatusDot tone={attention.tone} pulse={attention.pulse} aria-label={attention.label} role="img" />
         <span
+          data-slot="task-row-title"
           className={cn(
-            'min-w-0 flex-1 truncate text-[13px]',
+            // `min-w-[7rem]`: the floor of the width-priority rule above. The title never gives
+            // way past ~17 characters; metadata drops instead.
+            'min-w-[7rem] flex-1 truncate text-[13px]',
             unread ? 'font-semibold text-foreground' : readDone ? 'font-medium text-muted-foreground' : 'font-medium'
           )}
         >
-          {variant ? variantLabel(run, showTokens, showCost) : runTitle(run)}
+          {variant ? variantLabel(run, showTokens, showCost) : displayTitle}
         </span>
         {/* The diff numbers, once a turn has produced any (R2 #389). Nothing before that — a
-            sidebar row has no column to hold an em dash open for. */}
-        {run.diffStat ? <DiffStatLabel stat={run.diffStat} className="shrink-0 text-[10.5px]" /> : null}
-        {/* The PR chip takes the age's slot when there is one — same as the mockup. */}
-        {prUrl || !age ? null : (
+            sidebar row has no column to hold an em dash open for.
+
+            Droppable metadata, per the width-priority rule: `+59514 −12160` is ~82px, which a
+            264px column cannot spend and still name the task. It appears once the user has
+            dragged the sidebar wide enough to afford it AND the title's floor (#788), and its
+            exact numbers stay one hover away in the Tasks table's ± column either way. */}
+        {run.diffStat ? (
+          <DiffStatLabel
+            stat={run.diffStat}
+            className="hidden shrink-0 text-[10.5px] @min-[21rem]/sidebar:inline"
+          />
+        ) : null}
+        {/* The reference chip takes the age's slot when there is one — same as the mockup, and
+            the same trade as before: a row that knows its PR or issue number is identified by
+            that, not by how long ago it finished. */}
+        {reference || !age ? null : (
           <span className="shrink-0 text-[11px] text-soft-foreground tabular-nums">{age}</span>
         )}
         {/* The unread marker (#unread-done-items): a trailing violet dot, opposite end and
@@ -364,19 +422,6 @@ function RunRow({
           />
         ) : null}
       </Link>
-      {/* href protocol guard (#431): link only for http(s) URLs. */}
-      {prUrl && isHttpUrl(prUrl) ? (
-        <ReferenceChip
-          reference={{
-            kind: 'PR',
-            ...(prNumber(prUrl) ? { number: Number(prNumber(prUrl)) } : {}),
-            url: prUrl,
-          }}
-          taskTitle={runTitle(run)}
-          compact
-          className="mr-2.5 h-auto shrink-0 gap-[3px] px-1.5 py-px text-[10.5px]"
-        />
-      ) : null}
     </div>
   )
 }

--- a/packages/web/src/lib/sidebar-width.test.ts
+++ b/packages/web/src/lib/sidebar-width.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DEFAULT_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_STORAGE_KEY,
+  clampSidebarWidth,
+  readStoredSidebarWidth,
+  writeStoredSidebarWidth,
+} from './sidebar-width'
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('clampSidebarWidth', () => {
+  it.each([
+    // In range — rounded to whole pixels, because a drag produces fractions.
+    [264, 264],
+    [300, 300],
+    [420, 420],
+    [317.4, 317],
+    [317.5, 318],
+    // Out of range, both ends.
+    [0, MIN_SIDEBAR_WIDTH],
+    [-4000, MIN_SIDEBAR_WIDTH],
+    [263, MIN_SIDEBAR_WIDTH],
+    [421, MAX_SIDEBAR_WIDTH],
+    [99_999, MAX_SIDEBAR_WIDTH],
+  ])('%s → %s', (raw, expected) => {
+    expect(clampSidebarWidth(raw)).toBe(expected)
+  })
+
+  it('parses the strings localStorage actually returns', () => {
+    expect(clampSidebarWidth('300')).toBe(300)
+    expect(clampSidebarWidth('300.6')).toBe(301)
+    expect(clampSidebarWidth('9000')).toBe(MAX_SIDEBAR_WIDTH)
+  })
+
+  it('answers the default — not a bound — for anything it cannot read as a number', () => {
+    // "unparseable" is a different claim from "too small", and clamping junk up to the minimum
+    // would quietly turn a corrupt key into a deliberate-looking choice.
+    for (const junk of [NaN, Infinity, -Infinity, 'wide', '', null, undefined, {}, []]) {
+      expect(clampSidebarWidth(junk)).toBe(DEFAULT_SIDEBAR_WIDTH)
+    }
+  })
+})
+
+describe('readStoredSidebarWidth / writeStoredSidebarWidth', () => {
+  it('round-trips a width through the documented key', () => {
+    writeStoredSidebarWidth(340)
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe('340')
+    expect(readStoredSidebarWidth()).toBe(340)
+  })
+
+  it('clamps on write, so a bad value never reaches storage', () => {
+    writeStoredSidebarWidth(10_000)
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe(String(MAX_SIDEBAR_WIDTH))
+  })
+
+  it('clamps on read too, so a hand-edited or stale key cannot paint an unusable column', () => {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, '12')
+    expect(readStoredSidebarWidth()).toBe(MIN_SIDEBAR_WIDTH)
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, 'not a number')
+    expect(readStoredSidebarWidth()).toBe(DEFAULT_SIDEBAR_WIDTH)
+  })
+
+  it('defaults when nothing has been stored', () => {
+    expect(readStoredSidebarWidth()).toBe(DEFAULT_SIDEBAR_WIDTH)
+  })
+
+  it('degrades to the default when storage throws — private mode is not a crash', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError')
+    })
+    expect(readStoredSidebarWidth()).toBe(DEFAULT_SIDEBAR_WIDTH)
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+    expect(() => writeStoredSidebarWidth(300)).not.toThrow()
+  })
+})

--- a/packages/web/src/lib/sidebar-width.ts
+++ b/packages/web/src/lib/sidebar-width.ts
@@ -1,0 +1,65 @@
+/* The desktop sidebar's width: the pure half. No React, no side effects beyond `localStorage`,
+ * so the clamp and the storage contract are table-testable — the same shape `lib/theme.ts` uses
+ * for the other browser-local preference the cockpit keeps.
+ *
+ * Why browser-local (#788): the right sidebar width is a property of the SCREEN you are sitting
+ * at, not of the workspace. The same checkout opened on a 13" laptop and a 34" ultrawide wants
+ * two different answers, and `~/.cezar/config.json` can only hold one. That also keeps this out
+ * of a protected surface — nothing an older cezar has to be able to read.
+ */
+
+/** One key, one preference. Namespaced `cez-` like `cez-theme` and `cez-density`. */
+export const SIDEBAR_WIDTH_STORAGE_KEY = 'cez-sidebar-width'
+
+/**
+ * The bounds, in CSS pixels.
+ *
+ * `MIN` is the shipped 264px column (spec `2026-07-14-cockpit-ui-redesign`, "App shell &
+ * navigation") — the sidebar may grow but never shrink below the width the whole layout, the
+ * mobile drawer and every screenshot were designed around. `MAX` keeps a widened sidebar from
+ * eating the thread it exists to navigate; 420px is roughly the point where the main column on a
+ * 13" laptop stops being comfortable.
+ */
+export const MIN_SIDEBAR_WIDTH = 264
+export const MAX_SIDEBAR_WIDTH = 420
+export const DEFAULT_SIDEBAR_WIDTH = MIN_SIDEBAR_WIDTH
+
+/** How far one arrow key moves the handle. Big enough to get somewhere, small enough to aim. */
+export const SIDEBAR_WIDTH_STEP = 16
+
+/**
+ * Anything → a width the layout can actually paint.
+ *
+ * Deliberately total: the input can be a drag delta, a hand-edited `localStorage` value, or a
+ * `null` from an empty key, and none of those may produce a column that is 3px wide or `NaN`.
+ * Non-finite input falls back to the default rather than to a bound, because "unparseable" is
+ * not the same claim as "too small".
+ */
+export function clampSidebarWidth(raw: unknown): number {
+  const width = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isFinite(width)) return DEFAULT_SIDEBAR_WIDTH
+  return Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, Math.round(width)))
+}
+
+/** The stored width, or the default when storage is empty, unreadable (private mode) or junk. */
+export function readStoredSidebarWidth(): number {
+  try {
+    const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)
+    // An absent key is the default, not a `Number(null) === 0` clamped up to the minimum. Same
+    // answer today, but only by coincidence — say what is meant.
+    if (raw === null) return DEFAULT_SIDEBAR_WIDTH
+    return clampSidebarWidth(raw)
+  } catch {
+    return DEFAULT_SIDEBAR_WIDTH
+  }
+}
+
+/** Persist a width. Clamped on the way in as well as on the way out, so a bad value can never be
+ *  written in the first place and an already-bad one can never be read back. */
+export function writeStoredSidebarWidth(width: number): void {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(width)))
+  } catch {
+    // Private mode / storage disabled — the width still applies for this page.
+  }
+}

--- a/packages/web/src/lib/task-groups.test.ts
+++ b/packages/web/src/lib/task-groups.test.ts
@@ -8,8 +8,10 @@ import {
   groupTitle,
   listCounts,
   queuePositions,
+  refPrefixMatches,
   runTitle,
   sortRuns,
+  splitRefPrefix,
   type QuickListBucket,
 } from '@/lib/task-groups'
 
@@ -216,6 +218,41 @@ describe('queuePositions', () => {
     ]
     // The archived one is not in the engine's queue, so it must not push the real one to #2.
     expect(queuePositions(runs)).toEqual(new Map([['queued', 1]]))
+  })
+})
+
+describe('splitRefPrefix', () => {
+  it.each([
+    // Exactly what `postValidateTitle` writes.
+    ['775: implementing comment threads', 775, 'implementing comment threads'],
+    ['1: a', 1, 'a'],
+    ['123456789: nine digits still parse', 123_456_789, 'nine digits still parse'],
+    // Not the shape: no space, no digits, nothing after the colon, or a colon that is prose.
+    ['775:implementing comment threads', null, '775:implementing comment threads'],
+    ['fix: the login bug', null, 'fix: the login bug'],
+    ['775: ', null, '775: '],
+    ['775', null, '775'],
+    ['#775: hash-prefixed is not our shape', null, '#775: hash-prefixed is not our shape'],
+    [' 775: leading space is not our shape', null, ' 775: leading space is not our shape'],
+    ['1234567890: ten digits is not a tracker number', null, '1234567890: ten digits is not a tracker number'],
+    // A second `NNN: ` inside the rest is left alone — only the leading one is the prefix.
+    ['775: 776: nested', 775, '776: nested'],
+  ])('%s → %s / %s', (title, ref, rest) => {
+    expect(splitRefPrefix(title)).toEqual({ ref, rest })
+  })
+})
+
+describe('refPrefixMatches', () => {
+  it('agrees only when the prefix IS the reference the chip will show', () => {
+    expect(refPrefixMatches('775: implementing comment threads', 775)).toBe(true)
+    // Opened on issue #788, shipped as PR #790 — two numbers, two facts. Neither may be hidden.
+    expect(refPrefixMatches('788: implementing comment threads', 790)).toBe(false)
+    // A title that legitimately begins with a number is never mistaken for a reference.
+    expect(refPrefixMatches('2026: the year in review', 2026)).toBe(true)
+    expect(refPrefixMatches('2026: the year in review', 790)).toBe(false)
+    // Nothing to match against, or nothing to strip.
+    expect(refPrefixMatches('775: implementing comment threads', undefined)).toBe(false)
+    expect(refPrefixMatches('implementing comment threads', 775)).toBe(false)
   })
 })
 

--- a/packages/web/src/lib/task-groups.ts
+++ b/packages/web/src/lib/task-groups.ts
@@ -125,8 +125,12 @@ export function runTitle(run: RunRecord): string {
  */
 export function splitRefPrefix(title: string): { ref: number | null; rest: string } {
   const match = /^(\d{1,9}): (.+)$/.exec(title)
-  if (!match) return { ref: null, rest: title }
-  const [, digits, rest] = match as unknown as [string, string, string]
+  const digits = match?.[1]
+  const rest = match?.[2]
+  // Both groups are non-optional in the pattern, so this narrowing is only for the type system —
+  // but it is the narrowing rather than a cast, so a future edit to the pattern is caught here
+  // instead of producing an `undefined` that has been asserted to be a string.
+  if (digits === undefined || rest === undefined) return { ref: null, rest: title }
   return { ref: Number(digits), rest }
 }
 

--- a/packages/web/src/lib/task-groups.ts
+++ b/packages/web/src/lib/task-groups.ts
@@ -110,6 +110,39 @@ export function runTitle(run: RunRecord): string {
 }
 
 /**
+ * The `NNN: ` reference prefix `postValidateTitle` writes onto every auto-named run
+ * (`packages/cezar/src/runs/auto-name.ts`), split off the display title — issue #788, option C.
+ *
+ * RENDER-ONLY. The stored `title`/`titleSummary` keep the prefix: it is what makes a run findable
+ * by number in search, in the Tasks table and in the page title, and `runs.json` field semantics
+ * are a protected surface. This only lets a surface that ALREADY paints the number elsewhere —
+ * the sidebar row, whose leading chip is the reference — stop spending five characters of a
+ * ~10-character title budget saying it twice.
+ *
+ * The shape is exactly what `postValidateTitle` produces (`^\d+: `) and nothing looser, so a title
+ * that merely contains a colon (`"fix: the login bug"`) or a number in prose is left alone. The
+ * caller decides whether the split is safe to use — see `refPrefixMatches`.
+ */
+export function splitRefPrefix(title: string): { ref: number | null; rest: string } {
+  const match = /^(\d{1,9}): (.+)$/.exec(title)
+  if (!match) return { ref: null, rest: title }
+  const [, digits, rest] = match as unknown as [string, string, string]
+  return { ref: Number(digits), rest }
+}
+
+/**
+ * May the row drop the title's `NNN: ` prefix in favour of its reference chip?
+ *
+ * Only when the two numbers are the SAME number. A task opened on issue `#788` whose PR later
+ * becomes `#790` shows `790` in its chip while its title still leads with `788: ` — two different
+ * facts, and hiding one of them would be a lie rather than a saving. An unrelated leading number
+ * (`"2026: the year in review"`) fails the same test, which is what keeps this from over-matching.
+ */
+export function refPrefixMatches(title: string, reference: number | undefined): boolean {
+  return reference !== undefined && splitRefPrefix(title).ref === reference
+}
+
+/**
  * A variant's shared title: `"Add autocomplete (A)"` → `"Add autocomplete"`.
  *
  * The suffix is the server's own convention (`startVariants` appends ` (A)`…` (C)`), so this


### PR DESCRIPTION
Closes #788
Tracking plan: .ai/runs/2026-08-05-readable-sidebar-task-names.md
Status: complete

## 🎯 Goal
- A sidebar quick-list row shows a readable task **name** again. At the fixed 264px column a worst-case row spent its 244px on a status dot, an unabbreviated `+59514 −12160` diff pair, a `PR ↗` chip and an unread dot — every one of them `shrink-0` — leaving the title, the only `min-w-0 flex-1` element, about 68px ≈ 10 characters, five of which were the `775: ` prefix the row *also* showed in its PR chip. This implements **option C** of #788, the option chosen on the issue, plus the drag-to-resize sidebar @patzick asked for in the follow-up comment. Measured in a real browser: the same row's title goes from ~68px to **132px** at the default width and **208px** once the column is dragged to 340px.

## What Changed
- **`packages/web/src/lib/task-groups.ts`** — two pure helpers: `splitRefPrefix` peels the `NNN: ` prefix `postValidateTitle` writes onto every auto-named run, and `refPrefixMatches` decides whether it is safe to drop. Render-only: the stored `title`/`titleSummary` keep the prefix, so the Tasks table, the page title and search are untouched.
- **`packages/web/src/components/task-quick-list.tsx`** — the row now paints its reference **once**, as a *leading* chip that is itself the PR/issue link, replacing the trailing `PR ↗` chip; the status dot moved out of the row `<Link>` so the reading order can be dot → chip → title (an anchor inside an anchor is invalid, so both stay siblings). The prefix is dropped **only when its number is the number the chip is showing** — a run opened on issue #788 that shipped as PR #790 keeps `788: `, because there the two numbers are two different facts. The row also gained the width-priority rule it never had, written down as a comment: the title is the only element allowed to grow, it has a `min-w-[7rem]` floor, and metadata drops beneath it. The group tile got the same floor.
- **`packages/web/src/components/reference-chip.tsx`** — `compact` changes meaning from "render the word `PR`" to "render the number alone" (`#775`). Which kind it is stays carried by the accessible name, the `title` and the `data-slot`; the quick-list is its only caller.
- **`packages/web/src/lib/sidebar-width.ts`** (new) — the width preference: clamp 264–420, `localStorage` key `cez-sidebar-width`, defensive on both read and write so private mode, an empty key or a hand-edited value can never paint an unusable column. Its own module rather than an edit to the `sidebar-collapse.ts` PR #786 is adding, so the two land without conflicting.
- **`packages/web/src/components/app-shell.tsx`** — the desktop `<aside>` takes its width from state and grew a `role="separator"` drag handle on its right border: pointer-captured drag, arrow keys, `Home`/`End`, double-click to reset. `SidebarContent` declares `@container/sidebar`, which is what lets a row decide what it can afford at the width the user actually chose. The `<md` drawer keeps its fixed 264px and has no handle.
- **`packages/web/e2e/*`** — drive-by fix, called out because it is not cosmetic: 16 e2e specs still spawned a pre-monorepo `<root>/dist/index.js`, which the build no longer emits, so every fixture-server spec failed to boot. That was invisible because the browser provider skips when it cannot be provisioned. They now share a `cezarCli` constant from `agent-browser.ts`, which also gained a `dragTo` helper.

### The one judgement call worth reviewing
The diff pair is the metadata that drops, via `@min-[23rem]/sidebar:inline`. 23rem is not where the pair *fits* — it is where it fits **and** the name still gets at least the budget it had in the default column. A first attempt at 21rem was measured in a real browser and rejected: dragging the column from 336px to 340px cut the title from 204px to 118px, i.e. widening the sidebar made task names *shorter*, which is the exact bargain this issue exists to stop making. The exact numbers stay in the element's `title` tooltip and in the Tasks table's ± column, which is untouched.

## 🧪 Tests
- `npm run typecheck` ✅ · `npm test` ✅ **5391 passed / 300 files** · `npm run test:unit` ✅ 36 passed · `npm run build` ✅ (`check:pack ok`) · `npm run test:package` ✅ 12 passed.
- New unit coverage: `splitRefPrefix`/`refPrefixMatches` table tests (12 shapes, including the `775:implementing` and `1234567890:` near-misses and the two-different-numbers case); nine quick-list cases for the leading chip, the conditional prefix strip, an inert chip for a number with no URL, and the worst-case row's floor; eleven `AppShell` cases for the resize handle (first-paint restore, drag, clamp, non-primary button, arrow/Home/End, Tab left alone, double-click reset, drawer unaffected, container declared); seventeen `sidebar-width` cases.
- New e2e (`packages/web/e2e/quick-list.e2e.ts`): its own fixture server for one deliberately worst-case row, asserting the stripped title, the `#775` chip, the measured title width against the floor, no horizontal overflow, monotonic growth across the width range, drag/clamp/persist-across-reload, keyboard resize, and the `<md` no-op.
- ⚠️ `npm run test:e2e` **could not run in the automation environment** — the `agent-browser` provider cannot be provisioned here (no network to the Chrome-for-Testing host), so it reported `TEST_E2E_STATUS=skipped`. The specs above are therefore written but **not executed by the harness**. The behaviour they assert *was* verified manually in a real headless Chrome over CDP against a real cezar serving a fixture `runs.json`; the screenshots and measurements are in the summary comment. The e2e specs still need a normal CI/QA run to count as harness-verified.

## 💥 Breaking Changes
- None. Every change is presentational, inside the cockpit bundle. `postValidateTitle`, the stored `titleSummary`, `runs.json` field semantics and the marker vocabulary are untouched — the prefix strip is render-only, so the Tasks table, the page title and search still read the same field byte-for-byte. The sidebar width is a browser-local `localStorage` preference, so nothing is added to `~/.cezar/config.json` and no older cezar has to read anything new.

## 📋 Progress
See the Progress section in the tracking plan.
