### PR TITLE
fix(web): validate history route responses at the client boundary (#827)

### DIFF
--- a/packages/web/src/api/client.test.ts
+++ b/packages/web/src/api/client.test.ts
@@ -20,6 +20,8 @@ import {
   getRun,
   getRunDiff,
   getRunHandoff,
+  getRunHistory,
+  getRunHistoryContext,
   getRuns,
   getSkills,
   getSkillsWhenReady,
@@ -551,5 +553,81 @@ describe('errors', () => {
     const error = (await getRunDiff('nope').catch((e: unknown) => e)) as ApiError
     expect(error.status).toBe(404)
     expect(error.message).toBe('not found')
+  })
+})
+
+/**
+ * The history routes are the two whose 200 is VALIDATED, not merely cast (#827).
+ *
+ * `useRunHistory` iterates `page.events`, so a body that is not a page would throw a `TypeError`
+ * mid-render instead of rejecting the query — and the hook's full-replay fallback only triggers
+ * on a rejection. These pin that a malformed 200 becomes an `ApiError`, which is what routes it
+ * into that fallback.
+ */
+describe('history responses are validated at the boundary (#827)', () => {
+  const PAGE = {
+    events: [{ seq: 1, ts: '2026-01-01T00:00:00.000Z', type: 'assistant', text: 'hi' }],
+    itemCount: 1,
+    liveCursor: 'cursor-live',
+    asOfSeq: 1,
+    hasOlder: false,
+  }
+  const CONTEXT = {
+    contextEvents: [{ seq: 1, ts: '2026-01-01T00:00:00.000Z', type: 'assistant' }],
+    asOfSeq: 1,
+  }
+
+  it('passes a well-formed page through unchanged, additive event keys included', async () => {
+    reply({ ...PAGE, olderCursor: 'cursor-older' })
+    const page = await getRunHistory('run-1')
+    expect(page.itemCount).toBe(1)
+    expect(page.olderCursor).toBe('cursor-older')
+    expect(page.newerCursor).toBeUndefined()
+    // The event schema is open (append-only vocabulary) — payload keys must survive validation.
+    expect(page.events[0]).toMatchObject({ seq: 1, type: 'assistant', text: 'hi' })
+  })
+
+  it('passes a well-formed context through unchanged', async () => {
+    reply(CONTEXT)
+    const context = await getRunHistoryContext('run-1')
+    expect(context.asOfSeq).toBe(1)
+    expect(context.contextEvents).toHaveLength(1)
+  })
+
+  it('rejects a 200 whose page body is the catch-all empty object', async () => {
+    reply({})
+    const error = (await getRunHistory('run-1').catch((e: unknown) => e)) as ApiError
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.status).toBe(200)
+    expect(error.message).toBe('the cezar server answered /runs/run-1/history with an unexpected body')
+  })
+
+  it('rejects a 200 whose page carries a non-array `events`', async () => {
+    reply({ ...PAGE, events: 'nope' })
+    const error = (await getRunHistory('run-1').catch((e: unknown) => e)) as ApiError
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.message).toContain('unexpected body')
+  })
+
+  it('rejects a 200 whose context body is the catch-all empty object', async () => {
+    reply({})
+    const error = (await getRunHistoryContext('run-1').catch((e: unknown) => e)) as ApiError
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.status).toBe(200)
+    expect(error.message).toBe(
+      'the cezar server answered /runs/run-1/history-context with an unexpected body',
+    )
+  })
+
+  it('still reports a real HTTP failure with the server\'s own words', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'run not found' }), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    const error = (await getRunHistory('nope').catch((e: unknown) => e)) as ApiError
+    expect(error.status).toBe(404)
+    expect(error.message).toBe('run not found')
   })
 })

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -108,6 +108,8 @@ import {
   getApiBaseUrl,
   getApiScope,
   queryScope,
+  runHistoryContextSchema,
+  runHistoryPageSchema,
 } from '@open-mercato/cezar-api-client'
 import type { Ok, OkJson } from '@open-mercato/cezar-api-client'
 import type { ClientResponse } from 'hono/client'
