### PR TITLE
fix(runs): resume parked monitors by default, expand /skill on continuations (#810, #811)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,65 @@ Practical rules:
 - Never trade a working default for a knob.
 - Adding, renaming, or removing a `CEZ_*` env var — or changing what its default does — MUST update `.env.example` in the same commit (and the README env table when the var is user-facing). `.env.example` is the env contract's single documentation surface; an undocumented env var is a bug.
 
+## Changing a mechanism that already works
+
+Replacing working behavior is the highest-risk change in this repo, and it fails in a
+characteristic way: the new mechanism is correct, the tests are green, the spec is
+thorough — and the DEFAULT path quietly lost a guarantee nobody wrote down. #810 and #811
+are the worked examples; both shipped a well-specified improvement that left the
+zero-config user worse off than before.
+
+**Name what the old mechanism was load-bearing FOR, not what it was for.** Those are
+different questions. `IDLE_TIMEOUT_MS` read as session hygiene, and #661 removed it from
+the monitoring branch for a good reason (it was closing live sessions mid-CI and recording
+them as `done`). It was also the only liveness bound on `CEZ:MONITORING` and the only
+reason a parked monitor eventually stopped holding a `maxParallel` slot. Neither
+dependency was named in the spec, so neither was replaced, and `monitoring` became a state
+with no exit. Before deleting a timer, lock, cap or timeout, grep for everything that
+reaches a terminal state *because* of it.
+
+**A replacement that ships OFF is not a replacement.** Diff the default path, not the
+feature. The question is always: *with every new knob at its shipped default, what does
+the old scenario do now?* If the answer is "nothing", the change removed a mechanism and
+added a setting. A spec's "Resolved assumptions" table answering a COST question with
+"opt-in, default null" is not an answer to whether the zero-config path still works —
+cost-safe and functional are separate reviews. See § Zero config: *never trade a working
+default for a knob*.
+
+**Enumerate the transitions out of every state you add or keep.** "Who fires this?" is the
+question that finds these bugs in one step. A parked run has exactly three wake sources —
+a user message (`deliverMessage`), the autonomous nudge (turn-end only), and the monitoring
+wake timer. Cezar has no process-exit callback, no CI webhook and no sub-agent-completion
+event, so a state whose only on-by-default exit is "a human types something" is a dead end,
+however well it renders.
+
+**Find every construction site of a shared in-memory object — grep the TYPE, not the
+field.** `ActiveRun` is built in `execute` AND in `runContinuation`; #811 populated
+`state.skills` in the first only, so registry `/skill` expansion worked on new tasks and
+silently failed on every Continue and every restart recovery. The same shape recurs in the
+two near-identical turn-end handlers in `workflows/run.ts` (streaming and non-streaming):
+a lifecycle change applied to one of them ships half a fix. When you add a field that a
+delivery path reads, add it everywhere in the same commit or route both sites through one
+helper.
+
+**A fail-open helper needs a populated-input guarantee, or it lies.**
+`expandRegistrySlashSkill` returning its input unchanged on no-match is right on its own —
+a backend's own slash commands must survive. Against an empty registry that same branch
+turns "cezar never loaded the list" into a confident user-facing "Unknown skill". Pair
+every silent pass-through with a test that pins the *empty/absent input* case.
+
+**Prove the regression test fails without the fix.** `git stash push -- <source files>`,
+run the new test, confirm red, `git stash pop`. A test written after the diagnosis passes
+against the bug more often than anyone expects, and a green-either-way test is how the
+same regression ships twice. Keep the guard tests that pass both ways — they pin the
+behavior you did NOT want to change (park mode stays reachable; unknown slashes stay
+untouched) — but know which is which.
+
+**Read the run-history evidence before theorizing, and cite it.** `.ai/specs/` records the
+design, `git log -S` and `git merge-base --is-ancestor <commit> <tag>` settle "was this in
+the release the user is on", and a user's "it worked in 0.9.1" is a testable claim, not an
+opinion. #810 was confirmed in one command before a line of code was read.
+
 ## The HTTP API
 
 Four invariants. A feature that breaks any of them compiles on its own branch and stops working

--- a/packages/cezar/src/server/workspace-api.test.ts
+++ b/packages/cezar/src/server/workspace-api.test.ts
@@ -102,7 +102,7 @@ describe('the workspace settings API (step 2.7)', () => {
       resources: {
         maxParallel: 2,
         maxMonitoringSessions: 2,
-        monitoringWakeIntervalMinutes: null,
+        monitoringWakeIntervalMinutes: 5,
         autoResumeOnUsageLimit: true,
         memoryLimitMb: null,
         worktreeRetentionDefault: 10,
@@ -174,13 +174,28 @@ describe('the workspace settings API (step 2.7)', () => {
     expect(semaphore.memoryLimitMb()).toBe(2048);
   });
 
+  /** #810 — the cadence now ships ON, so the write worth pinning is the one that turns it
+   *  OFF. `null` must survive the round-trip and reach the semaphore as `null`; re-defaulting
+   *  it to 5 would silently overrule an operator who chose "Park until resumed". */
+  it('PUT null parks monitoring and is never re-defaulted back to the shipped cadence', async () => {
+    expect(semaphore.monitoringWakeIntervalMinutes()).toBe(5); // the zero-config default
+    const res = await putConfig({ resources: { monitoringWakeIntervalMinutes: null } });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as WorkspaceConfigResponse).resources.monitoringWakeIntervalMinutes).toBeNull();
+    expect(
+      ((await (await getConfig()).json()) as WorkspaceConfigResponse).resources.monitoringWakeIntervalMinutes,
+    ).toBeNull();
+    expect((rawConfig().resources as Record<string, unknown>).monitoringWakeIntervalMinutes).toBeNull();
+    expect(semaphore.monitoringWakeIntervalMinutes()).toBeNull();
+  });
+
   it('partial updates leave the other keys untouched', async () => {
     await putConfig({ resources: { maxParallel: 5 } });
     await putConfig({ resources: { worktreeRetentionDefault: 3 } });
     expect(((await (await getConfig()).json()) as WorkspaceConfigResponse).resources).toEqual({
       maxParallel: 5,
       maxMonitoringSessions: 2,
-      monitoringWakeIntervalMinutes: null,
+      monitoringWakeIntervalMinutes: 5,
       autoResumeOnUsageLimit: true,
       memoryLimitMb: null,
       worktreeRetentionDefault: 3,

--- a/packages/cezar/src/workflows/run.test.ts
+++ b/packages/cezar/src/workflows/run.test.ts
@@ -887,6 +887,45 @@ describe('CEZ:MONITORING parks as running/monitoring, not waiting (#490)', () =>
     expect(state?.idleTimer).toBeUndefined(); // durable monitors do not inherit the 15-minute user-wait timer
   }, 30_000);
 
+  /**
+   * #810 — the regression the two 0.9.2 reports describe. #661 removed the 15-minute
+   * idle timer from the monitoring branch and replaced it with a wake timer that
+   * defaulted OFF, so a zero-config parked monitor had NO timer at all and cezar has no
+   * other resume path (no process-exit callback, no CI webhook, no sub-agent-completion
+   * event). It sat in `monitoring` until a human typed something. A default manager must
+   * therefore publish a wake deadline: the run has to be able to resume itself.
+   */
+  it('a parked monitor schedules its own re-check under the zero-config default (#810)', async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: 'mock:monitoring keep going', worktree: false });
+    currentId = record.id;
+    await waitFor(record.id, (r) => r?.activity === 'monitoring');
+    await waitFor(record.id, (r) => Boolean(r?.monitoringWakeAt));
+    const parked = store.getRun(record.id);
+    const deadline = Date.parse(String(parked?.monitoringWakeAt));
+    expect(Number.isNaN(deadline)).toBe(false);
+    expect(deadline).toBeGreaterThan(Date.now()); // a real future re-check, not a stale stamp
+    const state = (manager as unknown as {
+      active: Map<string, { idleTimer?: NodeJS.Timeout; monitoringWakeTimer?: NodeJS.Timeout }>;
+    }).active.get(record.id);
+    expect(state?.monitoringWakeTimer).toBeDefined();
+    expect(state?.idleTimer).toBeUndefined(); // still no user-wait timeout — #661's fix stands
+  }, 30_000);
+
+  it('park mode remains reachable as an explicit operator choice (#810)', async () => {
+    manager.dispose();
+    manager = new RunManager(store, repoRoot, {
+      semaphore: new WorkspaceSemaphore({ initial: { monitoringWakeIntervalMinutes: null } }),
+    });
+    const record = manager.startRun(SINGLE_STEP, { task: 'mock:monitoring keep going', worktree: false });
+    currentId = record.id;
+    await waitFor(record.id, (r) => r?.activity === 'monitoring');
+    expect(store.getRun(record.id)?.monitoringWakeAt).toBeUndefined();
+    const state = (manager as unknown as {
+      active: Map<string, { monitoringWakeTimer?: NodeJS.Timeout }>;
+    }).active.get(record.id);
+    expect(state?.monitoringWakeTimer).toBeUndefined();
+  }, 30_000);
+
   it('optionally wakes a parked monitor without fabricating a user message', async () => {
     manager.dispose();
     const semaphore = new WorkspaceSemaphore({ initial: { monitoringWakeIntervalMinutes: 0.001 } });
@@ -1765,4 +1804,130 @@ describe('native Codex requestUserInput parks and resumes the run (#565)', () =>
     await waitFor(() => readFileSync(eventsPath, 'utf8').includes('"type":"turn-end"'));
     expect(store.getRun(record.id)?.status).toBe('waiting');
   }, 30_000);
+});
+
+/**
+ * #811 — registry `/skill` expansion on the CONTINUATION path.
+ *
+ * `expandRegistrySlashSkill` (#676) reads `state.skills`, which only `execute` ever
+ * populated. `runContinuation` builds its OWN `ActiveRun`, so a Reply into a finished
+ * run — and every restart recovery, which routes through `continueRun` — expanded
+ * against an empty registry and handed the raw `/om-...` to the backend, which answered
+ * "Unknown skill". Two seams have to hold: the continuation's opening prompt (the
+ * session's `userPrompt`, which never passes through `deliverMessage`) and the
+ * follow-ups delivered into that same session.
+ *
+ * The mock CLI echoes the prompt it received (`Okay — looking into: …`), so the
+ * transcript is a faithful witness of what actually reached the backend.
+ */
+describe('registry /skill expansion survives a continuation (#811)', () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: RunManager;
+  let runId: string | undefined;
+  let savedDryRun: string | undefined;
+  const SINGLE_STEP: WorkflowDef = {
+    name: 'quick-task',
+    source: 'built-in',
+    steps: [{ id: 'task', name: 'Task', prompt: '{{task}}' }],
+  };
+
+  beforeEach(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-811-'));
+    savedDryRun = process.env.CEZ_DRY_RUN;
+    process.env.CEZ_DRY_RUN = '1';
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    mkdirSync(join(repoRoot, '.ai/cezar/skills'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.ai/cezar/skills/demo-review.md'),
+      '---\nname: demo-review\ndescription: Review a diff.\n---\n\nRun the demo review playbook.\n',
+    );
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot);
+    runId = undefined;
+  });
+
+  afterEach(() => {
+    if (runId) manager.cancel(runId);
+    if (savedDryRun === undefined) delete process.env.CEZ_DRY_RUN;
+    else process.env.CEZ_DRY_RUN = savedDryRun;
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  const eventsOf = (id: string) =>
+    readFileSync(join(repoRoot, '.ai/cezar/runs', `${id}.ndjson`), 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { type: string; text?: string; stepId?: string });
+
+  const waitFor = async (predicate: () => boolean, ms = 20_000) => {
+    const deadline = Date.now() + ms;
+    while (!predicate()) {
+      if (Date.now() > deadline) throw new Error('condition not met in time');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  };
+
+  /** A finished run, ready for the cockpit's Reply composer. The dry-run mock ends its
+   *  turn with no marker, so the run parks at `waiting` with the session open — closing
+   *  it is what a user pressing Finish does, and `continueRun` only accepts a run that
+   *  reached a terminal status. */
+  const finishedRun = async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: 'do the first thing', worktree: false });
+    runId = record.id;
+    await waitFor(() => store.getRun(record.id)?.status === 'waiting');
+    expect(manager.finish(record.id)).toBe(true);
+    await waitFor(() => ['done', 'review'].includes(store.getRun(record.id)?.status ?? ''));
+    return record.id;
+  };
+
+  it("expands the continuation's OPENING prompt before it becomes the session userPrompt", async () => {
+    const id = await finishedRun();
+    expect(manager.continueRun(id, { text: '/demo-review look at the diff' })).toEqual({ ok: true });
+    await waitFor(() =>
+      eventsOf(id).some((e) => e.stepId === 'continue-1' && e.type === 'text' && e.text?.includes('looking into')),
+    );
+
+    const echoed = eventsOf(id).find(
+      (e) => e.stepId === 'continue-1' && e.type === 'text' && e.text?.includes('looking into'),
+    );
+    // The backend saw the expanded skill prompt, NOT a bare slash command it would
+    // reject as an unknown skill.
+    expect(echoed?.text).toContain('Selected skill: /demo-review');
+    expect(echoed?.text).not.toContain('/demo-review look at the diff');
+
+    // Delivery-only: the transcript still shows what the user actually typed.
+    const typed = eventsOf(id).find((e) => e.type === 'user-message' && e.stepId === 'continue-1');
+    expect(typed?.text).toBe('/demo-review look at the diff');
+  }, 40_000);
+
+  it('expands a FOLLOW-UP delivered into the reopened continuation session', async () => {
+    const id = await finishedRun();
+    expect(manager.continueRun(id, { text: 'keep going' })).toEqual({ ok: true });
+    await waitFor(() => store.getRun(id)?.status === 'waiting');
+
+    expect(manager.sendMessage(id, [{ type: 'text', text: '/demo-review now review it' }])).toBe(true);
+    await waitFor(() =>
+      eventsOf(id).filter((e) => e.type === 'text' && e.text?.includes('Selected skill: /demo-review')).length > 0,
+    );
+    expect(
+      eventsOf(id).some((e) => e.type === 'text' && e.text?.includes('Selected skill: /demo-review')),
+    ).toBe(true);
+  }, 40_000);
+
+  it('leaves an unknown slash command untouched so backend-native commands still work', async () => {
+    const id = await finishedRun();
+    expect(manager.continueRun(id, { text: '/compact please' })).toEqual({ ok: true });
+    await waitFor(() =>
+      eventsOf(id).some((e) => e.stepId === 'continue-1' && e.type === 'text' && e.text?.includes('looking into')),
+    );
+    const echoed = eventsOf(id).find(
+      (e) => e.stepId === 'continue-1' && e.type === 'text' && e.text?.includes('looking into'),
+    );
+    expect(echoed?.text).toContain('/compact please');
+  }, 40_000);
 });

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -2117,6 +2117,11 @@ export class RunManager {
     }
     this.armAutosave(state);
     if (record) seedHandoffFile(this.dataDir, record); // idempotent — normally already there
