### PR TITLE
fix(runs): stop markAllRead stamping a run waiting out a usage limit (#803)

### DIFF
--- a/packages/cezar/src/runs/store.test.ts
+++ b/packages/cezar/src/runs/store.test.ts
@@ -1278,4 +1278,35 @@ describe('RunStore — read receipts (#unread-done-items)', () => {
     expect(store.getRun(active)?.seenAt).toBeDefined();
     expect(store.getRun(archived)?.seenAt).toBeUndefined();
   });
+
+  it('markAllRead skips a run waiting out a usage limit, exactly as the cockpit rule does (#803)', () => {
+    // The drift this pins: `isUnread()` (web/src/lib/read-state.ts) gained an `isScheduledResume`
+    // exclusion with the auto-resume work — a `failed` run with a pending `autoResumeAt` is not a
+    // done item, so it wears no marker and the nav badge does not count it — and this sweep never
+    // gained the matching clause. The user-visible symptom: "Mark all read" silently stamped a
+    // task the UI never presented as unread, and reported a count larger than the badge showed.
+    const store = RunStore.open(dataDir);
+    const scheduled = finishedRun(store, 'failed');
+    store.updateRun(scheduled, { autoResumeAt: '2026-08-03T18:41:48.000Z', autoResumeAttempts: 1 });
+    const ordinary = finishedRun(store, 'done');
+
+    // The count is the badge's number: one, not two.
+    expect(store.markAllRead()).toBe(1);
+    expect(store.getRun(ordinary)?.seenAt).toBeDefined();
+    expect(store.getRun(scheduled)?.seenAt).toBeUndefined();
+  });
+
+  it('markAllRead stamps the same run once its resume is no longer pending (#803)', () => {
+    // The exclusion is about the APPOINTMENT, not the failure: clear the schedule and the run is
+    // an ordinary unread `failed` done item again. Without this, the clause above would be
+    // indistinguishable from "never stamp a failed run", which is a different (wrong) rule.
+    const store = RunStore.open(dataDir);
+    const id = finishedRun(store, 'failed');
+    store.updateRun(id, { autoResumeAt: '2026-08-03T18:41:48.000Z' });
+    expect(store.markAllRead()).toBe(0);
+
+    store.updateRun(id, { autoResumeAt: undefined });
+    expect(store.markAllRead()).toBe(1);
+    expect(store.getRun(id)?.seenAt).toBeDefined();
+  });
 });

