### PR TITLE
fix(runs): let Continue reconcile a stale active registration (#798)

### DIFF
--- a/packages/cezar/src/workflows/continue-stale-active.test.ts
+++ b/packages/cezar/src/workflows/continue-stale-active.test.ts
@@ -140,16 +140,101 @@ describe("Continue reconciles a stale 'active' registration (#798)", () => {
     });
     expect(manager.continueRun(runId, { text: 'carry on' })).toEqual({ ok: true });
 
-    // The released session is signalled on the way out and settles shortly afterwards. Its own
-    // step is closed, but the run record belongs to the continuation that took over.
+    // The released session settles on its own terms and says so. It closes out its own step and
+    // writes nothing to the run record — which is why the continuation that took over is free to
+    // bring the run up to `running` afterwards, in either order.
     await waitFor(() =>
       store
         .readEvents(runId)
         .some((event) => event.type === 'note' && String(event.message).includes('had been released')),
     );
+    await waitFor(() => store.getRun(runId)?.status === 'running');
     const record = store.getRun(runId);
-    expect(record?.status).toBe('running');
     expect(record?.steps.find((step) => step.id === 'continue-1')?.status).not.toBe('running');
+    expect(record?.steps.find((step) => step.id === 'continue-2')?.status).toBe('running');
     expect(manager.isActive(runId)).toBe(true);
+  }, 30_000);
+});
+
+/**
+ * The repo-root lease is the sharpest edge of #798: a continuation parks on it BEFORE it writes
+ * `status: running`, so a lease-blocked run genuinely sits in `active` with a terminal record —
+ * the exact desync, produced by ordinary engine behavior rather than by a stall. Releasing such a
+ * session must not let its own `acquireRepoRoot` rejection cancel the run or evict the
+ * continuation that replaced it.
+ */
+describe('a session released while parked on the repo-root lease (#798)', () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: RunManager;
+  const savedBin = process.env.CEZ_CLAUDE_BIN;
+  const savedLock = process.env.CEZ_DISABLE_REPO_LOCK;
+
+  beforeEach(async () => {
+    process.env.CEZ_CLAUDE_BIN = HANGING_CLAUDE;
+    // The lease IS the subject here, so it stays on.
+    delete process.env.CEZ_DISABLE_REPO_LOCK;
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-stale-lease-'));
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot);
+  });
+
+  afterEach(async () => {
+    for (const record of store.listRuns()) manager.cancel(record.id);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    manager.dispose();
+    if (savedBin === undefined) delete process.env.CEZ_CLAUDE_BIN;
+    else process.env.CEZ_CLAUDE_BIN = savedBin;
+    if (savedLock !== undefined) process.env.CEZ_DISABLE_REPO_LOCK = savedLock;
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  function rootRunWithSession(): string {
+    const record = store.createRun({
+      title: 'root',
+      workflow: 'quick-task',
+      task: 'work in place',
+      runner: 'claude',
+      steps: [{ id: 'work', name: 'Work', kind: 'agent' }],
+    });
+    store.updateStep(record.id, 'work', {
+      status: 'failed',
+      sessionId: `session-${record.id}`,
+      backend: 'claude',
+      finishedAt: new Date().toISOString(),
+    });
+    store.updateRun(record.id, {
+      status: 'failed',
+      error: 'Claude AI usage limit reached|1',
+      finishedAt: new Date().toISOString(),
+    });
+    return record.id;
+  }
+
+  it('neither cancels the run nor evicts the continuation that replaced it', async () => {
+    // The holder takes the lease and never lets go — its session ignores EOF.
+    const holder = rootRunWithSession();
+    expect(manager.continueRun(holder, { text: 'hold the tree' })).toEqual({ ok: true });
+    await waitFor(() => store.getRun(holder)?.status === 'running');
+
+    // The blocked run parks on the lease: registered as active, record still terminal.
+    const blocked = rootRunWithSession();
+    expect(manager.continueRun(blocked, { text: 'go' })).toEqual({ ok: true });
+    await waitFor(() => manager.isActive(blocked));
+    expect(store.getRun(blocked)?.status).toBe('failed');
+
+    // Continue again — this is what the reporter could never get past.
+    expect(manager.continueRun(blocked, { text: 'carry on' })).toEqual({ ok: true });
+
+    // The released waiter wakes on the interrupt and rejects its lease. Before the ownership
+    // guard it answered that by cancelling the run and dropping the newcomer out of `active`.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(store.getRun(blocked)?.status).not.toBe('cancelled');
+    expect(manager.isActive(blocked)).toBe(true);
   }, 30_000);
 });

