### PR TITLE
fix(server): route every launcher through its injectable seam, and stop tests spawning windows (#824)

### DIFF
--- a/packages/cezar/src/server/agent-profiles-api.test.ts
+++ b/packages/cezar/src/server/agent-profiles-api.test.ts
@@ -679,14 +679,24 @@ describe('agent profiles API', () => {
 
     it('allows a terminal for the FOLDER, which is the case it does apply to', async () => {
       const account = await create('work', signedIn('claude-klaudiusz'));
-      // `openInApp` is the real thing here, so assert only that the target passed validation:
-      // a 400 would mean it was refused, and anything else means it reached the launcher.
-      const res = await apiRequest(makeApp(), `/api/v1/workspace/agent-profiles/${account.id}/open`, {
+      // #820: this reached the REAL launcher and opened a Terminal on whoever ran the suite,
+      // sitting in a `cez-profiles-home-*` fixture that `afterEach` had already deleted. Inject
+      // the launcher instead — which also lets the assertion say what it means: `not.toBe(400)`
+      // passed whether the target was accepted OR the launcher blew up behind it.
+      const launched: Array<[string, string]> = [];
+      const app = makeApp({
+        openApp: async (target, path) => {
+          launched.push([target, path]);
+          return true;
+        },
+      });
+      const res = await apiRequest(app, `/api/v1/workspace/agent-profiles/${account.id}/open`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ file: 'folder', target: 'terminal' }),
       });
-      expect(res.status).not.toBe(400);
+      expect(res.status).toBe(200);
+      expect(launched).toEqual([['terminal', account.path]]);
     });
 
     it('409s a file the agent has not written yet rather than reporting a false success', async () => {

--- a/packages/cezar/src/server/open-in-app.test.ts
+++ b/packages/cezar/src/server/open-in-app.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // `vi.hoisted` so `spawnMock` is initialized before the (hoisted) vi.mock factory runs — the
 // factory sets its default implementation, so a bare `const` would be read before init.
@@ -16,6 +16,19 @@ vi.mock('node:child_process', async (importOriginal) => {
     (actual.spawn as (...a: unknown[]) => unknown)(...args),
   );
   return { ...actual, spawn: (...args: unknown[]) => spawnMock(...args) };
+});
+
+// This file is the one place allowed past the #820 spawn guard, and both reasons are visible
+// above: `spawn` is replaced file-wide, and where it does fall through to the real one it launches
+// a stub binary this test wrote onto its own temp PATH — never a GUI app. Scoped to the file and
+// restored afterwards, so no other suite inherits the exemption.
+const savedAllowSpawn = process.env.CEZ_ALLOW_TEST_SPAWN;
+beforeAll(() => {
+  process.env.CEZ_ALLOW_TEST_SPAWN = '1';
+});
+afterAll(() => {
+  if (savedAllowSpawn === undefined) delete process.env.CEZ_ALLOW_TEST_SPAWN;
+  else process.env.CEZ_ALLOW_TEST_SPAWN = savedAllowSpawn;
 });
 
 import {

--- a/packages/cezar/src/server/open-in-app.ts
+++ b/packages/cezar/src/server/open-in-app.ts
@@ -3,7 +3,7 @@ import { accessSync, constants, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { openInTerminal } from './open-in-terminal.ts';
+import { openInTerminal, refuseSpawnUnderTest } from './open-in-terminal.ts';
 import { isWsl, translateToWindowsPath } from './wsl.ts';
 
 /**
@@ -238,6 +238,7 @@ function pickInstalledMacApp(names: string | string[]): string {
 /** Spawn detached; success = no error within a short settle window (mirrors open-in-terminal). */
 function runDetached(bin: string, args: string[]): Promise<boolean> {
   return new Promise((resolve) => {
+    refuseSpawnUnderTest(bin, args);
     let child;
     try {
       child = spawn(bin, args, { stdio: 'ignore', detached: true });

--- a/packages/cezar/src/server/open-in-terminal.test.ts
+++ b/packages/cezar/src/server/open-in-terminal.test.ts
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { createLaunchScript, openInTerminal, wslTerminalLaunchers } from './open-in-terminal.ts';
+import { createLaunchScript, openInTerminal, refuseSpawnUnderTest, wslTerminalLaunchers } from './open-in-terminal.ts';
 
 describe('wslTerminalLaunchers (#361 WSL support)', () => {
   it('tries Windows Terminal first, re-entering the distro through wsl.exe', () => {
@@ -82,5 +82,48 @@ describe('openInTerminal env (spec 2026-07-29-agent-profiles)', () => {
         CLAUDE_CONFIG_DIR: `/home/u${String.fromCharCode(10)}evil`,
       }),
     ).resolves.toBe(false);
+  });
+});
+
+/**
+ * #820 — the backstop. A test that reaches a real launcher opens a window on the developer's
+ * machine; the suite once left a Terminal sitting in a fixture directory it had already deleted.
+ * The guard makes that omission impossible to commit, because it fails loudly instead of
+ * succeeding quietly.
+ */
+describe('the spawn guard (#820)', () => {
+  const saved = process.env.CEZ_ALLOW_TEST_SPAWN;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CEZ_ALLOW_TEST_SPAWN;
+    else process.env.CEZ_ALLOW_TEST_SPAWN = saved;
+  });
+
+  it('refuses, naming the command and the seam to inject', () => {
+    delete process.env.CEZ_ALLOW_TEST_SPAWN;
+    expect(() => refuseSpawnUnderTest('osascript', ['-e', 'tell application "Terminal"']))
+      .toThrow(/refusing to spawn a launcher from a test: osascript -e tell application "Terminal"/)
+    expect(() => refuseSpawnUnderTest('osascript', [])).toThrow(/ServerDeps\.openTerminal/);
+  });
+
+  it('lets a file that has mocked child_process through, explicitly', () => {
+    process.env.CEZ_ALLOW_TEST_SPAWN = '1';
+    expect(() => refuseSpawnUnderTest('osascript', ['-e', 'x'])).not.toThrow();
+  });
+
+  it('never fires outside a test run', () => {
+    delete process.env.CEZ_ALLOW_TEST_SPAWN;
+    const vitest = process.env.VITEST;
+    delete process.env.VITEST;
+    try {
+      expect(() => refuseSpawnUnderTest('osascript', ['-e', 'x'])).not.toThrow();
+    } finally {
+      if (vitest !== undefined) process.env.VITEST = vitest;
+    }
+  });
+
+  it('stops openInTerminal before it can reach the OS', async () => {
+    delete process.env.CEZ_ALLOW_TEST_SPAWN;
+    // The exact call #820 reported: `openInApp('terminal', dir)` → `openInTerminal(dir, ':')`.
+    await expect(openInTerminal('/tmp/some-account-folder', ':')).rejects.toThrow(/refusing to spawn/);
   });
 });

--- a/packages/cezar/src/server/open-in-terminal.ts
+++ b/packages/cezar/src/server/open-in-terminal.ts
@@ -139,9 +139,34 @@ export function createLaunchScript(
   return scriptPath;
 }
 
+/**
+ * A test that reaches a real launcher opens a window on the developer's machine — a Terminal on
+ * macOS, a `cmd` window on Windows, an emulator on Linux — and #820 is what that looks like: a
+ * suite run left a Terminal sitting in a `cez-profiles-home-*` fixture directory the same run had
+ * already deleted. Throwing beats returning `false`: a silent refusal would let the omission
+ * survive as a passing test, and the fix is always the same one line — inject the launcher seam
+ * (`openTerminal` / `openFile` / `openApp` on `ServerDeps`) instead of reaching the real one.
+ *
+ * `CEZ_ALLOW_TEST_SPAWN=1` is the deliberate exception, for a file that has replaced
+ * `node:child_process` with a mock: nothing reaches a real process there, and asserting the argv a
+ * launcher WOULD pass is exactly how the Windows launcher-safety cases (#469, BatBadBut) are
+ * pinned. Set it around those tests, never process-wide.
+ *
+ * Exported so `open-in-app.ts` shares this one definition rather than keeping a second copy that
+ * could drift.
+ */
+export function refuseSpawnUnderTest(bin: string, args: readonly string[]): void {
+  if (!process.env.VITEST || process.env.CEZ_ALLOW_TEST_SPAWN === '1') return;
+  throw new Error(
+    `refusing to spawn a launcher from a test: ${[bin, ...args].join(' ')}\n` +
+      'Inject the launcher (ServerDeps.openTerminal / openFile / openApp) instead of calling the real one.',
+  );
+}
+
 /** Spawn detached; success = no error within a short settle window. */
 function runDetached(bin: string, args: string[]): Promise<boolean> {
   return new Promise((resolve) => {
+    refuseSpawnUnderTest(bin, args);
     let child;
     try {
       child = spawn(bin, args, { stdio: 'ignore', detached: true });

--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -225,6 +225,10 @@ export interface ServerDeps {
   /** Hand a local FILE (or folder) to the OS default app. Injected so the account-file open route
    *  is testable without actually launching an editor. */
   openFile?: typeof openFileInDefaultApp;
+  /** Hand a folder to a detected app by target id — editor, file manager, or `terminal`, which
+   *  reaches `openInTerminal`. Injected for the same reason as the two above: a test that reaches
+   *  this for real opens a window on the developer's machine (#820). */
+  openApp?: typeof openInApp;
   /** Process-wide Open Mercato skills update detector. Injected in tests and
    * shared by every workspace route/project; createApp owns the default. */
   skillsUpdate?: SkillsUpdateService;
@@ -1131,6 +1135,7 @@ export function createApp(deps: ServerDeps) {
   };
   const openTerminal = deps.openTerminal ?? openInTerminal;
   const openFile = deps.openFile ?? openFileInDefaultApp;
+  const openApp = deps.openApp ?? openInApp;
   const skillsUpdate = deps.skillsUpdate ?? new SkillsUpdateService();
 
   // ---- workspace boot-project identity (multi-project spec) ----------------
@@ -2231,7 +2236,7 @@ export function createApp(deps: ServerDeps) {
         }
         const opened = target === undefined
           ? await openFile(path)
-          : await openInApp(target, path);
+          : await openApp(target, path);
         if (!opened) return c.json({ error: `could not open ${basename(path)}`, path }, 409);
         return c.json({ opened: true as const, path });
       },
@@ -3863,7 +3868,7 @@ export function createApp(deps: ServerDeps) {
       if (fallback === null) {
         return c.json({ error: 'this account\'s folder cannot be used in a terminal command' }, 409);
       }
-      const opened = await openInTerminal(cwd, command, account.env);
+      const opened = await openTerminal(cwd, command, account.env);
       if (!opened) {
         return c.json({ error: 'no terminal emulator found', command: fallback }, 409);
       }
@@ -3931,7 +3936,7 @@ export function createApp(deps: ServerDeps) {
           );
         }
         const filePath = join(run.worktreePath, result.path);
-        const opened = await openFileInDefaultApp(filePath);
+        const opened = await openFile(filePath);
         if (!opened) return c.json({ error: `could not open ${result.path}`, path: filePath }, 409);
         return c.json({ opened: true, path: filePath });
       }
@@ -3971,14 +3976,14 @@ export function createApp(deps: ServerDeps) {
         if (fallback === null) {
           return c.json({ error: 'this account\'s folder cannot be used in a terminal command' }, 409);
         }
-        const opened = await openInTerminal(dir, command, account.env);
+        const opened = await openTerminal(dir, command, account.env);
         if (!opened) {
           return c.json({ error: 'no terminal emulator found', command: fallback }, 409);
         }
         return c.json({ opened: true, path: dir, command });
       }
 
-      const opened = await openInApp(target, dir);
+      const opened = await openApp(target, dir);
       if (!opened) return c.json({ error: `could not open ${target}`, path: dir }, 409);
       return c.json({ opened: true, path: dir });
     })
@@ -4340,7 +4345,7 @@ export function createApp(deps: ServerDeps) {
       if (!detectOpenTargets().some((candidate) => candidate.id === target)) {
         return c.json({ error: `no such app on this machine: ${target}` }, 400);
       }
-      const opened = await openInApp(target, root);
+      const opened = await openApp(target, root);
       if (!opened) return c.json({ error: `could not open ${target}`, path: root }, 409);
       return c.json({ opened: true as const, path: root });
     });


### PR DESCRIPTION
Fixes #824

## 🎯 Goal

`npm test` no longer opens a window on the machine running it, and the seams that were supposed to
prevent that are actually used.

## 🔍 Problem

Reported from a real suite run: a Terminal window appeared on macOS showing

```
cd '/private/var/folders/…/T/cez-profiles-home-shJEdX/claude-klaudiusz' && :
```

`cez-profiles-home-*` is `agent-profiles-api.test.ts`'s `mkdtemp` fixture and `claude-klaudiusz` is
the account slug it creates, so the suite launched it. The window is left in a directory the same
run's `afterEach` has already deleted. Windows would `start` a `cmd` window; Linux probes emulators;
any CI box with a desktop session does it too.

## 🔍 Root Cause

**1. The seams existed and almost nothing used them.** `ServerDeps` declares `openTerminal` and
`openFile`, and `createApp` resolves both at `server.ts:1132-1133` — but exactly ONE call site read
the resolved value. Every launcher call added since went straight to the import:

| line | call | seam |
| --- | --- | --- |
| 1854 | `openTerminal(bootRoot, command)` | ✅ resolved |
| 2233 | `openInApp(target, path)` | ❌ no seam existed |
| 3866 | `openInTerminal(cwd, command, account.env)` | ❌ raw import |
| 3934 | `openFileInDefaultApp(filePath)` | ❌ raw import |
| 3974 | `openInTerminal(dir, command, account.env)` | ❌ raw import |
| 3981 | `openInApp(target, dir)` | ❌ no seam existed |
| 4348 | `openInApp(target, root)` | ❌ no seam existed |

So injecting `openFile` and still hitting the real launcher was possible — and is exactly what
happened. The accounts open route ends `target === undefined ? openFile(path) : openInApp(target,
path)`, and `openInApp('terminal', dir)` is `openInTerminal(dir, ':')` (`open-in-app.ts:202`) — the
literal `cd '…' && :` from the report.

**2. The test could not tell the difference.** `agent-profiles-api.test.ts` — *"allows a terminal
for the FOLDER"* — used bare `makeApp()` and asserted `expect(res.status).not.toBe(400)`. Its own
comment conceded it: *"`openInApp` is the real thing here"*. That assertion passes whether the
target was accepted **or** the launcher blew up behind it, so the spawn was never observable. This
is why it survived review and CI.

## What Changed

- **`server.ts`** — new `ServerDeps.openApp?: typeof openInApp`, resolved beside its two siblings;
  all seven call sites now read the resolved value. `grep -n "await openInTerminal(\|await
  openFileInDefaultApp(\|await openInApp(" server.ts` comes back empty.
- **`open-in-terminal.ts`** — exports `refuseSpawnUnderTest`, which **throws** from `runDetached`
  when `VITEST` is set, naming the offending command and the seam to inject. Throwing rather than
  returning `false` is deliberate: a silent refusal lets the omission survive as a passing test,
  which is the failure mode that produced this issue. `CEZ_ALLOW_TEST_SPAWN=1` is the explicit
  exception for a file that has replaced `node:child_process` with a mock.
- **`open-in-app.ts`** — imports that guard rather than keeping a second copy, and calls it from
  its own `runDetached`. One definition, per AGENTS.md § *Changing a mechanism that already works*.
- **`agent-profiles-api.test.ts`** — injects `openApp` and asserts `200` plus
  `[['terminal', account.path]]`, which is what the old assertion could not say.
- **`open-in-app.test.ts`** — sets and restores `CEZ_ALLOW_TEST_SPAWN=1` around itself, with the
  justification in a comment: `spawn` is mocked file-wide, and where it falls through it launches a
  stub binary the test wrote to its own temp PATH, never a GUI app.

## 🧪 Tests

Four new cases in `open-in-terminal.test.ts` pin the guard: it refuses and names both the command
and the seam; the explicit opt-out lets a mocked file through; it never fires outside a test run;
and `openInTerminal('/tmp/x', ':')` — the exact call from the report — rejects instead of reaching
the OS.

Turning the guard on surfaced **four more real spawns**, all in `open-in-app.test.ts` and all
legitimate; they are covered by the scoped opt-out. Nothing else in 5632 tests reaches a launcher,
which is the useful negative result here.

Full gate:

- `npm run typecheck` ✅
- `npm test` ✅ — 5632 passed, 308 files
- `npm run test:unit` ✅ — 35 passed, 1 skipped
- `npm run build` ✅ — `check:pack ok — 462 files, 88 under web/dist`
- `npm run test:package` ✅ — 12/12

## 💥 Breaking Changes

None at runtime. `ServerDeps` gains one optional field, and the launcher guard is inert unless
`VITEST` is set — production behaviour is byte-identical.

## 📋 Notes for maintainers

- **Not a 0.9.3 concern.** Agent accounts (#750) are not on `release/0.9.x`, so neither the test nor
  the bypassing routes exist there. #813 is unaffected.
- The stray `scd` in the reported transcript is **not** a cezar quoting bug — `shellQuote` emitted
  `'…'` correctly. Terminal.app's `do script` types into a window whose shell is still starting, so
  a character from the startup banner interleaved with the injected text. That corruption race is
  its own argument against reaching a launcher from a test.
- Suggested labels: `bug`, `testing`, `review`, `priority-medium`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU6VTaU8XRUp1VytgzsgcE
