### PR TITLE
feat(ui): surface the canonical model identity on the agent badge (#546)

### DIFF
--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -111,7 +111,11 @@ export const runRecordSchema = z.object({
    *  (e.g. `anthropic/claude-opus-4-8`) the run actually used, resolved from the
    *  free-text `model` against the chosen runner. Additive and optional: pre-#405
    *  records carry only `model`, and it stays the human/hand-edit surface; this
-   *  is the parseable identity cost attribution and reproducible replay key off. */
+   *  is the parseable identity cost attribution and reproducible replay key off.
+   *
+   *  Read in production by the session header's agent badge (#546), which shows it
+   *  whenever it says something `model` does not — so this is no longer a
+   *  write-only field whose next reader has to guess whether it is load-bearing. */
   modelIdentity: z.string().optional(),
   /** Agent backend this run used — drives "open in CLI" resume command. */
   runner: z.enum(['claude', 'codex', 'opencode']).optional(),

--- a/packages/web/src/routes/task-thread/run-header.test.tsx
+++ b/packages/web/src/routes/task-thread/run-header.test.tsx
@@ -917,6 +917,57 @@ describe('meta line, tabs, pill and resume hint', () => {
     })
   })
 
+  describe('the canonical model identity (#546)', () => {
+    /** Opens the agent badge's menu — `DropdownMenuContent` is not in the DOM until it does. */
+    const openAgentMenu = async () => {
+      const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+      const badge = within(meta).getByRole('button', { name: /^Agent:/ })
+      fireEvent.pointerDown(badge, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+      await waitFor(() => expect(document.querySelector('[role="menu"]')).not.toBeNull())
+      return document.querySelector('[role="menu"]') as HTMLElement
+    }
+
+    it('shows the provider/model the run actually resolved to', async () => {
+      // The reader `modelIdentity` was missing (#546): #405 persisted it for cost attribution and
+      // replay and nothing read it, so the field could rot without anyone noticing.
+      stubFetch()
+      renderHeader(run('done', {
+        runner: 'claude',
+        model: 'opus',
+        modelIdentity: 'anthropic/claude-opus-4-8',
+      }))
+      const menu = await openAgentMenu()
+      expect(menu.querySelector('[data-slot="agent-badge-identity"]')?.textContent)
+        .toBe('identity: anthropic/claude-opus-4-8')
+      // It ADDS to the asked-for model rather than replacing it — `model` is still the free-text
+      // the caller typed, and losing that would make the badge answer a different question.
+      expect(menu.textContent).toContain('model: opus')
+    })
+
+    it('says nothing for a run from before the identity was recorded', async () => {
+      // Same omitted-not-guessed rule as the account line: resolving it now would attribute a
+      // provider to a run that never wrote one down.
+      stubFetch()
+      renderHeader(run('done', { runner: 'claude', model: 'opus' }))
+      const menu = await openAgentMenu()
+      expect(menu.querySelector('[data-slot="agent-badge-identity"]')).toBeNull()
+    })
+
+    it('omits the line when it would only repeat the model', async () => {
+      // A gateway id is already in provider/model form, so echoing it would be noise in a menu
+      // whose whole value is that every line answers something.
+      stubFetch()
+      renderHeader(run('done', {
+        runner: 'claude',
+        model: 'anthropic/claude-opus-4-8',
+        modelIdentity: 'anthropic/claude-opus-4-8',
+      }))
+      const menu = await openAgentMenu()
+      expect(menu.querySelector('[data-slot="agent-badge-identity"]')).toBeNull()
+      expect(menu.textContent).toContain('model: anthropic/claude-opus-4-8')
+    })
+  })
+
   it('a claude run still gets an agent badge — Claude is the default, not a hidden runner', () => {
     stubFetch()
     renderHeader(run('done', { runner: 'claude' }))

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -630,11 +630,18 @@ function MonitoringSchedule({ run }: { run: ApiRun }) {
   )
 }
 
-/** The agent icon by the token counter (#416): hover/focus reveals the runner, account and model —
- *  the answer to "what am I actually running here?" — without turning them into permanent text next
- *  to the live status pill. Always rendered (a run always has an effective runner, `model`
- *  reads "auto" when the runner picks it), and reuses the same click/keyboard-accessible
- *  `DropdownMenu` as the rest of this header instead of inventing a hover-only affordance. */
+/** The agent icon by the token counter (#416): hover/focus reveals the runner, account, model and
+ *  canonical model identity — the answer to "what am I actually running here?" — without turning
+ *  them into permanent text next to the live status pill. Always rendered (a run always has an
+ *  effective runner, `model` reads "auto" when the runner picks it), and reuses the same
+ *  click/keyboard-accessible `DropdownMenu` as the rest of this header instead of inventing a
+ *  hover-only affordance.
+ *
+ *  This is the production reader for `RunRecord.modelIdentity` (#546): the field was persisted by
+ *  #405 for cost attribution and replay and had none, which is how a persisted field rots into
+ *  something nobody can tell is load-bearing. The menu is the right home for it — it answers a
+ *  question only a user debugging "which provider actually served this?" asks, so it belongs
+ *  behind the same disclosure as the account rather than in the truncating summary line. */
 function AgentBadge({ run }: { run: ApiRun }) {
   // The record keeps only what the caller ASKED for: `POST /api/runs` persists the raw optional
   // `runner` (`src/runs/store.ts`), while the run actually executes as
@@ -660,6 +667,14 @@ function AgentBadge({ run }: { run: ApiRun }) {
       // A deleted account still names the folder this run's sessions live in, so the id is shown
       // rather than swallowed — "gone" is the useful half of that answer.
       : profiles.data?.profiles.find((p) => p.id === accountId)?.label ?? `${accountId} (removed)`
+  // The canonical `provider/model` the run actually resolved to (#405), shown only when it says
+  // something `model` does not (#546). `model` is the free-text the caller ASKED for — `opus`,
+  // `auto`, a gateway id — so on a repo whose Claude runner points at a custom endpoint the two
+  // genuinely differ, and "which provider served this?" is a question only this field answers.
+  // Absent on pre-#405 records and skipped when it merely repeats `model`, following the same
+  // omitted-not-guessed rule as the account line below: an identity nothing wrote down is not
+  // one this header may invent.
+  const identity = run.modelIdentity && run.modelIdentity !== model ? run.modelIdentity : undefined
   const summary = [runner, account, model].filter(Boolean).join(' · ')
   return (
     <DropdownMenu>
@@ -699,6 +714,14 @@ function AgentBadge({ run }: { run: ApiRun }) {
         <DropdownMenuLabel className="font-mono text-[11px] font-normal text-muted-foreground">
           model: {model}
         </DropdownMenuLabel>
+        {identity ? (
+          <DropdownMenuLabel
+            data-slot="agent-badge-identity"
+            className="font-mono text-[11px] font-normal text-muted-foreground"
+          >
+            identity: {identity}
+          </DropdownMenuLabel>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   )


### PR DESCRIPTION
Closes #546

## 🎯 Goal

`RunRecord.modelIdentity` — the canonical `provider/model` a run actually resolved to — was added by #405, written at three spawn sites in `workflows/run.ts`, and read by **nothing**. The issue offered two outcomes: give it a real consumer, or document that it is deliberately write-only and name the issue that will change that.

This PR takes the first. The field's problem was never that it lacked a *plan* — its schema comment already named cost attribution and replay — it was that a persisted field with no reader stops being maintained, and the next person cannot tell whether it is load-bearing or dead weight to delete. A comment saying "a reader is coming" does not fix that; a reader does.

## What Changed

**`packages/web/src/routes/task-thread/run-header.tsx` — the agent badge is now the reader.**

The badge (`#416`) already exists to answer "what am I actually running here?" and already carries runner, account and model. The identity belongs on that same disclosure:

- Rendered as one more labelled line in the dropdown (`identity: anthropic/claude-opus-4-8`), behind the same click the `account` line already lives behind — **not** in the truncating summary next to the live status pill. It answers a question only someone debugging provider routing asks, so it earns a place in the menu, not permanent header real estate. `#416`'s whole point was cutting noise there, and this respects it.
- **Shown only when it says something `model` does not.** `model` is the free-text the caller *asked for* (`opus`, `auto`, a gateway id); `modelIdentity` is what that resolved to. On a Claude runner pointed at a custom Anthropic-compatible endpoint the two genuinely differ, which is exactly the case worth surfacing. When the asked-for model is already in `provider/model` form the line would only repeat it, so it is omitted — in a menu whose value is that every line answers something, a redundant row is a cost.
- **Absent on pre-#405 records, and not resolved on the fly for them.** Same omitted-not-guessed rule the account line follows: an identity nothing wrote down is not one this header may invent.

**`packages/cezar/src/runs/store.ts`** — the schema comment now names the reader, so the next person reading `modelIdentity` finds out in one line that it is live.

No contract change: `modelIdentity` has been on `runRecordSchema` in `packages/contract` since #405, so the data already reached the cockpit. This is a pure consumer.

## 🧪 Tests

New describe block in `packages/web/src/routes/task-thread/run-header.test.tsx` (3 cases), with a small helper that opens the menu, since Radix does not mount `DropdownMenuContent` until it is open:

- the identity renders when it differs from `model`, **and** `model: opus` is still there — it adds, never replaces;
- a pre-#405 record renders no identity line;
- an identity that only repeats `model` renders no line.

**Proved the behavioral test fails without the fix**, per AGENTS.md: `git stash push -- packages/web/src/routes/task-thread/run-header.tsx`, re-ran → **1 failed / 2 passed**. The two absence cases pass both ways by design — they pin what must *not* appear, which is the half a new-feature test usually gets wrong. Stash popped.

Full gate:

- `npm run typecheck` — ✅
- `npm test` — ✅ 5631 passed / 308 files
- `npm run test:unit` — ✅ 35 passed, 1 skipped
- Targeted: `npm test -- packages/web/src/routes/task-thread/run-header.test.tsx` — ✅ 71 passed

## 💥 Breaking Changes

None. Additive, presentation-only, behind an existing disclosure. No API, contract, or state-file change; nothing is removed from the badge or its summary line.

## Related

Follow-up from #466 (finding **n2**), which implements #405; siblings #547, #548.