--- a/packages/cezar/src/workflows/continue-stale-active.test.ts
+++ b/packages/cezar/src/workflows/continue-stale-active.test.ts
@@ -1,0 +1,155 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RunStore } from '../runs/store.ts';
+import { RunManager } from './run.ts';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+
+/** A `claude` that opens a session and then never settles on its own: it ignores stdin EOF and
+ *  only exits when signalled. That is the field shape behind #798 — a continuation parked on
+ *  `await session.result` while the record has already moved on. */
+const HANGING_CLAUDE = fileURLToPath(
+  new URL('../core/__fixtures__/claude/stub-ignores-eof-exits-143.mjs', import.meta.url),
+);
+
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('timed out waiting for the expected state');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/**
+ * #798 — "Getting 'run is still active' when trying to Continue session".
+ *
+ * The cockpit offers Continue off the RECORD (`done`/`failed`/`cancelled`/`review`), while the
+ * engine refused off the in-memory registry. A session that stalls in teardown leaves the two
+ * disagreeing, and nothing ever reconciled them: Continue was refused permanently, and a restart
+ * re-entered the same continuation path rather than clearing it.
+ */
+describe("Continue reconciles a stale 'active' registration (#798)", () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: RunManager;
+  const savedBin = process.env.CEZ_CLAUDE_BIN;
+  const savedLock = process.env.CEZ_DISABLE_REPO_LOCK;
+
+  beforeEach(async () => {
+    process.env.CEZ_CLAUDE_BIN = HANGING_CLAUDE;
+    // The repo-root lease is orthogonal here; bypassing it keeps the test about the registry.
+    process.env.CEZ_DISABLE_REPO_LOCK = '1';
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-stale-active-'));
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot);
+  });
+
+  afterEach(async () => {
+    // Signal whatever session is still parked, then let its teardown run before the tree goes.
+    for (const record of store.listRuns()) manager.cancel(record.id);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    manager.dispose();
+    if (savedBin === undefined) delete process.env.CEZ_CLAUDE_BIN;
+    else process.env.CEZ_CLAUDE_BIN = savedBin;
+    if (savedLock === undefined) delete process.env.CEZ_DISABLE_REPO_LOCK;
+    else process.env.CEZ_DISABLE_REPO_LOCK = savedLock;
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  /** A finished run with a session Continue can resume — the state the cockpit shows the button on. */
+  function settledRunWithSession(error: string): string {
+    const record = store.createRun({
+      title: 'stuck',
+      workflow: 'quick-task',
+      task: 'carry the work on',
+      runner: 'claude',
+      steps: [{ id: 'work', name: 'Work', kind: 'agent' }],
+    });
+    store.updateStep(record.id, 'work', {
+      status: 'failed',
+      sessionId: 'session-1',
+      backend: 'claude',
+      finishedAt: new Date().toISOString(),
+    });
+    store.updateRun(record.id, { status: 'failed', error, finishedAt: new Date().toISOString() });
+    return record.id;
+  }
+
+  it('continues a run whose record settled while the engine still held it', async () => {
+    const runId = settledRunWithSession('Claude AI usage limit reached|1');
+
+    // The user's first Continue opens a session that will never settle on its own.
+    expect(manager.continueRun(runId, { text: 'go' })).toEqual({ ok: true });
+    await waitFor(() => store.getRun(runId)?.status === 'running');
+    expect(manager.isActive(runId)).toBe(true);
+
+    // The reported desync: the record settles (its teardown stalled behind the hung session), so
+    // the cockpit shows Continue again — while the registry still holds the run.
+    store.updateRun(runId, {
+      status: 'failed',
+      error: 'interrupted — cezar process exited during the run',
+      finishedAt: new Date().toISOString(),
+    });
+
+    // Before this fix the engine answered `run is still active` here, forever, and a restart
+    // re-created the same state rather than clearing it.
+    expect(manager.continueRun(runId, { text: 'carry on' })).toEqual({ ok: true });
+    await waitFor(() => store.getRun(runId)?.steps.some((step) => step.id === 'continue-2') === true);
+
+    const events = store.readEvents(runId);
+    expect(
+      events.some(
+        (event) => event.type === 'lifecycle' && String(event.message).includes('stale session registration'),
+      ),
+    ).toBe(true);
+  }, 30_000);
+
+  it('still refuses a genuinely live run', async () => {
+    const runId = settledRunWithSession('interrupted');
+
+    expect(manager.continueRun(runId, { text: 'go' })).toEqual({ ok: true });
+    await waitFor(() => store.getRun(runId)?.status === 'running');
+
+    // Record and registry agree that the run is live — that refusal is the guard working.
+    expect(manager.continueRun(runId, { text: 'again' })).toEqual({
+      ok: false,
+      error: 'run is still active',
+    });
+  }, 30_000);
+
+  it('does not let the released session overwrite the record it no longer owns', async () => {
+    const runId = settledRunWithSession('Claude AI usage limit reached|1');
+
+    expect(manager.continueRun(runId, { text: 'go' })).toEqual({ ok: true });
+    await waitFor(() => store.getRun(runId)?.status === 'running');
+    store.updateRun(runId, {
+      status: 'failed',
+      error: 'interrupted — cezar process exited during the run',
+      finishedAt: new Date().toISOString(),
+    });
+    expect(manager.continueRun(runId, { text: 'carry on' })).toEqual({ ok: true });
+
+    // The released session is signalled on the way out and settles shortly afterwards. Its own
+    // step is closed, but the run record belongs to the continuation that took over.
+    await waitFor(() =>
+      store
+        .readEvents(runId)
+        .some((event) => event.type === 'note' && String(event.message).includes('had been released')),
+    );
+    const record = store.getRun(runId);
+    expect(record?.status).toBe('running');
+    expect(record?.steps.find((step) => step.id === 'continue-1')?.status).not.toBe('running');
+    expect(manager.isActive(runId)).toBe(true);
+  }, 30_000);
+});

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -38,7 +38,7 @@ import { loadConfig, resolveWorktreeRetention } from '../config.ts';
 import { autosaveCommit, createWorktree, resolveBaseRef, worktreeDiff, worktreeShortstat } from '../git-worktree.ts';
 import { getHeadCommit, getRepoInfo } from '../server/git.ts';
 import { loadWorkflows } from './load.ts';
