### PR TITLE
test(workflows): synchronize the repository-root lease test instead of racing a timer (#797)

### DIFF
--- a/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
+++ b/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
@@ -72,6 +72,8 @@ complete configured validation gate.
 
 ## Progress
 
+PR: #800
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Replace the fixed-duration holder with an explicit gate

--- a/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
+++ b/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Make `src/workflows/run-lease.test.ts` deterministic under full-suite load by replacing its
+Make `packages/cezar/src/workflows/run-lease.test.ts` deterministic under full-suite load by replacing its
 fixed wall-clock lease holder with explicit test synchronization, and make its teardown wait for
 every spawned run to settle before the temporary fixture repository is removed — without
 weakening the scheduling proof the file exists for.
@@ -24,11 +24,11 @@ holder releases the lease, while the holder itself is still finalizing (`settleS
 write → `dropActive`). The holder's trailing NDJSON event append then lands on a directory that no
 longer exists → `ENOENT`.
 
-Both are test-harness defects; `src/workflows/run.ts` behaves correctly and is not touched.
+Both are test-harness defects; `packages/cezar/src/workflows/run.ts` behaves correctly and is not touched.
 
 ## Scope
 
-- `src/workflows/run-lease.test.ts` only.
+- `packages/cezar/src/workflows/run-lease.test.ts` only.
 
 ### Non-goals
 
@@ -76,13 +76,16 @@ complete configured validation gate.
 
 ### Phase 1: Replace the fixed-duration holder with an explicit gate
 
-- [ ] 1.1 Add a gate-file-driven holder workflow and release helper to the fixture
-- [ ] 1.2 Drive both tests off the explicit release instead of the 1.5 s timer
+- [x] 1.1 Add a gate-file-driven holder workflow and release helper to the fixture — dedacffd
+- [x] 1.2 Drive both tests off the explicit release instead of the 1.5 s timer — dedacffd
 
 ### Phase 2: Drain every spawned run before removing the fixture
 
-- [ ] 2.1 Track every started run per fixture
-- [ ] 2.2 Open the gate, drain to settled and dispose the manager before `rmSync`
+- [x] Also landed: both tests now wait for the holder to actually own the lease before queueing
+  behind it — `startRun` order never guaranteed it, so the lease could go to the short run and the
+  first test would pass without exercising the slot hand-back at all — dedacffd
+- [x] 2.1 Track every started run per fixture — dedacffd
+- [x] 2.2 Open the gate, drain to settled and dispose the manager before `rmSync` — dedacffd
 
 ### Phase 3: Prove stability
 

--- a/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
+++ b/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
@@ -89,6 +89,9 @@ complete configured validation gate.
 
 ### Phase 3: Prove stability
 
+- [x] Post-review fix: POSIX single-quote escaping for the gate path handed to `bash -lc`, and
+  `manager.dispose()` moved into a `finally` so a failed drain cannot leak the usage-sampler
+  subscription — d33e91e8
 - [x] 3.1 Repeated targeted runs plus a full-suite run — 6× targeted (all green, ~0.9 s of test time
   each, down from ~3 s of sleeping) and 3× `npm test` (303 files / 5407 tests, green each time). The
   proof was also checked negatively: with the #438 slot hand-back reverted locally, the first test

--- a/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
+++ b/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
@@ -89,5 +89,10 @@ complete configured validation gate.
 
 ### Phase 3: Prove stability
 
-- [ ] 3.1 Repeated targeted runs plus a full-suite run
-- [ ] 3.2 Full validation gate
+- [x] 3.1 Repeated targeted runs plus a full-suite run — 6× targeted (all green, ~0.9 s of test time
+  each, down from ~3 s of sleeping) and 3× `npm test` (303 files / 5407 tests, green each time). The
+  proof was also checked negatively: with the #438 slot hand-back reverted locally, the first test
+  fails on the isolated run starving.
+- [x] 3.2 Full validation gate — `npm run typecheck` ✅, `npm test` ✅ (5407 passed), `npm run
+  test:unit` ✅ (36 passed), `npm run build` ✅ (`check:pack ok — 459 files`), `npm run test:package`
+  ✅ (12 passed).

--- a/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
+++ b/.ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
@@ -1,0 +1,90 @@
+# Fix the flaky repository-root lease timing assertion (#797)
+
+## Goal
+
+Make `src/workflows/run-lease.test.ts` deterministic under full-suite load by replacing its
+fixed wall-clock lease holder with explicit test synchronization, and make its teardown wait for
+every spawned run to settle before the temporary fixture repository is removed — without
+weakening the scheduling proof the file exists for.
+
+## Context
+
+`7cf03125` ("stop the repo-root lease from starving isolated runs", #438/#441) added
+`run-lease.test.ts`. Its holder workflow is a single check step, `node -e "setTimeout(()=>{},1500)"`,
+so the repository-root lease is held for a **fixed 1.5 s of wall-clock time**. The first test then
+asserts `holder` is still `running` at the moment the isolated worktree run settles. That assertion
+is only true while the holder's timer has not expired, so the test silently depends on the whole
+sequence — two `git init` fixtures, a real `git worktree add`, three `RunManager` runs — completing
+inside that window. Under the loaded full Vitest suite reported in #797 it took ~3.6 s, the holder
+had already finished, and the assertion read `done` instead of `running`.
+
+The same fixed duration causes the secondary failure. `afterEach` `rmSync`s the fixture root as
+soon as the test body returns, but in the second test the `after` run settles the instant the
+holder releases the lease, while the holder itself is still finalizing (`settleSuccess` → status
+write → `dropActive`). The holder's trailing NDJSON event append then lands on a directory that no
+longer exists → `ENOENT`.
+
+Both are test-harness defects; `src/workflows/run.ts` behaves correctly and is not touched.
+
+## Scope
+
+- `src/workflows/run-lease.test.ts` only.
+
+### Non-goals
+
+- No change to `RunManager`, the lease implementation, or any production source file.
+- No weakening, relaxing or deletion of the two scheduling assertions (`holder` still `running`
+  when the isolated run finishes; a cancelled lease waiter frees the chain).
+- No global Vitest configuration change (timeouts are set per test in this file).
+- No changes to the sibling suites (`run-isolation.test.ts`, `workspace-semaphore.test.ts`).
+
+## Implementation Plan
+
+### Phase 1: Replace the fixed-duration holder with an explicit gate
+
+The holder workflow becomes a check step that polls for a **release file** the test writes when it
+deliberately wants the lease handed on, with a generous safety deadline so a broken test can never
+hang the suite. Wall-clock timing stops being load-bearing: the holder is `running` because nothing
+has released it yet, not because a timer has not fired. Both tests drive the release explicitly and
+keep their assertions unchanged.
+
+### Phase 2: Drain every spawned run before removing the fixture
+
+Wrap fixture creation so every `startRun` id is tracked. `afterEach` then opens the gate (so a
+failed assertion cannot leave a holder parked), waits for every tracked run to reach a settled
+status, disposes the manager, and only then removes the temp repo. A run that refuses to settle is
+cancelled and, if still stuck, reported loudly rather than silently swallowed.
+
+### Phase 3: Prove stability
+
+Repeated targeted runs of the file, a full-suite run (which is what exposed the flake), then the
+complete configured validation gate.
+
+## Risks
+
+- **A gate file that is never released hangs the suite.** Mitigated by the holder's own safety
+  deadline and by `afterEach` opening every gate before it waits.
+- **Draining in `afterEach` could mask a genuinely stuck run.** Mitigated by bounding the drain,
+  cancelling what is left, and failing the teardown when a run still will not settle.
+- **The gate file sits inside the fixture repo.** It is written under `.ai/cezar/`, which no
+  assertion and no `git` operation in these tests looks at, so it cannot perturb the worktree
+  diff/review gate.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Replace the fixed-duration holder with an explicit gate
+
+- [ ] 1.1 Add a gate-file-driven holder workflow and release helper to the fixture
+- [ ] 1.2 Drive both tests off the explicit release instead of the 1.5 s timer
+
+### Phase 2: Drain every spawned run before removing the fixture
+
+- [ ] 2.1 Track every started run per fixture
+- [ ] 2.2 Open the gate, drain to settled and dispose the manager before `rmSync`
+
+### Phase 3: Prove stability
+
+- [ ] 3.1 Repeated targeted runs plus a full-suite run
+- [ ] 3.2 Full validation gate

--- a/packages/cezar/src/workflows/run-lease.test.ts
+++ b/packages/cezar/src/workflows/run-lease.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -8,17 +8,116 @@ import { RunManager } from './run.ts';
 import type { WorkflowDef } from './types.ts';
 
 const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
-const roots: string[] = [];
+
+const SETTLED = ['done', 'failed', 'cancelled', 'review'];
+
+/** Ceiling on how long a lease holder keeps the tree when nothing releases it.
+ *  A passing test never reaches it — the test's own `release()` ends the step —
+ *  so it is purely the escape hatch for a failed assertion that skipped the
+ *  release: the suite fails on that assertion instead of wedging. */
+const HOLD_SAFETY_MS = 20_000;
+
+/** These tests drive real Git and real child processes across three runs, so
+ *  they need more than Vitest's 5 s default. Racing that budget under a loaded
+ *  full-suite run is half of what made this file flaky (#797). */
+const TEST_TIMEOUT_MS = 30_000;
+
+/**
+ * A root workflow whose single step blocks until `gate` appears on disk.
+ *
+ * The holder used to sleep for a fixed 1.5 s, which made every assertion below
+ * a bet that the rest of the suite reached it before that timer expired — a bet
+ * a loaded full-suite run lost (#797). Now the holder is still `running`
+ * because the test has not released it yet, which no amount of machine load
+ * can change.
+ */
+function leaseHolder(gate: string): WorkflowDef {
+  const hold = [
+    'const fs = require("fs");',
+    'const gate = process.argv[1];',
+    `const deadline = Date.now() + ${HOLD_SAFETY_MS};`,
+    'const poll = () => { if (fs.existsSync(gate) || Date.now() > deadline) return; setTimeout(poll, 10); };',
+    'poll();',
+  ].join(' ');
+  return {
+    name: 'held-root',
+    source: 'built-in',
+    steps: [{ id: 'hold', command: `node -e '${hold}' ${JSON.stringify(gate)}` }],
+  };
+}
+
+const INSTANT: WorkflowDef = {
+  name: 'instant',
+  source: 'built-in',
+  steps: [{ id: 'noop', command: 'node -e ""' }],
+};
+
+interface Fixture {
+  root: string;
+  store: RunStore;
+  manager: RunManager;
+  /** Occupies the repo-root lease until `release()` is called. */
+  holdsLease: WorkflowDef;
+  /** Let the holder's step exit, handing the lease to the next waiter. */
+  release: () => void;
+  /** `manager.startRun`, recording the run so teardown can wait for it. */
+  start: (
+    workflow: WorkflowDef,
+    input: Parameters<RunManager['startRun']>[1],
+  ) => ReturnType<RunManager['startRun']>;
+  started: string[];
+}
+
+const fixtures: Fixture[] = [];
 
 /** Real Git fixture — unlike `run-isolation.test.ts`, worktree creation is not
  *  mocked here, so isolated runs genuinely succeed and can be observed
  *  overtaking root runs that are queued behind the lease. */
-function fixtureRepo(): string {
+function fixtureRepo(): Fixture {
   const root = mkdtempSync(join(tmpdir(), 'cez-root-lease-'));
-  roots.push(root);
   execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: root });
   execFileSync('git', [...GIT_ID, 'commit', '--allow-empty', '-q', '-m', 'base'], { cwd: root });
-  return root;
+  const store = RunStore.open(join(root, '.ai/cezar'));
+  const manager = new RunManager(store, root);
+  // Under `.ai/cezar` on purpose: nothing treats that directory as repository
+  // content, so the gate can never turn up in a worktree diff or the review gate.
+  const gate = join(root, '.ai/cezar', 'lease-gate');
+  const started: string[] = [];
+  const fixture: Fixture = {
+    root,
+    store,
+    manager,
+    holdsLease: leaseHolder(gate),
+    release: () => writeFileSync(gate, ''),
+    start: (workflow, input) => {
+      const run = manager.startRun(workflow, input);
+      started.push(run.id);
+      return run;
+    },
+    started,
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+/**
+ * Block until the holder is demonstrably *inside* its hold step, and therefore
+ * demonstrably owns the repo-root lease.
+ *
+ * Starting the holder first does not make it the first waiter: both runs reach
+ * `acquireRepoRoot` through their own async prologue, so the lease can just as
+ * easily go to whichever run gets there first. When it went to the short run,
+ * that run finished on its own instead of parking on the lease — and the test
+ * below "passed" without ever exercising the slot hand-back it exists to prove.
+ */
+async function holdsTheLease(fixture: Fixture, runId: string): Promise<void> {
+  await waitFor(
+    () =>
+      fixture.store
+        .readEvents(runId)
+        .some((event) => event.type === 'step-start' && event.stepId === 'hold'),
+    'the holder to take the repository-root lease',
+  );
 }
 
 async function waitFor(predicate: () => boolean, what: string): Promise<void> {
@@ -30,81 +129,111 @@ async function waitFor(predicate: () => boolean, what: string): Promise<void> {
   throw new Error(`timed out waiting for ${what}`);
 }
 
-const settled = ['done', 'failed', 'cancelled', 'review'];
+/**
+ * Every run a fixture started has to be finished before its repository is
+ * deleted. A run that is still settling writes its closing NDJSON event, and
+ * against an already-removed fixture that surfaced as the teardown `ENOENT`
+ * reported in #797 — the second test in particular returns the moment `after`
+ * completes, while the holder it queued behind is still finalizing.
+ */
+async function drain(fixture: Fixture): Promise<void> {
+  const unsettled = () =>
+    fixture.started.filter((id) => !SETTLED.includes(fixture.store.getRun(id)?.status ?? ''));
+  try {
+    await waitFor(() => unsettled().length === 0, 'every started run to settle');
+  } catch {
+    // A run that will not finish on its own is a real problem, so cancel it and
+    // let the second wait throw rather than deleting the fixture underneath it.
+    for (const id of unsettled()) fixture.manager.cancel(id);
+    await waitFor(() => unsettled().length === 0, 'the cancelled leftover runs to settle');
+  }
+}
 
-/** Occupies the repo-root lease long enough to observe what queues behind it. */
-const SLOW_ROOT: WorkflowDef = {
-  name: 'slow-root',
-  source: 'built-in',
-  steps: [{ id: 'hold', command: 'node -e "setTimeout(()=>{},1500)"' }],
-};
-const INSTANT: WorkflowDef = {
-  name: 'instant',
-  source: 'built-in',
-  steps: [{ id: 'noop', command: 'node -e ""' }],
-};
-
-afterEach(() => {
-  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
-});
+afterEach(async () => {
+  for (const fixture of fixtures.splice(0)) {
+    // Open the gate first. A failed assertion skips the test's own release, and
+    // teardown must not sit out HOLD_SAFETY_MS waiting for the holder to give up.
+    fixture.release();
+    await drain(fixture);
+    fixture.manager.dispose();
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}, TEST_TIMEOUT_MS);
 
 describe('RunManager repository-root lease scheduling', () => {
-  it('does not let a lease-blocked run consume a parallel slot', async () => {
-    const root = fixtureRepo();
-    const store = RunStore.open(join(root, '.ai/cezar'));
-    const manager = new RunManager(store, root);
+  it(
+    'does not let a lease-blocked run consume a parallel slot',
+    async () => {
+      const fixture = fixtureRepo();
+      const { store, holdsLease, release, start } = fixture;
 
-    // maxParallel defaults to 2. `holder` takes the lease; `blocked` waits on
-    // it while idle and must hand its slot back, or `isolated` — which needs
-    // no lease at all — would be starved until the holder finishes (#438).
-    const holder = manager.startRun(SLOW_ROOT, { task: 'holder', worktree: false });
-    const blocked = manager.startRun(INSTANT, { task: 'blocked', worktree: false });
-    const isolated = manager.startRun(INSTANT, { task: 'isolated' });
+      // maxParallel defaults to 2. `holder` takes the lease; `blocked` waits on
+      // it while idle and must hand its slot back, or `isolated` — which needs
+      // no lease at all — would be starved until the holder finishes (#438).
+      const holder = start(holdsLease, { task: 'holder', worktree: false });
+      await holdsTheLease(fixture, holder.id);
+      const blocked = start(INSTANT, { task: 'blocked', worktree: false });
+      const isolated = start(INSTANT, { task: 'isolated' });
 
-    await waitFor(
-      () => settled.includes(store.getRun(isolated.id)?.status ?? ''),
-      'the isolated worktree run to finish',
-    );
-    // The point of the assertion: it got through while the root lease holder
-    // was still running, instead of queueing behind an idle lease waiter.
-    expect(store.getRun(holder.id)?.status).toBe('running');
+      await waitFor(
+        () => SETTLED.includes(store.getRun(isolated.id)?.status ?? ''),
+        'the isolated worktree run to finish',
+      );
+      // The point of the assertion: it got through while the root lease holder
+      // was still running, instead of queueing behind an idle lease waiter.
+      expect(store.getRun(holder.id)?.status).toBe('running');
+      // And `blocked` was still parked on the lease at that moment, so the slot
+      // `isolated` ran in is the one `blocked` handed back — not one it freed by
+      // finishing. A lease waiter deliberately keeps the store status `running`,
+      // so the GUI never shows it as awaiting user input.
+      expect(store.getRun(blocked.id)?.status).toBe('running');
 
-    await waitFor(
-      () => [holder.id, blocked.id].every((id) => settled.includes(store.getRun(id)?.status ?? '')),
-      'the root runs to finish',
-    );
-    expect(store.getRun(holder.id)?.status).toBe('done');
-    expect(store.getRun(blocked.id)?.status).toBe('done');
-  });
+      release();
+      await waitFor(
+        () => [holder.id, blocked.id].every((id) => SETTLED.includes(store.getRun(id)?.status ?? '')),
+        'the root runs to finish',
+      );
+      expect(store.getRun(holder.id)?.status).toBe('done');
+      expect(store.getRun(blocked.id)?.status).toBe('done');
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-  it('cancels a run blocked on the lease without waiting for the holder', async () => {
-    const root = fixtureRepo();
-    const store = RunStore.open(join(root, '.ai/cezar'));
-    const manager = new RunManager(store, root);
+  it(
+    'cancels a run blocked on the lease without waiting for the holder',
+    async () => {
+      const fixture = fixtureRepo();
+      const { store, manager, holdsLease, release, start } = fixture;
 
-    const holder = manager.startRun(SLOW_ROOT, { task: 'holder', worktree: false });
-    const blocked = manager.startRun(INSTANT, { task: 'blocked', worktree: false });
-    // The note is emitted immediately before the lease is awaited, so it — not
-    // the `running` status, which lands well before — is what pins the run to
-    // the blocked state this test is about.
-    await waitFor(
-      () =>
-        store
-          .readEvents(blocked.id)
-          .some((event) => event.type === 'note' && String(event.message).includes('exclusive access')),
-      'the blocked run to reach the lease',
-    );
+      const holder = start(holdsLease, { task: 'holder', worktree: false });
+      await holdsTheLease(fixture, holder.id);
+      const blocked = start(INSTANT, { task: 'blocked', worktree: false });
+      // The note is emitted immediately before the lease is awaited, so it — not
+      // the `running` status, which lands well before — is what pins the run to
+      // the blocked state this test is about.
+      await waitFor(
+        () =>
+          store
+            .readEvents(blocked.id)
+            .some((event) => event.type === 'note' && String(event.message).includes('exclusive access')),
+        'the blocked run to reach the lease',
+      );
 
-    expect(manager.cancel(blocked.id)).toBe(true);
-    await waitFor(() => store.getRun(blocked.id)?.status === 'cancelled', 'the cancel to settle');
-    // Settled while the holder still owns the tree — the lease wait aborted
-    // rather than reporting success and sitting in `active` until the holder
-    // released.
-    expect(store.getRun(holder.id)?.status).toBe('running');
+      expect(manager.cancel(blocked.id)).toBe(true);
+      await waitFor(() => store.getRun(blocked.id)?.status === 'cancelled', 'the cancel to settle');
+      // Settled while the holder still owns the tree — the lease wait aborted
+      // rather than reporting success and sitting in `active` until the holder
+      // released. Nothing has released the holder yet, so this is a fact about
+      // the cancel path and not about how fast the assertion got here.
+      expect(store.getRun(holder.id)?.status).toBe('running');
 
-    // The lease chain survives the cancel: a later root run still gets it.
-    const after = manager.startRun(INSTANT, { task: 'after', worktree: false });
-    await waitFor(() => settled.includes(store.getRun(after.id)?.status ?? ''), 'the later run to finish');
-    expect(store.getRun(after.id)?.status).toBe('done');
-  });
+      // The lease chain survives the cancel: a later root run still gets the
+      // tree once the holder hands it on.
+      const after = start(INSTANT, { task: 'after', worktree: false });
+      release();
+      await waitFor(() => SETTLED.includes(store.getRun(after.id)?.status ?? ''), 'the later run to finish');
+      expect(store.getRun(after.id)?.status).toBe('done');
+    },
+    TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/cezar/src/workflows/run-lease.test.ts
+++ b/packages/cezar/src/workflows/run-lease.test.ts
@@ -22,6 +22,13 @@ const HOLD_SAFETY_MS = 20_000;
  *  full-suite run is half of what made this file flaky (#797). */
 const TEST_TIMEOUT_MS = 30_000;
 
+/** POSIX single-quote escaping. A check step is a command string handed to
+ *  `bash -lc`, so the fixture's temp path has to reach node verbatim whatever
+ *  `TMPDIR` happens to contain — double quotes would still expand `$`. */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 /**
  * A root workflow whose single step blocks until `gate` appears on disk.
  *
@@ -32,6 +39,7 @@ const TEST_TIMEOUT_MS = 30_000;
  * can change.
  */
 function leaseHolder(gate: string): WorkflowDef {
+  // Double quotes only — the script itself is single-quoted for the shell.
   const hold = [
     'const fs = require("fs");',
     'const gate = process.argv[1];',
@@ -42,7 +50,7 @@ function leaseHolder(gate: string): WorkflowDef {
   return {
     name: 'held-root',
     source: 'built-in',
-    steps: [{ id: 'hold', command: `node -e '${hold}' ${JSON.stringify(gate)}` }],
+    steps: [{ id: 'hold', command: `node -e '${hold}' ${shellQuote(gate)}` }],
   };
 }
 
@@ -154,8 +162,16 @@ afterEach(async () => {
     // Open the gate first. A failed assertion skips the test's own release, and
     // teardown must not sit out HOLD_SAFETY_MS waiting for the holder to give up.
     fixture.release();
-    await drain(fixture);
-    fixture.manager.dispose();
+    try {
+      await drain(fixture);
+    } finally {
+      // Dispose either way: a manager left registered keeps its usage-sampler
+      // subscription and its semaphore membership alive for the rest of the suite.
+      fixture.manager.dispose();
+    }
+    // Reached only once nothing is still writing into the fixture. A failed
+    // drain therefore leaks a temp directory, which is strictly better than
+    // deleting one out from under a live run — the failure this file is fixing.
     rmSync(fixture.root, { recursive: true, force: true });
   }
 }, TEST_TIMEOUT_MS);


### PR DESCRIPTION
Closes #797
Tracking plan: .ai/runs/2026-08-07-issue-797-root-lease-test-sync.md
Status: complete

## 🎯 Goal
`packages/cezar/src/workflows/run-lease.test.ts` held the repository-root lease with a fixed 1.5 s sleep and then asserted the holder was still `running` when an isolated worktree run finished. That made the assertion a bet on wall-clock time: under the loaded full-suite run reported in #797 the sequence took ~3.6 s, the holder's timer had already fired, and the assertion read `done`. The same fixed duration produced the secondary teardown `ENOENT`, because the fixture repository was deleted while a run was still writing its closing NDJSON event. This PR replaces the timing assumption with explicit synchronization and drains every spawned run before teardown, while making the scheduling proof stronger rather than weaker.

## What Changed
- **`packages/cezar/src/workflows/run-lease.test.ts` — gated lease holder.** The holder workflow's check step now blocks on a release file the test writes when it deliberately hands the lease on, instead of `node -e "setTimeout(()=>{},1500)"`. A 20 s safety deadline means a failed assertion that skips the release fails the suite rather than wedging it. The holder is `running` because nothing has released it — a fact machine load cannot change.
- **Lease ownership is now established, not assumed.** Starting the holder first never made it the first lease waiter: both runs reach `acquireRepoRoot` through their own async prologue, and when the lease went to the short run instead, that run finished on its own rather than parking — so the test could pass without ever exercising the slot hand-back it exists to prove. Both tests now wait for the holder's `hold` step to actually start before queueing anything behind it.
- **A stronger first assertion.** Alongside "the holder is still `running`", the first test now asserts `blocked` was still parked on the lease at that moment — so the slot the isolated run used is demonstrably the one the lease waiter handed back, not one it freed by finishing.
- **Teardown drains before it deletes.** Every `startRun` is tracked per fixture; `afterEach` opens the gate, waits for every run to reach a settled status (cancelling and then failing loudly if one will not settle), disposes the `RunManager`, and only then `rmSync`s the fixture. This removes the `ENOENT`, and disposing also stops the previously leaked usage-sampler subscriptions.
- **Per-test timeouts** replace Vitest's 5 s default, which the old timing was already brushing under load.

No production source is touched — `RunManager` and the lease implementation are unchanged.

## 🧪 Tests
- `npm run typecheck` — ✅
- `npm test` — ✅ 5407 passed / 303 files, run 3× (the full-suite load is what exposed the flake)
- `npm run test:unit` — ✅ 36 passed
- `npm run build` — ✅ (`check:pack ok — 459 files`)
- `npm run test:package` — ✅ 12 passed
- Targeted: `npx vitest run packages/cezar/src/workflows/run-lease.test.ts` — ✅ 6× consecutively, ~0.9 s of test time each (down from ~3 s, which was mostly sleeping).
- **Negative check — the proof still bites.** With the #438 slot hand-back (`this.waiting.add(runId); this.releaseSlot();` in `acquireRepoRoot`) reverted locally, `does not let a lease-blocked run consume a parallel slot` fails with `timed out waiting for the isolated worktree run to finish`: the isolated run starves exactly as it did before #438. The revert was undone before committing; `run.ts` is byte-identical to `main`.

## 💥 Breaking Changes
- None. The change is confined to one test file; no contract, no production behavior.

## 📋 Progress
See the Progress section in the tracking plan.
