### PR TITLE
fix(ui): keep CPU/Mem folded on queued task rows (#821)

### DIFF
--- a/packages/web/src/routes/tasks-overview.test.tsx
+++ b/packages/web/src/routes/tasks-overview.test.tsx
@@ -317,7 +317,8 @@ describe('TasksOverview — the table', () => {
 
     expect(logicalRowIds('aligned')).toEqual(headerIds)
     expect(logicalRowIds('aligned-queue')).toEqual(headerIds)
-    expect(tableRow('aligned-queue')?.querySelector('[data-slot="queue-note"]')?.getAttribute('colspan')).toBe('2')
+    // Both live columns folded, so the queued row folds with everyone else — no spanning note.
+    expect(tableRow('aligned-queue')?.querySelector('[data-slot="queue-note"]')).toBeNull()
     expect(document.querySelector('th[data-column-id="cpu"]')?.getAttribute('data-folded')).toBe('true')
     expect(document.querySelector('th[data-column-id="memory"]')?.getAttribute('data-folded')).toBe('true')
   })
@@ -463,6 +464,31 @@ describe('TasksOverview — the table', () => {
     // The note replaces the CPU/Mem cells — a queued run has no process to measure.
     expect(tableRow('q2')?.querySelectorAll('[data-usage]')).toHaveLength(0)
     expect(tableRow('q1')?.querySelector('[data-slot="queue-note"]')?.textContent).toBe('#1 in queue')
+  })
+
+  it('lets the fold win over the queue note when both live columns are folded', () => {
+    renderOverview({
+      expandedColumns: { cpu: false, memory: false },
+      runs: [run({ id: 'q1', status: 'queued' })],
+    })
+
+    const row = tableRow('q1') as HTMLElement
+    // The note's nowrap text would prise both 42px columns back open on an auto-layout table.
+    expect(row.querySelector('[data-slot="queue-note"]')).toBeNull()
+    expect(row.querySelector('td[data-column-id="cpu"]')?.getAttribute('data-folded')).toBe('true')
+    expect(row.querySelector('td[data-column-id="memory"]')?.getAttribute('data-folded')).toBe('true')
+    expect(row.textContent).not.toContain('in queue')
+  })
+
+  it.each([
+    ['CPU', { cpu: true, memory: false }],
+    ['Mem', { cpu: false, memory: true }],
+  ])('still shows the queue note while %s is expanded to carry it', (_label, expandedColumns) => {
+    renderOverview({ expandedColumns, runs: [run({ id: 'q1', status: 'queued' })] })
+
+    const note = tableRow('q1')?.querySelector('[data-slot="queue-note"]')
+    expect(note?.textContent).toBe('#1 in queue')
+    expect(note?.getAttribute('colspan')).toBe('2')
   })
 
   it('keeps queue numbers stable under search — the engine does not care what you typed', () => {

--- a/packages/web/src/routes/tasks-overview.tsx
+++ b/packages/web/src/routes/tasks-overview.tsx
@@ -526,7 +526,12 @@ function TableRow({
       {columns.map((column) => {
         if (column.id === 'memory') return null
         if (column.id === 'cpu') {
-          return queuePosition !== null ? (
+          const cpuExpanded = isColumnExpanded('cpu', expandedColumns)
+          const memoryExpanded = isColumnExpanded('memory', expandedColumns)
+          // The queue note borrows the CPU/Mem pair, but only while there is room to borrow: the
+          // table is auto-layout, so `#N in queue` under `whitespace-nowrap` would push both folded
+          // columns back open (#821). Fold beats the note; one expanded column is enough to carry it.
+          return queuePosition !== null && (cpuExpanded || memoryExpanded) ? (
             <td
               key={column.id}
               data-slot="queue-note"
@@ -540,8 +545,8 @@ function TableRow({
             <UsageTds
               key={column.id}
               run={run}
-              cpuExpanded={isColumnExpanded('cpu', expandedColumns)}
-              memoryExpanded={isColumnExpanded('memory', expandedColumns)}
+              cpuExpanded={cpuExpanded}
+              memoryExpanded={memoryExpanded}
             />
           )
         }


### PR DESCRIPTION
Closes #821

## 🎯 Goal
A user who folds the CPU and Mem columns in the desktop Tasks table keeps that fold even while runs sit in the queue — the horizontal room they asked for stays theirs.

## 🔍 Problem
`TableRow` replaces the CPU and Mem cells of a queued run with a single `colSpan={2}` note reading `#N in queue`. That branch was taken before the per-column fold check, so the note rendered no matter what the user had folded. The table uses auto layout (`<table className="w-full border-collapse">`), which makes the `<col style={{width: '42px'}}>` hints suggestions rather than rules, so the note's `whitespace-nowrap` content prised both folded columns back open for as long as any queued task was in the list.

## 🔍 Root Cause
`packages/web/src/routes/tasks-overview.tsx` — inside the `columns.map` callback, the `column.id === 'cpu'` branch chose between the spanning queue note and `<UsageTds>` purely on `queuePosition !== null`. `isColumnExpanded('cpu' | 'memory', expandedColumns)` was only consulted on the non-queued path, so the fold state had no say over the note.

## What Changed
- `packages/web/src/routes/tasks-overview.tsx` — the `cpu` branch now reads `isColumnExpanded('cpu', …)` and `isColumnExpanded('memory', …)` up front and renders the spanning note only when `queuePosition !== null && (cpuExpanded || memoryExpanded)`. With both columns folded it falls through to `<UsageTds>`, which already renders the pair of `FoldedTd`s — so a queued row folds exactly like every other row. With at least one of the two expanded there is a cell wide enough to carry the text and the note renders as before.
- `packages/web/src/routes/tasks-overview.test.tsx` — the alignment test `keeps headers and normal/queued rows logically aligned when several columns are folded` folded both live columns yet asserted the note was still present; it now asserts the fold holds. Two new cases were added beside the existing queue-note tests.

## 🧪 Tests
- `npx vitest run packages/web` — 3146 passed / 146 files.
- `npm run typecheck`, `npm run test:unit`, `npm run build`, `npm run test:package` — all green.
- New: `lets the fold win over the queue note when both live columns are folded` — a queued run with `expandedColumns: { cpu: false, memory: false }` renders no `[data-slot="queue-note"]`, both `td[data-column-id="cpu"|"memory"]` carry `data-folded="true"`, and the row's text contains no `in queue`.
- New: `still shows the queue note while %s is expanded to carry it` — an `it.each` pair covering CPU-expanded and Mem-expanded, each asserting `#1 in queue` with `colspan="2"`.
- Both new cases and the corrected alignment case were confirmed to fail against the unpatched component and pass with it.
- The repo-wide `npm test` run is red in this local environment on `packages/cezar` server-workflow suites (`run.test.ts`, `auto-resume.test.ts`, `pasted-attachments.test.ts`) with temp-directory `ENOENT` and process-spawn timeouts. Those failures reproduce in isolation, are unrelated to this diff — which touches only two files under `packages/web` — and are left for CI to arbitrate.

## 💥 Breaking Changes
- None. The queue note's markup, `data-slot`, `data-column-id="cpu-memory"` and `colSpan` are unchanged whenever it renders; only the condition under which it renders is narrower.