+    // Registry snapshot for `/skill` expansion. `execute` loads this for the workflow's own
+    // sessions; a continuation builds its OWN ActiveRun, and without this the resumed session
+    // expanded against an empty registry and leaked `/om-...` verbatim to the backend, which
+    // answered "Unknown skill" (#811). Best-effort — discovery must never break Continue.
+    state.skills = await discoverSkills(this.repoRoot).catch(() => [] as Skill[]);
 
     this.store.updateRun(runId, {
       status: 'running',
@@ -2338,6 +2343,11 @@ export class RunManager {
     const runner = createRunner(continueBackend);
     state.currentStepId = stepId;
     this.beginUsageInvocation(runId, state, stepId);
+    // A continuation's opening message becomes the session's `userPrompt` and never passes
+    // through `deliverMessage`, so it needs the SAME delivery-only `/skill` rewrite the
+    // live path applies (#811). Delivery-only: the `user-message` event above already
+    // persisted the user's original text, and the transcript must keep showing that.
+    const openingPrompt = expandRegistrySlashSkillText(prompt, state.skills ?? []);
     const session = runner.startSession(
       {
         // The Continue step is a fresh agent session on the same run — the
@@ -2347,7 +2357,9 @@ export class RunManager {
           record?.systemPrompt,
           generateFollowups ? HANDOFF_INSTRUCTIONS : HANDOFF_ONLY_INSTRUCTIONS,
         ),
-        userPrompt: attachments.length ? `${prompt}\n\n${pastedAttachmentsText(attachments)}` : prompt,
+        userPrompt: attachments.length
+          ? `${openingPrompt}\n\n${pastedAttachmentsText(attachments)}`
+          : openingPrompt,
         ...(openingImages.length ? { images: openingImages } : {}),
         cwd: state.cwd,
         allowedTools: DEFAULT_ALLOWED_TOOLS,
@@ -2553,6 +2565,8 @@ export class RunManager {
     if (seeded) seedHandoffFile(this.dataDir, seeded);
 
     const skills = await discoverSkills(this.repoRoot);
+    // Every ActiveRun construction site must carry the registry — `runContinuation` builds
+    // its own, and the one that skipped this leaked raw `/skill` text to the backend (#811).
     state.skills = skills;
     const retriesUsed = new Map<string, number>();
     let checkFailure: string | null = null;
@@ -3553,13 +3567,33 @@ export function skillSystemPrompt(
 }
 
 /**
- * Expand a registry-backed slash skill in a live chat message before it reaches
- * a backend. Claude otherwise intercepts an unknown leading slash command, and
+ * Expand a registry-backed slash skill in one prompt string before it reaches a
+ * backend. Claude otherwise intercepts an unknown leading slash command, and
  * Codex/OpenCode have no native slash-skill lookup at all (#676).
  *
- * Only the first text block is eligible, only at character zero, and unknown
- * commands pass through byte-for-byte. The caller persists the original user
- * content before applying this delivery-only rewrite.
+ * Only a match at character zero counts, and unknown commands pass through
+ * byte-for-byte — a backend's OWN slash commands must keep working. The caller
+ * persists the original user text before applying this delivery-only rewrite.
+ *
+ * Both delivery seams route through here: live-session messages via
+ * `expandRegistrySlashSkill`, and a continuation's opening prompt, which becomes
+ * the session's `userPrompt` and never passes through `deliverMessage` at all
+ * (#811).
+ */
+export function expandRegistrySlashSkillText(text: string, skills: readonly Skill[]): string {
+  const match = /^\/([A-Za-z0-9][A-Za-z0-9._-]*)(?=\s|$)/.exec(text);
+  if (!match) return text;
+  const skill = skills.find((candidate) => candidate.name === match[1]);
+  if (!skill) return text;
+
+  const request = text.slice(match[0].length).trim();
+  return request ? `${skillSystemPrompt(skill)}\n\nUser request:\n${request}` : skillSystemPrompt(skill);
+}
+
+/**
+ * `expandRegistrySlashSkillText` over a live chat message: only the first text
+ * block is eligible, and an unchanged block returns the caller's array
+ * identity untouched.
  */
 export function expandRegistrySlashSkill(
   content: ContentBlock[],
@@ -3569,17 +3603,10 @@ export function expandRegistrySlashSkill(
   if (textIndex < 0) return content;
   const block = content[textIndex];
   if (!block || block.type !== 'text') return content;
-  const match = /^\/([A-Za-z0-9][A-Za-z0-9._-]*)(?=\s|$)/.exec(block.text);
-  if (!match) return content;
-  const skill = skills.find((candidate) => candidate.name === match[1]);
-  if (!skill) return content;
+  const text = expandRegistrySlashSkillText(block.text, skills);
+  if (text === block.text) return content;
 
-  const request = block.text.slice(match[0].length).trim();
-  const replacement: ContentBlock = {
-    type: 'text',
-    text: request ? `${skillSystemPrompt(skill)}\n\nUser request:\n${request}` : skillSystemPrompt(skill),
-  };
   const expanded = [...content];
-  expanded[textIndex] = replacement;
+  expanded[textIndex] = { type: 'text', text };
   return expanded;
 }

--- a/packages/cezar/src/workflows/skill-system-prompt.test.ts
+++ b/packages/cezar/src/workflows/skill-system-prompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ContentBlock } from '../core/agent-runner.ts';
-import { expandRegistrySlashSkill, skillSystemPrompt } from './run.ts';
+import { expandRegistrySlashSkill, expandRegistrySlashSkillText, skillSystemPrompt } from './run.ts';
 
 describe('skillSystemPrompt — installed-path hint for worktree agents', () => {
   const base = { name: 'om-code-review', description: 'Review a diff.', body: 'Do the review.' };
@@ -70,5 +70,38 @@ describe('expandRegistrySlashSkill — live chat delivery', () => {
 
     expect(expanded[0]).toBe(image);
     expect((expanded[1] as Extract<ContentBlock, { type: 'text' }>).text).toContain('Do the review.');
+  });
+
+  /**
+   * #811 — a continuation's opening message becomes the session's `userPrompt` and
+   * never passes through `deliverMessage`, so the string form is the seam that path
+   * needs. Both spellings must agree, or `/skill` would expand on a live follow-up and
+   * leak verbatim on the Reply-after-finish that opens the same session.
+   */
+  describe('expandRegistrySlashSkillText — the continuation seam (#811)', () => {
+    it('expands the same way the content-block form does', () => {
+      const text = '/om-code-review PR 42';
+      const viaText = expandRegistrySlashSkillText(text, [skill]);
+      const viaBlocks = expandRegistrySlashSkill([{ type: 'text', text }], [skill]);
+
+      expect(viaText).toContain('Selected skill: /om-code-review');
+      expect(viaText).toContain('Skill instructions:\nDo the review.\n\nUser request:\nPR 42');
+      expect((viaBlocks[0] as Extract<ContentBlock, { type: 'text' }>).text).toBe(viaText);
+    });
+
+    it('expands a bare skill name with no trailing request', () => {
+      expect(expandRegistrySlashSkillText('/om-code-review', [skill])).toBe(skillSystemPrompt(skill));
+    });
+
+    it.each(['/unknown PR 42', ' /om-code-review PR 42', '/om-code-reviewer PR 42', 'Continue.'])(
+      'returns non-matching text unchanged so a backend keeps its own slash commands: %s',
+      (text) => {
+        expect(expandRegistrySlashSkillText(text, [skill])).toBe(text);
+      },
+    );
+
+    it('returns the text unchanged against an empty registry (the #811 failure mode)', () => {
+      expect(expandRegistrySlashSkillText('/om-code-review PR 42', [])).toBe('/om-code-review PR 42');
+    });
   });
 });

--- a/packages/cezar/src/workspace/config.test.ts
+++ b/packages/cezar/src/workspace/config.test.ts
@@ -68,7 +68,7 @@ describe('workspace config', () => {
     expect(config.schemaVersion).toBe(0);
     expect(config.browseRoot).toBe('~/');
     expect(config.projectsDir).toBe('~/cezar/projects');
-    expect(config.resources).toEqual({ maxParallel: 2, maxMonitoringSessions: 2, monitoringWakeIntervalMinutes: null, autoResumeOnUsageLimit: true, memoryLimitMb: null, worktreeRetentionDefault: 10 });
+    expect(config.resources).toEqual({ maxParallel: 2, maxMonitoringSessions: 2, monitoringWakeIntervalMinutes: 5, autoResumeOnUsageLimit: true, memoryLimitMb: null, worktreeRetentionDefault: 10 });
     expect(config.composerDefaults).toEqual({});
     expect(config.projects).toEqual([]);
     expect(warn).not.toHaveBeenCalled();
@@ -250,8 +250,40 @@ describe('workspace config', () => {
     expect(config.schemaVersion).toBe(0);
     expect(config.browseRoot).toBe('~/');
     expect(config.projectsDir).toBe('~/cezar/projects');
-    expect(config.resources).toEqual({ maxParallel: 2, maxMonitoringSessions: 2, monitoringWakeIntervalMinutes: null, autoResumeOnUsageLimit: true, memoryLimitMb: null, worktreeRetentionDefault: 10 });
+    expect(config.resources).toEqual({ maxParallel: 2, maxMonitoringSessions: 2, monitoringWakeIntervalMinutes: 5, autoResumeOnUsageLimit: true, memoryLimitMb: null, worktreeRetentionDefault: 10 });
     expect(config.projects).toEqual([project('good')]);
+  });
+
+  /**
+   * #810 — the monitoring re-check cadence ships ON. It shipped as `null` and that
+   * made a `CEZ:MONITORING` run a dead end: #661 had already removed the idle timer
+   * that used to bound a parked monitor, so nothing was left to resume it. `null`
+   * remains reachable, but only as a deliberate operator choice.
+   */
+  describe('monitoringWakeIntervalMinutes default (#810)', () => {
+    it('defaults to 5 minutes when the key is absent', async () => {
+      write({ resources: { maxParallel: 3 } });
+      const config = await loadWorkspaceConfig();
+      expect(config.resources.monitoringWakeIntervalMinutes).toBe(5);
+    });
+
+    it('preserves an explicit null — "park until resumed" is a real choice, not a missing value', async () => {
+      write({ resources: { monitoringWakeIntervalMinutes: null } });
+      const config = await loadWorkspaceConfig();
+      expect(config.resources.monitoringWakeIntervalMinutes).toBeNull();
+    });
+
+    it('keeps an explicit in-range cadence', async () => {
+      write({ resources: { monitoringWakeIntervalMinutes: 17 } });
+      const config = await loadWorkspaceConfig();
+      expect(config.resources.monitoringWakeIntervalMinutes).toBe(17);
+    });
+
+    it('degrades an out-of-range cadence to the working default, not to park', async () => {
+      write({ resources: { monitoringWakeIntervalMinutes: 999 } });
+      const config = await loadWorkspaceConfig();
+      expect(config.resources.monitoringWakeIntervalMinutes).toBe(5);
+    });
   });
 
   it('drops a corrupt registry entry but keeps the rest (per-entry salvage)', async () => {

--- a/packages/cezar/src/workspace/config.ts
+++ b/packages/cezar/src/workspace/config.ts
@@ -53,14 +53,43 @@ const workspaceProjectSchema = z
 
 export type WorkspaceProject = z.infer<typeof workspaceProjectSchema>;
 
+/**
+ * Zero-config cadence, in minutes, for re-checking a run parked with
+ * `CEZ:MONITORING` (#810). The single source of truth for that default — the
+ * schema below and `WorkspaceSemaphore`'s fallback both read it, so an install
+ * with no `~/.cezar/config.json` and a semaphore built without boot wiring
+ * agree. `null` (explicit park) is a user choice and is never replaced by it.
+ */
+export const DEFAULT_MONITORING_WAKE_MINUTES = 5;
+
 const resourcesSchema = z
   .object({
     /** Workspace-wide parallel-task cap (moved from per-repo config.json). */
     maxParallel: z.number().int().min(1).max(16).default(2).catch(2),
     /** Extra durable `CEZ:MONITORING` sessions exempt from the active-task cap. */
     maxMonitoringSessions: z.number().int().min(0).max(16).default(2).catch(2),
-    /** Optional cadence for re-checking monitored work; null parks at zero model cost. */
-    monitoringWakeIntervalMinutes: z.number().int().min(1).max(60).nullable().default(null).catch(null),
+    /**
+     * Cadence for re-checking monitored work; `null` parks at zero model cost until a
+     * user (or an external integration) resumes the session.
+     *
+     * Default-ON at 5 minutes (#810). It shipped as `null` and that made monitoring a
+     * dead end: #661 removed the 15-minute idle timer that used to bound a parked
+     * monitor, so with no wake timer a `CEZ:MONITORING` run has NO timer at all — and
+     * cezar has no other resume path (no process-exit callback, no CI webhook, no
+     * sub-agent-completion event). Tasks sat in `monitoring` for hours until a human
+     * typed something. Same reasoning as `autoResumeOnUsageLimit` below: it spends
+     * nothing while the downstream work is genuinely pending and it finishes the work
+     * the user already asked for. `MAX_AUTO_CONTINUES` still caps a forgotten loop, and
+     * an explicit `null` (Settings → Resources → "Park until resumed") is preserved.
+     */
+    monitoringWakeIntervalMinutes: z
+      .number()
+      .int()
+      .min(1)
+      .max(60)
+      .nullable()
+      .default(DEFAULT_MONITORING_WAKE_MINUTES)
+      .catch(DEFAULT_MONITORING_WAKE_MINUTES),
     /**
      * Resume a task the provider's usage limit stopped, once that limit resets
      * (spec 2026-08-03-auto-resume-after-usage-limit). ON by default, which is the one

--- a/packages/cezar/src/workspace/semaphore.test.ts
+++ b/packages/cezar/src/workspace/semaphore.test.ts
@@ -28,7 +28,40 @@ describe('WorkspaceSemaphore', () => {
     const sem = new WorkspaceSemaphore();
     expect(sem.maxParallel()).toBe(2);
     expect(sem.memoryLimitMb()).toBeNull();
+    expect(sem.monitoringWakeIntervalMinutes()).toBe(5); // #810 — monitoring must self-resume
     expect(sem.busy()).toBe(0);
+  });
+
+  /** #810 — the getter used to be `?? null`. Flipping the default to 5 made that a trap:
+   *  `null ?? 5` is 5, which would have silently overridden every operator who chose
+   *  "Park until resumed". Absent and null must therefore answer differently. */
+  describe('monitoringWakeIntervalMinutes: absent vs. explicit null (#810)', () => {
+    it('falls back to the shipped default only when the key is ABSENT', () => {
+      const sem = new WorkspaceSemaphore({ initial: { maxParallel: 2, monitoringWakeIntervalMinutes: undefined } });
+      expect(sem.monitoringWakeIntervalMinutes()).toBe(5);
+    });
+
+    it('preserves an explicit null (park until resumed)', () => {
+      const sem = new WorkspaceSemaphore({ initial: { monitoringWakeIntervalMinutes: null } });
+      expect(sem.monitoringWakeIntervalMinutes()).toBeNull();
+    });
+
+    it('preserves an explicit cadence', () => {
+      const sem = new WorkspaceSemaphore({ initial: { monitoringWakeIntervalMinutes: 12 } });
+      expect(sem.monitoringWakeIntervalMinutes()).toBe(12);
+    });
+
+    it('a refresh that reports null parks, and one that reports a number re-arms', async () => {
+      let wake: number | null = null;
+      const sem = new WorkspaceSemaphore({
+        load: () => Promise.resolve({ maxParallel: 2, memoryLimitMb: null, monitoringWakeIntervalMinutes: wake }),
+      });
+      await sem.refresh();
+      expect(sem.monitoringWakeIntervalMinutes()).toBeNull();
+      wake = 9;
+      await sem.refresh();
+      expect(sem.monitoringWakeIntervalMinutes()).toBe(9);
+    });
   });
 
   it('honors an initial override (test seam)', () => {

--- a/packages/cezar/src/workspace/semaphore.ts
+++ b/packages/cezar/src/workspace/semaphore.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { loadWorkspaceConfig } from './config.ts';
+import { DEFAULT_MONITORING_WAKE_MINUTES, loadWorkspaceConfig } from './config.ts';
 
 /**
  * Workspace-wide resource governance (spec 2026-07-20-multi-project-workspace,
@@ -38,7 +38,9 @@ export interface WorkspaceResourceLimits {
   maxParallel: number;
   /** Durable monitoring sessions that do not consume active-task capacity. */
   maxMonitoringSessions?: number;
-  /** Optional automatic monitoring re-check cadence; null means stay parked. */
+  /** Automatic monitoring re-check cadence in minutes. Default ON at
+   *  `DEFAULT_MONITORING_WAKE_MINUTES`; explicit `null` means stay parked; absent means
+   *  "this loader predates the key" and reads as the default. */
   monitoringWakeIntervalMinutes?: number | null;
   /** Resume a run stopped by a provider usage limit when that limit resets. Default ON. */
   autoResumeOnUsageLimit?: boolean;
@@ -109,13 +111,14 @@ export interface SemaphoreParticipant {
 const DEFAULT_LIMITS: WorkspaceResourceLimits = {
   maxParallel: 2,
   maxMonitoringSessions: 2,
-  monitoringWakeIntervalMinutes: null,
+  monitoringWakeIntervalMinutes: DEFAULT_MONITORING_WAKE_MINUTES,
   autoResumeOnUsageLimit: true,
   memoryLimitMb: null,
 };
 
 /** Production loader: the `resources` slice of `~/.cezar/config.json`
- *  (schema-defaulted, so a missing/corrupt file yields the zero-config 2/null),
+ *  (schema-defaulted, so a missing/corrupt file yields the zero-config
+ *  2 parallel / 2 monitoring / 5-minute wake / no memory cap),
  *  plus the per-project `maxParallel` overrides built into a root→limit map.
  *  The registry `root` is already realpath-normalized (`registerProject`), so
  *  the keys match `normalizeRootSync`'s output at lookup time. */
@@ -184,8 +187,13 @@ export class WorkspaceSemaphore {
     return this.limits.maxMonitoringSessions ?? 2;
   }
 
+  /** Cadence for automatic monitoring re-checks, or null when the operator chose "park
+   *  until resumed". Deliberately NOT `?? DEFAULT`: `null` is a real user choice and
+   *  `null ?? 5` would silently override it (#810). Only an ABSENT key — an older `load`
+   *  stub, a partial `initial` — falls back to the shipped default. */
   monitoringWakeIntervalMinutes(): number | null {
-    return this.limits.monitoringWakeIntervalMinutes ?? null;
+    const configured = this.limits.monitoringWakeIntervalMinutes;
+    return configured === undefined ? DEFAULT_MONITORING_WAKE_MINUTES : configured;
   }
 
   /** Whether a usage-limit stop schedules its own resume. Absent (an older `load` stub, a config


### PR DESCRIPTION
Fixes #810
Fixes #811

## 🎯 Goal

- A run parked with `CEZ:MONITORING` re-checks its own downstream work again instead of sitting in `monitoring` until a human pokes it.
- A registry `/skill` typed into the Reply composer of a finished run expands, instead of reaching the backend verbatim as "Unknown skill".
- `AGENTS.md` records the review discipline that would have caught both.

Both regressions were reported by users on 0.9.2 and both were introduced between v0.9.1 and v0.9.2.

## 🔍 Problem

**#810** — two independent reports, both on Codex/macOS:

> cezar started the tests — after 1h of waiting still nothing and the state is `monitoring`; only when I asked whether it had finished did it confirm and move on.

> when it finishes and waits for CI, it doesn't see that CI completed — only when you poke it does it check. If CI is quick it checks, but if it takes ~30 min you always have to poke it. If memory serves, this did not happen in 0.9.1.

The "fast CI works, slow CI hangs" detail is the tell: quick downstream work gets polled inside the same turn, so the turn never ends and no marker is emitted. Slow work makes the agent do the *correct* thing — end its turn with `CEZ:MONITORING` — and that is exactly what parked it forever. The bug punished correct agent behaviour.

**#811** — reported as flaky:

> once in a while it says the skills are not there — but when I start a new chat, or write the same request again, the skills exist again.

Not flaky: two code paths, one of which was never wired up.

## 🔍 Root Cause

### #810 — the replacement mechanism ships OFF

`git merge-base --is-ancestor 2bf75f8 v0.9.1` → false, so #661 landed in 0.9.2 only.

v0.9.1 armed the idle timer on **every** turn end, monitoring included. That was a bad bound — it closed live sessions mid-CI and recorded them as `done`, which is precisely the failure #661 set out to fix (see `.ai/specs/2026-07-24-long-running-waiting-sessions.md`, with four production runs from `mercato-development` as evidence) — but it *was* a bound.

#661 removed it (`packages/cezar/src/workflows/run.ts`, the monitoring branch of both turn-end handlers):

```ts
if (monitoring) {
  this.monitoring.add(runId);
  this.clearIdleTimer(state);                  // old bound removed
  this.armMonitoringWakeTimer(runId, state);   // new bound…
}
if (!monitoring) this.armIdleTimer(runId, state);
```

…and the new bound is a no-op in the shipped configuration:

```ts
const minutes = this.semaphore.monitoringWakeIntervalMinutes();
if (minutes === null) { this.clearMonitoringWakeTimer(state, runId); return; }   // no timer at all
```

because `monitoringWakeIntervalMinutes` defaulted to `null` (`workspace/config.ts`, `workspace/semaphore.ts`).

Net effect on a zero-config install: **a monitoring run has no idle timer and no wake timer.** There is no other resume path — cezar has no process-exit callback, no CI webhook and no sub-agent-completion event. The only three things that can restart a parked turn are a user message (`deliverMessage`), the immediate autonomous nudge (turn-end only), and the wake timer that was switched off. `deliverMessage` clears the timers and the `monitoring` activity regardless of message content, which is why "are you done?" resumes it just as well as anything else.

The spec's "Resolved assumptions" table answered a **cost** question with "opt-in, default null". That is a correct answer to a different question than "does the zero-config path still work".

### #811 — one of two construction sites

`expandRegistrySlashSkill` (#676, PR #679) reads a per-run registry snapshot:

```ts
const expanded = userAuthored ? expandRegistrySlashSkill(content, state.skills ?? []) : content;
```

`state.skills` was assigned in exactly one place — the initial workflow driver in `execute`. `runContinuation` builds its **own** `ActiveRun`:

```ts
const state: ActiveRun = { cancelled: false, interrupt: () => undefined, cwd };
```

so `state.skills ?? []` was empty, nothing matched, and the helper failed **open** (`if (!skill) return content` — correct in isolation, since a backend's own slash commands must survive). The raw `/om-auto-review-pr` reached the vendor CLI, which produced the "Unknown skill" string. That string appears nowhere in cezar's source.

| Path | `state.skills` | `/om-auto-review-pr` |
| --- | --- | --- |
| New task → live-session follow-up | populated | expands |
| Reply into a finished run (Continue) | `undefined` | "Unknown skill" |
| Restart recovery (`recover` → `continueRun`) | `undefined` | "Unknown skill" |

Second hole on the same path: a continuation's **opening** message never passes through `deliverMessage` at all — it is handed to the runner as the session's `userPrompt`, which no expansion touched. Fixing `state.skills` alone would still have leaked the first `/skill` reply after a run finishes.

## What Changed

**`packages/cezar/src/workspace/config.ts`** — new exported `DEFAULT_MONITORING_WAKE_MINUTES = 5`, the single source of truth for the default; `monitoringWakeIntervalMinutes` defaults and `.catch`es to it. An out-of-range value now degrades to the working default rather than to park, matching how `maxParallel`/`maxMonitoringSessions` already degrade. Rationale is recorded in the schema comment next to `autoResumeOnUsageLimit`, the existing precedent for a cost-bearing default-ON automation: it spends nothing while the downstream work is genuinely pending, and it finishes work the user already asked for. `MAX_AUTO_CONTINUES` (40) still caps a forgotten loop.

**`packages/cezar/src/workspace/semaphore.ts`** — `DEFAULT_LIMITS` reads the same constant. The getter is deliberately **not** `?? DEFAULT`:

```ts
const configured = this.limits.monitoringWakeIntervalMinutes;
return configured === undefined ? DEFAULT_MONITORING_WAKE_MINUTES : configured;
```

`null` is a real operator choice ("Park until resumed") and `null ?? 5` would have silently overruled it. Only an absent key — an older `load` stub, a partial `initial` — falls back.

**`packages/cezar/src/workflows/run.ts`** —
- `expandRegistrySlashSkillText(text, skills)` extracted; `expandRegistrySlashSkill` now delegates to it, so the two spellings cannot drift.
- `runContinuation` loads the registry into its own `ActiveRun`, best-effort (`.catch(() => [])` — skill discovery must never break Continue).
- The continuation's opening prompt is expanded before it becomes `userPrompt`. Delivery-only: the `user-message` event is appended earlier and keeps the user's original text, exactly as `deliverMessage` does.
- A comment at the `execute` site names the invariant: every `ActiveRun` construction site must carry the registry.

**`AGENTS.md`** — new section **"Changing a mechanism that already works"**, six rules each anchored to one of these two bugs: name what the old mechanism was load-bearing *for* (not what it was for); a replacement that ships OFF is not a replacement, so diff the default path; enumerate the transitions out of every state and who fires them; grep the **type**, not the field, when a shared in-memory object has more than one construction site; pair a fail-open helper with a test that pins the empty-input case; and prove the regression test red before the fix.

**Deliberately not changed:** `busySlots()`. Overflow monitors consuming active capacity is designed back-pressure (`long-running-waiting-sessions.md`, Q2), and it was safe only while the idle timer guaranteed a monitor eventually left the set. Restoring self-resume drains it in the default configuration; redesigning capacity semantics inside a bugfix would be the wrong place. Noted in #810 instead.

## 🧪 Tests

14 new tests. Every regression test was proven **red → green** (`git stash push -- <source files>`, run, confirm failure, `git stash pop`):

| Test | Unfixed tree |
| --- | --- |
| `run.test.ts` — a parked monitor schedules its own re-check under the zero-config default (#810) | ❌ fails |
| `run.test.ts` — expands the continuation's OPENING prompt before it becomes the session userPrompt (#811) | ❌ fails |
| `run.test.ts` — expands a FOLLOW-UP delivered into the reopened continuation session (#811) | ❌ fails |
| `config.test.ts` — absent key → 5; out-of-range → 5 | ❌ fails |
| `semaphore.test.ts` — zero-config default; absent key falls back | ❌ fails |
| `workspace-api.test.ts` — zero-config GET; partial updates | ❌ fails |

Guard tests that pass either way, pinning what must **not** change: park mode stays reachable (`run.test.ts`, `config.test.ts`, `semaphore.test.ts`, and a new `workspace-api.test.ts` round-trip proving `PUT null` persists as null and reaches the semaphore as null); an unknown slash command stays untouched so backend-native commands keep working (`run.test.ts`, `skill-system-prompt.test.ts`).

The #811 suite asserts against the transcript rather than an internal field: the dry-run mock echoes the prompt it received (`Okay — looking into: …`), so the persisted events are a faithful witness of what actually reached the backend, and the same suite checks the `user-message` event still shows what the user typed.

Validation gate, all green on this branch:

- `npm run typecheck` ✅
- `npm test` ✅ — 5580 passed, 307 files
- `npm run test:unit` ✅ — 35 passed, 1 skipped
- `npm run build` ✅ — `check:pack ok — 462 files, 88 under web/dist`
- `npm run test:package` ✅ — 12/12

## 💥 Breaking Changes

No contract, route, response shape, event name or persisted field changes. `packages/contract` is untouched — `monitoringWakeIntervalMinutes` is already `z.number().nullable()` and `5` satisfies it.

One **behavioural** change worth calling out explicitly: an existing install that has never touched Settings → Resources moves from "park forever" to "re-check every 5 minutes", which is cost-bearing. That is the point of the fix, and it is bounded by the existing 40-wakeup cap and reversible in one click. An install that already wrote `monitoringWakeIntervalMinutes: null` keeps park mode — that path has its own test at three layers.

## 📋 Notes for maintainers

- **Settings copy is unchanged.** The existing hint ("Park uses no model turns. Re-check sends the same agent a follow-up on this cadence until work completes or the 40-wakeup safety cap is reached.") stays accurate; the UI derives its mode from the config value, so a fresh install now opens on "Re-check on an interval / 5". Worth a look during QA if you want the copy to name the default.
- **Not added on purpose:** a cezar-side warning when a leading `/word` matches no registry skill. It would fire on every legitimate backend-native slash command (`/compact`, `/clear`), so the fail-open branch stays silent and is pinned by a test instead.
- **Also spotted, not filed:** `codex-app-server-runner.ts` assumes the resumed thread id (`this.threadId = this.spec.sessionId`) and ignores the `thread/resume` response, while #600's `isForeignThreadTurn` guard drops every turn-lifecycle frame whose `threadId` differs. If the app-server ever returns a different id on resume, the parent turn would never end. Not needed to explain either issue here, but worth confirming against a real app-server trace.
- Suggested labels: `bug`, `review`, `priority-high`, `risk-medium`, `needs-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU6VTaU8XRUp1VytgzsgcE
