### PR TITLE
feat(ui): animated top-right toast stack

### DIFF
--- a/.ai/runs/2026-08-09-animated-top-right-toasts.md
+++ b/.ai/runs/2026-08-09-animated-top-right-toasts.md
@@ -79,16 +79,16 @@ Lock the new lifecycle and the new anchor in unit tests, then run the repo's ful
 
 ### Phase 1: Two-phase dismissal in the store
 
-- [ ] 1.1 Add an `exiting` flag to `ToastItem` and re-publish instead of dropping at `TOAST_MS`
-- [ ] 1.2 Track pending timers so `resetToasts()` clears the queue and every scheduled handle
+- [x] 1.1 Add an `exiting` flag to `ToastItem` and re-publish instead of dropping at `TOAST_MS` — 7e2558c3
+- [x] 1.2 Track pending timers so `resetToasts()` clears the queue and every scheduled handle — 7e2558c3
 
 ### Phase 2: Top-right anchor and the enter/exit animation
 
-- [ ] 2.1 Re-anchor the toaster wrapper top-right with safe-area insets, `items-end`, and a raised z-layer
-- [ ] 2.2 Emit `data-state` and the `motion-safe:` enter/exit animation classes on each toast, preserving `data-slot`/`data-tone`/`role`
+- [x] 2.1 Re-anchor the toaster wrapper top-right with safe-area insets, `items-end`, and a raised z-layer — 7e2558c3
+- [x] 2.2 Emit `data-state` and the `motion-safe:` enter/exit animation classes on each toast, preserving `data-slot`/`data-tone`/`role` — 7e2558c3
 
 ### Phase 3: Tests and the validation gate
 
