### PR TITLE
fix(cli): import the bare specifier in the cezar-cli alias (#851)

### DIFF
--- a/alias-cezar/bin.js
+++ b/alias-cezar/bin.js
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 // `npx cezar` resolves this unscoped alias; the real tool is @open-mercato/cezar.
-import('@open-mercato/cezar/dist/index.js');
+// Bare specifier, never a deep path: that package declares an `exports` map, so Node serves
+// only the subpaths it lists and hard-blocks the rest — importing `./dist/index.js` threw
+// ERR_PACKAGE_PATH_NOT_EXPORTED at every user, on a file sitting right there in the tarball
+// (#851). `.` already maps to ./dist/index.js, so this lands on the same module legally.
+import('@open-mercato/cezar');

--- a/packages/cezar/test/e2e/alias-bin-exports.test.ts
+++ b/packages/cezar/test/e2e/alias-bin-exports.test.ts
@@ -39,7 +39,8 @@ const packageManifest = join(repoRoot, 'packages', 'cezar', 'package.json');
 /** Every `@open-mercato/cezar` specifier the alias entry point imports. */
 async function aliasSpecifiers(): Promise<string[]> {
   const source = await readFile(aliasBin, 'utf8');
-  return [...source.matchAll(/['"](@open-mercato\/cezar(?:\/[^'"]*)?)['"]/g)].map((m) => m[1] as string);
+  const pattern = /['"](@open-mercato\/cezar(?:\/[^'"]*)?)['"]/g;
+  return [...source.matchAll(pattern)].map((match) => match[1] as string);
 }
 
 test('the cezar-cli alias imports a specifier the exports map exposes', async () => {

--- a/packages/cezar/test/e2e/alias-bin-exports.test.ts
+++ b/packages/cezar/test/e2e/alias-bin-exports.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { execFile as execFileCallback } from 'node:child_process';
+import { mkdtemp, mkdir, copyFile, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCallback);
+// This file lives at packages/cezar/test/e2e; the alias package it guards is at the REPO
+// root, because it is published alongside this package rather than from inside it.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const aliasBin = join(repoRoot, 'alias-cezar', 'bin.js');
+const packageManifest = join(repoRoot, 'packages', 'cezar', 'package.json');
+
+/**
+ * The `cezar-cli` alias must import this package through a specifier its `exports` map
+ * actually exposes.
+ *
+ * 0.9.3 shipped an alias whose `bin.js` did `import('@open-mercato/cezar/dist/index.js')`
+ * while this manifest exported only `.`, `./app-type` and `./package.json`. Once a package
+ * declares `exports`, Node serves ONLY the listed subpaths and hard-blocks the rest — so
+ * every `npx cezar-cli` died with ERR_PACKAGE_PATH_NOT_EXPORTED against a file that was
+ * sitting right there in the tarball (#851).
+ *
+ * Nothing else in the gate could see it. The manifest's own `bin` entries name the same
+ * path and work fine, because bin paths resolve inside the package and never pass through
+ * the exports gate; `check:pack` counts packed files rather than resolving them; and the
+ * release e2e drives a synthetic fixture whose `bin.js` is a bare shebang. The break was
+ * only reachable by resolving the real specifier against the real manifest from OUTSIDE
+ * the package — which is what this does.
+ *
+ * Resolution is all it takes: Node applies the exports gate while resolving, before it
+ * ever touches the target file, so this needs the manifest only and runs green on a fresh
+ * checkout with no `dist/`.
+ */
+
+/** Every `@open-mercato/cezar` specifier the alias entry point imports. */
+async function aliasSpecifiers(): Promise<string[]> {
+  const source = await readFile(aliasBin, 'utf8');
+  return [...source.matchAll(/['"](@open-mercato\/cezar(?:\/[^'"]*)?)['"]/g)].map((m) => m[1] as string);
+}
+
+test('the cezar-cli alias imports a specifier the exports map exposes', async () => {
+  const specifiers = await aliasSpecifiers();
+  // A computed specifier would slip past the regex; fail loudly rather than vacuously pass.
+  assert.ok(
+    specifiers.length > 0,
+    `${aliasBin} names no literal @open-mercato/cezar specifier — this guard can no longer see what the alias imports`,
+  );
+
+  const root = await mkdtemp(join(tmpdir(), 'cezar-alias-exports-'));
+  try {
+    // A consumer that has only the published manifest installed — the exports gate reads
+    // nothing else, so this reproduces a real `npx cezar-cli` resolution exactly.
+    await writeFile(join(root, 'package.json'), '{"private":true,"type":"module"}\n', 'utf8');
+    const installed = join(root, 'node_modules', '@open-mercato', 'cezar');
+    await mkdir(installed, { recursive: true });
+    await copyFile(packageManifest, join(installed, 'package.json'));
+
+    for (const specifier of specifiers) {
+      const resolved = await execFile(
+        process.execPath,
+        ['--input-type=module', '-e', `console.log(import.meta.resolve(${JSON.stringify(specifier)}))`],
+        { cwd: root },
+      ).catch((error: Error & { stderr?: string }) => {
+        assert.fail(
+          `the alias imports '${specifier}', which the @open-mercato/cezar exports map does not expose — ` +
+            `npx cezar-cli would fail for every user (#851): ${error.stderr?.trim() ?? error.message}`,
+        );
+      });
+
+      // Whatever entry point the alias picks, it has to land on the CLI itself.
+      assert.match(
+        resolved.stdout.trim(),
+        /\/dist\/index\.js$/,
+        `the alias specifier '${specifier}' resolves to ${resolved.stdout.trim()}, not the CLI entry point`,
+      );
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #851

## 🎯 Goal
Make `npx cezar-cli` (and the `cezar` / `cez` shims it installs) start again. Since 0.9.3 every invocation of the unscoped alias died on startup with `ERR_PACKAGE_PATH_NOT_EXPORTED` before printing anything, leaving `npm i -g @open-mercato/cezar` as the only way in.

## 🔍 Problem
`cezar-cli` is a thin alias package whose only job is to hand off to the real tool. Its `bin.js` did `import('@open-mercato/cezar/dist/index.js')`. That deep subpath is not one of the three the scoped package exposes, so Node refused to resolve it and the process crashed before any cezar code ran. Reproduced against the published artifacts: `npm view @open-mercato/cezar@latest exports` lists only `.`, `./app-type` and `./package.json`, and `npm view cezar-cli@latest dependencies` shows the alias pinned to `^0.9.3`, so the break reached every user of the current release.

## 🔍 Root Cause
Once a package declares an `exports` map, Node serves **only** the subpaths it lists and hard-blocks everything else — including a file that exists and ships in the tarball. `packages/cezar/package.json` declares such a map. The manifest's own `bin` entries name the very same `dist/index.js` and work fine, because bin paths resolve *inside* the package and never pass through the exports gate; the alias resolves from *outside* it and therefore hits the gate. In other words the alias was asking through the side door for something `.` already serves through the front.

Nothing in the gate could catch it: `check:pack` counts packed files rather than resolving them, and the release e2e drives a synthetic fixture whose `bin.js` is a bare shebang, so the real specifier was never resolved against the real manifest.

## What Changed
- `alias-cezar/bin.js` — imports the bare specifier `@open-mercato/cezar` instead of the deep `@open-mercato/cezar/dist/index.js`. `.` already maps to `./dist/index.js`, so this resolves to the identical module through a supported entry point. Deliberately *not* fixed by adding a `./dist/index.js` passthrough to the exports map, which would re-publish an internal build path as public API; `npx` always fetches the newest alias, so the corrected `bin.js` reaches users at the next release.
- `packages/cezar/test/e2e/alias-bin-exports.test.ts` *(new)* — a guard for this bug class. It builds a throwaway consumer holding only the real `packages/cezar/package.json`, extracts every literal `@open-mercato/cezar…` specifier from the real `alias-cezar/bin.js`, resolves each through Node's own resolver via `import.meta.resolve`, and asserts it lands on `dist/index.js`. Resolution alone is enough — Node applies the exports gate before it touches the target file — so the test needs no `dist/` and runs green on a fresh checkout.

## 🧪 Tests
- `npm run test:package` — **13 passed / 0 failed**, including the new guard.
- `npm run test:unit` — **35 passed, 1 skipped, 0 failed**.
- `npm run typecheck` — clean across contract, api-client, server and web.
- `npm run build` — clean; `check:pack ok — 468 files, 88 under web/dist`.
- `npm test` (vitest) — red, and **pre-existing**: this branch fails 35 files / 174 tests, while a baseline run of the same suite on clean `origin/main` (38a99e2a) in a separate worktree fails 33 files / 205 tests. Both are `ENOENT` on temp-dir paths under `packages/cezar/src/**`, and the counts move between runs — a local environment flake, not a regression. This diff cannot reach those suites: `bin.js` is imported by nothing in `src`, and the new test is under `test/e2e`, outside vitest's scope. CI is the arbiter.
- The new test was verified to actually catch the bug: with the fix reverted it fails with the issue's exact error — `ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './dist/index.js' is not defined by "exports"` — and passes with the fix. It also fails loudly rather than passing vacuously if the alias ever switches to a computed specifier.

## 💥 Breaking Changes
- None. The import is side-effect-only and resolves to the same module; no exported API, CLI flag, or manifest contract changes. Users pinned to `cezar-cli@0.9.3` stay broken until they take a new version — unavoidable for an already-published tarball, and the `npm i -g @open-mercato/cezar` workaround from the issue still covers them.
