### PR TITLE
fix(web): make the /new header follow the resolved run mode (#793)

### DIFF
--- a/packages/web/src/routes/new-task-draft.test.ts
+++ b/packages/web/src/routes/new-task-draft.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   clearDraftText,
+  composerRunModeNote,
   readDraft,
   resetDraft,
   resolveComposerRunMode,
@@ -180,5 +181,41 @@ describe('the new-task draft store', () => {
       autonomous: null,
       generateFollowups: null,
     })
+  })
+})
+
+describe('composerRunModeNote (#793)', () => {
+  // One line per place the run can land. The header used to print the first one unconditionally,
+  // so the other two states read as an outright false promise of isolation.
+  const cases: Array<{ worktree: boolean; hasGit: boolean; expected: string }> = [
+    {
+      worktree: true,
+      hasGit: true,
+      expected: 'Runs in an isolated worktree — review everything before it lands.',
+    },
+    {
+      worktree: false,
+      hasGit: true,
+      expected: 'Runs in the repo working tree — your checkout is modified directly.',
+    },
+    {
+      worktree: false,
+      hasGit: false,
+      expected: 'Runs in place — no git repository detected, so there is no worktree to isolate in.',
+    },
+  ]
+
+  for (const { worktree, hasGit, expected } of cases) {
+    it(`worktree=${worktree}, hasGit=${hasGit}`, () => {
+      expect(composerRunModeNote({ worktree, hasGit })).toBe(expected)
+    })
+  }
+
+  it('never promises isolation without a worktree', () => {
+    // The invariant the header actually owes the user, independent of the exact copy: the word
+    // only appears when the run really gets one.
+    for (const hasGit of [true, false]) {
+      expect(composerRunModeNote({ worktree: false, hasGit })).not.toContain('isolated worktree')
+    }
   })
 })

--- a/packages/web/src/routes/new-task-draft.ts
+++ b/packages/web/src/routes/new-task-draft.ts
@@ -73,6 +73,27 @@ export function resolveComposerRunMode(input: ComposerRunModeInput): {
   return { autonomous, worktree }
 }
 
