### PR TITLE
docs(changelog): credit contributors for 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,15 @@
   is now anchored at HEAD so it counts only the task's own changes, and the Changes tab says so when
   a repointed HEAD has narrowed what it shows.
 
+## 👥 Contributors
+
+- @pkarw
+- @pat-lewczuk
+- @patzick
+- @andrzejewsky
+- @sheeerth
+- @wojciechszyjka
+
 # 0.9.1 (2026-07-24)
 
 ## Highlights


### PR DESCRIPTION
## What

Adds the `## 👥 Contributors` section — which 0.9.0 and 0.9.1 both carry — to the **0.9.2** entry, which shipped without one.

@pkarw, @pat-lewczuk, @patzick, @andrzejewsky, @sheeerth, @wojciechszyjka

## How the names were derived

Unique commit authors across `v0.9.1..v0.9.2`, ordered by commit count (@pkarw 72, @pat-lewczuk 15, @patzick 3, @andrzejewsky 2, @sheeerth 2, @wojciechszyjka 1). Credit follows commit authorship, not who merged, and emails were resolved to GitHub logins through the commits API rather than guessed from names.

## Scope

Docs only — one file, additive, no code paths touched.

Companion to #829, which adds the same block to `release/0.9.x` (where it also covers 0.9.3, an entry that does not exist on `main`). Keeping both changelogs in step is the reason this PR exists separately.

## Noted, not fixed here

`main`'s 0.9.2 entry documents the workspace-wide ⌘K search (#773), but that feature is not in the `v0.9.2` tag — the 0.9.3 preamble on `release/0.9.x` says it stays on `main` for the next minor. Looks like a misfiled entry; out of scope for a contributor-credit change, and its author (@patzick) is in the list either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
