### PR TITLE
docs(compat): document the exports map in the §6 package surface (#853)

### DIFF
--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -6,7 +6,7 @@ cezar is a published npm CLI (`@open-mercato/cezar`, currently 0.x — renamed f
 
 ## 1. CLI commands, flags and exit codes (`packages/cezar/src/index.ts`)
 
-- **Bins:** `cezar` and `cez` (both in `package.json` `bin`). Removing either alias is breaking.
+- **Bins:** `cezar`, `cez` and `cezar-cli` (all three in the manifest's `bin`; section 6 has the full package surface). Removing any alias is breaking.
 - **Commands:** bare invocation = `serve` (cockpit); `cezar run "<task>"`; `cezar init`.
 - **`cezar projects` subcommands:** `list` (the default), `add`, `remove`/`rm`, `tag`. `tag <id> [<tag>…]` replaces a project's grouping tags wholesale; naming none clears them.
 - **Flags:** `-p/--port` (default 4321, auto-picks the next free port), `--repo <dir>`, `--workflow <name>` (default `quick-task`), `--model <model>`, `--no-open`, `-h/--help`.
@@ -116,14 +116,15 @@ Breaking: requiring frontmatter, dropping a discovery directory, or inverting pr
 
 The Manage-skills opt-out (`importedSkills` in the global `~/.cezar/ui-state.json`) preserves this contract: the key is a tri-state and its **absence keeps the historical full default-repo catalog**, so an existing install that never curated sees exactly what it saw before. Only a *present* array (the user actively curated in the Skills page) narrows the default repo, and only that repo — a `config.json` `skillsRepos` the user configured is never gated. The selection lives at workspace scope (not the per-repo `.ai/cezar/ui-state.json`) so it follows the user across projects and never depends on the launch directory. Emptying the default catalog for a not-yet-curated install would be the breaking case, and is deliberately not what happens.
 
-## 6. npm package surface (`package.json`)
+## 6. npm package surface (`packages/cezar/package.json`)
 
-- Name `@open-mercato/cezar` (plus the `cezar-cli` npx alias documented in the README); `bin` entries `cezar` + `cez`; published `files`: `dist`, `packages/cezar/web/dist`, `packages/web/public/open-mercato.svg`, `scripts`, `README.md`; `engines.node >= 20`; `"type": "module"`.
-- There is **no** `exports`/library API — the package is CLI-only. Keep it that way deliberately: adding one creates a new compatibility surface; if it happens, this document gains a section first.
+- Name `@open-mercato/cezar` (plus the separately published `cezar-cli` alias package documented in the README); `bin` entries `cezar`, `cez` + `cezar-cli`; published `files`: `dist`, `web/dist`, `scripts`, `README.md`; `engines.node >= 20`; `"type": "module"`. Manifest paths are package-relative — the package root is `packages/cezar/`, so `web/dist` is `packages/cezar/web/dist` in the repo.
+- **`exports` — the resolution gate, not a library API.** The manifest declares exactly three subpaths: `.` → `./dist/index.js` (the CLI entry), `./app-type` → `./dist/server/app-type.js`, and `./package.json`. There is still no *runtime* library API — `./app-type` is type-only by construction (`import type` erases at build, which is what lets a browser bundle consume it without dragging `node:*` in) and exists because `@open-mercato/api-client` and the cockpit type their client off the server's own route table (`packages/web/src/api/client.ts`, spec `2026-07-23-independent-server-web-packages`). The map itself is load-bearing regardless: once a package declares `exports`, Node serves **only** the listed subpaths and hard-blocks the rest, so this is what keeps the deep-path surface closed. Adding or removing a subpath is breaking.
+- **First-party consumers import the bare specifier `@open-mercato/cezar`, never a deep path.** 0.9.3 shipped an alias whose `bin.js` did `import('@open-mercato/cezar/dist/index.js')`; the exports gate blocked it and every `npx cezar-cli` died with `ERR_PACKAGE_PATH_NOT_EXPORTED` against a file sitting right there in the tarball (#851, fixed in #852). Nothing else in the gate could see it — bin paths resolve inside the package and never pass through `exports`, and `check:pack` counts packed files rather than resolving them. `packages/cezar/test/e2e/alias-bin-exports.test.ts` now pins it: it resolves every specifier `alias-cezar/bin.js` imports against the real manifest and requires it to land on `dist/index.js`.
 - `dist/index.js` must remain the bin entry, and `web/` must stay resolvable relative to `dist/server` (`resolveWebDir` walks `../../web`; the built cockpit lives at `packages/cezar/web/dist`).
 - The tarball MUST contain the built UI (`packages/cezar/web/dist/index.html` + hashed `packages/cezar/web/dist/assets/*`) — `npm run check:pack` (`packages/cezar/scripts/check-pack.mjs`, run as the last leg of `npm run build`, hence by `prepublishOnly`) enforces this; do not remove it from the build chain.
 
-Breaking: dropping a bin alias, raising `engines.node`, removing `packages/cezar/web/dist/` or `scripts/` from `files`, renaming the package. Required path: raise `engines` only in a version bump flagged as breaking; keep old aliases through a deprecation release.
+Breaking: dropping a bin alias, raising `engines.node`, removing `packages/cezar/web/dist/` or `scripts/` from `files`, adding or removing an `exports` subpath, renaming the package. Required path: raise `engines` only in a version bump flagged as breaking; keep old aliases and old `exports` subpaths through a deprecation release. `packages/cezar/src/bc-package-surface.test.ts` holds this section's `bin`, `files` and `exports` lists to what the manifest actually declares — the drift it now guards is what let the `exports` map ship undocumented and #851 happen.
 
 ## 7. Agent event protocol (`packages/cezar/src/core/agent-runner.ts`, `packages/cezar/src/core/ui-events.ts`)
 

--- a/packages/cezar/src/bc-package-surface.test.ts
+++ b/packages/cezar/src/bc-package-surface.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The `BACKWARD_COMPATIBILITY.md` §6 package-surface drift guard (#853).
+ *
+ * §6 declares the published npm surface protected, but the declaration is prose and nothing
+ * verified it against the manifest it describes. It didn't match: the package split (#695)
+ * added an `exports` map and dropped `web/open-mercato.svg` from `files` while §6 kept saying
+ * "there is **no** `exports`/library API" and kept listing the svg, and the `cezar-cli` bin had
+ * been missing from §1 and §6 since it was added.
+ *
+ * That drift was not cosmetic. The undocumented `exports` map silently governed resolution:
+ * once a package declares one, Node serves ONLY the listed subpaths and hard-blocks the rest,
+ * so the alias's `import('@open-mercato/cezar/dist/index.js')` died with
+ * ERR_PACKAGE_PATH_NOT_EXPORTED at every user (#851, fixed in #852) — an undocumented surface
+ * breaking a documented one. `test/e2e/alias-bin-exports.test.ts` pins that specific resolution;
+ * this pins the *description*, so the next manifest change cannot ship undocumented.
+ *
+ * Like the §2 route inventory guard (`server/bc-route-inventory.test.ts`), this is the cause fix
+ * rather than the instance fix — it would have failed on the commit that introduced each of the
+ * three drifts above.
+ *
+ * Deliberately loose about prose, strict about lists: it reads only the enumerations §6 spells
+ * out in backticks, so the section can be rewritten, reordered or expanded freely as long as the
+ * names it names stay true. Manifest paths are package-relative and §6 sometimes says where a
+ * path lands in the repo, which is why the `files` comparison normalizes the `packages/cezar/`
+ * prefix away rather than demanding one spelling.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '../../..');
+const doc = readFileSync(join(REPO_ROOT, 'BACKWARD_COMPATIBILITY.md'), 'utf8');
+const manifest = JSON.parse(
+  readFileSync(join(REPO_ROOT, 'packages/cezar/package.json'), 'utf8'),
+) as { bin: Record<string, string>; files: string[]; exports: Record<string, string> };
+
+/** The text of one `## <n>. …` section, up to the next one. */
+export function section(markdown: string, heading: string): string {
+  const start = markdown.indexOf(heading);
+  if (start === -1) throw new Error(`BACKWARD_COMPATIBILITY.md has no "${heading}" section`);
+  const end = markdown.indexOf('\n## ', start + heading.length);
+  return markdown.slice(start, end === -1 ? undefined : end);
+}
+
+/** Every `backticked` token in a slice of prose. */
+export function backticked(text: string): string[] {
+  return [...text.matchAll(/`([^`]+)`/g)].map((match) => match[1] as string);
+}
+
+/**
+ * The backticked names in the clause introduced by `label`, which runs to the next `;` — the
+ * shape §6 writes its two inline enumerations in ("`bin` entries `a`, `b` + `c`; published
+ * `files`: …"). The label itself is dropped, so its own backticks never leak into the result.
+ */
+export function clauseNames(text: string, label: string): string[] {
+  const start = text.indexOf(label);
+  if (start === -1) throw new Error(`§6 no longer contains the "${label}" clause`);
+  const from = start + label.length;
+  const end = text.indexOf(';', from);
+  return backticked(text.slice(from, end === -1 ? undefined : end));
+}
+
+/** `packages/cezar/web/dist` and `web/dist` are the same published entry, said two ways. */
+function normalizeFile(path: string): string {
+  return path.replace(/^packages\/cezar\//, '').replace(/\/+$/, '');
+}
+
+const packageSurface = section(doc, '## 6. npm package surface');
+
+describe('BACKWARD_COMPATIBILITY.md §6 package surface', () => {
+  it('names exactly the manifest bin entries', () => {
+    expect(new Set(clauseNames(packageSurface, '`bin` entries'))).toEqual(
+      new Set(Object.keys(manifest.bin)),
+    );
+  });
+
+  it('names exactly the manifest files entries', () => {
+    expect(new Set(clauseNames(packageSurface, 'published `files`:').map(normalizeFile))).toEqual(
+      new Set(manifest.files.map(normalizeFile)),
+    );
+  });
+
+  it('names exactly the manifest exports subpaths', () => {
+    // The bullet names both sides of the map (`./app-type` → `./dist/server/app-type.js`); the
+    // targets are what the subpaths resolve TO, not subpaths themselves, so they are folded away
+    // and what remains has to be the keys. Anything else backticked in the bullet — prose, error
+    // codes, file paths — is not `.`-rooted and never enters the comparison.
+    //
+    // `./package.json` maps to itself, so folding targets blindly would fold a real subpath out
+    // of the comparison and let it vanish from the docs unnoticed: only targets that are not
+    // themselves keys count as targets.
+    const subpaths = new Set(Object.keys(manifest.exports));
+    const targets = new Set(Object.values(manifest.exports).filter((to) => !subpaths.has(to)));
+    const bullet = packageSurface
+      .split('\n')
+      .find((line) => line.includes('`exports`') && line.includes('subpaths'));
+    expect(bullet, '§6 no longer has a bullet describing the `exports` subpaths').toBeDefined();
+
+    const named = backticked(bullet!).filter((token) => /^\.(\/\S*)?$/.test(token));
+    expect(new Set(named.filter((token) => !targets.has(token)))).toEqual(subpaths);
+  });
+
+  it('says an exports change is breaking', () => {
+    // The map is the whole reason #851 was reachable; §6 promising to keep it is the point of
+    // documenting it at all, so a rewrite that quietly drops the promise fails here.
+    const breaking = packageSurface.slice(packageSurface.indexOf('\nBreaking:'));
+    expect(breaking).toMatch(/`exports`/);
+  });
+
+  it('reads a non-trivial number of names on both sides — guards against a vacuous pass', () => {
+    // Without this, a parser that silently stopped seeing the enumerations would pass the guards
+    // above by comparing two empty sets, which is the one failure mode a drift guard must not
+    // have. The manifest side is asserted too: a manifest read that returned `{}` would be just
+    // as invisible.
+    expect(clauseNames(packageSurface, '`bin` entries').length).toBeGreaterThan(2);
+    expect(clauseNames(packageSurface, 'published `files`:').length).toBeGreaterThan(3);
+    expect(Object.keys(manifest.bin).length).toBeGreaterThan(2);
+    expect(Object.keys(manifest.exports).length).toBeGreaterThan(2);
+  });
+});
+
+describe('BACKWARD_COMPATIBILITY.md §1 bins', () => {
+  it('names exactly the manifest bin entries', () => {
+    // §1 lists the bins too, from the CLI's side. It drifted the same way §6 did (`cezar-cli`
+    // missing from both), so it gets the same guard — a doc that contradicts itself is worse
+    // than one that is merely stale.
+    const cli = section(doc, '## 1. CLI commands');
+    const bins = cli.split('\n').find((line) => line.startsWith('- **Bins:**'));
+    expect(bins, '§1 no longer has a `- **Bins:**` line').toBeDefined();
+    const named = backticked(bins!.slice(0, bins!.indexOf('(')));
+    expect(new Set(named)).toEqual(new Set(Object.keys(manifest.bin)));
+  });
+});

--- a/packages/cezar/src/bc-package-surface.test.ts
+++ b/packages/cezar/src/bc-package-surface.test.ts
@@ -92,9 +92,12 @@ describe('BACKWARD_COMPATIBILITY.md §6 package surface', () => {
     // themselves keys count as targets.
     const subpaths = new Set(Object.keys(manifest.exports));
     const targets = new Set(Object.values(manifest.exports).filter((to) => !subpaths.has(to)));
+    // Bullets only: the trailing "Breaking:" paragraph names `exports` subpaths too, and a
+    // reworded bullet would otherwise let this latch onto that paragraph and fail with a
+    // comparison nobody can read instead of the "no bullet" message below.
     const bullet = packageSurface
       .split('\n')
-      .find((line) => line.includes('`exports`') && line.includes('subpaths'));
+      .find((line) => line.startsWith('- ') && line.includes('`exports`') && line.includes('subpaths'));
     expect(bullet, '§6 no longer has a bullet describing the `exports` subpaths').toBeDefined();
 
     const named = backticked(bullet!).filter((token) => /^\.(\/\S*)?$/.test(token));
@@ -108,15 +111,20 @@ describe('BACKWARD_COMPATIBILITY.md §6 package surface', () => {
     expect(breaking).toMatch(/`exports`/);
   });
 
-  it('reads a non-trivial number of names on both sides — guards against a vacuous pass', () => {
+  it('reads names on both sides — guards against a vacuous pass', () => {
     // Without this, a parser that silently stopped seeing the enumerations would pass the guards
     // above by comparing two empty sets, which is the one failure mode a drift guard must not
-    // have. The manifest side is asserted too: a manifest read that returned `{}` would be just
-    // as invisible.
-    expect(clauseNames(packageSurface, '`bin` entries').length).toBeGreaterThan(2);
-    expect(clauseNames(packageSurface, 'published `files`:').length).toBeGreaterThan(3);
-    expect(Object.keys(manifest.bin).length).toBeGreaterThan(2);
-    expect(Object.keys(manifest.exports).length).toBeGreaterThan(2);
+    // have. The manifest side is asserted too: a read that returned `{}` would be just as
+    // invisible.
+    //
+    // Non-emptiness, deliberately, not a count: dropping a bin or an `exports` subpath is a
+    // legitimate (breaking, deprecation-path) change, and pinning today's number would fail it
+    // here — on an assertion that is not about what the author did — rather than in the
+    // comparisons above, which is where such a change belongs.
+    expect(clauseNames(packageSurface, '`bin` entries').length).toBeGreaterThan(0);
+    expect(clauseNames(packageSurface, 'published `files`:').length).toBeGreaterThan(0);
+    expect(Object.keys(manifest.bin).length).toBeGreaterThan(0);
+    expect(Object.keys(manifest.exports).length).toBeGreaterThan(0);
   });
 });
 
@@ -128,7 +136,11 @@ describe('BACKWARD_COMPATIBILITY.md §1 bins', () => {
     const cli = section(doc, '## 1. CLI commands');
     const bins = cli.split('\n').find((line) => line.startsWith('- **Bins:**'));
     expect(bins, '§1 no longer has a `- **Bins:**` line').toBeDefined();
-    const named = backticked(bins!.slice(0, bins!.indexOf('(')));
+    // Everything before the parenthetical, which backticks `bin` itself and would otherwise
+    // enter the set. Without the -1 guard, a rewrite that drops the parenthetical would make
+    // `slice(0, -1)` eat the closing backtick of the last alias and lose it silently.
+    const aside = bins!.indexOf('(');
+    const named = backticked(aside === -1 ? bins! : bins!.slice(0, aside));
     expect(new Set(named)).toEqual(new Set(Object.keys(manifest.bin)));
   });
 });


### PR DESCRIPTION
Closes #853

## 🎯 Goal
`BACKWARD_COMPATIBILITY.md` §6 should describe the npm package surface that ships, so the next manifest change cannot quietly introduce an undocumented compatibility surface the way the `exports` map did.

## 🔍 Problem
§6 declared the published surface protected and then described a manifest that no longer exists. It stated the package has **no** `exports`/library API while `packages/cezar/package.json` declares three subpaths; it listed `packages/web/public/open-mercato.svg` among the published `files`, which the manifest does not publish; and it named only `cezar` + `cez` as bins while the manifest has `cezar-cli` too — the same omission §1 carried. The document contradicted the manifest in three places at once.

## 🔍 Root Cause
The package split (`b47d507b`, #695) introduced all three drifts in one commit. It added the `exports` map — `@open-mercato/api-client` and the cockpit need `./app-type` to type their client off the server's route table — and dropped `web/open-mercato.svg` from `files`, but in the document it only rewrote the path prefixes (`web/dist` → `packages/cezar/web/dist`, `web/open-mercato.svg` → `packages/web/public/open-mercato.svg`) instead of re-reading the manifest. The "no `exports`" sentence was left standing by the very commit that added one. `cezar-cli` had been in `bin` since `0bf2281a` and was never written down.

This is why it mattered: the undocumented `exports` map silently governed resolution. Once a package declares one, Node serves only the listed subpaths and hard-blocks the rest, so the alias's `import('@open-mercato/cezar/dist/index.js')` died with `ERR_PACKAGE_PATH_NOT_EXPORTED` at every user (#851, fixed in #852) — an undocumented surface breaking a documented one.

## What Changed
- `BACKWARD_COMPATIBILITY.md` §6 — the "no `exports`" sentence is replaced by two bullets. The first names the three subpaths (`.`, `./app-type`, `./package.json`), records the decision to **keep** `./app-type` and why the package is still not a runtime library (it is type-only by construction — `import type` erases at build, which is what lets a browser bundle consume it without dragging `node:*` in), and states that the map is load-bearing regardless because it is what keeps the deep-path surface closed. The second records that first-party consumers import the bare specifier and never a deep path, citing #851 as the precedent and pointing at the `alias-bin-exports.test.ts` guard from #852. The `files` list now reads the manifest's own `dist`, `web/dist`, `scripts`, `README.md` with a note that manifest paths are package-relative, the `bin` list gains `cezar-cli`, the heading points at `packages/cezar/package.json`, and the Breaking line covers adding or removing an `exports` subpath.
- `BACKWARD_COMPATIBILITY.md` §1 — the `Bins:` line carried the same untruth about `cezar-cli`; a document that contradicts itself is worse than one that is merely stale.
- `packages/cezar/src/bc-package-surface.test.ts` (new) — the drift guard, in the idiom of the existing §2 route-inventory guard (`src/server/bc-route-inventory.test.ts`). It parses §6's and §1's backticked enumerations and compares them against the manifest, asserts §6 still promises that an `exports` change is breaking, and carries a vacuity guard so a parser that silently stopped seeing the enumerations cannot pass by comparing empty sets. It is deliberately loose about prose and strict about lists, so the section can be rewritten freely as long as the names it names stay true.

## 🧪 Tests
- `npx vitest run packages/cezar/src/bc-package-surface.test.ts` — 6 passed. Against the pre-fix document all 6 fail, each drift caught separately: the missing `cezar-cli` bin (§6 and §1), the stale `files` entry, the absent `exports` bullet, and the Breaking line that did not mention `exports`.
- `npm run typecheck` ✅ · `npm run test:unit` — 35 passed / 1 skipped ✅ · `npm run build` ✅ (`check:pack ok — 478 files, 88 under web/dist`) · `npm run test:package` — 13 passed ✅.
- `npm test` is red **locally** on this machine and is not a regression from this PR: two identical runs produced different failure sets (36 then 20 files), every failure is `Test timed out` (47×) or `ENOENT` under the OS temp dir in tests that spawn processes and git worktrees, and re-running those same 20 files serially (`--no-file-parallelism`) gives 354/354 passing. None of them touch the changed files. Deferring to CI for the authoritative verdict.

## 💥 Breaking Changes
- None. Documentation plus one new test; no production code changes behavior. The document now *describes* the `exports` map as a protected surface, which constrains future changes rather than making one.
