### PR TITLE
fix(tests): stop the JetBrains launcher case racing a real process (#823)

### DIFF
--- a/packages/cezar/src/server/open-in-app.test.ts
+++ b/packages/cezar/src/server/open-in-app.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,20 +9,23 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 const spawnMock = vi.hoisted(() => vi.fn());
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
-  // Default to the REAL spawn: the JetBrains stub test launches actual detached processes and
-  // reads back their log. The openFileInDefaultApp arg-surface tests (#365) override this
-  // per-test with mockReturnValue in their own beforeEach.
-  spawnMock.mockImplementation((...args: unknown[]) =>
-    (actual.spawn as (...a: unknown[]) => unknown)(...args),
-  );
+  // Default to an INERT child — nothing in this file needs a real process. `runDetached` only
+  // touches `once`/`unref` before resolving true on its own settle timer, so a stub is enough to
+  // exercise every launcher path. The previous default (delegate to the real spawn, so the
+  // JetBrains case could execute stubs and read back their log) is what made that case flaky
+  // (#823): it raced fork+exec latency, which is unbounded on a loaded host, against a fixed
+  // poll budget. The openFileInDefaultApp arg-surface tests (#365) still override this per-test
+  // with mockReturnValue in their own beforeEach.
+  spawnMock.mockImplementation(() => ({ once: vi.fn(), unref: vi.fn() }));
   return { ...actual, spawn: (...args: unknown[]) => spawnMock(...args) };
 });
 
 import { RUNNER_IDS } from '../core/agent-runner.ts';
 
