### PR TITLE
fix(runners): escalate to SIGKILL regardless of ChildProcess.killed (#844)

### DIFF
--- a/AGENT_PROTOCOL.md
+++ b/AGENT_PROTOCOL.md
@@ -83,6 +83,13 @@ settle such an exit on the normal path — `isSignalTerminationExit(exitCode)`
 (`packages/cezar/src/core/agent-runner.ts`) plus a `note` — instead of throwing. Throwing makes
 a finished run settle as `failed` and a cancelled run settle as `failed` too.
 
+That watchdog MUST gate its SIGKILL escalation on real termination, never on
+`ChildProcess.killed` (#844). Node sets `killed` when a signal is *delivered*,
+so the watchdog's own SIGTERM flips it while the CLI — which handles the signal
+— keeps running, and the escalation written for exactly that case is skipped.
+Use `trackChildExit(child)` (`packages/cezar/src/core/agent-runner.ts`), which
+seeds from `exitCode`/`signalCode` and listens for `exit`.
+
 `SessionOptions`:
 
 - `autoEndAfterFirstTurn?` — single-turn behavior for non-interactive workflow

--- a/AGENT_PROTOCOL.md
+++ b/AGENT_PROTOCOL.md
@@ -85,10 +85,10 @@ a finished run settle as `failed` and a cancelled run settle as `failed` too.
 
 That watchdog MUST gate its SIGKILL escalation on real termination, never on
 `ChildProcess.killed` (#844). Node sets `killed` when a signal is *delivered*,
-so the watchdog's own SIGTERM flips it while the CLI — which handles the signal
-— keeps running, and the escalation written for exactly that case is skipped.
-Use `trackChildExit(child)` (`packages/cezar/src/core/agent-runner.ts`), which
-seeds from `exitCode`/`signalCode` and listens for `exit`.
+so the watchdog's own SIGTERM flips it while the CLI — which handles the
+signal — keeps running, and the escalation written for exactly that case is
+skipped. Use `trackChildExit(child)` (`packages/cezar/src/core/agent-runner.ts`),
+which seeds from `exitCode`/`signalCode` and listens for `exit`.
 
 `SessionOptions`:
 

--- a/packages/cezar/src/core/agent-runner.ts
+++ b/packages/cezar/src/core/agent-runner.ts
@@ -80,6 +80,35 @@ export function isSignalTerminationExit(exitCode: number | null): boolean {
   return exitCode === 130 || exitCode === 137 || exitCode === 143;
 }
 
+/** The slice of `ChildProcess` a termination tracker needs — keeps the helper
+ *  usable from the transport layer and from test fakes alike. */
+export interface TrackableChild {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  once(event: 'exit', listener: () => void): unknown;
+}
+
+/**
+ * Returns a predicate that answers "has this child actually terminated?".
+ *
+ * `ChildProcess.killed` answers a different question — it flips as soon as a
+ * signal is *delivered*, whether or not the child dies from it. Every agent CLI
+ * installs its own SIGTERM handler, so gating a SIGTERM→SIGKILL watchdog on
+ * `!child.killed` disables the escalation for exactly the child it exists for:
+ * `killed` is true, `exitCode` stays null, and the process outlives the whole
+ * grace window (#844, same defect fixed for the discovery probe in #841).
+ *
+ * Seeded from `exitCode`/`signalCode` so a child that died before the watchdog
+ * was armed is recognized without waiting for an event that already fired.
+ */
+export function trackChildExit(child: TrackableChild): () => boolean {
+  let exited = child.exitCode != null || child.signalCode != null;
+  child.once('exit', () => {
+    exited = true;
+  });
+  return () => exited;
+}
+
 /** One content block of a user message — mirrors the Anthropic wire format
  *  so it can be written to the claude CLI's stdin verbatim. */
 export type ContentBlock =

--- a/packages/cezar/src/core/claude-cli-runner.test.ts
+++ b/packages/cezar/src/core/claude-cli-runner.test.ts
@@ -1,12 +1,34 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from './agent-runner.ts';
 import { isSignalTerminationExit, prependSystemPrompt } from './agent-runner.ts';
-import { buildClaudeArgs, ClaudeCliRunner } from './claude-cli-runner.ts';
+import {
+  buildClaudeArgs,
+  ClaudeCliRunner,
+  EOF_KILL_GRACE_MS,
+  EOF_TERM_GRACE_MS,
+  KILL_GRACE_MS,
+} from './claude-cli-runner.ts';
 import type { UiEvent } from './ui-events.ts';
+
+/** Only the escalation tests below swap the child out; every other test in this
+ *  file keeps spawning its real stub binary through the untouched `spawn`. */
+const spawnHook = vi.hoisted(() => ({ override: null as null | (() => unknown) }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnHook.override ? spawnHook.override() : actual.spawn(...args),
+  };
+});
 
 /**
  * The per-backend system-prompt delivery mechanism (spec §protocol v2
@@ -107,6 +129,109 @@ describe('a teardown cezar initiated', () => {
       events.some((e) => e.type === 'note' && e.message.includes('terminated by cezar (code 143)')),
     ).toBe(true);
   }, 15_000);
+});
+
+/**
+ * #844 — the watchdogs used to ask `!child.killed` before escalating, but Node
+ * sets `killed` the moment a signal is *delivered*. claude installs its own
+ * SIGTERM handler, so the flag went true while the process ran on and the
+ * SIGKILL that exists for exactly that case was never sent — one leaked CLI per
+ * teardown. The escalation now follows real termination instead.
+ */
+describe('SIGTERM→SIGKILL escalation for a CLI that survives SIGTERM', () => {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
+    const signals: NodeJS.Signals[] = [];
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      killed: false,
+      pid: 4242,
+      // Node's semantics: delivery flips `killed`; a CLI with its own handler
+      // keeps running with `exitCode` still null.
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal);
+        Object.assign(child, { killed: true });
+        return true;
+      },
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
+  }
+
+  function withFakeChild(run: (fake: ReturnType<typeof signallableChild>) => void): void {
+    const fake = signallableChild();
+    spawnHook.override = () => fake.child;
+    vi.useFakeTimers();
+    try {
+      run(fake);
+    } finally {
+      vi.useRealTimers();
+      spawnHook.override = null;
+    }
+  }
+
+  it('escalates after end() even though Node already flagged the child as killed', () => {
+    withFakeChild((fake) => {
+      const session = new ClaudeCliRunner({ bin: 'claude', timeoutMs: 0 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      session.end();
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      // Delivered, not dead — the state that used to disable the escalation.
+      expect(fake.child.killed).toBe(true);
+      expect(fake.child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('escalates on the wall-clock timeout path as well', () => {
+    withFakeChild((fake) => {
+      const session = new ClaudeCliRunner({ bin: 'claude', timeoutMs: 20 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('stops escalating once the CLI really exits after SIGTERM', () => {
+    withFakeChild((fake) => {
+      const session = new ClaudeCliRunner({ bin: 'claude', timeoutMs: 0 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      session.end();
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      fake.exit(143);
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+    });
+  });
 });
 
 describe('prependSystemPrompt (codex/opencode delivery)', () => {

--- a/packages/cezar/src/core/claude-cli-runner.ts
+++ b/packages/cezar/src/core/claude-cli-runner.ts
@@ -14,7 +14,7 @@ import type {
 
 // Re-exported for backends and the run manager that still import them from here.
 export type { AgentSession, SessionOptions } from './agent-runner.ts';
-import { isSignalTerminationExit } from './agent-runner.ts';
+import { isSignalTerminationExit, trackChildExit } from './agent-runner.ts';
 import { buildChildEnv } from './agent-env.ts';
 import { costWeightedTokens, type RawUsage } from './usage.ts';
 import { readNdjson } from './ndjson.ts';
@@ -156,6 +156,11 @@ export class ClaudeCliRunner implements AgentRunner {
       terminatedByCezar = true;
       child.kill(signal);
     };
+    // Every watchdog below asks "is the child still alive?" — and that question
+    // is NOT `child.killed`, which only reports signal delivery. claude handles
+    // SIGTERM itself, so `killed` is true while the process runs on; escalation
+    // has to follow real termination or it never fires (#844).
+    const hasExited = trackChildExit(child);
 
     const end = (): void => {
       if (!stdinOpen) return;
@@ -166,9 +171,9 @@ export class ClaudeCliRunner implements AgentRunner {
         // already gone
       }
       eofTermTimer = setTimeout(() => {
-        if (child.exitCode == null && !child.killed) signalChild('SIGTERM');
+        if (!hasExited()) signalChild('SIGTERM');
         eofKillTimer = setTimeout(() => {
-          if (child.exitCode == null && !child.killed) signalChild('SIGKILL');
+          if (!hasExited()) signalChild('SIGKILL');
         }, EOF_KILL_GRACE_MS);
         eofKillTimer.unref?.();
       }, EOF_TERM_GRACE_MS);
@@ -177,7 +182,7 @@ export class ClaudeCliRunner implements AgentRunner {
 
     const interrupt = (): void => {
       stdinOpen = false;
-      if (!child.killed) signalChild('SIGTERM');
+      if (!hasExited()) signalChild('SIGTERM');
     };
 
     // Seed the first user message — the same path every follow-up takes.
@@ -209,7 +214,7 @@ export class ClaudeCliRunner implements AgentRunner {
         interrupt();
         child.stdout.destroy();
         killTimer = setTimeout(() => {
-          if (child.exitCode == null && !child.killed) signalChild('SIGKILL');
+          if (!hasExited()) signalChild('SIGKILL');
         }, KILL_GRACE_MS);
         killTimer.unref?.();
       }, limitMs);

--- a/packages/cezar/src/core/codex-app-server-runner.test.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.test.ts
@@ -1,7 +1,24 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from './agent-runner.js';
+import { KILL_GRACE_MS } from './claude-cli-runner.js';
 import { CodexAppServerRunner } from './codex-app-server-runner.js';
+
+/** Only the escalation tests below swap the child out; every other test in this
+ *  file keeps spawning the real mock app-server through the untouched `spawn`. */
+const spawnHook = vi.hoisted(() => ({ override: null as null | (() => unknown) }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnHook.override ? spawnHook.override() : actual.spawn(...args),
+  };
+});
 
 /**
  * #703 backend parity — `claude-cli-runner.test.ts` proves the Claude half;
@@ -58,4 +75,104 @@ describe('a teardown cezar initiated (codex app-server)', () => {
     expect(events).toContainEqual({ type: 'error', message: 'model unavailable' });
     expect(events).toContainEqual({ type: 'turn-end' });
   }, 15_000);
+});
+
+/**
+ * #844 — the runner's own SIGTERM sets `ChildProcess.killed`, so a watchdog
+ * gated on `!child.killed` refused to escalate for exactly the app-server it
+ * was written for: one that handles the signal and keeps running. The guard now
+ * tracks real termination, and `terminatedByCezar` (#703) is still set before
+ * every signal so the resulting 137/143 stays a teardown note, not a failure.
+ */
+describe('SIGTERM→SIGKILL escalation for an app-server that survives SIGTERM', () => {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
+    const signals: NodeJS.Signals[] = [];
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      killed: false,
+      pid: 4243,
+      // Node's semantics: delivery flips `killed` whether or not the child dies.
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal);
+        Object.assign(child, { killed: true });
+        return true;
+      },
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
+  }
+
+  function withFakeChild(run: (fake: ReturnType<typeof signallableChild>) => void): void {
+    const fake = signallableChild();
+    spawnHook.override = () => fake.child;
+    vi.useFakeTimers();
+    try {
+      run(fake);
+    } finally {
+      vi.useRealTimers();
+      spawnHook.override = null;
+    }
+  }
+
+  it('escalates on the wall-clock timeout even after Node flagged the child as killed', () => {
+    withFakeChild((fake) => {
+      const session = new CodexAppServerRunner({ bin: 'codex', timeoutMs: 20 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      // Delivered, not dead — the state that used to disable the escalation.
+      expect(fake.child.killed).toBe(true);
+      expect(fake.child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('stops escalating once the app-server really exits after SIGTERM', () => {
+    withFakeChild((fake) => {
+      const session = new CodexAppServerRunner({ bin: 'codex', timeoutMs: 20 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      fake.exit(143);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+    });
+  });
+
+  it('does not signal a second time once interrupt() saw the child exit', () => {
+    withFakeChild((fake) => {
+      const session = new CodexAppServerRunner({ bin: 'codex', timeoutMs: 0 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+      fake.exit(0);
+
+      session.interrupt();
+      expect(fake.signals).toEqual([]);
+    });
+  });
 });

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -9,7 +9,7 @@ import type {
   ContentBlock,
   SessionOptions,
 } from './agent-runner.ts';
-import { isSignalTerminationExit, prependSystemPrompt } from './agent-runner.ts';
+import { isSignalTerminationExit, prependSystemPrompt, trackChildExit } from './agent-runner.ts';
 import {
   AUTO_END_DELAY_MS,
   DEFAULT_RUN_TIMEOUT_MS,
@@ -124,6 +124,10 @@ class CodexSession implements AgentSession {
    *  codex handles the signal and exits 143, so without this the runner reads
    *  its own teardown as a codex failure (#703). */
   private terminatedByCezar = false;
+  /** "Has the app-server really terminated?" — the question `child.killed`
+   *  does not answer: it flips on signal delivery, so the SIGTERM this runner
+   *  sends would otherwise veto its own SIGKILL escalation (#844). */
+  private hasExited!: () => boolean;
   /** Protocol v2 emission — additive alongside v1 (`onEvent` keeps flowing
    *  byte-identical); the channel is `opts.onUiEvent` (RunManager wiring
    *  lands in R2 step 2.1). */
@@ -143,6 +147,7 @@ class CodexSession implements AgentSession {
       throw codexSpawnError(err, bin);
     }
 
+    this.hasExited = trackChildExit(this.child);
     this.child.on('error', (err: NodeJS.ErrnoException) => {
       this.spawnFailed = codexSpawnError(err, bin);
     });
@@ -160,7 +165,7 @@ class CodexSession implements AgentSession {
         this.interrupt();
         this.child.stdout.destroy();
         killTimer = setTimeout(() => {
-          if (this.child.exitCode == null && !this.child.killed) {
+          if (!this.hasExited()) {
             this.terminatedByCezar = true;
             this.child.kill('SIGKILL');
           }
@@ -325,7 +330,7 @@ class CodexSession implements AgentSession {
         () => undefined,
       );
     }
-    if (!this.child.killed) {
+    if (!this.hasExited()) {
       this.terminatedByCezar = true;
       this.child.kill('SIGTERM');
     }

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -127,7 +127,7 @@ class CodexSession implements AgentSession {
   /** "Has the app-server really terminated?" — the question `child.killed`
    *  does not answer: it flips on signal delivery, so the SIGTERM this runner
    *  sends would otherwise veto its own SIGKILL escalation (#844). */
-  private hasExited!: () => boolean;
+  private readonly hasExited: () => boolean;
   /** Protocol v2 emission — additive alongside v1 (`onEvent` keeps flowing
    *  byte-identical); the channel is `opts.onUiEvent` (RunManager wiring
    *  lands in R2 step 2.1). */

--- a/packages/cezar/src/core/codex-app-server-transport.test.ts
+++ b/packages/cezar/src/core/codex-app-server-transport.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -80,18 +81,32 @@ describe('Codex app-server transport', () => {
  * the SIGTERM the escalation issues comes back as an unexplained 143.
  */
 describe('endCodexAppServer watchdog', () => {
-  function signallableChild(): { child: ChildProcessWithoutNullStreams; signals: NodeJS.Signals[] } {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
     const signals: NodeJS.Signals[] = [];
-    const child = {
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
       stdin: new PassThrough(),
-      exitCode: null,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
       killed: false,
+      // Mirrors Node: `killed` records that a signal was *delivered*, not that
+      // the child died. An app-server with its own SIGTERM handler stays alive
+      // with the flag already set (#844).
       kill: (signal: NodeJS.Signals) => {
         signals.push(signal);
+        Object.assign(child, { killed: true });
         return true;
       },
-    } as unknown as ChildProcessWithoutNullStreams;
-    return { child, signals };
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
   }
 
   it('reports each escalation step so the runner can classify the exit', () => {
@@ -121,16 +136,55 @@ describe('endCodexAppServer watchdog', () => {
   it('stays silent when the app-server exits on EOF by itself', () => {
     vi.useFakeTimers();
     try {
-      const { child, signals } = signallableChild();
+      const { child, signals, exit } = signallableChild();
       let reported = 0;
       endCodexAppServer(child, undefined, () => {
         reported += 1;
       });
-      (child as unknown as { exitCode: number | null }).exitCode = 0;
+      exit(0);
 
       vi.advanceTimersByTime(EOF_TERM_GRACE_MS + EOF_KILL_GRACE_MS);
       expect(signals).toEqual([]);
       expect(reported).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #844 — the regression that gating on `child.killed` produced: the SIGTERM
+  // this watchdog sends sets the flag, so the escalation vetoed itself and an
+  // app-server that handles SIGTERM survived the entire teardown window.
+  it('escalates to SIGKILL even though Node already flagged the child as killed', () => {
+    vi.useFakeTimers();
+    try {
+      const { child, signals } = signallableChild();
+      endCodexAppServer(child);
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
+      // Delivery, not death: the app-server handled the signal and runs on.
+      expect(child.killed).toBe(true);
+      expect(child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops escalating once the app-server really exits after SIGTERM', () => {
+    vi.useFakeTimers();
+    try {
+      const { child, signals, exit } = signallableChild();
+      endCodexAppServer(child);
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
+      exit(143);
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/cezar/src/core/codex-app-server-transport.ts
+++ b/packages/cezar/src/core/codex-app-server-transport.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { trackChildExit } from './agent-runner.ts';
 import { buildChildEnv } from './agent-env.ts';
 import { EOF_KILL_GRACE_MS, EOF_TERM_GRACE_MS, KILL_GRACE_MS } from './claude-cli-runner.ts';
 
@@ -115,14 +116,18 @@ export function endCodexAppServer(
   } catch {
     // already gone
   }
+  // Real termination, not `child.killed` — the latter is set by the SIGTERM
+  // this very watchdog sends, which would then suppress its own SIGKILL for an
+  // app-server that handles the signal instead of dying from it (#844).
+  const hasExited = trackChildExit(child);
   let killTimer: NodeJS.Timeout | undefined;
   const termTimer = setTimeout(() => {
-    if (child.exitCode == null && !child.killed) {
+    if (!hasExited()) {
       onSignal?.();
       child.kill('SIGTERM');
     }
     killTimer = setTimeout(() => {
-      if (child.exitCode == null && !child.killed) {
+      if (!hasExited()) {
         onSignal?.();
         child.kill('SIGKILL');
       }


### PR DESCRIPTION
Closes #844

## 🎯 Goal
A run's teardown must not leave a live agent CLI behind. When cezar decides a session is over — goal reached, user cancel, or the wall-clock kill switch — the SIGTERM→SIGKILL watchdog now actually escalates, so a CLI that handles SIGTERM instead of dying from it is still reaped at the end of the grace window rather than surviving indefinitely.

## 🔍 Problem
All three production teardown paths gated their SIGKILL escalation on `ChildProcess.killed`: `claude-cli-runner.ts` (`end()` EOF watchdog, `interrupt()`, and the wall-clock kill timer), `codex-app-server-runner.ts` (kill timer and `interrupt()`), and `codex-app-server-transport.ts` (`endCodexAppServer`, both steps). PR #841 shipped the same pattern for its model-discovery probe, review caught it there, and it was fixed in `a67b327d` — but the defect predates that PR in these files, where the leaked process outlives a whole run's teardown rather than a short probe.

## 🔍 Root Cause
`ChildProcess.killed` answers "was a signal delivered?", not "is the child dead?". Node flips it the instant `kill()` succeeds. Every agent CLI installs its own SIGTERM handler (that is the entire premise of #703), so the watchdog's own SIGTERM set `killed = true` while the process kept running with `exitCode === null` — and the nested `if (child.exitCode == null && !child.killed)` guard then evaluated to `false`. The escalation vetoed itself: SIGKILL was unreachable in precisely the scenario it was written for. On the claude timeout path the same thing happened one level up, where `interrupt()` delivers the SIGTERM that then disables the kill timer.

## What Changed
- **`packages/cezar/src/core/agent-runner.ts`** — new `trackChildExit(child)` (plus the `TrackableChild` structural type) at the seam that already owns `isSignalTerminationExit`. It returns a predicate seeded from `exitCode`/`signalCode` — so a child that died before the watchdog was armed is recognized without waiting for an event that already fired — and flipped by the child's `exit` event.
- **`packages/cezar/src/core/claude-cli-runner.ts`** — one tracker per session; `end()`'s SIGTERM and SIGKILL steps, `interrupt()`, and the wall-clock kill timer all test `!hasExited()` instead of `!child.killed`.
- **`packages/cezar/src/core/codex-app-server-runner.ts`** — a `hasExited` field created right after the app-server is spawned; used by the timeout kill timer and by `interrupt()`.
- **`packages/cezar/src/core/codex-app-server-transport.ts`** — `endCodexAppServer` tracks termination locally; both escalation steps now escalate, and `onSignal?.()` still fires before each kill.
- **`AGENT_PROTOCOL.md`** — the rule is stated next to the existing #703 paragraph, pointing at `trackChildExit`, so a new backend inherits it instead of rediscovering the trap.

#703's behaviour is preserved verbatim: `signalChild()` still sets `terminatedByCezar`, the codex runner still sets it before each kill, and `endCodexAppServer` still reports every signal through `onSignal` — a self-inflicted 137/143 remains a `note`, never an agent failure.

## 🧪 Tests
- `npm run typecheck` — ✅ green (contract, client, server, web)
- `npm run build` — ✅ green, incl. `check:pack` (468 files)
- `npm run test:unit` — ✅ 35 passed / 1 skipped
- `npm run test:package` — ✅ 12 passed
- `npx vitest run packages/cezar/src/core` — ✅ green, including the 8 new cases
- `npm test` (full suite) is red on this machine — 38 files, all in `src/workflows/*`, failing on `spawn`/temp-dir errors from local endpoint security. Not a regression: the identical `packages/cezar/src/core packages/cezar/src/workflows` selection run in a clean `origin/main` worktree fails **59 tests across 12 files**, versus **56 across 10** on this branch, with **zero** `src/core/*` failures on either side. CI is the authority here.

New regressions, one group per affected file, each mutation-checked (restoring the `!child.killed` guard fails them — 2 in the claude runner, 1 in the codex runner, 2 in the transport):
- `claude-cli-runner.test.ts` — escalation after `end()`, escalation on the wall-clock timeout path, and no escalation once the child really exits.
- `codex-app-server-runner.test.ts` — escalation on the timeout path, the converse, and `interrupt()` staying silent after a real exit.
- `codex-app-server-transport.test.ts` — both directions added to the existing watchdog suite; `signallableChild()` now mirrors Node.

Every fake mirrors Node's actual semantics: `kill('SIGTERM')` records the signal and sets `killed = true` **while the child stays alive**. The two runner test files install a `vi.hoisted` + `vi.mock('node:child_process')` factory that delegates to the real `spawn` unless a test opts in, so the existing real-binary stub tests in those files are untouched.

## 💥 Breaking Changes
- None. `trackChildExit` and `TrackableChild` are additive exports; no runner contract, event shape, grace constant, or exit classification changed.

## Follow-up (out of scope)
`packages/cezar/src/core/opencode-server-runner.ts` (lines 182, 237, 239) and `opencode-model-catalog.ts:146` carry the same `!child.killed` pattern. They are outside this issue's stated scope and are tracked separately in #858 rather than widened into this PR.