-- [ ] 3.1 Update the auto-dismiss test for the two-phase lifecycle (closed, then gone)
-- [ ] 3.2 Add regression tests for the top-right anchor and the open/closed animation state
+- [x] 3.1 Update the auto-dismiss test for the two-phase lifecycle (closed, then gone) — 7e2558c3
+- [x] 3.2 Add regression tests for the top-right anchor and the open/closed animation state — 7e2558c3
 - [ ] 3.3 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`)

--- a/.ai/runs/2026-08-09-animated-top-right-toasts.md
+++ b/.ai/runs/2026-08-09-animated-top-right-toasts.md
@@ -1,0 +1,94 @@
+# Execution plan — animated top-right toast stack in the cockpit
+
+**Issue:** #818 — Implement: animated top-right toast stack in the cockpit
+**Branch:** `feat/animated-top-right-toasts`
+**Engine:** `Engine: om-auto-create-pr (steps: 7, --loop: no)`
+
+## Goal
+
+Move the cockpit's toast stack from bottom-centre to the top-right corner and give it a real
+enter/exit transition (slide from the right + fade), so a toast no longer lands on top of the
+thread's action row and no longer pops in and out with no animation — which today reads as a
+rendering glitch rather than a notification.
+
+## Scope
+
+Everything lives in one primitive plus its unit test:
+
+- `packages/web/src/components/ui/toaster.tsx` — the module-level store, `toast()`,
+  `resetToasts()`, and the `<Toaster />` renderer.
+- `packages/web/src/components/ui/toaster.test.tsx` — the unit suite that locks the new
+  lifecycle and the new anchor in place.
+
+No caller changes: `<Toaster />` is mounted once at the app root (`packages/web/src/app.tsx`)
+and every `toast(...)` call site keeps its current signature.
+
+### Non-goals
+
+Deliberately untouched, per the issue's own out-of-scope list:
+
+- Swapping the hand-rolled primitive for a toast library (sonner, Radix Toast). The file's
+  comment explains the deliberate no-dependency choice and this run does not revisit it.
+- New toast features: manual dismiss buttons, action buttons, per-toast durations,
+  swipe-to-dismiss, extra tones beyond `default`/`danger`.
+- Changing the 5s `TOAST_MS` lifetime, the stack order (oldest first stays), or the wording of
+  any existing toast message.
+- Any change to `toast()` call sites — the signature stays exactly as it is.
+
+## Implementation Plan
+
+### Phase 1 — Two-phase dismissal in the store
+
+The current `toast()` drops the item from the store the instant the 5s timer fires, so the node
+unmounts before any exit animation could run. An exit transition therefore needs a lifecycle
+change, not just CSS: at `TOAST_MS` the item is re-published with `exiting: true`, and a second
+timer removes it once the exit animation has had time to play. `resetToasts()` must clear both
+the queue and every pending timer so one test's toasts cannot leak into the next.
+
+### Phase 2 — Top-right anchor and the enter/exit animation
+
+Re-anchor the `data-slot="toaster"` wrapper to the top-right (respecting the top/right safe-area
+insets), cap each item's width so a long message wraps instead of spanning the viewport, and
+raise the wrapper above the Radix dialog layer — dialogs do fire toasts, and at an equal
+`z-50` the dialog's portal (later in `<body>`) would paint over the toast. Animation uses the
+`tw-animate-css` utilities already imported by `packages/web/src/styles/index.css`, gated on
+`motion-safe:` so `prefers-reduced-motion: reduce` gets an instant appear/disappear, matching
+the rest of the cockpit. The `data-slot`, `data-tone` and `role="status"` hooks stay
+byte-identical — three e2e specs and the unit test query them.
+
+### Phase 3 — Tests and the validation gate
+
+Lock the new lifecycle and the new anchor in unit tests, then run the repo's full gate.
+
+## Risks
+
+- **Timer bookkeeping.** Two timers per toast is the easiest thing to get subtly wrong; a leaked
+  timer would fire against a later test's store. Mitigated by tracking every handle in a module
+  set that `resetToasts()` clears, plus a test asserting two toasts keep independent clocks.
+- **Z-order regression.** Raising the toaster above the dialog layer is the intended fix for
+  toasts fired from inside a dialog, but it also means a toast now paints over a dialog's top
+  edge. That is the accepted trade — a notification the user cannot see is worse than one that
+  briefly overlaps a dialog corner — and it stays below the `z-[100]` image lightbox.
+- **e2e contract drift.** `packages/web/e2e/{new-task,settings-skills,workflows}.e2e.ts` poll for
+  `[data-slot="toast"]` / `[data-slot="toaster"]` text. Keeping those attributes unchanged is an
+  explicit step, not a side effect.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Two-phase dismissal in the store
+
+- [ ] 1.1 Add an `exiting` flag to `ToastItem` and re-publish instead of dropping at `TOAST_MS`
+- [ ] 1.2 Track pending timers so `resetToasts()` clears the queue and every scheduled handle
+
+### Phase 2: Top-right anchor and the enter/exit animation
+
+- [ ] 2.1 Re-anchor the toaster wrapper top-right with safe-area insets, `items-end`, and a raised z-layer
+- [ ] 2.2 Emit `data-state` and the `motion-safe:` enter/exit animation classes on each toast, preserving `data-slot`/`data-tone`/`role`
+
+### Phase 3: Tests and the validation gate
+
+- [ ] 3.1 Update the auto-dismiss test for the two-phase lifecycle (closed, then gone)
+- [ ] 3.2 Add regression tests for the top-right anchor and the open/closed animation state
+- [ ] 3.3 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`)

--- a/.ai/runs/2026-08-09-animated-top-right-toasts.md
+++ b/.ai/runs/2026-08-09-animated-top-right-toasts.md
@@ -69,11 +69,14 @@ Lock the new lifecycle and the new anchor in unit tests, then run the repo's ful
   toasts fired from inside a dialog, but it also means a toast now paints over a dialog's top
   edge. That is the accepted trade — a notification the user cannot see is worse than one that
   briefly overlaps a dialog corner — and it stays below the `z-[100]` image lightbox.
+- **Intermittent unrelated test.** `packages/cezar/src/server/open-in-app.test.ts` failed once across five full `npm test` runs on this branch (`ENOENT` on the stub call log its `waitFor` polls). The file is byte-identical to `main`, is server-side, and passes 10/10 in isolation — it loses a timing race only under full-suite load. Filed as #823 rather than fixed here, since touching an unrelated server test from a cockpit-UI PR would be scope creep.
 - **e2e contract drift.** `packages/web/e2e/{new-task,settings-skills,workflows}.e2e.ts` poll for
   `[data-slot="toast"]` / `[data-slot="toaster"]` text. Keeping those attributes unchanged is an
   explicit step, not a side effect.
 
 ## Progress
+
+PR: #820
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
@@ -86,9 +89,11 @@ Lock the new lifecycle and the new anchor in unit tests, then run the repo's ful
 
 - [x] 2.1 Re-anchor the toaster wrapper top-right with safe-area insets, `items-end`, and a raised z-layer — 7e2558c3
 - [x] 2.2 Emit `data-state` and the `motion-safe:` enter/exit animation classes on each toast, preserving `data-slot`/`data-tone`/`role` — 7e2558c3