+/**
+ * The `/new` header's one-line answer to "where will this run land?" (#793).
+ *
+ * Derived from the RESOLVED run mode, never assumed. The header used to print the isolation
+ * line unconditionally, so it was simply false whenever the Worktree chip was unchecked — or,
+ * as in #791, not rendered at all — and it is the first thing a user reads when trying to work
+ * out where their run went. Three states, because they send the user to three different places
+ * to find their changes.
+ *
+ * Takes the resolved `worktree` rather than the draft so it cannot disagree with the chip:
+ * `resolveComposerRunMode` already folds in the variants constraint, the explicit opt-out, the
+ * interactive-skill recommendation and the workspace default. `hasGit` only distinguishes
+ * "opted out" from "there is no repository here", which is the difference between a warning
+ * and an explanation.
+ */
+export function composerRunModeNote(input: { worktree: boolean; hasGit: boolean }): string {
+  if (input.worktree) return 'Runs in an isolated worktree — review everything before it lands.'
+  if (input.hasGit) return 'Runs in the repo working tree — your checkout is modified directly.'
+  return 'Runs in place — no git repository detected, so there is no worktree to isolate in.'
+}
+
 const EMPTY: NewTaskDraft = {
   text: '',
   source: null,

--- a/packages/web/src/routes/new-task.test.tsx
+++ b/packages/web/src/routes/new-task.test.tsx
@@ -356,6 +356,9 @@ describe('the hero surface', () => {
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('What should the agent work on?')
     expect(screen.getByText('Runs in an isolated worktree — review everything before it lands.')).toBeTruthy()
     expect(document.querySelector('[data-route="new"] [data-slot="twinkle-backdrop"]')).not.toBeNull()
+    // Asserted here for the DEFAULT run mode only. #793: this line used to be printed
+    // unconditionally, so it also claimed isolation for runs that had opted out of it — the
+    // per-state cases live in "the run-mode note" below.
     await pillReady()
     // ⌘N drops you here to type — after the provider check enables the composer, the caret
     // must land in the box without the user clicking it.
@@ -465,6 +468,49 @@ describe('picker data flows', () => {
     fireEvent.pointerDown(modelPill)
     const options = await screen.findAllByRole('menuitemradio')
     expect(options.some((option) => option.textContent?.includes('claude-opus-4-8'))).toBe(false)
+  })
+
+  describe('the run-mode note (#793)', () => {
+    const note = () => document.querySelector('[data-slot="run-mode-note"]')?.textContent
+
+    it('promises isolation only while the run will actually get a worktree', async () => {
+      serve()
+      renderNewTask()
+      await pillReady()
+      expect(note()).toBe('Runs in an isolated worktree — review everything before it lands.')
+
+      // Unchecking the chip changes where the work lands, so it has to change what the header
+      // says. This is the regression: the line was printed unconditionally, so it kept promising
+      // isolation for a run that was about to edit the user's checkout directly.
+      fireEvent.click(document.querySelector('[data-slot="worktree-toggle"]') as HTMLButtonElement)
+      await waitFor(() => expect(note())
+        .toBe('Runs in the repo working tree — your checkout is modified directly.'))
+    })
+
+    it('explains a non-git folder rather than warning about a checkout', async () => {
+      // There is no worktree to opt into here, so "your checkout is modified directly" would be
+      // the wrong half of the truth — the user needs to know WHY there is no isolation on offer.
+      serve({ health: HEALTH_NO_GIT, repo: REPO_NO_GIT })
+      renderNewTask()
+      await pillReady()
+      expect(note())
+        .toBe('Runs in place — no git repository detected, so there is no worktree to isolate in.')
+    })
+
+    it('follows the workspace Worktree-off policy, not just an explicit click', async () => {
+      // The resolved mode, not the draft: a run can land in the checkout because policy said so,
+      // and the header has to be honest about that too.
+      serve({
+        workspaceConfig: {
+          ...WORKSPACE_CONFIG,
+          composerDefaults: { ...WORKSPACE_CONFIG.composerDefaults!, inheritedWorktree: false },
+        },
+      })
+      renderNewTask()
+      await pillReady()
+      await waitFor(() => expect(note())
+        .toBe('Runs in the repo working tree — your checkout is modified directly.'))
+    })
   })
 
   it('gates variants on git: no repo → pill disabled with the honest reason, base pill gone', async () => {

--- a/packages/web/src/routes/new-task.tsx
+++ b/packages/web/src/routes/new-task.tsx
@@ -79,6 +79,7 @@ import {
 } from './new-task-autostart'
 import {
   clearDraftText,
+  composerRunModeNote,
   readDraft,
   resolveComposerRunMode,
   writeDraft,
@@ -562,8 +563,11 @@ export function NewTaskRoute() {
           <h1 className="text-lg font-semibold tracking-tight max-md:text-base">
             What should the agent work on?
           </h1>
-          <p className="mt-1.5 text-[13.5px] text-muted-foreground max-md:text-xs">
-            Runs in an isolated worktree — review everything before it lands.
+          {/* Follows the resolved run mode (#793). Printing the isolation promise
+              unconditionally made this line false for every run the user opted out of — and
+              for a non-git folder, where there is no worktree to opt into. */}
+          <p data-slot="run-mode-note" className="mt-1.5 text-[13.5px] text-muted-foreground max-md:text-xs">
+            {composerRunModeNote({ worktree: worktreeOn, hasGit })}
           </p>
         </header>
 


### PR DESCRIPTION
Closes #793

## 🎯 Goal

The `/new` composer header printed

> Runs in an isolated worktree — review everything before it lands.

**unconditionally**, regardless of the run mode the composer had actually resolved. When the Worktree chip is unchecked — or, as in #791, not rendered at all because there is no git repository — that line is simply false. It is also the first thing a user reads when trying to work out where their run went, which is the moment it matters most.

## What Changed

Three states, because they send the user to three different places to look for their changes:

| Resolved mode | Header |
| --- | --- |
| worktree on | Runs in an isolated worktree — review everything before it lands. *(unchanged)* |
| git repo, worktree opted out | Runs in the repo working tree — your checkout is modified directly. |
| no git detected | Runs in place — no git repository detected, so there is no worktree to isolate in. |

- **`packages/web/src/routes/new-task-draft.ts` — new `composerRunModeNote({ worktree, hasGit })`.** Placed next to `resolveComposerRunMode` and fed by its **output**, not by the draft, so the header cannot disagree with the chip: the variants hard constraint, the explicit opt-out, an interactive skill's recommendation and the workspace default are all already folded in by the time the note is picked. A pure function, table-tested, matching how the other deciders in this codebase are built.
- **`hasGit` only separates "opted out" from "there is no repository here."** That is the difference between a warning about the user's checkout and an explanation of why isolation was never on offer — the non-git case has no checkout to warn about.
- **`packages/web/src/routes/new-task.tsx`** — the header renders the note, tagged `data-slot="run-mode-note"`.

Loading behavior is deliberately unchanged: `hasGit` reads `true` while `/repo` is in flight (the existing anti-flicker rule), so the header shows the isolation line during load exactly as it does today, rather than flashing a "your checkout is modified directly" warning that then corrects itself.

## 🧪 Tests

The issue called out that this needs an existing test's expectations changed, which is why it wanted its own PR.

- **`new-task.test.tsx:357`** — the hero test still asserts the isolation line, but now explicitly for the **default** run mode only, with a comment pointing at the per-state cases. The unconditional assertion is what let the unconditional string survive.
- **New `the run-mode note (#793)` describe (3 cases):** unchecking the Worktree chip flips the line to the working-tree copy; a non-git project gets the explanation instead of the warning; and a workspace `inheritedWorktree: false` policy flips it too — the resolved mode, not just an explicit click, which is the case a draft-driven implementation would have got wrong.
- **New table test for the pure helper** in `new-task-draft.test.ts`, plus an invariant case: the words "isolated worktree" never appear when `worktree` is false, in either git state. That one holds even if the exact copy is revised later — the copy is the maintainers' call, per the issue, but the promise is not.

**Proved the tests fail without the fix**, per AGENTS.md: `git stash push -- packages/web/src/routes/new-task.tsx`, re-ran → **3 failed**. Stash popped.

Full gate:

- `npm run typecheck` — ✅
- `npm test` — ✅ 5635 passed / 308 files
- `npm run test:unit` — ✅ 35 passed, 1 skipped
- `npm run build` — ✅ (`check:pack ok — 462 files, 88 under web/dist`)
- `npm run test:package` — ✅ 12 passed

## 💥 Breaking Changes

None. One UI string becomes conditional; no API, contract, state or behavior change. Nothing about where a run actually lands is altered — only what the header says about it.

## Related

Raised as the "Also worth a look" item on #791 and deliberately left out of #792 so that fix could stay a two-expression diff.