-// This file is the one place allowed past the #820 spawn guard, and both reasons are visible
-// above: `spawn` is replaced file-wide, and where it does fall through to the real one it launches
-// a stub binary this test wrote onto its own temp PATH — never a GUI app. Scoped to the file and
+// This file is the one place allowed past the #824 spawn guard, and the reason is visible above:
+// `spawn` is replaced file-wide by an inert stub, so no launcher call here reaches the OS. The
+// exemption is still required because `refuseSpawnUnderTest` runs inside `runDetached` BEFORE
+// `spawn`, so it trips on the mock exactly as it would on the real thing. Scoped to the file and
 // restored afterwards, so no other suite inherits the exemption.
 const savedAllowSpawn = process.env.CEZ_ALLOW_TEST_SPAWN;
 beforeAll(() => {
@@ -42,22 +45,6 @@ import {
   openInApp,
   resolveOnPath,
 } from './open-in-app.ts';
-
-/** Polls `assertion` until it stops throwing or `timeoutMs` elapses (then rethrows) — there is
- *  no @testing-library here, and the detached child processes this suite launches settle on
- *  their own schedule, not the test's. */
-async function waitFor(assertion: () => void, timeoutMs = 2000, intervalMs = 20): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      if (Date.now() >= deadline) throw error;
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-  }
-}
 
 describe('detectOpenTargets', () => {
   it('always offers a file manager and a terminal, first, both with an icon', () => {
@@ -83,16 +70,13 @@ describe('detectOpenTargets', () => {
 
     const STUBS = ['idea', 'pycharm', 'webstorm', 'goland', 'rubymine', 'phpstorm', 'clion', 'rider', 'studio'];
 
-    let callLog: string;
-
     function withStubsOnPath() {
       stubDir = mkdtempSync(join(tmpdir(), 'cez-open-in-test-'));
-      callLog = join(stubDir, 'calls.log');
       for (const name of STUBS) {
         const p = join(stubDir, name);
-        // Records its own name and argv so the "opens with the right dir" test can confirm the
-        // resolved binary actually ran with the worktree path, not just that spawn didn't throw.
-        writeFileSync(p, `#!/usr/bin/env bash\necho "${name} $1" >> ${JSON.stringify(callLog)}\ntrue\n`, 'utf8');
+        // Marker files, not scripts: `resolveOnPath` probes them with `accessSync(X_OK)` and
+        // nothing in this file executes them, because `spawn` is mocked file-wide.
+        writeFileSync(p, '', 'utf8');
         chmodSync(p, 0o755);
       }
       originalPath = process.env.PATH;
@@ -122,16 +106,30 @@ describe('detectOpenTargets', () => {
 
     it('opens the resolved JetBrains stub with the worktree dir as its argument', async () => {
       withStubsOnPath();
+      spawnMock.mockClear();
+
       expect(await openInApp('clion', '/tmp/some-worktree')).toBe(true);
       expect(await openInApp('rider', '/tmp/some-worktree')).toBe(true);
-      // runDetached's own 250ms settle window is enough for these trivial scripts to run, but
-      // it unrefs rather than waiting on the child — poll briefly rather than risk a flaky
-      // exact-timing race under load.
-      await waitFor(() => {
-        const log = readFileSync(callLog, 'utf8');
-        expect(log).toContain('clion /tmp/some-worktree');
-        expect(log).toContain('rider /tmp/some-worktree');
+
+      // Read off the spawn seam rather than by executing the stubs and polling a log they append
+      // to (#823). `runDetached` unrefs its child instead of waiting on it, so the log version
+      // raced real fork+exec latency — unbounded on a loaded host, and measured at 2.1–2.6s
+      // against a 2s poll budget — for no extra coverage: the recorded argv proves the same
+      // property the log did, that the RESOLVED binary was launched with the worktree path,
+      // while executing the stub only ever proved that bash works.
+      const launched = spawnMock.mock.calls.map((call) => {
+        const [bin, args] = call as [string, string[]];
+        return { bin, args };
       });
+      expect(launched).toEqual([
+        { bin: 'clion', args: ['/tmp/some-worktree'] },
+        { bin: 'rider', args: ['/tmp/some-worktree'] },
+      ]);
+      // Detached and stdio-free, which a launch must stay: an editor may outlive the cockpit and
+      // must never inherit its stdio. Reading the stub's own log could not observe this at all.
+      for (const call of spawnMock.mock.calls) {
+        expect(call[2]).toMatchObject({ stdio: 'ignore', detached: true });
+      }
     });
   });
 });


### PR DESCRIPTION
Closes #823

## 🎯 Goal

`packages/cezar/src/server/open-in-app.test.ts` stops failing intermittently under a full
`npm test` run. The JetBrains launcher case now proves the same property deterministically,
without executing a process, so the fast unit gate no longer has a case whose pass/fail depends
on how busy the machine running it happens to be.

## 🔍 Problem

`detectOpenTargets > with stub CLIs on PATH > opens the resolved JetBrains stub with the
worktree dir as its argument` failed intermittently in a full-suite run — 1 failure in 5
consecutive runs when #823 was filed — while passing reliably on its own. The failure was always
the same: `ENOENT: no such file or directory, open '…/cez-open-in-test-XXXX/calls.log'` raised
from `readFileSync` inside the test's `waitFor` poll.

## 🔍 Root Cause

The file mocks `node:child_process` file-wide, but defaulted `spawnMock` to delegate to the
**real** `spawn` so this one case could launch bash stubs and read back the log they append to.
`openInApp('clion', …)` therefore reached `runDetached` (`open-in-app.ts:241-263`), which spawns
detached, `unref`s the child after a 250 ms settle window and resolves `true` **without waiting
for it** — so the test polled `calls.log` through `waitFor`, whose budget is 2000 ms.

Two corrections to the issue's own analysis, both of which change what the fix has to be:

1. **`waitFor` already tolerates a missing file.** `readFileSync`'s `ENOENT` is thrown inside the
   polled assertion, caught by the `try`/`catch`, and retried. The `ENOENT` in the report is the
   *rethrow after the budget expired*, not a first-read race. The issue's suggested direction
   ("treat `ENOENT` as not-ready-yet and keep polling") is therefore already implemented.
2. **The budget bounds something unbounded.** Forking `#!/usr/bin/env bash` costs whatever the
   host's process-start path costs, and that is not a property the test controls. Measured here
   with a standalone probe — plain Node, no vitest, no suite load — the child completed at
   **2163 ms / 2368 ms / 2605 ms** across three runs, i.e. over the 2000 ms budget every time.
   On this host `syspolicyd` (macOS Gatekeeper, consulted on every `exec`) sits at ~77% CPU
   alongside an endpoint-protection daemon; under a 319-file parallel suite the same latency is
   simply hit more often. Raising the budget would make the flake rarer, not absent.

So the fix removes the real process rather than widening the window.

## What Changed

- **`packages/cezar/src/server/open-in-app.test.ts`** — the `vi.mock('node:child_process')`
  factory now defaults `spawnMock` to an inert child (`{ once, unref }`) instead of the real
  `spawn`. `runDetached` only ever touches `once`/`unref` before resolving on its own settle
  timer, so a stub exercises every launcher path. This is the part that reaches beyond the one
  failing case, and it is deliberate: leaving the default at "delegate to the real spawn" leaves
  the same landmine armed for the next test added to this file.
- **The failing case now reads the spawn seam.** It asserts the recorded calls are exactly
  `clion` then `rider`, each with `['/tmp/some-worktree']` — the same property the log proved,
  that the *resolved* binary was launched with the worktree path — plus a new assertion the log
  version could not make at all: every launch carries `{ stdio: 'ignore', detached: true }`.
  Executing the stub only ever additionally proved that bash works.
- **Dead scaffolding removed** — the `waitFor` helper, `callLog`, and the stubs' bash body. The
  PATH stubs stay as empty executable marker files, because `resolveOnPath` probes them with
  `accessSync(X_OK)` and the sibling *detects every JetBrains product* case depends on that;
  this matches how the `resolveOnPath` describe's own `addStub` already writes its stubs.
- **The `CEZ_ALLOW_TEST_SPAWN` comment is corrected, and the exemption kept.** #825's comment
  said the file "falls through to the real one" — no longer true. The exemption is still
  required, because `refuseSpawnUnderTest` runs inside `runDetached` *before* `spawn` and so
  trips on the mock exactly as it would on the real thing.

No production file is touched.

## 🧪 Tests

Characterised by repetition rather than a single run, as #823 asked:

- **Pre-fix, file reverted:** 5 isolated runs → **4 failed**, each with the reported `ENOENT` on
  `calls.log`. (This host reproduces far more readily than the reporter's did.)
- **Post-fix:** 10 isolated runs → **10 passed**. The file's test time dropped from 3.57 s to
  1.55 s, since it no longer waits on processes.

Validation gate:

- `npm run typecheck` ✅
- `npm run test:unit` ✅ — 35 pass, 0 fail
- `npm run build` ✅ — `check:pack ok — 478 files, 88 under web/dist`
- `npm run test:package` ✅ — 13/13
- `npm test` ❌ **on this host, and not attributable to this change.** Two consecutive full runs
  failed 38 then 39 files of 319, and **113 of those failures are bare `Test timed out` /
  `Hook timed out`**; the runs took 553 s and 578 s against a normal ~100 s, on a machine with a
  load average of 16 and `syspolicyd` + the endpoint-protection daemon saturating CPU. The
  decisive check: re-running six of the failing files as their own vitest run — with
  `open-in-app.test.ts` **not in the run at all** — still failed five of them, so the red cannot
  be attributed to the only file this PR touches. `open-in-app.test.ts` appears in neither
  failure list. **CI is the arbiter for this gate command**, and the point of this PR is
  precisely that a wall-clock-dependent test is not a trustworthy signal.

## 💥 Breaking Changes

None. Test-only change; no production code, contract, or public surface is affected.
