### PR TITLE
feat(release): publish main npm snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,16 @@ jobs:
 
   # npm preview publishing (spec .ai/specs/2026-07-18-npm-preview-publish.md, #482).
   # Publishes a snapshot of both packages after a fully green verify run:
-  # same-repo PRs → dist-tag pr-<N>, develop pushes → @develop. `main` pushes do
-  # NOT publish — stable `latest` releases are owner-driven and manual via
-  # release.yml, so CI never moves `latest`. Without the NPM_TOKEN secret the
-  # script degrades to a loud dry run, so this job stays green on unconfigured forks.
+  # same-repo PRs → dist-tag pr-<N>, develop pushes → @develop, main pushes → @main.
+  # Stable `latest` releases remain owner-driven and manual via release.yml, so
+  # CI never moves `latest`. Without the NPM_TOKEN secret the script degrades to
+  # a loud dry run, so this job stays green on unconfigured forks.
   publish-snapshot:
     name: Publish npm snapshot
     needs: verify
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+      (github.event_name == 'push' &&
+       (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')) ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -6,10 +6,11 @@ How cezar reaches npm. Two paths, deliberately separate
 - **Stable releases** (`latest`) are **owner-driven and manual**: a maintainer
   runs the [`Release`](../.github/workflows/release.yml) workflow from the
   Actions tab (`workflow_dispatch`) and picks the version bump. CI never moves
-  `latest` — a push to `main` publishes nothing.
+  `latest` — a push to `main` publishes only the moving `main` preview tag.
 - **Previews** are **CI-driven**: the `publish-snapshot` job in
   [`ci.yml`](../.github/workflows/ci.yml) publishes a snapshot of every package
-  after a fully green `verify` run — on `develop` pushes and same-repo PRs only.
+  after a fully green `verify` run — on `develop` and `main` pushes and same-repo
+  PRs.
 
 Three packages are in the release, always at the same version; two of them ship:
 

--- a/packages/cezar/src/release/snapshot.test.ts
+++ b/packages/cezar/src/release/snapshot.test.ts
@@ -39,15 +39,18 @@ describe('computeSnapshot', () => {
     expect(computeSnapshot({ ...base, prNumber: 1.5 })).toBeNull();
   });
 
-  it('publishes push events only for develop', () => {
+  it('publishes push events for develop and main', () => {
     const push = { ...base, eventName: 'push', prNumber: undefined };
     expect(computeSnapshot({ ...push, refName: 'develop' })).toEqual({
       channel: 'develop',
       version: '0.1.5-develop.123',
       distTag: 'develop',
     });
-    // main never publishes a snapshot — stable releases are owner-driven.
-    expect(computeSnapshot({ ...push, refName: 'main' })).toBeNull();
+    expect(computeSnapshot({ ...push, refName: 'main' })).toEqual({
+      channel: 'main',
+      version: '0.1.5-main.123',
+      distTag: 'main',
+    });
     expect(computeSnapshot({ ...push, refName: 'feat/other' })).toBeNull();
   });
 

--- a/packages/cezar/src/release/snapshot.ts
+++ b/packages/cezar/src/release/snapshot.ts
@@ -18,8 +18,8 @@ import { stampManifestSet, type ReleaseManifests as ReleaseManifestSet } from '.
 export interface SnapshotContext {
   /** `GITHUB_EVENT_NAME` — only `pull_request` and `push` ever publish. */
   eventName: string;
-  /** `GITHUB_REF_NAME` for push events — only `develop` publishes a snapshot;
-   *  `main` is reserved for owner-driven stable releases (see stable.ts). */
+  /** `GITHUB_REF_NAME` for push events — `develop` and `main` publish snapshots;
+   *  stable releases still move `latest` through the owner-driven release workflow. */
   refName: string;
   /** PR number for pull_request events; absent/invalid → no publish. */
   prNumber?: number;
@@ -68,11 +68,10 @@ function resolveChannel(ctx: SnapshotContext): { channel: string; distTag: strin
     return { channel: `pr${n}`, distTag: `pr-${n}` };
   }
   if (ctx.eventName === 'push') {
-    // Only `develop` publishes a snapshot. `main` is deliberately excluded so a
-    // merge to main never touches npm — stable `latest` releases are cut
-    // manually via the Release workflow (stable.ts). Defense in depth: the
-    // workflow's `if` already restricts the push channel to develop.
-    if (ctx.refName === 'develop') return { channel: 'develop', distTag: 'develop' };
+    // Both moving preview channels are explicit and never affect stable `latest`.
+    if (ctx.refName === 'develop' || ctx.refName === 'main') {
+      return { channel: ctx.refName, distTag: ctx.refName };
+    }
     return null;
   }
   return null;

--- a/packages/cezar/test/e2e/release-snapshot.test.ts
+++ b/packages/cezar/test/e2e/release-snapshot.test.ts
@@ -162,6 +162,26 @@ test('a missing NPM token forces a dry run instead of failing the job', { timeou
   }
 });
 
+test('a main push publishes under the moving main dist-tag', { timeout: 120_000 }, async () => {
+  const root = await makeFixture();
+  try {
+    await writeFile(join(root, 'github-output.txt'), '');
+    const { stdout } = await runScript(root, {
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_REF_NAME: 'main',
+      GITHUB_REPOSITORY: 'open-mercato/cezar',
+      GITHUB_RUN_NUMBER: '9',
+    });
+    assert.match(stdout, /forcing --dry-run/);
+    const output = await readFile(join(root, 'github-output.txt'), 'utf8');
+    assert.match(output, /^dryRun=true$/m);
+    assert.match(output, /"distTag":"main"/);
+    assert.match(output, /npx fake-alias@0\.9\.9-main\.9/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('a non-publishable event exits 0 without touching the manifests', { timeout: 60_000 }, async () => {
   const root = await makeFixture();
   try {


### PR DESCRIPTION
## Summary

- restore CI snapshot publishing for pushes to `main` under the moving `main` dist-tag
- keep stable `latest` releases owner-driven through the manual release workflow
- add unit and orchestrator coverage for `npx cezar-cli@main`

## Why

The repository documentation and release spec describe `npx cezar-cli@main`, but the snapshot resolver and CI job intentionally excluded main pushes. This PR brings the implementation back in line with that contract.

## Behavior

A green push to `main` publishes versions such as `0.9.2-main.<run>` with `--tag main`. The alias remains published last with exact snapshot dependencies, and `latest` is not moved.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run test:package -w @open-mercato/cezar` — 13/13 passed
- snapshot unit test — 15/15 passed
- `git diff --check`

The local full `npm test` baseline has unrelated environment failures in web tests because `localStorage` is unavailable, plus an existing automations-gate failure; these are not part of this change.