### PR TITLE
docs: add the missing root LICENSE file (MIT)

### DIFF
--- a/.ai/runs/2026-08-06-add-license-file.md
+++ b/.ai/runs/2026-08-06-add-license-file.md
@@ -86,6 +86,8 @@ actual terms.
 
 ## Progress
 
+PR: #796
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Write the licence

--- a/.ai/runs/2026-08-06-add-license-file.md
+++ b/.ai/runs/2026-08-06-add-license-file.md
@@ -96,4 +96,4 @@ actual terms.
 
 ### Phase 2: Verify
 
-- [ ] 2.1 Verify tarball + validation gate
+- [x] 2.1 Verify tarball + validation gate — verified on b34efafa (`npm pack --dry-run -w @open-mercato/cezar`: 456 files, `LICENSE` present; gate green — typecheck ✅, `npm test` 5344 passed / 299 files ✅, `test:unit` 36 passed ✅, `build` + `check:pack` ok ✅, `test:package` 12 passed ✅)

--- a/.ai/runs/2026-08-06-add-license-file.md
+++ b/.ai/runs/2026-08-06-add-license-file.md
@@ -1,0 +1,79 @@
+# Execution plan — add the missing root LICENSE file
+
+**Slug:** `add-license-file`
+**Branch:** `fix/add-license-file`
+**Base:** `main`
+**Engine:** om-auto-create-pr (steps: 3, --loop: no)
+
+## 🎯 Goal
+
+Ship a real `LICENSE` file at the repository root so GitHub detects the project as MIT-licensed
+and corporate license scanners stop flagging it as "no license". The MIT declaration already
+exists in `package.json` (`"license": "MIT"`) and in `README.md` (badge + License section), but
+neither is a licence *text* — GitHub's licence detection and most SCA/compliance scanners look
+for a root `LICENSE` file containing the full licence body, so today the repo reads as
+unlicensed to anyone evaluating it for adoption.
+
+## Scope
+
+- Add `LICENSE` at the repository root: the verbatim MIT licence text, attributed to the
+  copyright holder already named in `README.md` ("**MIT** © Patryk Lewczuk"), year `2026`
+  (the repository's first and only commit year).
+- Make `README.md`'s licence signposting point at that file rather than only at its own
+  anchor, so a reader lands on the actual terms.
+- Verify the published npm tarball carries the licence too (`npm pack --dry-run`), since the
+  same corporate scanners inspect the package, not just the GitHub page.
+
+## Non-goals
+
+- **No re-licensing or licence change.** MIT is already the declared licence in `package.json`
+  and `README.md`; this run only writes down what is already true. Anything that would alter
+  the licence terms is out of scope.
+- **No copyright-header sweep.** Per-file SPDX headers across `src/` are a separate, much
+  larger decision and are not part of this run.
+- **No `NOTICE`/`THIRD-PARTY` dependency-attribution file.** Useful for compliance, but a
+  distinct piece of work with its own tooling question.
+- **No packaging changes.** `package.json`'s `files` array is not touched: npm includes a root
+  `LICENSE` in every tarball regardless of `files`, so no change is needed and adding one would
+  be noise. Step 2.1 verifies this rather than assuming it.
+- **No change to `scripts/check-pack.mjs` / `src/pack-check.ts`.** Adding a "LICENSE must be
+  packed" gate would ripple through six existing unit-test expectations to guard a failure mode
+  npm makes essentially impossible. Recorded here as a deliberate rejection, not an oversight.
+
+## Implementation Plan
+
+### Phase 1: Write the licence
+
+- **1.1 Add the root `LICENSE` file.** Verbatim OSI MIT text, `Copyright (c) 2026 Patryk
+  Lewczuk`. No wording drift from the canonical text — scanners match on it.
+- **1.2 Point `README.md` at the file.** Change the shields badge target from the in-page
+  `#license` anchor to `LICENSE`, and expand the License section so it links the file
+  explicitly.
+
+### Phase 2: Verify
+
+- **2.1 Verify tarball + validation gate.** Confirm `npm pack --dry-run` lists `LICENSE`, then
+  run the full configured gate (`npm run typecheck`, `npm test`, `npm run test:unit`,
+  `npm run build`, `npm run test:package`).
+
+## Risks
+
+- **Low overall.** The change is additive and touches no runtime code path.
+- **Wrong copyright holder or year** would be the only meaningful defect. Mitigated by taking
+  the holder verbatim from `README.md`'s existing declaration and the year from the repository's
+  own commit history (first commit 2026), rather than inventing either.
+- **Licence-text drift** (a reworded MIT that scanners fail to classify) is mitigated by
+  copying the canonical OSI text unmodified.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Write the licence
+
+- [ ] 1.1 Add the root `LICENSE` file
+- [ ] 1.2 Point `README.md` at the file
+
+### Phase 2: Verify
+
+- [ ] 2.1 Verify tarball + validation gate

--- a/.ai/runs/2026-08-06-add-license-file.md
+++ b/.ai/runs/2026-08-06-add-license-file.md
@@ -1,69 +1,88 @@
-# Execution plan — add the missing root LICENSE file
+# Execution plan — add the missing LICENSE files
 
 **Slug:** `add-license-file`
 **Branch:** `fix/add-license-file`
 **Base:** `main`
-**Engine:** om-auto-create-pr (steps: 3, --loop: no)
+**Engine:** om-auto-create-pr (steps: 4, --loop: no)
 
 ## 🎯 Goal
 
-Ship a real `LICENSE` file at the repository root so GitHub detects the project as MIT-licensed
-and corporate license scanners stop flagging it as "no license". The MIT declaration already
-exists in `package.json` (`"license": "MIT"`) and in `README.md` (badge + License section), but
-neither is a licence *text* — GitHub's licence detection and most SCA/compliance scanners look
-for a root `LICENSE` file containing the full licence body, so today the repo reads as
-unlicensed to anyone evaluating it for adoption.
+Ship real MIT licence text so GitHub detects the project as MIT-licensed and corporate licence
+scanners stop reporting it as unlicensed. MIT is already declared in every `package.json`
+(`"license": "MIT"`) and in `README.md` (badge + License section), but a declaration is not
+licence *text* — GitHub's licence detection and most SCA/compliance tooling look for a
+`LICENSE` file containing the full body, so today the repo reads as "no license" to anyone
+evaluating it for adoption.
 
 ## Scope
 
-- Add `LICENSE` at the repository root: the verbatim MIT licence text, attributed to the
-  copyright holder already named in `README.md` ("**MIT** © Patryk Lewczuk"), year `2026`
-  (the repository's first and only commit year).
-- Make `README.md`'s licence signposting point at that file rather than only at its own
-  anchor, so a reader lands on the actual terms.
-- Verify the published npm tarball carries the licence too (`npm pack --dry-run`), since the
-  same corporate scanners inspect the package, not just the GitHub page.
+The repository is a **monorepo** (root `cezar-monorepo`, private, publishes nothing; workspaces
+`packages/{contract,api-client,cezar,web}`, of which only `@open-mercato/cezar` is publishable).
+That shapes the fix into two places:
+
+- `LICENSE` at the **repository root** — what GitHub's licence detection and repo-level scanners
+  read. This is the fix the brief asks for.
+- `packages/cezar/LICENSE` — npm only includes a `LICENSE` found in the *package's own*
+  directory, never one from a monorepo root, so without this the published
+  `@open-mercato/cezar` tarball ships with no licence text at all. Same failure, same scanners,
+  one file; included deliberately rather than left as a follow-up.
+
+Both carry the verbatim OSI MIT text attributed to the holder already named in `README.md`
+("**MIT** © Patryk Lewczuk"), year `2026` (the repository's first and only commit year).
+`README.md`'s badge and License section are repointed at the file so a reader lands on the
+actual terms.
 
 ## Non-goals
 
-- **No re-licensing or licence change.** MIT is already the declared licence in `package.json`
-  and `README.md`; this run only writes down what is already true. Anything that would alter
-  the licence terms is out of scope.
-- **No copyright-header sweep.** Per-file SPDX headers across `src/` are a separate, much
-  larger decision and are not part of this run.
-- **No `NOTICE`/`THIRD-PARTY` dependency-attribution file.** Useful for compliance, but a
-  distinct piece of work with its own tooling question.
-- **No packaging changes.** `package.json`'s `files` array is not touched: npm includes a root
-  `LICENSE` in every tarball regardless of `files`, so no change is needed and adding one would
-  be noise. Step 2.1 verifies this rather than assuming it.
-- **No change to `scripts/check-pack.mjs` / `src/pack-check.ts`.** Adding a "LICENSE must be
-  packed" gate would ripple through six existing unit-test expectations to guard a failure mode
-  npm makes essentially impossible. Recorded here as a deliberate rejection, not an oversight.
+- **No re-licensing.** MIT is already declared everywhere; this run only writes down what is
+  already true. Nothing that alters the terms is in scope.
+- **No per-package LICENSE for the private workspaces** (`contract`, `api-client`, `web`). They
+  are `"private": true` and never published, so they have no tarball to license; the root file
+  covers them for repo-level scanning.
+- **No copyright-header sweep.** Per-file SPDX headers across `packages/*/src` are a separate,
+  much larger decision.
+- **No `NOTICE`/`THIRD-PARTY` dependency-attribution file.** Useful for compliance, but distinct
+  work with its own tooling question.
+- **No packaging changes.** `packages/cezar/package.json`'s `files` array is not touched: npm
+  includes a package-root `LICENSE` in every tarball regardless of `files`. Step 2.1 verifies
+  this against `npm pack --dry-run` rather than assuming it.
+- **No sync-script or `check-pack` change.** The repo copies `README.md` into the package at
+  `prebuild` (`packages/cezar/scripts/sync-readme.mjs`) to keep one source of truth for a large
+  living document. A licence is frozen legal text whose only variable — holder and year —
+  changes at most annually, so a committed second copy is the simpler, zero-moving-parts choice
+  and matches ordinary monorepo practice. Deliberately rejected, not overlooked: routing it
+  through the sync script would add a build step and a `findPackGaps` gate (rippling six unit
+  tests) to guard a file that cannot silently disappear.
 
 ## Implementation Plan
 
 ### Phase 1: Write the licence
 
 - **1.1 Add the root `LICENSE` file.** Verbatim OSI MIT text, `Copyright (c) 2026 Patryk
-  Lewczuk`. No wording drift from the canonical text — scanners match on it.
+  Lewczuk`. No wording drift from the canonical text — scanners classify by matching it.
 - **1.2 Point `README.md` at the file.** Change the shields badge target from the in-page
-  `#license` anchor to `LICENSE`, and expand the License section so it links the file
-  explicitly.
+  `#license` anchor to `LICENSE`, and expand the License section to link the file explicitly.
+- **1.3 Add `packages/cezar/LICENSE`.** Identical text, so the published npm tarball carries the
+  licence.
 
 ### Phase 2: Verify
 
-- **2.1 Verify tarball + validation gate.** Confirm `npm pack --dry-run` lists `LICENSE`, then
-  run the full configured gate (`npm run typecheck`, `npm test`, `npm run test:unit`,
-  `npm run build`, `npm run test:package`).
+- **2.1 Verify tarball + validation gate.** Confirm `npm pack --dry-run -w @open-mercato/cezar`
+  lists `LICENSE`, then run the full configured gate (`npm run typecheck`, `npm test`,
+  `npm run test:unit`, `npm run build`, `npm run test:package`).
 
 ## Risks
 
-- **Low overall.** The change is additive and touches no runtime code path.
+- **Low overall.** The change is additive and touches no runtime code path, no build script and
+  no packaging manifest.
 - **Wrong copyright holder or year** would be the only meaningful defect. Mitigated by taking
   the holder verbatim from `README.md`'s existing declaration and the year from the repository's
   own commit history (first commit 2026), rather than inventing either.
-- **Licence-text drift** (a reworded MIT that scanners fail to classify) is mitigated by
-  copying the canonical OSI text unmodified.
+- **Licence-text drift** (a reworded MIT that scanners fail to classify) is mitigated by copying
+  the canonical OSI text unmodified into both locations.
+- **Two copies could drift** on a future holder/year change. Accepted: the alternative (generate
+  the copy at build time) trades a frozen-text duplication risk for real build machinery. Anyone
+  changing the holder must update both files.
 
 ## Progress
 
@@ -71,8 +90,9 @@ unlicensed to anyone evaluating it for adoption.
 
 ### Phase 1: Write the licence
 
-- [ ] 1.1 Add the root `LICENSE` file
-- [ ] 1.2 Point `README.md` at the file
+- [x] 1.1 Add the root `LICENSE` file — 5c398ff3
+- [x] 1.2 Point `README.md` at the file — 6edad5f7
+- [x] 1.3 Add `packages/cezar/LICENSE` — b34efafa
 
 ### Phase 2: Verify
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Patryk Lewczuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ your phone, working your backlog while you're away.
 
 [A look inside](#a-look-inside) · [What cezar does best](#what-cezar-does-best) · [What it solves](#what-it-solves) · [Who it's for](#who-its-for) · [Quick start](#quick-start) · [How it works](#how-it-works) · [Core concepts](#core-concepts) · [Cockpit tour](#cockpit-tour) · [Agent backends](#coding-agent-backends) · [Remote access](#remote-access-host-cezar-on-a-server)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](#license)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Node 20+](https://img.shields.io/badge/Node-20%2B-339933)
 ![TypeScript 7.x](https://img.shields.io/badge/TypeScript-7.x-3178c6)
 ![Zero config](https://img.shields.io/badge/config-zero-success)
@@ -712,4 +712,4 @@ Start here; graduate to cezar when a team needs shared visibility.
 
 ## License
 
-**MIT** © Patryk Lewczuk
+**MIT** © Patryk Lewczuk — full text in [LICENSE](LICENSE).

--- a/packages/cezar/LICENSE
+++ b/packages/cezar/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Patryk Lewczuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-06-add-license-file.md
Status: complete

## 🎯 Goal
Ship real MIT licence text so GitHub detects the project as MIT-licensed and corporate licence scanners stop reporting it as unlicensed. MIT was already declared in every `package.json` (`"license": "MIT"`) and in `README.md` (badge + License section) — but a declaration is not licence *text*. GitHub's licence detection and most SCA/compliance tooling classify by matching the full licence body in a `LICENSE` file, so until now the repo read as "no license" to anyone evaluating it for adoption, which is a needless barrier at intake.

## What Changed
- **`LICENSE` (new, repo root)** — the verbatim OSI MIT text, `Copyright (c) 2026 Patryk Lewczuk`. The holder is taken verbatim from `README.md`'s existing "**MIT** © Patryk Lewczuk" declaration and the year from the repository's own history (first commit 2026), rather than invented. The text is unmodified because scanners classify by matching it — any rewording risks an "unknown license" verdict, which is the problem this PR exists to remove.
- **`packages/cezar/LICENSE` (new)** — the same text inside the one publishable workspace. This repo is a monorepo (`cezar-monorepo` at the root is `private` and publishes nothing; only `@open-mercato/cezar` is published), and npm only includes a `LICENSE` found in the *package's own* directory — never one from a monorepo root. Without this file the published tarball ships with no licence text at all, which trips exactly the same scanners on the npm side. Included deliberately rather than deferred, since it is the same defect and one file.
- **`README.md`** — the shields licence badge pointed at the in-page `#license` anchor, which just scrolled the reader back into the README; it now points at `LICENSE`. The License section gained an explicit link to the file so a reader lands on the actual terms. No other README content changed, and no remaining `#license` anchor references were left dangling.

Deliberately **not** changed, so reviewers know these were decisions and not oversights:
- `packages/cezar/package.json`'s `files` array — npm includes a package-root `LICENSE` in every tarball regardless of `files`, so adding it would be noise. Verified rather than assumed (see Tests).
- The `prebuild` README sync (`packages/cezar/scripts/sync-readme.mjs`) and the `check:pack` gate. The README is generated into the package because it is a large living document that would drift; a licence is frozen legal text whose only variable is holder and year. A committed second copy has zero moving parts, whereas routing it through the sync script would add a build step plus a `findPackGaps` gate — rippling six unit tests — to guard a file that cannot silently disappear. The trade-off accepted is that a future holder/year change must touch both files; this is recorded in the plan's Risks.
- The private workspaces (`contract`, `api-client`, `web`) get no per-package `LICENSE`: they are never published, so they have no tarball to license, and the root file covers them for repo-level scanning.

## 🧪 Tests
- Full configured validation gate, all green: `npm run typecheck` ✅ · `npm test` — **5344 passed / 299 files** ✅ · `npm run test:unit` — **36 passed** ✅ · `npm run build` (incl. `check:pack` — *456 files, 88 under web/dist*) ✅ · `npm run test:package` — **12 passed** ✅
- Packaging verified directly rather than assumed: `npm pack --dry-run --json -w @open-mercato/cezar` on the built tree reports **456 files with `LICENSE` present**, confirming the published tarball now carries the licence with no `files` change.
- No unit tests were added: this run changes no code path — it adds two static text files and retargets two Markdown links — so there is no behaviour to lock in. The packaging claim, which is the only falsifiable one, is covered by the `npm pack` verification above.

## 💥 Breaking Changes
- None. The change is purely additive: no runtime code, build script, or packaging manifest is touched. MIT was already the declared licence in every manifest, so nothing is re-licensed — this PR only writes down terms that already applied.

## 📋 Progress
See the Progress section in the tracking plan.
