### PR TITLE
fix(server-install): restore registered-project uninstall guard (#535)

### DIFF
--- a/packages/cezar/src/server-install/engine.test.ts
+++ b/packages/cezar/src/server-install/engine.test.ts
@@ -7,6 +7,7 @@ import { loadServerState } from './state.ts';
 import { StepAborted } from './steps.ts';
 import { createAutoUi } from './ui.ts';
 import type { InstallStep, PlatformStrategy, Runner } from './types.ts';
+import { mergeWriteWorkspaceConfig } from '../workspace/config.ts';
 
 const noRunner: Runner = { capture: async () => ({ code: 0, stdout: '', stderr: '' }), interactive: async () => 0 };
 
@@ -164,6 +165,39 @@ describe('engine', () => {
     expect(after.installed).toBe(false);
     // platform is cleared so the host can be re-installed with any platform
     expect(after.platform).toBeUndefined();
+  });
+
+  it('warns and cancels before uninstalling a server that serves registered projects', async () => {
+    await mergeWriteWorkspaceConfig((config) => {
+      config.projects = [
+        {
+          id: 'api',
+          root: '/srv/api',
+          name: 'API',
+          addedAt: '2026-07-20T00:00:00.000Z',
+          lastOpenedAt: '2026-07-20T00:00:00.000Z',
+          source: 'local',
+        },
+        {
+          id: 'web',
+          root: '/srv/web',
+          name: 'Web',
+          addedAt: '2026-07-20T00:00:00.000Z',
+          lastOpenedAt: '2026-07-20T00:00:00.000Z',
+          source: 'local',
+        },
+      ];
+    });
+    await runInstall(strategyOf([fakeStep('a')]), opts());
+    const undo = fakeStep('a');
+    const warn = vi.fn();
+    const ui = { ...createAutoUi(), warn, confirm: vi.fn(async () => false) };
+
+    const res = await runUninstall(strategyOf([undo]), opts({ ui, assumeYes: false }));
+
+    expect(res.status).toBe('cancelled');
+    expect(undo.undo).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('2 projects are registered in ~/.cezar/config.json.');
   });
 
   it('after a full uninstall the host can be installed with a different platform', async () => {

--- a/packages/cezar/src/server-install/engine.ts
+++ b/packages/cezar/src/server-install/engine.ts
@@ -1,6 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { cezarHomeDir } from '../paths.ts';
+import { loadWorkspaceConfig } from '../workspace/config.ts';
 import { acquireLock, deleteServerState, isResolved, loadServerState, saveServerState } from './state.ts';
 import { StepAborted, StepCancelled, StepSkipped, defaultRunner } from './steps.ts';
 import { createAutoUi, createClackUi } from './ui.ts';
@@ -277,10 +275,13 @@ export async function runUninstall(strategy: PlatformStrategy, opts: RunOptions)
       );
     }
 
-    if (liveInstancesExist()) {
-      ctx.ui.warn('Other cezar instances are registered under ~/.cezar/instances/.');
+    const registeredProjects = (await loadWorkspaceConfig()).projects.length;
+    if (registeredProjects > 0) {
+      ctx.ui.warn(
+        `${registeredProjects} ${registeredProjects === 1 ? 'project is' : 'projects are'} registered in ~/.cezar/config.json.`,
+      );
       const proceed = await ctx.ui.confirm({
-        message: 'Removing the shared proxy/service will break them. Continue?',
+        message: 'Removing this server will make them unavailable. Continue?',
         initialValue: false,
       });
       if (proceed !== true) return { status: 'cancelled', state };
@@ -382,16 +383,5 @@ export async function runDeploy(strategy: PlatformStrategy, opts: RunOptions): P
     return { status: 'complete', state };
   } finally {
     release();
-  }
-}
-
-/** True when at least one repo instance is registered (multi-project registry). */
-function liveInstancesExist(): boolean {
-  const dir = join(cezarHomeDir(), 'instances');
-  if (!existsSync(dir)) return false;
-  try {
-    return readdirSync(dir).some((f) => f.endsWith('.json'));
-  } catch {
-    return false;
   }
 }

--- a/packages/cezar/test/e2e/package-cli.test.ts
+++ b/packages/cezar/test/e2e/package-cli.test.ts
@@ -184,10 +184,12 @@ if (args.join(' ') === 'auth status --json') {
     assert.match(projects.stdout, /fixture-repo/);
     assert.match(projects.stdout, /1 project\(s\)/);
 
-    // server-install / server-uninstall dry-run round-trip. CEZ_HOME isolates
-    // ~/.cezar/server.json to a temp dir; CEZ_DRY_RUN performs no real sudo.
+    // server-install / server-uninstall dry-run round-trip. A separate CEZ_HOME
+    // isolates ~/.cezar/server.json from the project-registry fixture above;
+    // CEZ_DRY_RUN performs no real sudo.
     assert.match(help.stdout, /cezar server-install/);
-    const serverEnv = { ...process.env, CEZ_DRY_RUN: '1', CEZ_HOME: cezHome };
+    const serverHome = join(root, 'server-home');
+    const serverEnv = { ...process.env, CEZ_DRY_RUN: '1', CEZ_HOME: serverHome };
     const serverExec = { cwd: consumerDir, env: serverEnv, timeout: 60_000, maxBuffer: 10 * 1024 * 1024 } as const;
 
     await execFile(
@@ -195,7 +197,7 @@ if (args.join(' ') === 'auth status --json') {
       [cliPath, 'server-install', '--platform', 'ubuntu-vps', '--yes', '--repo', fixtureRepo],
       serverExec,
     );
-    const state = JSON.parse(await readFile(join(cezHome, 'server.json'), 'utf8')) as {
+    const state = JSON.parse(await readFile(join(serverHome, 'server.json'), 'utf8')) as {
       platform: string;
       installed: boolean;
       steps: Record<string, unknown>;
@@ -209,7 +211,7 @@ if (args.join(' ') === 'auth status --json') {
       [cliPath, 'server-uninstall', '--platform', 'ubuntu-vps', '--yes'],
       serverExec,
     );
-    const reversed = JSON.parse(await readFile(join(cezHome, 'server.json'), 'utf8')) as {
+    const reversed = JSON.parse(await readFile(join(serverHome, 'server.json'), 'utf8')) as {
       installed: boolean;
       steps: Record<string, unknown>;
     };
@@ -226,7 +228,7 @@ if (args.join(' ') === 'auth status --json') {
       [cliPath, 'server-install', '--platform', 'ubuntu-vps', '--yes', '--repo', fixtureRepo],
       serverExec,
     );
-    const resumedExternal = JSON.parse(await readFile(join(cezHome, 'server.json'), 'utf8')) as {
+    const resumedExternal = JSON.parse(await readFile(join(serverHome, 'server.json'), 'utf8')) as {
       externalProxy?: boolean;
       steps: Record<string, unknown>;
     };


### PR DESCRIPTION
Closes #535

## 🎯 Goal
- Restore the uninstall safety prompt when the workspace registry contains projects that would become unavailable after removing the server.

## 🔍 Problem
`server-uninstall` still checked the abandoned `~/.cezar/instances/` directory, so the warning could never fire after the multi-project workspace moved its registry to `~/.cezar/config.json`.

## 🔍 Root Cause
The uninstall engine bypassed the workspace configuration loader and scanned state from the retired per-process-instances design. No current code writes that directory, leaving the safety branch unreachable and its message misleading.

## What Changed
- Load the current workspace registry through `loadWorkspaceConfig()` and warn with the actual registered-project count before uninstalling.
- Preserve the fail-closed confirmation and cancel before reversing any install step when the operator declines.
- Add a regression test for the registry-backed warning, and isolate the package CLI's server-state fixture from its separate project-registry fixture.

## 🧪 Tests
- `npm test --workspace @open-mercato/cezar -- --run src/server-install/engine.test.ts` — 25 passed; the new test was observed failing with `complete` before the fix and passing with `cancelled` after it.
- `npm run typecheck` — passed.
- `npm run test:unit` — 35 passed, 1 platform skip.
- `npm run build` — passed, including package integrity.
- `npm run test:package` — 12 passed.
- `npm test` — 5,337 passed and 8 failed in three untouched scheduler suites (`run-isolation`, `run-lease`, and `workspace-semaphore`); those existing environment/timing failures are unrelated to the server-install diff.

## 💥 Breaking Changes
- None.