--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -709,11 +709,28 @@ export class RunStore extends EventEmitter {
 
   /** Bulk mark-read: stamp every currently-unread finished run; returns the count.
    *  "Unread" here is the same rule the cockpit paints (`isUnread` in read-state.ts),
-   *  clause for clause: a `done` or `failed` run that finished and has not been seen
-   *  since. Cancelled runs are never unread — you stopped them yourself — and archived
-   *  ones never are either, since archiving is a stronger "done with this" than reading;
-   *  both are skipped, as are runs already read. Keeping the two rules identical is what
-   *  makes the returned count the number the cockpit's unread badge was showing. */
+   *  clause for clause:
+   *   - a `done` or `failed` run that finished and has not been seen since;
+   *   - cancelled runs are never unread — you stopped them yourself;
+   *   - archived ones never are either, since archiving is a stronger "done with this"
+   *     than reading;
+   *   - and a `failed` run with a pending `autoResumeAt` is not a done item AT ALL
+   *     (`isScheduledResume`, spec 2026-08-03-auto-resume-after-usage-limit): it has an
+   *     appointment to pick the work back up, so there is no outcome to have missed.
+   *
+   *  Keeping the two rules identical is what makes the returned count the number the
+   *  cockpit's unread badge was showing. The `autoResumeAt` clause is the one that drifted
+   *  (#803): `isUnread` gained it with auto-resume and this sweep did not, so a task waiting
+   *  out a usage limit was uncounted by the badge but stamped read by the sweep — and this
+   *  comment asserted an invariant the code no longer held.
+   *
+   *  This rule lives in two languages of the same repo, which is why it has now drifted
+   *  once. The cockpit cannot import it (`packages/web` does not depend on the service, and
+   *  should not), so a single definition would have to move to `packages/contract` — the one
+   *  package both sides already import. Worth doing; deliberately not done here, because
+   *  widening the contract package's remit from "shapes" to "behavior" is a design change
+   *  that deserves its own review rather than riding along in a bug fix. Until then: EDIT
+   *  BOTH, and the case-table tests on either side are what catch you if you don't. */
   markAllRead(): number {
     const now = new Date().toISOString();
     let count = 0;
@@ -721,6 +738,7 @@ export class RunStore extends EventEmitter {
       const unread =
         !run.archived &&
         (run.status === 'done' || run.status === 'failed') &&
+        !(run.status === 'failed' && run.autoResumeAt !== undefined) &&
         run.finishedAt !== undefined &&
         (run.seenAt === undefined || run.seenAt < run.finishedAt);
       if (!unread) continue;


### PR DESCRIPTION
Closes #803

## 🎯 Goal

`RunStore.markAllRead()` (`packages/cezar/src/runs/store.ts`) re-implements the cockpit's unread rule server-side, and its own doc comment stated the contract it had to hold:

> "Unread" here is the same rule the cockpit paints (`isUnread` in read-state.ts), **clause for clause** […] Keeping the two rules identical is what makes the returned count the number the cockpit's unread badge was showing.

The auto-resume-after-usage-limit work added an `isScheduledResume` exclusion to `isUnread` — a `failed` run with a pending `autoResumeAt` is not a *done item*, so it carries no unread marker and the Tasks nav badge does not count it. `markAllRead()` never gained the matching clause, so the rule disagreed with itself: the badge did **not** count a task waiting out a usage limit, "Mark all read" **did** stamp it, and the sweep's returned count came back larger than the badge the user had just clicked. The doc comment was, as written, false.

## What Changed

- **`packages/cezar/src/runs/store.ts` — the missing clause.** `markAllRead()` now skips a `failed` run with a pending `autoResumeAt`, matching `isUnread` exactly.
- **The doc comment is true again.** Rewritten to enumerate all four exclusions (cancelled, archived, already-read, scheduled-resume) rather than describing three and asserting an invariant that covered four, and it names #803 so the next reader knows this pair has drifted before.

## On the fourth acceptance criterion — removing the duplication

Considered, and deliberately **not** done here; the reasoning is recorded in the code comment rather than lost in a PR thread.

The rule lives in two languages of the same repo and has now drifted once, so the criterion is a fair ask. But the cheap versions of "share it" do not work: `packages/web` does not depend on `@open-mercato/cezar` and should not — the service ships the web build, not the reverse — and the two suites are separate vitest projects, so even a shared case-table test cannot import both implementations without a new dependency edge pointing the wrong way.

The version that *would* work is moving the predicate into `packages/contract`, the one package both sides already import at runtime (the service imports contract values today, and `inline-contract.mjs` folds them into the published tarball). That is the right fix. It also widens the contract package's remit from "every request and response shape" to "shared behavior", which is a deliberate architectural change and deserves its own review rather than riding along inside a `priority-low` bug fix.

**Happy to file that as a follow-up issue if you want it tracked** — say the word and I will, or close this thread with the comment as the record.

## 🧪 Tests

Two new cases in `packages/cezar/src/runs/store.test.ts`, in the existing read-receipts describe:

- a store holding one usage-limited `failed` run and one ordinary `done` run: the sweep returns **1**, stamps the `done` run, and leaves the scheduled one untouched — i.e. the count is the badge's number;
- **the exclusion is about the appointment, not the failure** — clear `autoResumeAt` and the same run is stamped on the next sweep. Without this, the first test would be satisfied by the wrong rule ("never stamp a failed run"), which is exactly the kind of over-broad fix this pair keeps producing.

**Proved both fail without the fix**, per AGENTS.md: `git stash push -- packages/cezar/src/runs/store.ts`, re-ran → **2 failed**. Stash popped.

Full gate:

- `npm run typecheck` — ✅
- `npm test` — ✅ 5630 passed / 308 files
- `npm run test:unit` — ✅ 35 passed, 1 skipped
- Targeted: `npm test -- packages/cezar/src/runs/store.test.ts` — ✅ 79 passed

## 💥 Breaking Changes

None. `POST /api/v1/runs/read-all` keeps its shape; the only change is that its count and its writes now exclude a category the cockpit already excluded. No state-file change — this reads `autoResumeAt`, which #778 already persists.

## Related

Follow-up from #776; the rule it re-syncs with is spec `2026-08-03-auto-resume-after-usage-limit`. Sibling: #775.