@@ -298,6 +300,45 @@ async function unwrap<R extends ClientResponse<unknown, number, ResponseFormat>>
 }
 
 /**
+ * The `safeParse` half of a contract schema, spelled structurally.
+ *
+ * Keeps this package free of a direct `zod` dependency: the schemas arrive through the
+ * api-client barrel as runtime values (`contract-pipeline.test.ts` pins that), and this is the
+ * only part of them `unwrapValidated` uses.
+ */
+type ResponseValidator<T> = {
+  safeParse: (value: unknown) => { success: true; data: T } | { success: false }
+}
+
+/**
+ * `unwrap`, plus the shape check its cast cannot make.
+ *
+ * `unwrap` ends in `parsed as OkJson<R>` — a compile-time claim about a body the server sent at
+ * runtime. For most routes the claim is harmless: a caller reading a missing field gets
+ * `undefined` and renders nothing. The history routes are different — `useRunHistory` iterates
+ * `page.events`, so a 200 whose body is not a page throws a `TypeError` mid-render and takes the
+ * session view down with it, bypassing the hook's own full-replay fallback (which only triggers
+ * on a REJECTED query). Validating here turns that body into the same `ApiError` a non-JSON body
+ * already produces, so the malformed case degrades exactly like the unreachable one.
+ *
+ * Its own server cannot produce such a body (`contract-parity.test.ts` pins both response types
+ * to these schemas) — this guards the boundary against a proxy, a stale server, or a stub.
+ */
+async function unwrapValidated<R extends ClientResponse<unknown, number, ResponseFormat>, T>(
+  res: R,
+  label: string,
+  schema: ResponseValidator<T>,
+): Promise<T> {
+  const status = res.status
+  const parsed = await unwrap(res, label)
+  const result = schema.safeParse(parsed)
+  if (!result.success) {
+    throw new ApiError(status, `the cezar server answered ${label} with an unexpected body`)
+  }
+  return result.data
+}
+
+/**
  * The one `fetch` both request paths go through — hand-written and typed alike.
  *
  * Shared rather than duplicated because the two behaviours below are the contract, and a
@@ -462,12 +503,14 @@ export async function getRun(id: string, opts?: ReadOptions): Promise<ApiRun> {
   )
 }
 
+/** One reverse-paged history page. Validated (not merely cast) because `useRunHistory` iterates
+ *  `events`: see `unwrapValidated`. */
 export async function getRunHistory(
   id: string,
   cursor?: string,
   opts?: ReadOptions,
 ): Promise<RunHistoryPage> {
-  return unwrap(
+  return unwrapValidated(
     await cez.api.v1.p[':projectId'].runs[':id'].history.$get(
       {
         param: { projectId: queryScope(), id: encodeURIComponent(id) },
@@ -476,16 +519,19 @@ export async function getRunHistory(
       init(opts),
     ),
     `${runPath(id)}/history`,
+    runHistoryPageSchema,
   )
 }
 
+/** The compact current-state context for a run. Validated for the same reason as the page above. */
 export async function getRunHistoryContext(id: string, opts?: ReadOptions): Promise<RunHistoryContext> {
-  return unwrap(
+  return unwrapValidated(
     await cez.api.v1.p[':projectId'].runs[':id']['history-context'].$get(
       { param: { projectId: queryScope(), id: encodeURIComponent(id) } },
       init(opts),
     ),
     `${runPath(id)}/history-context`,
+    runHistoryContextSchema,
   )
 }
 

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -324,11 +324,11 @@ type ResponseValidator<T> = {
  * Its own server cannot produce such a body (`contract-parity.test.ts` pins both response types
  * to these schemas) — this guards the boundary against a proxy, a stale server, or a stub.
  */
-async function unwrapValidated<R extends ClientResponse<unknown, number, ResponseFormat>, T>(
+async function unwrapValidated<R extends ClientResponse<unknown, number, ResponseFormat>>(
   res: R,
   label: string,
-  schema: ResponseValidator<T>,
-): Promise<T> {
+  schema: ResponseValidator<OkJson<R>>,
+): Promise<OkJson<R>> {
   const status = res.status
   const parsed = await unwrap(res, label)
   const result = schema.safeParse(parsed)

--- a/packages/web/src/api/run-history.test.tsx
+++ b/packages/web/src/api/run-history.test.tsx
@@ -169,4 +169,44 @@ describe('useRunHistory', () => {
     expect(FakeEventSource.instances.length).toBeGreaterThanOrEqual(2)
     vi.unstubAllGlobals()
   })
+
+  /**
+   * The compaction call is fire-and-forget, so it has no query to carry a rejection (#827).
+   * Since the client now REJECTS a malformed history page instead of casting it, this path can
+   * be reached by a bad body as well as by a transport error — and must stay a silent no-op
+   * rather than an unhandled rejection that fails the surrounding render.
+   */
+  it('survives a failed compaction: the live transcript stands and the guard reopens', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    const unhandled = vi.fn()
+    process.on('unhandledRejection', unhandled)
+    mockHistory
+      .mockResolvedValueOnce(page(100))
+      .mockRejectedValue(new Error('the cezar server answered /runs/run-1/history with an unexpected body'))
+    mockContext.mockResolvedValue(context())
+    const { wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    act(() => {
+      for (let seq = 101; seq <= 300; seq += 1) {
+        FakeEventSource.instances[0]!.emit(
+          'run-event',
+          JSON.stringify({ seq, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: `event-${seq}` }),
+        )
+      }
+    })
+
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+    // Nothing was compacted, so the events the SSE already delivered are still what renders.
+    expect(result.current.visibleEvents.at(-1)?.seq).toBe(300)
+    // A failed compaction is not a load failure: the transcript must NOT drop to full replay.
+    expect(result.current.fallback).toBe(false)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(unhandled).not.toHaveBeenCalled()
+
+    process.off('unhandledRejection', unhandled)
+    vi.unstubAllGlobals()
+  })
 })

--- a/packages/web/src/api/run-history.ts
+++ b/packages/web/src/api/run-history.ts
@@ -101,6 +101,12 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
           },
         )
       })
+      // Compaction is an optimization, not a load: this call is fire-and-forget (`void`), so a
+      // rejection here has no query to reject and would surface as an unhandled rejection. The
+      // live buffer still holds every event, and the next `onCompact` retries — so swallowing is
+      // the graceful outcome. Reachable via a transport error, and now also via a malformed page
+      // body, which the client validates rather than casts (#827).
+      .catch(() => {})
       .finally(() => {
         compactingLive.current = false
       })


### PR DESCRIPTION
Closes #827

## 🎯 Goal
A malformed `200` on either run-history route no longer white-screens the session view. The transcript degrades to the full-replay path the hook already documents — the same way a transport error or a `404` degrades today.

## 🔍 Problem
`getRunHistory` and `getRunHistoryContext` (`packages/web/src/api/client.ts`) returned their results straight through `unwrap`. `unwrap` owns this module's answer contract — it turns a non-2xx into an `ApiError` carrying the server's own words, and a non-JSON body into an `ApiError` naming the route — but for a 2xx JSON body it ends in `return parsed as OkJson<R>`. That last step is a cast, not a check, so `Promise<RunHistoryPage>` / `Promise<RunHistoryContext>` were compile-time claims about a body that arrives at runtime.

`useRunHistory` (`packages/web/src/api/run-history.ts`) then reads `page.events` directly and spreads it through `orderedUnique`, so a `200` whose body is not a page threw an uncaught `TypeError: group is not iterable` during render and took the whole session view down with it. That is exactly the case the hook's own docstring promises is handled: *"Any optimized-path failure switches once to the protected full-replay hook so a missing optimization never makes a session unreadable."*

Follow-up from the code review of #739, which deferred this rather than widening a `risk-high` change.

## 🔍 Root Cause
The hook's `fallback` switch keys on `history.isError || context.isError` — it needs a **rejected** query to fire. A transport error and a `404` both reject, so both degrade correctly. A malformed `200` never became a rejection, because nothing between the wire and the render validated the shape. The gap is one unchecked cast at the boundary, not a flaw in the fallback.

## What Changed
- **`packages/web/src/api/client.ts`** — added `unwrapValidated`, a thin wrapper over `unwrap` that runs the unwrapped body through a contract schema and, on failure, throws `new ApiError(status, "the cezar server answered <route> with an unexpected body")` — the same voice and the same error type `unwrap` already uses for a non-JSON body. Wired `getRunHistory` and `getRunHistoryContext` through it against `runHistoryPageSchema` / `runHistoryContextSchema`. Because the rejection is an ordinary query failure, it routes into the hook's existing `fallback` path for free — no change was needed in `run-history.ts`.
- The schemas arrive as **runtime values** through the api-client barrel; `contract-pipeline.test.ts` already pins that the `sync-contract` pipeline delivers schemas and not merely inferred types.
- The schema argument is typed structurally (`ResponseValidator<T>`, exposing just `safeParse`) rather than as a `ZodType`. `packages/web` has no direct `zod` dependency, and adding one to type a single parameter is scope this issue does not ask for.
- **Scope is deliberately the two history routes.** The other ~40 call sites in the module still use `unwrap` — for them the cast is harmless, since a caller reading a missing field gets `undefined` and renders nothing. Only these two feed an iteration.
- **`packages/web/src/api/client.test.ts`** — six regression tests, described below.

Two further changes came out of this PR's own code review (commit `609ce816`) and are part of the diff:

- **`packages/web/src/api/client.ts`** — `unwrapValidated` now takes `ResponseValidator<OkJson<R>>` and returns `Promise<OkJson<R>>` instead of an independent `T`. The first draft inferred the return type from the schema alone, which quietly dropped the compile-time link between the route and its response type — the very thing the typed client exists to provide. With the tighter signature a route/schema drift is a compile error (verified: passing the context schema to the history route fails typecheck with `TS2345`).
- **`packages/web/src/api/run-history.ts`** — `compactLive` calls `getRunHistory` fire-and-forget (`void … .then(…).finally(…)`), so its promise has no query to absorb a rejection and a failure escaped as an unhandled rejection. That is pre-existing — a transport error already rejected — but this PR widens the reachable set to malformed bodies, so it would have traded a render crash for an unhandled rejection on the same input. Fixed with a documented `.catch(() => {})` no-op: the live buffer still holds every event and the next `onCompact` retries. One regression test added alongside it.

## 🧪 Tests
Gate commands from `.ai/agentic.config.json`:

- `npm run typecheck` — ✅ all four projects (contract, api-client, server, web)
- `npm run test:unit` — ✅ 35 passed / 1 pre-existing skip
- `npm run build` — ✅ including `check:pack` (478 files, 88 under `web/dist`)
- `npm run test:package` — ✅ 13 passed
- `npx vitest run --project web` — ✅ **146 files / 3150 tests**, the project this diff touches
- `npm test` — ⚠️ red locally, **not from this change**. 45 files / 201 tests failed, every one of them in the `|server|` project, with a signature of 104 test timeouts + 29 hook timeouts + `ENOENT` spawns on a machine sitting at load average ~13 under parallel agent sessions. This diff contains no server-side change at all; a sampled red server file (`route-parity.test.ts`) passes 9/9 when run alone. CI is the authority here.

New cases, under `history responses are validated at the boundary (#827)`:

- A well-formed page passes through unchanged, **including additive event payload keys** — `runHistoryEventSchema` is open by design (append-only vocabulary, BACKWARD_COMPATIBILITY.md §7), and this pins that validation does not strip them.
- A well-formed context passes through unchanged.
- A `200` whose body is the catch-all `{}` rejects with an `ApiError` on **both** routes, asserted on the exact message so the route label stays in it.
- A `200` whose `events` is a string rejects — the precise shape that produced the original `TypeError`.
- A real `404` still surfaces the server's own message verbatim, proving the existing error contract did not shift.

Plus one case in `run-history.test.tsx` from the review pass — `survives a failed compaction: the live transcript stands and the guard reopens` — asserting that a rejected compaction leaves the rendered transcript intact, does **not** drop the session to full replay (a failed optimization is not a load failure), and raises no unhandled rejection.

Four of the seven fail against the unpatched source: three verified by swapping in the `origin/main` `client.ts` (3 failed / 76 passed), and the compaction case verified by removing the `.catch` (1 failed / 4 passed). Tests that cannot fail are not coverage; these can.

No further test was added to `run-history.test.tsx` for the fallback itself: it already pins that a rejected history query flips the hook to `fallback: true`, which is the other half of this chain. A near-duplicate there would be noise rather than coverage.

## 💥 Breaking Changes
None. No exported signature, route, response shape, or contract schema changed — only the client's reaction to a body the server is already pinned never to send (`contract-parity.test.ts` and `route-parity.test.ts` cover that, and both are unmodified).

One behavioral note worth a reviewer's eye: the page and context schemas are non-strict objects, so validation strips unknown **top-level** keys. That is harmless today — server and cockpit ship together, and the event schema keeps additive payload keys — but it does mean a future additive page field must be added to the contract schema to survive the boundary. Likewise `itemCount` is capped at `RUN_HISTORY_PAGE_ITEMS`, so an over-long page from a mismatched server now degrades to full replay instead of rendering. That is the intended trade, and it is the safe direction.