-import type { QueuedMessage, RunRecord, RunStore, StepState } from '../runs/store.ts';
+import type { QueuedMessage, RunRecord, RunStatus, RunStore, StepState } from '../runs/store.ts';
 import { reclaimWorktrees, rematerializeReclaimedWorktree } from '../runs/retention.ts';
 import {
   AgentTempDirError,
@@ -233,6 +233,20 @@ export const AUTO_RESUME_MISSED_WINDOW_MS = 24 * 60 * 60_000;
 export const QUEUE_WATCHDOG_MS = 60_000;
 /** Shared empty holds for the common "nothing is held" pump — avoids allocating per sweep. */
 const NO_HOLDS: AccountHolds = { deadline: new Set(), inFlight: new Set() };
+
+/**
+ * The statuses a run can be continued from — the record's own way of saying "this run has
+ * settled". `review` is in the list because "Send back" is a continuation (spec 009).
+ *
+ * Also the reconciliation key for #798: a record in one of these states while the in-memory
+ * `active` registry still holds the run is a broken invariant, not a live session.
+ */
+const CONTINUABLE_STATUSES: readonly RunStatus[] = ['done', 'failed', 'cancelled', 'review'];
+
+/** Posted when a released session finally settles — see `releaseStaleActive` (#798). */
+const RELEASED_SESSION_SETTLED_NOTE =
+  'a previously stalled agent session finished after it had been released — the task record was'
+  + ' left to whichever session owns it now';
 
 /**
  * May this run start, given what its account is holding?
@@ -1136,9 +1150,25 @@ export class RunManager {
     return workflows.find((w) => w.name === run.workflow) ?? null;
   }
 
-  /** Remove a run from the live registries — keeps `waiting ⊆ active`. */
-  private dropActive(runId: string): void {
+  /**
+   * Remove a run from the live registries — keeps `waiting ⊆ active`.
+   *
+   * `expected` is the caller's own `ActiveRun`, and passing it makes the drop conditional: a
+   * stalled session can be released by `releaseStaleActive` (#798) and a NEW session registered
+   * under the same run id while the old one is still parked on an await. When that old session
+   * finally unwedges, its teardown must free its own resources without evicting the newcomer —
+   * otherwise the recovery this fix exists for would itself strand the very run it just revived.
+   * Omit `expected` (every synchronous, pre-registration path) to drop unconditionally.
+   */
+  private dropActive(runId: string, expected?: ActiveRun): void {
     const state = this.active.get(runId);
+    if (expected !== undefined && state !== expected) {
+      // Not ours any more: release what this state alone holds, and touch nothing shared —
+      // the slot, the tmp dir and the retention sweep all belong to the live registration now.
+      expected.releaseRepoRoot?.();
+      expected.releaseRepoRoot = undefined;
+      return;
+    }
     state?.releaseRepoRoot?.();
     if (state) state.releaseRepoRoot = undefined;
     this.waiting.delete(runId);
@@ -1173,6 +1203,53 @@ export class RunManager {
     // there is no keep-count to respect and nothing left to recover from it. A
     // Continue (or an auto-resume) re-creates it through `agentEnv`.
     removeAgentTmpDir(this.dataDir, runId);
+  }
+
+  /**
+   * Reconcile the in-memory registry against the durable record before Continue refuses (#798).
+   *
+   * Every terminal transition is supposed to funnel through `dropActive`, which is why
+   * `continueRun` could treat `active` as authoritative. But `dropActive` sits at the END of a
+   * session's teardown, behind awaits that can stall without bound — `await session.result` on a
+   * provider session that never settles once a usage window closes, then `autosaveCommit` on the
+   * way out. Stall there and the record says the run finished while the registry says it is
+   * live. The cockpit reads the record, so it offers Continue; the engine read memory, so it
+   * refused with `run is still active` — permanently, since nothing else ever cleared the entry
+   * and `recover()` re-enters the same continuation path on every boot.
+   *
+   * The record wins: a settled status means this registration is a leftover. Release it (ending
+   * the session so a merely-slow one stops writing), and let the caller continue. A genuinely
+   * live run — `queued`/`running`/`waiting` — is untouched here and still refused, by the status
+   * check that follows, with the more accurate `cannot continue a … run`.
+   *
+   * Returns whether a stale entry was released.
+   */
+  private releaseStaleActive(runId: string): boolean {
+    const state = this.active.get(runId);
+    if (!state) return false;
+    const run = this.store.getRun(runId);
+    if (!run || !CONTINUABLE_STATUSES.includes(run.status)) return false;
+    console.warn(
+      `[cez] releasing a stale session registration for run ${runId} — the record settled to`
+      + ` ${run.status} while the engine still held it`,
+    );
+    // `cancelled` + `end()` together: the flag stops the released session's own settle path from
+    // writing the run record (it checks ownership), and `end()` gives a session that is merely
+    // slow, rather than wedged, a chance to actually stop.
+    state.cancelled = true;
+    try {
+      state.session?.end();
+    } catch {
+      // A wedged session may throw on teardown — releasing the run must not depend on it.
+    }
+    this.clearIdleTimer(state);
+    this.clearAutosaveTimer(state);
+    this.dropActive(runId, state);
+    this.store.appendEvent(runId, {
+      type: 'lifecycle',
+      message: `released a stale session registration (the task had already settled to ${run.status})`,
+    });
+    return true;
   }
 
   // ---- usage-limit auto-resume (spec 2026-08-03-auto-resume-after-usage-limit) --------------
@@ -1981,11 +2058,16 @@ export class RunManager {
     if (agentModelsLocked(this.repoRoot) && opts.model?.trim()) {
       return { ok: false, error: AGENT_MODELS_LOCKED_ERROR };
     }
-    if (this.active.has(runId)) return { ok: false, error: 'run is still active' };
+    // `this.active` is a liveness HINT; the record is the truth (#798). A run whose record has
+    // already settled is not live no matter what the registry still holds, so reconcile the two
+    // here rather than refusing forever — see `releaseStaleActive` for why that desync happens.
+    if (this.active.has(runId) && !this.releaseStaleActive(runId)) {
+      return { ok: false, error: 'run is still active' };
+    }
     const run = this.store.getRun(runId);
     if (!run) return { ok: false, error: 'not found' };
     // `review` is continuable too — that's the "Send back" path (spec 009).
-    if (!['done', 'failed', 'cancelled', 'review'].includes(run.status)) {
+    if (!CONTINUABLE_STATUSES.includes(run.status)) {
       return { ok: false, error: `cannot continue a ${run.status} run` };
     }
     const sessionStep = [...run.steps].reverse().find((s) => s.sessionId);
@@ -2403,10 +2485,23 @@ export class RunManager {
     if (session.pid !== undefined) registerRunProcess(runId, session.pid);
 
     const finishedAt = () => new Date().toISOString();
+    /** Does the registry still consider THIS session the run's live one? A stalled session can be
+     *  released by `releaseStaleActive` (#798) and a newer continuation registered in its place;
+     *  when the old one finally settles, it may close out its own step but must not write the run
+     *  record the newcomer now owns. */
+    const stillRegistered = () => this.active.get(runId) === state;
     try {
       await session.result;
       if (sessionError) throw new Error(sessionError);
       sink.sessionEnded(state.cancelled ? 'cancelled' : 'end_turn');
+      if (!stillRegistered()) {
+        this.store.updateStep(runId, stepId, {
+          status: state.cancelled ? 'cancelled' : 'done',
+          finishedAt: finishedAt(),
+        });
+        this.store.appendEvent(runId, { type: 'note', message: RELEASED_SESSION_SETTLED_NOTE });
+        return;
+      }
       if (state.cancelled) {
         this.store.updateStep(runId, stepId, { status: 'cancelled', finishedAt: finishedAt() });
         this.store.updateRun(runId, { status: 'cancelled', finishedAt: finishedAt(), currentStepId: undefined });
@@ -2422,6 +2517,10 @@ export class RunManager {
       const message = err instanceof Error ? err.message : String(err);
       sink.sessionEnded('error', message);
       this.store.updateStep(runId, stepId, { status: 'failed', error: message, finishedAt: finishedAt() });
+      if (!stillRegistered()) {
+        this.store.appendEvent(runId, { type: 'note', message: RELEASED_SESSION_SETTLED_NOTE });
+        return;
+      }
       appendHandoffHeartbeat(this.dataDir, runId, `step "${stepId}" complete — status=failed`);
       this.store.updateRun(runId, {
         status: 'failed',
@@ -2435,7 +2534,7 @@ export class RunManager {
       this.clearIdleTimer(state);
       this.clearAutosaveTimer(state);
       if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd, 'turn end');
-      this.dropActive(runId);
+      this.dropActive(runId, state);
     }
   }
 
@@ -2712,6 +2811,16 @@ export class RunManager {
     this.clearAutosaveTimer(state);
     if (state.cwd !== this.repoRoot) await autosaveCommit(state.cwd, 'run finalize');
 
+    // A workflow that stalled long enough for `releaseStaleActive` to hand the run to a newer
+    // session (#798) closes out quietly: its steps are already settled above, and the run record
+    // belongs to whoever holds the registration now.
+    if (this.active.get(runId) !== state) {
+      this.clearIdleTimer(state);
+      emit({ type: 'note', message: RELEASED_SESSION_SETTLED_NOTE });
+      this.dropActive(runId, state);
+      return;
+    }
+
     const finishedAt = new Date().toISOString();
     if (state.cancelled) {
       const run = this.store.getRun(runId);
@@ -2729,7 +2838,7 @@ export class RunManager {
       await this.settleSuccess(runId);
     }
     this.clearIdleTimer(state);
-    this.dropActive(runId);
+    this.dropActive(runId, state);
   }
 
   /** Returns an error message, or null on success. */

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -1233,11 +1233,14 @@ export class RunManager {
       `[cez] releasing a stale session registration for run ${runId} — the record settled to`
       + ` ${run.status} while the engine still held it`,
     );
-    // `cancelled` + `end()` together: the flag stops the released session's own settle path from
-    // writing the run record (it checks ownership), and `end()` gives a session that is merely
-    // slow, rather than wedged, a chance to actually stop.
+    // The flag stops the released session's own settle path from writing the run record (it
+    // checks ownership); `interrupt()` and `end()` then give it a chance to actually stop. Both,
+    // because "stalled" has two shapes here: a live session that needs a signal, and one still
+    // parked on the repo-root lease — which has no session at all and wakes only through
+    // `interrupt`, so without it the release would be honored but not felt.
     state.cancelled = true;
     try {
+      state.interrupt();
       state.session?.end();
     } catch {
       // A wedged session may throw on teardown — releasing the run must not depend on it.
@@ -1250,6 +1253,21 @@ export class RunManager {
       message: `released a stale session registration (the task had already settled to ${run.status})`,
     });
     return true;
+  }
+
+  /**
+   * Write a session's terminal outcome onto the run record — but only while that session is still
+   * the registered one (#798).
+   *
+   * Every such write sits behind an await that can stall for as long as the thing it is waiting
+   * on: the repo-root lease, worktree creation, skill discovery. Stall past a
+   * `releaseStaleActive` and the run belongs to a newer session, whose record this one must not
+   * touch. The released session says so on the transcript instead, and lets go either way.
+   */
+  private settleOwnedOrRelease(runId: string, state: ActiveRun, write: () => void): void {
+    if (this.active.get(runId) === state) write();
+    else this.store.appendEvent(runId, { type: 'note', message: RELEASED_SESSION_SETTLED_NOTE });
+    this.dropActive(runId, state);
   }
 
   // ---- usage-limit auto-resume (spec 2026-08-03-auto-resume-after-usage-limit) --------------
@@ -2208,14 +2226,17 @@ export class RunManager {
           type: 'note',
           message: 'waiting for exclusive access to the repository working tree',
         });
+        // The lease wait is unbounded, which makes this the likeliest place for a session to be
+        // released out from under itself (#798) — a released one is `cancelled`, so it lands here.
         if (!(await this.acquireRepoRoot(runId, state))) {
-          this.store.updateRun(runId, {
-            status: 'cancelled',
-            finishedAt: new Date().toISOString(),
-            currentStepId: undefined,
+          this.settleOwnedOrRelease(runId, state, () => {
+            this.store.updateRun(runId, {
+              status: 'cancelled',
+              finishedAt: new Date().toISOString(),
+              currentStepId: undefined,
+            });
+            this.store.appendEvent(runId, { type: 'lifecycle', message: 'run cancelled' });
           });
-          this.store.appendEvent(runId, { type: 'lifecycle', message: 'run cancelled' });
-          this.dropActive(runId);
           return;
         }
       }
@@ -2384,22 +2405,25 @@ export class RunManager {
     const failBeforeSpawn = (message: string): void => {
       const failedAt = new Date().toISOString();
       sink.sessionEnded('error', message);
+      // This step is always ours to close out; the RUN record only while we still own it (#798) —
+      // every caller below sits behind an await that a stale-active release can outlive.
       this.store.updateStep(runId, stepId, {
         status: 'failed',
         error: message,
         finishedAt: failedAt,
       });
-      this.store.updateRun(runId, {
-        status: 'failed',
-        error: `continue failed: ${message}`,
-        finishedAt: failedAt,
-        currentStepId: undefined,
+      this.settleOwnedOrRelease(runId, state, () => {
+        this.store.updateRun(runId, {
+          status: 'failed',
+          error: `continue failed: ${message}`,
+          finishedAt: failedAt,
+          currentStepId: undefined,
+        });
+        this.store.appendEvent(runId, {
+          type: 'lifecycle',
+          message: `continue failed — ${message}`,
+        });
       });
-      this.store.appendEvent(runId, {
-        type: 'lifecycle',
-        message: `continue failed — ${message}`,
-      });
-      this.dropActive(runId);
     };
     // Apply the SAME canonical-identity gate the first spawn applies (#405, review M1).
     // A follow-up may switch both runner and model (#401), so without this the record keeps
@@ -2444,6 +2468,19 @@ export class RunManager {
       return;
     }
     this.store.updateStep(runId, stepId, { profileId: continueProfile.profileId });
+
+    // Last line before the spawn, and the only place this can be asked honestly: a release (#798)
+    // that lands anywhere in the long run-up above — the lease, the profile probe, skill discovery
+    // — finds no session to signal and `state.interrupt` still the placeholder, so the release is
+    // recorded but not felt. Spawning now would leave an orphan turn writing into a task that has
+    // already moved on. Checking here makes "a released session never spawns" true outright,
+    // rather than true only when the release happened to arrive at a convenient moment.
+    if (this.active.get(runId) !== state) {
+      this.store.updateStep(runId, stepId, { status: 'cancelled', finishedAt: new Date().toISOString() });
+      this.store.appendEvent(runId, { type: 'note', message: RELEASED_SESSION_SETTLED_NOTE });
+      this.dropActive(runId, state);
+      return;
+    }
 
     const runner = createRunner(continueBackend);
     state.currentStepId = stepId;
@@ -2651,14 +2688,15 @@ export class RunManager {
         const message = err instanceof Error ? err.message : String(err);
         const error = `worktree creation failed: ${message}`;
         emit({ type: 'note', message: `${error} — task stopped before workflow execution` });
-        this.store.updateRun(runId, {
-          status: 'failed',
-          error,
-          finishedAt: new Date().toISOString(),
-          currentStepId: undefined,
+        this.settleOwnedOrRelease(runId, state, () => {
+          this.store.updateRun(runId, {
+            status: 'failed',
+            error,
+            finishedAt: new Date().toISOString(),
+            currentStepId: undefined,
+          });
+          emit({ type: 'lifecycle', message: `run failed — ${error}` });
         });
-        emit({ type: 'lifecycle', message: `run failed — ${error}` });
-        this.dropActive(runId);
         return;
       }
     } else {


### PR DESCRIPTION
## What

`continueRun` treated the in-memory `active` registry as authoritative, while the cockpit offers **Continue** off the durable record (`isRunActive` — `done`/`failed`/`cancelled`/`review`). A session parked in teardown leaves the two disagreeing, and nothing ever reconciled them: Continue answered `run is still active` **permanently**, and `recover()` re-entered the same continuation path on every boot rather than clearing it. The reporter re-authorized Claude, rebooted the whole VM, and still had no cockpit path back into the task — the only way on was resuming the session by hand in the `claude` CLI.

The record now wins. A new `releaseStaleActive()` sees a registry entry against a record in a continuable status, releases it, and lets the continuation proceed. A genuinely live run (`queued`/`running`/`waiting`) is untouched and still refused — by the status check that follows, with the more accurate `cannot continue a … run`.

Making that release safe is the second half, and it is the load-bearing part of this diff: `dropActive(runId, expected?)` no-ops when the caller's `ActiveRun` is no longer the registered one, and both `runContinuation` and `execute` check ownership before writing the run record. A released session that finally unwedges closes out its own step and posts a note instead of clobbering the continuation that took over — without it, this recovery would strand the very run it just revived.

## Where the desync comes from

`dropActive` is documented as the single funnel every terminal transition passes through, which is why the registry could be trusted. But it sits at the **end** of a session's teardown, behind awaits that can stall without bound — `await session.result` on a provider session that never settles once a usage window closes, then `autosaveCommit` on the way out. Stall there and the record says the run finished while the registry says it is live.

## Changes

- `packages/cezar/src/workflows/run.ts`
  - `releaseStaleActive()` — reconciles registry against record before Continue refuses; flags the session cancelled and calls `end()` so a merely-slow one stops writing.
  - `dropActive(runId, expected?)` — optional ownership argument; a stale state releases only what it alone holds (its repo-root lease) and never touches the slot, tmp dir or retention sweep the live registration now owns.
  - Ownership checks before the terminal `updateRun` writes in `runContinuation` and `execute`.
  - `CONTINUABLE_STATUSES` extracted so the guard and the status check cannot drift apart.
- `packages/cezar/src/workflows/continue-stale-active.test.ts` — new focused regression suite.

## Testing

Three cases driven through a real `RunManager` against the hanging-claude fixture (`stub-ignores-eof-exits-143.mjs`, which ignores stdin EOF — the field shape of a session that never settles):

1. Continue heals the desync and opens `continue-2`.
2. A genuinely live run is **still** refused — the guard against over-correcting.
3. A released session's late settle leaves the new record alone.

Verified 2 of the 3 fail on pristine `origin/main` with exactly `{ ok: false, error: 'run is still active' }`.

**Gate:** `npm run typecheck`, `npm run build`, `npm run test:unit` (35 pass / 1 skip) and `npm run test:package` (12/12) all green in full.

`npm test` was run in slices rather than one pass — a single full pass on this machine is dominated by load-induced spawn timeouts:

| slice | result |
|---|---|
| `packages/web` + `packages/contract` | 3139/3139 green |
| `packages/cezar/src/{core,runs,workspace}` | 911/911 green |
| `packages/cezar/src/workflows` | 56 red **both with and without the fix**, symmetric 7/7 churn of *different* tests between runs; every file re-run individually at `--maxWorkers=1` is green except `run-isolation.test.ts`, whose one failure reproduces identically on pristine `origin/main` |
| `packages/cezar/src/server` | red set (`git-changes`, `health-topic`, `route-parity`, `automations-gate`) reproduces identically on pristine `origin/main` |

None of the environmentally-red files touch the changed code. CI is the authority here — please read a red shard against `develop`/`main` rather than against this local noise.

## Backward compatibility

None broken. Per `BACKWARD_COMPATIBILITY.md`'s general rule this makes a previously-*rejected* input accepted in one broken state — the opposite of a break — and changes no route, record shape or response field. `POST /api/v1/runs/:id/continue` still answers `409 run is still active` for a genuinely live run, which `packages/web/src/routes/task-thread/ask-answer.ts:42` retries against.

## Reviewer notes

- **The ownership guard deserves the deepest look.** Getting it wrong is how a fix in this area strands more runs than it saves; `risk-high` is on the issue for exactly this surface.
- **Complementary, not overlapping:** #857 (SIGKILL escalation in the runners layer) kills a wedged CLI process. This PR releases the *registration*. Neither subsumes the other, and they touch different files.
- **Deliberately left open**, and worth a follow-up: a run wedged with status still `running` shows Cancel rather than Continue, and `cancel()` remains non-terminal — it sets `state.cancelled` and calls `state.interrupt()` (still the no-op placeholder until `startSession` replaces it) without ever removing the entry itself. That is the user-reachable "force release" the issue's second open question asks for, and it is a separate change from this one.
- The issue's **first** open question — was the stored status still `running` after the reboot, or already `failed`? — is answered structurally rather than empirically: the cockpit only renders Continue for a terminal record, so the reported 409 implies a terminal status alongside a live registry entry. That is the state this PR reconciles, whichever producer caused it.

Closes #798
