### PR TITLE
fix(web): derive composer git state from the project, not the boot folder (#791)

### DIFF
--- a/packages/web/src/routes/new-task.test.tsx
+++ b/packages/web/src/routes/new-task.test.tsx
@@ -489,7 +489,9 @@ describe('picker data flows', () => {
     expect(document.querySelector('[data-slot="worktree-toggle"]')).not.toBeNull()
     fireEvent.change(textarea(), { target: { value: 'Fix the composer git detection' } })
     await startTask()
-    expect(postedBody()).not.toMatchObject({ worktree: false })
+    // `worktree` is sent only when explicitly OFF (new-task-form.ts): an absent key IS the
+    // isolated-worktree default, so absence — not `worktree: false` — is what the fix restores.
+    expect(postedBody()).not.toHaveProperty('worktree')
   })
 
   it('base branch pill shows config default (falling back to the checkout) and PUTs /api/v1/config', async () => {

--- a/packages/web/src/routes/new-task.test.tsx
+++ b/packages/web/src/routes/new-task.test.tsx
@@ -477,6 +477,21 @@ describe('picker data flows', () => {
     expect(document.querySelector('[data-slot="base-pill"]')).toBeNull()
   })
 
+  // #791: health is bound to the boot folder, so a cezar booted outside a git repo answered
+  // `repo: null` for EVERY project. Reading git state from the project-scoped `/repo` instead is
+  // what keeps the worktree controls alive for a git project under a non-git boot root.
+  it('gates variants on the project repo, not the boot folder: boot without git still offers worktrees', async () => {
+    serve({ health: HEALTH_NO_GIT, repo: REPO })
+    renderNewTask()
+    await pillReady()
+    const pill = document.querySelector('[data-slot="variants-pill"]') as HTMLButtonElement
+    expect(pill.disabled).toBe(false)
+    expect(document.querySelector('[data-slot="worktree-toggle"]')).not.toBeNull()
+    fireEvent.change(textarea(), { target: { value: 'Fix the composer git detection' } })
+    await startTask()
+    expect(postedBody()).not.toMatchObject({ worktree: false })
+  })
+
   it('base branch pill shows config default (falling back to the checkout) and PUTs /api/v1/config', async () => {
     serve({ repo: { ...REPO, baseBranch: 'develop' } })
     renderNewTask()

--- a/packages/web/src/routes/new-task.tsx
+++ b/packages/web/src/routes/new-task.tsx
@@ -264,7 +264,11 @@ export function NewTaskRoute() {
   }, [providersReady])
 
   // Parallel variants need a worktree per variant, hence git (the server 409s without it).
-  const hasGit = health.data === undefined || health.data.repo !== null
+  // Read it from the PROJECT-scoped `/repo` above, never from `/api/health.repo`: health is bound
+  // to the boot folder, so booting outside a git repo hid the worktree controls for every
+  // registered project (#791) — the same per-project sweep as #700 (forge) and #699 (runner
+  // defaults). Loading still assumes git so the controls do not flicker.
+  const hasGit = repo.data === undefined || repo.data.info !== null
   const variants = hasGit ? draft.variants : 1
 
   // Worktree opt-out (#worktree-toggle): any ordinary run in a git repo may use the current

--- a/packages/web/src/routes/task-git/task-changes.test.tsx
+++ b/packages/web/src/routes/task-git/task-changes.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createQueryClient } from '@/api/query-client'
-import type { ApiRun, ChangesPayload, HealthResponse } from '@open-mercato/cezar-api-client'
+import type { ApiRun, ChangesPayload, HealthResponse, RepoResponse } from '@open-mercato/cezar-api-client'
 import { Toaster, resetToasts } from '@/components/ui/toaster'
 import type { GitActionBar } from '@/lib/git-actions'
 
@@ -47,6 +47,16 @@ const HEALTH: HealthResponse = {
   defaultRunner: 'claude',
   forge: { kind: 'github', available: true },
   capabilities: { localHandoff: true, tokenMetrics: true, tokenUsageMetrics: true, costMetrics: true, followups: false, singleProject: false },
+}
+
+/** The PROJECT-scoped `/repo` answer. The remote that gates Push is read from here rather than
+ *  from `health.repo`, which describes the boot folder only (#791). */
+const REPO: RepoResponse = {
+  info: { root: '/repo', branch: 'main', remote: 'git@github.com:acme/demo.git' },
+  status: [],
+  log: [],
+  branches: ['main'],
+  baseBranch: null,
 }
 
 const CHANGES: ChangesPayload = {
@@ -96,6 +106,7 @@ function stubFetch(overrides: Record<string, () => Response> = {}): SentRequest[
       if (method === 'GET' && path === '/api/v1/runs/r1') return jsonResponse(RUN)
       if (method === 'GET' && path === '/api/v1/runs/r1/changes') return jsonResponse(CHANGES)
       if (method === 'GET' && path === '/api/v1/health') return jsonResponse(HEALTH)
+      if (method === 'GET' && path === '/api/v1/repo') return jsonResponse(REPO)
       if (method === 'GET' && path === '/api/v1/runs') return jsonResponse([])
       return jsonResponse({})
     }),
@@ -264,6 +275,17 @@ describe('the Changes tab route', () => {
     await waitFor(() =>
       expect(document.body.textContent).toContain('Pushed cez/abc12345 to origin (upstream set)'),
     )
+  })
+
+  // #791: `/api/v1/health` reports the boot folder, so a cezar booted outside a git repo answered
+  // `repo: null` and Push went dark for every project. The remote must come from the
+  // project-scoped `/repo` instead.
+  it('offers Push from the project remote even when the boot folder has no git repo', async () => {
+    stubFetch({
+      'GET /api/v1/health': () => jsonResponse({ ...HEALTH, repo: null }),
+    })
+    renderChangesRoute()
+    await waitFor(() => expect(toolbarAction('push')?.disabled).toBe(false))
   })
 
   it('Create PR uses the existing /pr flow and flips to View PR once the record carries the URL', async () => {

--- a/packages/web/src/routes/task-git/task-changes.tsx
+++ b/packages/web/src/routes/task-git/task-changes.tsx
@@ -4,7 +4,7 @@ import { useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 
 import { ApiError, createRunPr, getRunFile, openRunFileInApp, openRunInCli, pushRun, runFileRawUrl } from '@/api/client'
-import { queryKeys, useHealth, useRun, useRunChanges } from '@/api/queries'
+import { queryKeys, useHealth, useRepo, useRun, useRunChanges } from '@/api/queries'
 import type { ApiRun } from '@open-mercato/cezar-api-client'
 import { CenteredState } from '@/components/centered-state'
 import { Diff, type DiffHandle, type DiffMode } from '@/components/diff'
@@ -41,6 +41,10 @@ export function TaskChangesRoute() {
 
 function ChangesView({ run }: { run: ApiRun }) {
   const health = useHealth()
+  // The remote that decides whether Push is offered comes from the PROJECT-scoped `/repo`, not
+  // from `/api/health.repo`: health is bound to the boot folder, so a cezar booted outside a git
+  // repo reported no remote for every project (#791).
+  const repo = useRepo()
   // Poll while the run is active so writes appear as the agent makes them.
   const changes = useRunChanges(run.id, isRunActive(run.status))
   const desktop = useIsDesktop()
@@ -103,7 +107,7 @@ function ChangesView({ run }: { run: ApiRun }) {
     hasWorktree: Boolean(run.worktreePath) && !changesRefused,
     branch: run.branch,
     changedFiles: changes.data?.stat.files,
-    remote: health.data?.repo?.remote,
+    remote: repo.data?.info?.remote,
     forge: health.data?.forge ?? null,
     localHandoff: health.data?.capabilities.localHandoff ?? false,
     hasSession: lastSessionId(run) !== undefined,


### PR DESCRIPTION
Fixes #791

## 🎯 Goal
- Booting `cezar` from a folder that is not a git repository no longer disables worktree isolation and the Push action for every registered project. The Worktree chip, parallel variants and Push now follow the **selected project's** git state, which is what the user already sees in the same composer row's `base:` pill.

## 🔍 Problem
The New Task composer decided whether the active project is a git repo from the boot-scoped `/api/v1/health.repo` rather than the project-scoped `/api/v1/p/:id/repo` it already had loaded. Launched from an umbrella workspace dir, a scratch folder or a stale checkout, **every** registered project silently lost worktree isolation: the Worktree chip disappeared, the variants pill was stuck at `×1` and disabled, and every run posted `worktree: false` and executed in the repo working tree. Meanwhile the `base:` pill in the same row listed the project's branches correctly, because it reads the project-scoped route — which is exactly what made this so confusing to diagnose. The task Changes tab had the same defect on its own surface: it gated the Push action on `health.data?.repo?.remote`, so Push went dark for every project under a non-git boot root.

## 🔍 Root Cause
`healthSnapshot` (`packages/cezar/src/server/server.ts:1473`) resolves its `repo` field with `getRepoInfo(bootRoot)` — the folder cezar was started in, never `c.get('project').root`. Two cockpit surfaces consumed that field on project-scoped views: `packages/web/src/routes/new-task.tsx:267` computed `hasGit = health.data === undefined || health.data.repo !== null`, and `packages/web/src/routes/task-git/task-changes.tsx:106` passed `remote: health.data?.repo?.remote` into `gitActionPolicy`. From `hasGit: false` the value flows into `resolveComposerRunMode` → `packages/web/src/routes/new-task-draft.ts:68` (`const worktree = !input.hasGit ? false : …`), so the body posted to `POST /api/v1/runs` was correct **given its input** — the input was wrong.

This is the same family as #698 (forge/GitHub tab gated on the boot folder, fixed per-project by #700) and #699 (runner defaults resolved from boot health). `hasGit` and the Push remote are the two readers those sweeps did not reach. The comment at `new-task.tsx:141` already recorded the rule for `useConfig()`; line 267 was simply not swept with it.

## What Changed
- **`packages/web/src/routes/new-task.tsx`** — `hasGit` is now derived from the project-scoped repo query already in scope a few lines above (`useRepo()`, L138): `repo.data === undefined || repo.data.info !== null`. `GET /p/:id/repo` already answers `{ info: null, branches: [], … }` for a non-git project root, so the non-git case degrades exactly as before, and the `undefined` branch preserves the existing "assume git while loading, do not flicker the controls" rule. The comment cites #791 and the #699/#700 precedent.
- **`packages/web/src/routes/task-git/task-changes.tsx`** — the same sweep on the other reader: the view now calls `useRepo()` and passes `remote: repo.data?.info?.remote` to `gitActionPolicy`. This is the "worth a sweep for any other `health.data.repo` reader on a project-scoped surface" item from the issue; a codebase-wide grep confirms these two were the only such readers.
- The swap is **type-identical**, not a refactor: `repoInfoSchema` is declared once in `packages/contract/src/health.ts` and reused by `repoResponseSchema.info` (`packages/contract/src/repo.ts:48`), so `health.repo` and `repo.info` are the same record and `.remote` reads identically. `repoResponseSchema` is a union discriminated on `info: null`, so `repo.data.info !== null` narrows it for the type checker.
- No server change. `RunManager` already calls `getRepoInfo(this.repoRoot)` per project and would happily build the worktree when asked.

## 🧪 Tests
- Two new regressions, both proven **red → green** (each fails on the unfixed tree and passes with the fix, while the other 110 tests in the same two files pass either way):
  - `packages/web/src/routes/new-task.test.tsx` — boot health with no repo (`HEALTH_NO_GIT`) plus a git-bearing project repo (`REPO`): the Worktree chip renders, the variants pill is enabled, and the posted body does not carry `worktree: false`. The pre-existing no-git test at L470 sets **both** fixtures to no-git, so it never pinned the buggy behavior — it stays green and unchanged.
  - `packages/web/src/routes/task-git/task-changes.test.tsx` — `health.repo: null` with a project remote: Push stays offered.
- That second test file's fetch stub did not serve `/api/v1/repo` at all, so a `REPO` fixture was added to `stubFetch`. Without it the pre-existing Push tests would have silently started asserting against the catch-all `{}` answer instead of a real payload.
- Validation gate, run with `LC_ALL=C`: `npm run typecheck` ✅ · `npm run test:unit` ✅ · `npm run build` ✅ (`check:pack ok — 455 files, 88 under web/dist`) · `npm run test:package` ✅ (12/12).
- **`npm test` — disclosed honestly:** every `packages/web` test passed, including both new regressions. Three **server** tests failed with 5000 ms timeouts — two in `packages/cezar/src/workflows/run-lease.test.ts`, one in `packages/cezar/src/server/health-topic.test.ts`. These are **pre-existing and environmental, not caused by this PR**: the identical files, tests and timeouts fail on the unmodified base commit `d3aff0aa` with a clean tree on the same machine, and this PR touches only `packages/web` — not one server file. Under heavier parallel load the same timeout family also reaches `host-guard`, `health-forge`, `run-isolation` and `open-in-app`. Happy to file a separate issue for that suite's timing sensitivity if maintainers consider it worth tracking.

## 💥 Breaking Changes
- None. No contract, route, response shape, event name or persisted field changes; `packages/contract` is untouched.

## 📋 Notes for maintainers

**Out of scope, deliberately.** The issue's "Also worth a look" item — the `/new` header printing *"Runs in an isolated worktree — review everything before it lands."* unconditionally (`new-task.tsx:562`) — is **not** in this PR. It is asserted unconditionally by `new-task.test.tsx:357`, so changing it means changing an existing test's expectations, which belongs in its own reviewable diff. A follow-up issue will be filed for it.

**Labels — please apply, this account cannot.** This PR comes from a fork and the author has `READ` on this repository, so label and assignee mutations return 403. The three-signal claim on #791 degraded to a claim comment alone. Per `SDLC.md` the intended set is:

| Label | Why |
| --- | --- |
| `bug` | Corrective change to broken behavior, not a new capability. |
| `review` | Pipeline state: a ready, non-draft PR awaiting a reviewer. |
| `priority-high` | Silent loss of worktree isolation means agent runs execute in the user's working tree while the control that governs it is not even rendered. `CODE_REVIEW.md` ranks run-lifecycle correctness first, because a bug there loses user work. |
| `risk-low` | Two type-identical expression swaps in the cockpit; no server, contract or state-file surface touched. |
| `needs-qa` | User-facing cockpit behavior that deserves manual exercise. A `CEZ_DRY_RUN=1` session covers it; see the QA note below. |

**QA evidence.** `qa-approved` / `qa-self-verified` are likewise unavailable to this account, so this is offered as the written account `SDLC.md`'s self-QA exception describes rather than as a label. The behavior is locked in by the two automated regressions above, which exercise the exact reported configuration — boot root without git, project with git — at the component level: the Worktree chip renders, the variants pill is enabled, the submitted body carries no `worktree: false`, and Push stays offered. A reviewer wanting the end-to-end version can reproduce with `mkdir -p /tmp/not-a-repo && cd /tmp/not-a-repo && npx cezar-cli`, then add a real git project and open New Task.
