### PR TITLE
refactor(core): drop the unused KNOWN_PROVIDERS export (#548)

### DIFF
--- a/packages/cezar/src/core/model-identity.ts
+++ b/packages/cezar/src/core/model-identity.ts
@@ -46,12 +46,13 @@ export class ModelIdentityError extends Error {
 }
 
 /**
- * Providers cezar names today. Informational and extensible — an unknown
- * provider in an explicit `provider/model` string still passes through, so
- * future models and new backends are never silently rejected.
+ * No provider allowlist lives here on purpose (#548). `resolveModelIdentity`
+ * lets an unknown provider in an explicit `provider/model` string pass through,
+ * so future models and new backends are never silently rejected — an exported
+ * roster of "providers cezar names today" would gate nothing, and an unused
+ * public export reads as a contract someone must keep current. The per-backend
+ * knowledge that IS load-bearing lives in `BACKEND_MODEL_MAP` below.
  */
-export const KNOWN_PROVIDERS = ['anthropic', 'openai', 'google', 'openrouter'] as const;
-export type KnownProvider = (typeof KNOWN_PROVIDERS)[number];
 
 interface BackendModelMap {
   /**


### PR DESCRIPTION
Closes #548

## 🎯 Goal

`KNOWN_PROVIDERS` and `KnownProvider` (`packages/cezar/src/core/model-identity.ts:53-54`) were exported and referenced nowhere in the tree — no importer, no test, only the two declaration lines. The issue asked for one of three outcomes: remove them, give them a real consumer, or downgrade them to non-exported/`@internal`.

Removal is the right one. They gated nothing **by design**: `resolveModelIdentity` deliberately lets an unknown provider in an explicit `provider/model` string pass through, so future models and new backends are never silently rejected. A list that validates nothing and is imported by nobody is not informational — it is an exported surface that reads as a contract someone must keep current, and the next provider cezar speaks to would have quietly made it wrong.

"Downgrade to non-exported" was not available as a middle path: with zero references, an unexported version would be dead code the compiler flags rather than a documented hint.

## What Changed

- **`packages/cezar/src/core/model-identity.ts`** — removed both declarations. In their place is a comment recording that the absence is deliberate (so the next reader does not "restore" an allowlist into a parser whose whole contract is pass-through) and pointing at `BACKEND_MODEL_MAP`, which is where the per-backend knowledge that *is* load-bearing lives.

No behavior changes: nothing read these symbols, so nothing can observe their removal.

## 🧪 Tests

- `npm run typecheck` — ✅
- `npm test` — ✅ 5628 passed / 308 files
- `npm run test:unit` — ✅ 35 passed, 1 skipped
- Targeted: `npm test -- packages/cezar/src/core` — ✅ 532 passed / 24 files
- Grep check: `KNOWN_PROVIDERS|KnownProvider` returns no matches across `packages/**/*.ts{,x}` outside `dist/`.

No new test is added: there is no behavior to pin, and the compiler plus the grep above are the whole proof.

## 💥 Breaking Changes

None. Both symbols were exported from a `private` workspace package (`@open-mercato/cezar`, whose published surface is the CLI and the server, not this module's named exports), and neither appeared in any importer. `BACKWARD_COMPATIBILITY.md` does not list them.

## Related

Follow-up from #466 (finding **n1**); siblings #546, #547.