+- [x] Post-review fix: clear the app shell's mobile header with a `md:` breakpoint pair — the flat 16px anchor covered the run status dot and kebab on phones — 69f27427
 
 ### Phase 3: Tests and the validation gate
 
 - [x] 3.1 Update the auto-dismiss test for the two-phase lifecycle (closed, then gone) — 7e2558c3
 - [x] 3.2 Add regression tests for the top-right anchor and the open/closed animation state — 7e2558c3
+- [x] Post-review fix: pin `motion-safe:duration-200` in the animation test so it cannot drift from `EXIT_MS` — 69f27427
 - [x] 3.3 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`) — 2ea68071

--- a/.ai/runs/2026-08-09-animated-top-right-toasts.md
+++ b/.ai/runs/2026-08-09-animated-top-right-toasts.md
@@ -91,4 +91,4 @@ Lock the new lifecycle and the new anchor in unit tests, then run the repo's ful
 
 - [x] 3.1 Update the auto-dismiss test for the two-phase lifecycle (closed, then gone) — 7e2558c3
 - [x] 3.2 Add regression tests for the top-right anchor and the open/closed animation state — 7e2558c3
-- [ ] 3.3 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`)
+- [x] 3.3 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`) — 2ea68071

--- a/packages/web/src/components/ui/toaster.test.tsx
+++ b/packages/web/src/components/ui/toaster.test.tsx
@@ -27,8 +27,46 @@ describe('Toaster', () => {
     expect(item.textContent).toBe('Command copied to clipboard.')
     expect(item.getAttribute('data-tone')).toBe('default')
 
+    // The lifetime timer only marks the toast as exiting — it stays mounted so the exit
+    // animation has something to animate.
     act(() => vi.advanceTimersByTime(5000))
+    expect(screen.getByRole('status').getAttribute('data-state')).toBe('closed')
+
+    // …and the second timer is what actually removes it.
+    act(() => vi.advanceTimersByTime(200))
     expect(document.querySelector('[data-slot="toast"]')).toBeNull()
+  })
+
+  it('anchors the stack to the top-right corner, not the bottom centre', () => {
+    render(<Toaster />)
+    act(() => toast('anchored'))
+
+    const stack = document.querySelector('[data-slot="toaster"]')!
+    const className = stack.className
+    expect(className).toContain('fixed')
+    expect(className).toContain('top-[calc(16px+env(safe-area-inset-top))]')
+    expect(className).toContain('right-[calc(16px+env(safe-area-inset-right))]')
+    expect(className).toContain('items-end')
+    // The bottom-centre anchor this replaced must not linger — it is what put the toast on
+    // top of the thread's action row (#818).
+    expect(className).not.toContain('items-center')
+    expect(className).not.toContain('bottom-')
+    expect(className).not.toContain('inset-x-0')
+  })
+
+  it('animates in on open and out on close, only when motion is allowed', () => {
+    render(<Toaster />)
+    act(() => toast('animated'))
+
+    const item = screen.getByRole('status')
+    expect(item.getAttribute('data-state')).toBe('open')
+    expect(item.className).toContain('motion-safe:animate-in')
+    expect(item.className).toContain('motion-safe:slide-in-from-right-4')
+    expect(item.className).toContain('motion-safe:data-[state=closed]:animate-out')
+    expect(item.className).toContain('motion-safe:data-[state=closed]:slide-out-to-right-4')
+
+    act(() => vi.advanceTimersByTime(5000))
+    expect(screen.getByRole('status').getAttribute('data-state')).toBe('closed')
   })
 
   it('stacks multiple toasts and dismisses each on its own clock', () => {
@@ -41,8 +79,23 @@ describe('Toaster', () => {
     expect(toasts.map((t) => t.textContent)).toEqual(['first', 'second'])
     expect(toasts[1]!.getAttribute('data-tone')).toBe('danger')
 
-    // 3s later the first (5s old) is gone, the second (3s old) remains.
+    // 3s later the first (5s old) starts exiting while the second (3s old) is untouched.
     act(() => vi.advanceTimersByTime(3000))
+    expect(
+      screen.getAllByRole('status').map((t) => [t.textContent, t.getAttribute('data-state')]),
+    ).toEqual([
+      ['first', 'closed'],
+      ['second', 'open'],
+    ])
+
+    // The first one's exit timer removes only itself; the second keeps its own clock running.
+    act(() => vi.advanceTimersByTime(200))
     expect(screen.getAllByRole('status').map((t) => t.textContent)).toEqual(['second'])
+
+    // The second reaches its own 5s at t=7000 and then leaves the same way.
+    act(() => vi.advanceTimersByTime(1800))
+    expect(screen.getByRole('status').getAttribute('data-state')).toBe('closed')
+    act(() => vi.advanceTimersByTime(200))
+    expect(document.querySelector('[data-slot="toast"]')).toBeNull()
   })
 })

--- a/packages/web/src/components/ui/toaster.test.tsx
+++ b/packages/web/src/components/ui/toaster.test.tsx
@@ -44,9 +44,13 @@ describe('Toaster', () => {
     const stack = document.querySelector('[data-slot="toaster"]')!
     const className = stack.className
     expect(className).toContain('fixed')
-    expect(className).toContain('top-[calc(16px+env(safe-area-inset-top))]')
+    expect(className).toContain('md:top-[calc(16px+env(safe-area-inset-top))]')
     expect(className).toContain('right-[calc(16px+env(safe-area-inset-right))]')
     expect(className).toContain('items-end')
+    // Below `md` the app shell renders its own 52px header whose right end holds the run
+    // status dot and kebab; anchoring at 16px there would cover the very controls #818 is
+    // about. The pair must stay a pair.
+    expect(className).toContain('top-[calc(61px+env(safe-area-inset-top))]')
     // The bottom-centre anchor this replaced must not linger — it is what put the toast on
     // top of the thread's action row (#818).
     expect(className).not.toContain('items-center')
@@ -64,6 +68,10 @@ describe('Toaster', () => {
     expect(item.className).toContain('motion-safe:slide-in-from-right-4')
     expect(item.className).toContain('motion-safe:data-[state=closed]:animate-out')
     expect(item.className).toContain('motion-safe:data-[state=closed]:slide-out-to-right-4')
+    // The animation duration and the store's EXIT_MS (200ms) remove the node together. Raise
+    // one without the other and the slide-out is unmounted mid-flight, so pin the class here:
+    // a failure points the editor straight at EXIT_MS in toaster.tsx.
+    expect(item.className).toContain('motion-safe:duration-200')
 
     act(() => vi.advanceTimersByTime(5000))
     expect(screen.getByRole('status').getAttribute('data-state')).toBe('closed')

--- a/packages/web/src/components/ui/toaster.tsx
+++ b/packages/web/src/components/ui/toaster.tsx
@@ -18,13 +18,24 @@ export interface ToastItem {
   id: number
   message: string
   tone: ToastTone
+  /** `true` once the lifetime timer fired. The item stays in the store — and mounted — for
+   *  `EXIT_MS` longer so the exit animation has something to animate; dropping it here is
+   *  what made the old toast vanish with no transition. */
+  exiting: boolean
 }
 
 const TOAST_MS = 5000
+/** Exit-animation window. Keep in step with the `duration-200` on the toast's animation
+ *  classes below: the node is removed once this elapses, so a shorter value would cut the
+ *  slide-out off mid-flight. */
+const EXIT_MS = 200
 
 let items: readonly ToastItem[] = []
 let nextId = 1
 const listeners = new Set<() => void>()
+/** Every pending lifetime/exit timer, so `resetToasts()` can cancel them — an orphaned timer
+ *  would publish into the *next* test's store. */
+const timers = new Set<ReturnType<typeof setTimeout>>()
 
 function publish(next: readonly ToastItem[]): void {
   items = next
@@ -36,16 +47,33 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener)
 }
 
+/** `setTimeout` that keeps its handle cancellable until it actually runs. */
+function schedule(fn: () => void, ms: number): void {
+  const handle = setTimeout(() => {
+    timers.delete(handle)
+    fn()
+  }, ms)
+  timers.add(handle)
+}
+
 /** Show a transient message. `danger` tone for failures — the message should be the server's
  *  own words wherever one exists (see ApiError). */
 export function toast(message: string, opts: { tone?: ToastTone } = {}): void {
-  const item: ToastItem = { id: nextId++, message, tone: opts.tone ?? 'default' }
+  const item: ToastItem = { id: nextId++, message, tone: opts.tone ?? 'default', exiting: false }
   publish([...items, item])
-  setTimeout(() => publish(items.filter((t) => t.id !== item.id)), TOAST_MS)
+  // Two phases, one clock per toast: mark it exiting so the renderer can animate it out, then
+  // remove it once the animation has played.
+  schedule(() => {
+    publish(items.map((t) => (t.id === item.id ? { ...t, exiting: true } : t)))
+    schedule(() => publish(items.filter((t) => t.id !== item.id)), EXIT_MS)
+  }, TOAST_MS)
 }
 
-/** Test seam: clears the module-level queue so one test's toasts never leak into the next. */
+/** Test seam: clears the module-level queue *and* every pending timer, so one test's toasts
+ *  never leak into the next. */
 export function resetToasts(): void {
+  for (const handle of timers) clearTimeout(handle)
+  timers.clear()
   publish([])
 }
 
@@ -55,7 +83,10 @@ export function Toaster() {
   return (
     <div
       data-slot="toaster"
-      className="pointer-events-none fixed inset-x-0 bottom-[calc(16px+env(safe-area-inset-bottom))] z-50 flex flex-col items-center gap-2 px-4"
+      // Top-right, the placement web apps have standardised on: bottom-centre landed straight
+      // on the thread's action row. z-[60] clears the Radix overlay layer (z-50) — dialogs fire
+      // toasts, and their portal sits later in <body>, so at an equal z-index the dialog wins.
+      className="pointer-events-none fixed top-[calc(16px+env(safe-area-inset-top))] right-[calc(16px+env(safe-area-inset-right))] z-[60] flex flex-col items-end gap-2"
     >
       {current.map((item) => (
         <div
@@ -63,8 +94,14 @@ export function Toaster() {
           role="status"
           data-slot="toast"
           data-tone={item.tone}
+          data-state={item.exiting ? 'closed' : 'open'}
           className={cn(
-            'pointer-events-auto max-w-full rounded-md px-3.5 py-2.5 text-[13px] font-medium shadow-modal',
+            'pointer-events-auto max-w-[min(360px,calc(100vw-32px))] rounded-md px-3.5 py-2.5 text-[13px] font-medium shadow-modal',
+            // tw-animate-css utilities (imported in styles/index.css), the same vocabulary the
+            // shadcn primitives use. motion-safe: so `prefers-reduced-motion` keeps the instant
+            // appear/disappear it had before.
+            'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-right-4 motion-safe:duration-200',
+            'motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:fade-out-0 motion-safe:data-[state=closed]:slide-out-to-right-4',
             item.tone === 'danger'
               ? 'bg-danger text-danger-foreground'
               : 'bg-contrast text-contrast-foreground',

--- a/packages/web/src/components/ui/toaster.tsx
+++ b/packages/web/src/components/ui/toaster.tsx
@@ -86,7 +86,12 @@ export function Toaster() {
       // Top-right, the placement web apps have standardised on: bottom-centre landed straight
       // on the thread's action row. z-[60] clears the Radix overlay layer (z-50) — dialogs fire
       // toasts, and their portal sits later in <body>, so at an equal z-index the dialog wins.
-      className="pointer-events-none fixed top-[calc(16px+env(safe-area-inset-top))] right-[calc(16px+env(safe-area-inset-right))] z-[60] flex flex-col items-end gap-2"
+      //
+      // The mobile offset clears the app shell's own header (app-shell.tsx: a 52px row plus its
+      // border, under the safe-area inset) whose right end holds the run status dot and kebab.
+      // Anchoring at 16px on a phone would cover exactly the controls #818 is about, which is
+      // the bug moved rather than fixed; `md:` is where that header stops rendering.
+      className="pointer-events-none fixed top-[calc(61px+env(safe-area-inset-top))] right-[calc(16px+env(safe-area-inset-right))] z-[60] flex flex-col items-end gap-2 md:top-[calc(16px+env(safe-area-inset-top))]"
     >
       {current.map((item) => (
         <div


### PR DESCRIPTION
Closes #818
Tracking plan: .ai/runs/2026-08-09-animated-top-right-toasts.md
Status: complete

## 🎯 Goal
- Move the cockpit's toast stack from bottom-centre to the top-right corner and give it a real enter/exit transition, so a toast no longer covers the controls a user reaches for next — the reported case is the "Added to the queue — PR #816" toast sitting on top of "Run again" and the "View task →" link — and no longer appears and vanishes with no transition, which reads as a rendering glitch rather than a notification.

## What Changed
- **`packages/web/src/components/ui/toaster.tsx` — the store now dismisses in two phases.** The old `toast()` dropped its item from the module store the instant the 5s timer fired, so the node unmounted before any exit animation could run; an exit transition was therefore impossible with CSS alone. `ToastItem` gains an `exiting` flag: at `TOAST_MS` the item is re-published as exiting, and a second timer removes it `EXIT_MS` (200ms) later. Every pending handle is tracked in a module set so `resetToasts()` cancels timers as well as clearing the queue — otherwise one test's orphaned timer would publish into the next test's store.
- **`packages/web/src/components/ui/toaster.tsx` — the stack is anchored top-right and animated.** The wrapper moves from `inset-x-0 bottom-[…] items-center` to `top-[calc(16px+env(safe-area-inset-top))] right-[calc(16px+env(safe-area-inset-right))] items-end`, each item caps its width (`max-w-[min(360px,calc(100vw-32px))]`) so a long message wraps instead of spanning the viewport, and the wrapper moves from `z-50` to `z-[60]`. That last part matters: dialogs do fire toasts, Radix portals its overlay to the end of `<body>`, and at an equal z-index the dialog paints over the toast — rare with a bottom-centre stack, common with a top-right one. Each toast emits `data-state={open|closed}` and carries `tw-animate-css` enter/exit classes (`animate-in`/`fade-in-0`/`slide-in-from-right-4` and their `data-[state=closed]` counterparts) gated on `motion-safe:`, so `prefers-reduced-motion: reduce` keeps the instant appear/disappear it had before. No new dependency and no new `@keyframes` — the utilities come from the `tw-animate-css` import already in `packages/web/src/styles/index.css`.
- **No caller changes.** `<Toaster />` is still mounted once at the app root and `toast()` keeps its exact signature, so every call site is untouched.

## 🔍 Review
- `om-auto-review-pr` ran in autofix mode and requested changes on one major finding: below the `md` breakpoint the new top-right anchor covered the app shell's own 52px mobile header, whose right end carries the run status dot and kebab — #818's complaint relocated rather than fixed. Fixed in `69f27427` with a breakpoint pair (`top-[calc(61px+…)] md:top-[calc(16px+…)]`), measured in a real 390×844 browser at an 8px gap below the header. A minor finding (the `EXIT_MS` ↔ `duration-200` coupling documented only in a comment) is now pinned by a test assertion. The re-review approved; the two remaining nits are documented and deliberately unchanged.

## 🧪 Tests
- `npm run typecheck` — ✅ clean across api-client, server and web.
- `npm test` — ✅ 5630 passed / 308 files (includes `packages/web/src/design-guardian.test.ts`).
- `npm run test:unit` — ✅ 35 passed, 1 skipped.
- `npm run build` — ✅ tsc + vite + `check:pack` (462 files, 88 under `web/dist`).
- `npm run test:package` — ✅ 12 passed.
- One intermittent failure was seen across five full `npm test` runs, in `packages/cezar/src/server/open-in-app.test.ts` — a file byte-identical to `main`, unrelated to this browser-only diff, and green 10/10 in isolation. Filed as #823 rather than absorbed silently; four of five full runs and CI on this head are green.
- `packages/web/src/components/ui/toaster.test.tsx` grew from 3 tests to 5 and now locks in: the two-phase lifecycle (at 5s the node is still present with `data-state="closed"`, at 5.2s it is gone), the top-right anchor (asserting the new classes are present *and* that the bottom-centre ones are gone — the regression guard for the actual ask), the `data-state` open→closed flip with the `motion-safe:` animation classes, and two toasts keeping independent clocks across the new exit timers.
- The four new/changed tests were confirmed red against the pre-fix `toaster.tsx` (`git stash push` on the source, run, `git stash pop`), so none of them passes against the bug.

## 💥 Breaking Changes
- None. The change is confined to the bundled cockpit UI (`packages/web`), which ships in lockstep with the server that serves it — `BACKWARD_COMPATIBILITY.md` covers the CLI surface, the `/api/v1` routes and SSE vocabulary, and the `.ai/cezar/` state formats, none of which are touched. The only internal contracts at stake are the `data-slot="toaster"` / `data-slot="toast"` / `data-tone` attributes and the `role="status"` live region queried by `packages/web/e2e/{new-task,settings-skills,workflows}.e2e.ts`, and all four are preserved byte-for-byte.

## 📋 Progress
See the Progress section in the tracking plan.
