### PR TITLE
fix(web): napraw wyszukiwanie skilli przy nieaktualnych wynikach

### DIFF
--- a/packages/web/src/lib/skills.test.ts
+++ b/packages/web/src/lib/skills.test.ts
@@ -4,6 +4,7 @@ import type { Skill, WorkflowDef } from '@open-mercato/cezar-api-client'
 
 import {
   bumpSkillUsage,
+  commandItemFilter,
   filterSkills,
   fuzzyMatch,
   isProjectSkill,
@@ -203,6 +204,18 @@ describe('multiWordFilter (#411: multi-keyword search for cmdk)', () => {
 
   it('matching is case-insensitive', () => {
     expect(multiWordFilter('skill Deploy /path', 'DEPLOY')).toBeGreaterThan(0)
+  })
+})
+
+describe('commandItemFilter', () => {
+  it('filters from cmdk input without re-ranking matching items', () => {
+    expect(commandItemFilter('workflow quick-task', 'qui')).toBe(1)
+    expect(commandItemFilter('skill om-auto-qa-pr', 'qui')).toBe(0)
+    expect(commandItemFilter('skill om-fix', 'fix')).toBe(1)
+    expect(commandItemFilter('skill prefix-helper', 'fix')).toBe(1)
+    expect(commandItemFilter('skill om-fix-issue', 'omfx')).toBe(1)
+    expect(commandItemFilter('skill om-fix /skills/quick-task.md', 'quick')).toBe(0)
+    expect(commandItemFilter('workflow quick-task', 'workflow')).toBe(0)
   })
 })
 

--- a/packages/web/src/lib/skills.ts
+++ b/packages/web/src/lib/skills.ts
@@ -191,6 +191,16 @@ export function multiWordFilter(value: string, search: string, keywords?: string
 }
 
 /**
+ * cmdk fallback for the grouped pickers. React remains responsible for ranking and tiering,
+ * while cmdk independently hides non-matches from its own live input value. Every hit returns
+ * the same score so cmdk cannot undo the JS ordering when both search paths are in sync.
+ */
+export function commandItemFilter(value: string, search: string, keywords?: string[]): number {
+  const [, name = ''] = value.split(/\s+/, 2)
+  return queryScore(name, keywords?.join(' '), search) > 0 ? 1 : 0
+}
+
+/**
  * How well a whole `query` matches a single `text` (a skill name or its description).
  * 0 = no match; higher = better: exact > prefix > word-boundary hit > buried substring >
  * subsequence. The subsequence fallback keeps `fuzzyMatch`'s permissiveness ("omfx" still

--- a/packages/web/src/routes/github/hand-to-agent.tsx
+++ b/packages/web/src/routes/github/hand-to-agent.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/lib/prompt-templates'
 import {
   bumpSkillUsage,
+  commandItemFilter,
   isProjectSkill,
   partitionSkillsForDisplay,
   searchSkills,
@@ -521,7 +522,7 @@ function SkillsPicker({
           </button>
         </PopoverTrigger>
         <PopoverContent align="start" sideOffset={8} className="w-[336px] max-w-[calc(100vw-2rem)] p-0">
-          <Command shouldFilter={false}>
+          <Command filter={commandItemFilter}>
             <CommandInput
               placeholder="search skills…"
               value={search}

--- a/packages/web/src/routes/new-task.test.tsx
+++ b/packages/web/src/routes/new-task.test.tsx
@@ -20,6 +20,17 @@ import { resetToasts, Toaster } from '@/components/ui/toaster'
 import { readDraft, resetDraft, writeDraft } from './new-task-draft'
 import { NewTaskRoute } from './new-task'
 
+const skillSearchMockState = vi.hoisted(() => ({ forceStaleResults: false }))
+
+vi.mock('@/lib/skills', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/skills')>()
+  return {
+    ...actual,
+    searchSkills: (...args: Parameters<typeof actual.searchSkills>) =>
+      skillSearchMockState.forceStaleResults ? [...args[0]] : actual.searchSkills(...args),
+  }
+})
+
 /**
  * The /new screen against a mocked API: picker data flows (runner hidden on single-backend
  * hosts, model presets switching per runner, variants gated on git), the EXACT submit bodies
@@ -45,6 +56,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  skillSearchMockState.forceStaleResults = false
   cleanup()
   resetToasts()
   vi.unstubAllGlobals()
@@ -624,6 +636,32 @@ describe('picker data flows', () => {
       expect(visible).toHaveLength(0)
     })
   })
+
+  it('lets cmdk hide unrelated Most used skills when React results are stale', async () => {
+    skillSearchMockState.forceStaleResults = true
+    serve({ uiState: { skillUsage: { 'om-fix': 5 } } })
+    renderNewTask()
+    await pillReady()
+    fireEvent.click(sourcePill())
+    const input = await screen.findByPlaceholderText('search skills & workflows…')
+
+    expect([...document.querySelectorAll('[cmdk-group-heading]')].map((heading) => heading.textContent)).toContain(
+      'Most used',
+    )
+
+    fireEvent.change(input, { target: { value: 'qui' } })
+
+    await waitFor(() => {
+      const options = [...document.querySelectorAll('[data-slot="source-option"]')]
+      expect(options.map((option) => option.getAttribute('data-source-ref'))).toEqual(['quick-task'])
+      expect(
+        [...document.querySelectorAll('[cmdk-group]:not([hidden]) [cmdk-group-heading]')].map(
+          (heading) => heading.textContent,
+        ),
+      ).toEqual(['Workflows'])
+    })
+  })
+
 })
 
 // ---- provider authentication gate -------------------------------------------------------------

--- a/packages/web/src/routes/new-task.tsx
+++ b/packages/web/src/routes/new-task.tsx
@@ -60,6 +60,7 @@ import {
 } from '@/lib/prompt-templates'
 import {
   bumpSkillUsage,
+  commandItemFilter,
   isProjectSkill,
   orderSkillsByUsage,
   partitionSkillsForDisplay,
@@ -1110,7 +1111,7 @@ function SourcePill({
           sideOffset={8}
           className="w-[336px] max-w-[calc(100vw-2rem)] p-0"
         >
-          <Command shouldFilter={false}>
+          <Command filter={commandItemFilter}>
             <CommandInput
               placeholder="search skills & workflows…"
               value={search}

--- a/packages/web/src/routes/settings/prompt-templates-section.tsx
+++ b/packages/web/src/routes/settings/prompt-templates-section.tsx
@@ -25,7 +25,13 @@ import {
   normalizePromptTemplates,
   type PromptTemplate,
 } from '@/lib/prompt-templates'
-import { isProjectSkill, partitionSkillsForDisplay, searchSkills, skillKeywords } from '@/lib/skills'
+import {
+  commandItemFilter,
+  isProjectSkill,
+  partitionSkillsForDisplay,
+  searchSkills,
+  skillKeywords,
+} from '@/lib/skills'
 import { cn } from '@/lib/utils'
 
 /**
@@ -352,7 +358,7 @@ function TemplateSkillsPicker({
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={8} className="w-[336px] max-w-[calc(100vw-2rem)] p-0">
-        <Command shouldFilter={false}>
+        <Command filter={commandItemFilter}>
           <CommandInput
             placeholder="search skills…"
             value={search}


### PR DESCRIPTION
## Co naprawia

- dodaje niezależne filtrowanie cmdk dla trzech grupowanych pickerów skilli
- zachowuje ranking Reacta oraz wyszukiwanie rozmyte
- nie dopasowuje technicznych prefiksów ani ścieżek plików
- dodaje test regresyjny odtwarzający nieaktualne wyniki Reacta

## Walidacja

- test regresyjny czerwony bez poprawki i zielony z poprawką
- 265 testów dotkniętego obszaru
- typecheck
- test:unit
- build i check:pack
- test:package
- skill-search-ranking E2E: 3/3
