### PR TITLE
test(e2e): browser-level spec for foldable Tasks-table columns

### DIFF
--- a/.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md
+++ b/.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md
@@ -1,0 +1,87 @@
+# Browser-level e2e spec for the foldable Tasks-table columns
+
+**Issue:** #822 — Add a browser-level e2e spec for foldable Tasks-table columns
+**Origin:** #743 (`feat(ui): add foldable task table columns`), merged 2026-08-10
+**Engine:** om-auto-create-pr (steps: 7, --loop: no)
+
+## Goal
+
+Close the browser-level coverage gap #743 left behind: the fold flow is exercised only in jsdom,
+so nothing proves that a folded column is actually *narrower* in a real layout engine, that the
+choice survives a reload, or that writing it preserves unrelated `ui-state.json` siblings.
+
+## Scope
+
+In scope — scenario points 1–5 and 7 from the issue:
+
+- default fold state at a desktop viewport (Branch folded, every other foldable column expanded,
+  no toggle inside the non-foldable Status and Task headers),
+- folding Workflow: `data-folded`, `aria-pressed`, and a **measured** width shrink,
+- persistence across a reload, verified against `$CEZ_HOME/ui-state.json`,
+- sibling preservation — an unrelated `appearance.accent` written first must survive a column toggle,
+- the sub-`md` card list rendering the same fields regardless of the desktop fold choices.
+
+**Non-goals:**
+
+- **Scenario point 6** (a queued run present while CPU and Mem are folded, asserting the two stay
+  narrow) is deliberately excluded. It pins the defect in #821, which is being fixed in parallel on
+  PR #861, so the assertion belongs with that fix rather than racing it here. Acceptance on #822 is
+  therefore partial on that one point, and it is called out on the PR.
+- No production code changes. This run adds a spec; if it found a product bug it would be filed,
+  not fixed here.
+- No new runner and no new CI wiring — the spec must be picked up by the existing
+  `npm run test:e2e` glob.
+
+## Approach
+
+The spec boots **its own** cezar over a throwaway `dataRoot` with a pinned fixture `runs.json`,
+following `quick-list.e2e.ts`, rather than attaching to the shared test env. Two reasons, both
+load-bearing:
+
+1. The run store reads `.ai/cezar/runs.json` **once, at startup** (`RunStore.open`), so a task rich
+   enough to render every column — branch, diff stat, reference, directional usage, cost — can only
+   be seeded *before* boot.
+2. Points 4 and 5 read and mutate `ui-state.json`. `fixtureServeEnv()` pins `CEZ_HOME` inside the
+   throwaway `dataRoot`, which is a stronger form of the issue's "isolated `CEZ_HOME`" than the
+   shared `.ai/qa/cez-home` — this spec cannot collide with `settings-appearance.e2e.ts`, which
+   save/restores that same file, and cleans itself up with the `dataRoot` it already removes.
+
+`.ai/scripts/e2e.sh` still boots the shared env for the suite; this spec simply owns its own data,
+exactly as `quick-list.e2e.ts` and `queued-stack.e2e.ts` already do.
+
+## Risks
+
+- **Measured width is the whole point and the most fragile assertion.** Under `table-layout: auto`
+  the `colgroup` width is a hint, so the spec compares `getBoundingClientRect().width` before and
+  after the fold and asserts a real shrink, with a margin rather than an exact pixel count.
+- **The write behind a toggle is fire-and-forget.** Assertions poll the API / the file until the
+  write lands, per `waitForServerAppearance` in `settings-appearance.e2e.ts`, instead of assuming
+  the click beat the assertion.
+- **Capability-gated columns.** Tokens and Cost only render when the health response allows them,
+  so the default-state assertion enumerates the foldable headers actually present rather than
+  hard-coding all nine.
+- The agent-browser provider may be unprovisionable on a given machine; `e2e.sh` then reports
+  `TEST_E2E_STATUS=skipped`, which this run reports as *not verified* rather than as a pass.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fixture and harness
+
+- [ ] 1.1 Add the spec file with its fixture-server boot: throwaway `dataRoot`, pinned `runs.json`
+      seeded with a task carrying a branch, a diff stat, a reference and usage numbers, isolated
+      `CEZ_HOME`, desktop viewport, and teardown that removes everything it created.
+
+### Phase 2: Assertions
+
+- [ ] 2.1 Default fold state and header affordances (issue point 2).
+- [ ] 2.2 Folding Workflow: attribute, `aria-pressed`, and measured width shrink (issue point 3).
+- [ ] 2.3 Persistence across a reload, verified in `ui-state.json` (issue point 4).
+- [ ] 2.4 Sibling preservation against an unrelated `appearance.accent` (issue point 5).
+- [ ] 2.5 The sub-`md` card list is unaffected by the desktop fold choices (issue point 7).
+
+### Phase 3: Verification
+
+- [ ] 3.1 Run `npm run test:e2e` and the full configured validation gate; report honestly when the
+      browser provider cannot be provisioned.

--- a/.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md
+++ b/.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md
@@ -69,17 +69,17 @@ exactly as `quick-list.e2e.ts` and `queued-stack.e2e.ts` already do.
 
 ### Phase 1: Fixture and harness
 
-- [ ] 1.1 Add the spec file with its fixture-server boot: throwaway `dataRoot`, pinned `runs.json`
+- [x] 1.1 Add the spec file with its fixture-server boot: throwaway `dataRoot`, pinned `runs.json`
       seeded with a task carrying a branch, a diff stat, a reference and usage numbers, isolated
-      `CEZ_HOME`, desktop viewport, and teardown that removes everything it created.
+      `CEZ_HOME`, desktop viewport, and teardown that removes everything it created. — 8e6e0677
 
 ### Phase 2: Assertions
 
-- [ ] 2.1 Default fold state and header affordances (issue point 2).
-- [ ] 2.2 Folding Workflow: attribute, `aria-pressed`, and measured width shrink (issue point 3).
-- [ ] 2.3 Persistence across a reload, verified in `ui-state.json` (issue point 4).
-- [ ] 2.4 Sibling preservation against an unrelated `appearance.accent` (issue point 5).
-- [ ] 2.5 The sub-`md` card list is unaffected by the desktop fold choices (issue point 7).
+- [x] 2.1 Default fold state and header affordances (issue point 2). — 8e6e0677
+- [x] 2.2 Folding Workflow: attribute, `aria-pressed`, and measured width shrink (issue point 3). — 8e6e0677
+- [x] 2.3 Persistence across a reload, verified in `ui-state.json` (issue point 4). — 8e6e0677
+- [x] 2.4 Sibling preservation against an unrelated `appearance.accent` (issue point 5). — 41170543
+- [x] 2.5 The sub-`md` card list is unaffected by the desktop fold choices (issue point 7). — 41170543
 
 ### Phase 3: Verification
 

--- a/.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md
+++ b/.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md
@@ -83,5 +83,27 @@ exactly as `quick-list.e2e.ts` and `queued-stack.e2e.ts` already do.
 
 ### Phase 3: Verification
 
-- [ ] 3.1 Run `npm run test:e2e` and the full configured validation gate; report honestly when the
-      browser provider cannot be provisioned.
+- [x] 3.1 Run `npm run test:e2e` and the full configured validation gate; report honestly when the
+      browser provider cannot be provisioned. — 2b510cd4
+
+## Verification
+
+- **The new spec:** 5/5 green, run three times in a row (13.6s / 20.9s / 18.0s) after the two
+  flakes below were fixed. It also passes inside the full suite.
+- **Mutation-checked.** Dropping the folded `42px` from the `colgroup` (and rebuilding — the
+  fixture server serves built assets, so a source-only edit proves nothing) turns the width
+  assertion red: the shrink falls to 15.42px against a `> 20` floor. The spec really does guard
+  the behavior it claims to.
+- **Two flakes found and fixed, both in the spec, neither in the app.** (1) A direct API write
+  landed on a keep-alive socket the server had already closed — `ECONNRESET` — so the spec passed
+  only when the whole run finished inside the ~5s keep-alive window; the first green run was 6.5s
+  and hid it. (2) The card-parity test inherited the fold state earlier tests happened to leave,
+  and a toggle clicked into the state it already held flipped it the wrong way and hung for the
+  full 25s provider timeout.
+- **Validation gate:** `npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`,
+  `npm run test:package` — all green.
+- **Full `npm run test:e2e` is red on this machine, and was already red without this change.**
+  With the new spec: 11 failed files / 30 failed tests. Baseline, same machine, same session, the
+  new spec temporarily moved out of the glob: 11 failed files / 31 failed tests. The failing set
+  is pre-existing and itself unstable between runs (`workflows.e2e.ts` and
+  `settings-monitoring.e2e.ts` swap places), and `task-columns.e2e.ts` is in neither list.

--- a/packages/web/e2e/task-columns.e2e.ts
+++ b/packages/web/e2e/task-columns.e2e.ts
@@ -1,0 +1,316 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
+
+/**
+ * The desktop Tasks table's foldable columns (#743), in a real browser (#822).
+ *
+ * What this proves that `task-columns.test.ts` and `use-task-table-columns.test.tsx` cannot: a
+ * folded column is really NARROWER. Those suites run in jsdom, which does no layout at all — every
+ * `getBoundingClientRect()` there is zero — so the only thing they can assert is that the
+ * `data-folded` attribute and the `colgroup` width prop changed. Under `table-layout: auto` that
+ * width is a *hint*: the browser is free to ignore it, and a fold that renders the attribute while
+ * the column stays wide would pass every existing test. Measured width is the assertion that
+ * closes that gap, and it needs a layout engine.
+ *
+ * Why this boots its OWN server instead of attaching to the shared test env, which is what the
+ * issue's step 1 literally asks for — two reasons, both load-bearing:
+ *
+ *   1. The run store reads `.ai/cezar/runs.json` ONCE, at startup (`RunStore.open`), so the task
+ *      rich enough to render every column (branch, diff stat, reference, directional usage, cost)
+ *      can only be seeded BEFORE boot. Writing it under the running shared instance would change
+ *      nothing — the same reason `quick-list.e2e.ts` boots its own.
+ *   2. This suite READS AND MUTATES `ui-state.json`. `fixtureServeEnv` pins `CEZ_HOME` inside the
+ *      throwaway `dataRoot`, which is a stronger form of the issue's "isolated CEZ_HOME" than the
+ *      shared `.ai/qa/cez-home`: it cannot collide with `settings-appearance.e2e.ts`, which
+ *      save/restores that very file, and it is removed with the `dataRoot` in `afterAll`.
+ *
+ * NOT covered here, deliberately: the issue's scenario point 6 (a queued run present while CPU and
+ * Mem are folded). That case pins the defect in #821, fixed in parallel on #861, so the assertion
+ * belongs with that fix rather than racing it.
+ */
+
+const artifactsDir = resolve(import.meta.dirname, '../../../.ai/qa/artifacts_e2e')
+const sessionId = `e2e-task-columns-${process.pid}`
+
+const DESKTOP = { width: 1440, height: 900 }
+/** Below the `md` breakpoint the table gives way to the card list. */
+const MOBILE = { width: 390, height: 844 }
+
+const now = Date.now()
+const ago = (ms: number) => new Date(now - ms).toISOString()
+
+/**
+ * A `RunRecord[]` — cezar's on-disk run index. One run, deliberately carrying something for EVERY
+ * foldable column: without a value the cell renders an em dash, and a table of dashes would let a
+ * fold that broke real content still pass.
+ */
+const FIXTURE = [
+  {
+    id: 'fold-columns-rich',
+    title: 'add a structured changes endpoint plz',
+    titleSummary: 'Structured changes endpoint for the git view',
+    workflow: 'default',
+    task: 'add a structured changes endpoint',
+    status: 'review',
+    createdAt: ago(40 * 60_000),
+    startedAt: ago(39 * 60_000),
+    finishedAt: ago(26 * 60_000),
+    branch: 'cez/fold-columns-fixture',
+    diffStat: { adds: 128, dels: 14, files: 6 },
+    pullRequestUrl: 'https://github.com/open-mercato/cezar/pull/743',
+    tokensUsed: 128_400,
+    inputTokens: 96_000,
+    outputTokens: 32_400,
+    costUsd: 1.23,
+    archived: false,
+    steps: [],
+  },
+]
+
+function freePort(): Promise<number> {
+  return new Promise((done, fail) => {
+    const probe = createServer()
+    probe.once('error', fail)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      probe.close(() => done(port))
+    })
+  })
+}
+
+async function waitForHealth(url: string): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      if ((await fetch(`${url}/api/v1/health`)).ok) return
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`cezar e2e: the task-columns fixture server never answered at ${url}`)
+}
+
+let browser: AgentBrowser
+let server: ChildProcess
+let dataRoot: string
+let cezHome: string
+let uiStateFile: string
+let baseUrl: string
+let bootProject: string
+
+const TABLE = '[data-slot="tasks-table"]'
+const th = (id: string) => `${TABLE} thead th[data-column-id="${id}"]`
+
+type UiState = {
+  appearance?: Record<string, unknown>
+  taskTable?: { expandedColumns?: Record<string, boolean> }
+} & Record<string, unknown>
+
+function readUiState(): UiState | null {
+  if (!existsSync(uiStateFile)) return null
+  try {
+    return JSON.parse(readFileSync(uiStateFile, 'utf8')) as UiState
+  } catch {
+    // A half-written file is a race, not a verdict — the caller polls.
+    return null
+  }
+}
+
+/** The write behind a toggle is fire-and-forget from the UI's point of view (a keepalive PUT), so
+ *  poll the file until it lands rather than assume the click beat the assertion. */
+async function waitForUiState(check: (state: UiState) => boolean, what: string): Promise<UiState> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const state = readUiState()
+    if (state && check(state)) return state
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`cezar e2e: ${uiStateFile} never showed ${what}`)
+}
+
+/** Open the Tasks overview and wait until the table is both rendered and interactive.
+ *
+ *  The `disabled` wait is not ceremony: the header toggles are disabled while the workspace
+ *  ui-state query is still pending, precisely so a click cannot write a `taskTable` that has not
+ *  yet learned its siblings. Clicking inside that window would test nothing and fail flakily. */
+function openTasks(): void {
+  browser.goto(`${baseUrl}/p/${bootProject}/`)
+  browser.waitForFunction(`document.querySelector('${TABLE} thead th[data-column-id="workflow"] button') !== null`)
+  browser.waitForFunction(`!document.querySelector('${TABLE} thead th[data-column-id="workflow"] button').disabled`)
+}
+
+/** The header's MEASURED width — the whole reason this spec needs a browser. */
+function headerWidth(id: string): number {
+  return Number(browser.evaluate(`document.querySelector('${th(id)}').getBoundingClientRect().width`))
+}
+
+/** Ids of the foldable headers currently rendered. Enumerated rather than hard-coded because the
+ *  Tokens and Cost columns are capability-gated by the health response. */
+function foldableHeaderIds(): string[] {
+  return browser.evaluate(
+    `[...document.querySelectorAll('${TABLE} thead th')].filter((el) => el.querySelector('button')).map((el) => el.dataset.columnId)`,
+  ) as string[]
+}
+
+function foldedHeaderIds(): string[] {
+  return browser.evaluate(
+    `[...document.querySelectorAll('${TABLE} thead th[data-folded="true"]')].map((el) => el.dataset.columnId)`,
+  ) as string[]
+}
+
+/** `textContent`, not the provider's `get text`: the latter returns *rendered* text, so the card's
+ *  flex meta row comes back newline-separated and the comparison would be about whitespace. */
+function cardText(): string {
+  return String(
+    browser.evaluate(`document.querySelector('[data-slot="task-card"]').textContent`),
+  ).replace(/\s+/g, ' ').trim()
+}
+
+beforeAll(async () => {
+  dataRoot = mkdtempSync(join(tmpdir(), 'cezar-e2e-task-columns-'))
+  mkdirSync(join(dataRoot, '.ai/cezar'), { recursive: true })
+  writeFileSync(join(dataRoot, '.ai/cezar/runs.json'), JSON.stringify(FIXTURE, null, 2), 'utf8')
+
+  // Mirrors `fixtureServeEnv`, which pins CEZ_HOME here — change one, change the other.
+  cezHome = resolve(dataRoot, '.cez-home')
+  uiStateFile = join(cezHome, 'ui-state.json')
+
+  const port = await freePort()
+  baseUrl = `http://localhost:${port}`
+  server = spawn(
+    process.execPath,
+    [cezarCli, 'serve', '--repo', dataRoot, '--port', String(port), '--no-open'],
+    { env: fixtureServeEnv(dataRoot), stdio: 'ignore' },
+  )
+  await waitForHealth(baseUrl)
+  bootProject = await bootProjectId(baseUrl)
+
+  browser = AgentBrowser.open(sessionId)
+  browser.setViewport(DESKTOP.width, DESKTOP.height)
+}, 90_000)
+
+afterAll(() => {
+  browser?.close()
+  server?.kill()
+  // The whole workspace home lived inside dataRoot, so this is the ui-state cleanup too.
+  if (dataRoot) rmSync(dataRoot, { recursive: true, force: true })
+})
+
+describe('foldable Tasks-table columns against a live cezar (#822)', () => {
+  it('ships with Branch folded, every other foldable column expanded, and no toggle in Status or Task', () => {
+    openTasks()
+
+    // The registry's one `defaultExpanded: false`, and nothing else.
+    expect(browser.count(`${th('branch')}[data-folded="true"]`)).toBe(1)
+    expect(foldedHeaderIds()).toEqual(['branch'])
+
+    // Status and Task are structurally immutable — not merely defaulted to expanded. A user who
+    // hand-edits `false` into either id must still get a header with nothing to press.
+    expect(foldableHeaderIds()).not.toContain('status')
+    expect(foldableHeaderIds()).not.toContain('task')
+    expect(browser.count(`${th('status')} button`)).toBe(0)
+    expect(browser.count(`${th('task')} button`)).toBe(0)
+    // …and the ones that ARE foldable really do offer the affordance.
+    expect(foldableHeaderIds()).toContain('workflow')
+    expect(foldableHeaderIds()).toContain('branch')
+
+    browser.screenshot(`${artifactsDir}/task-columns-defaults.png`)
+  })
+
+  it('folding Workflow measurably shrinks the column, not just its attribute', () => {
+    const expandedWidth = headerWidth('workflow')
+
+    browser.click(`${th('workflow')} button`)
+    browser.waitForFunction(`document.querySelector('${th('workflow')}[data-folded="true"]') !== null`)
+
+    expect(browser.count(`${th('workflow')} button[aria-pressed="false"]`)).toBe(1)
+
+    // The claim the jsdom suites cannot make. The registry asks for 124px expanded and 42px
+    // folded; assert a real, substantial shrink rather than an exact pixel count, which auto
+    // table layout is entitled to adjust.
+    const foldedWidth = headerWidth('workflow')
+    expect(foldedWidth).toBeLessThan(expandedWidth)
+    expect(expandedWidth - foldedWidth).toBeGreaterThan(20)
+
+    browser.screenshot(`${artifactsDir}/task-columns-workflow-folded.png`)
+  })
+
+  it('persists the fold across a reload, and writes it into ui-state.json', async () => {
+    const state = await waitForUiState(
+      (s) => s.taskTable?.expandedColumns?.workflow === false,
+      'taskTable.expandedColumns.workflow === false',
+    )
+    expect(state.taskTable?.expandedColumns?.workflow).toBe(false)
+
+    // A cold load: the choice has to come back from the server, not from a live query cache.
+    openTasks()
+    expect(browser.count(`${th('workflow')}[data-folded="true"]`)).toBe(1)
+    expect(browser.count(`${th('workflow')} button[aria-pressed="false"]`)).toBe(1)
+    expect(foldedHeaderIds().sort()).toEqual(['branch', 'workflow'])
+  })
+
+  it('preserves an unrelated ui-state sibling when a column is toggled', async () => {
+    // Write a preference this feature knows nothing about, through the same endpoint the app uses.
+    const response = await fetch(`${baseUrl}/api/v1/workspace/ui-state`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ appearance: { accent: 'violet' } }),
+    })
+    expect(response.ok).toBe(true)
+    await waitForUiState((s) => s.appearance?.accent === 'violet', 'appearance.accent === violet')
+
+    // Reload so the client's cache holds the authoritative state including that sibling — the
+    // controller composes its write from that cache, which is exactly where the regression lived.
+    openTasks()
+    browser.waitForFunction(`document.documentElement.dataset.accent === 'violet'`)
+
+    browser.click(`${th('reference')} button`)
+    browser.waitForFunction(`document.querySelector('${th('reference')}[data-folded="true"]') !== null`)
+
+    const after = await waitForUiState(
+      (s) => s.taskTable?.expandedColumns?.reference === false,
+      'taskTable.expandedColumns.reference === false',
+    )
+    // Both keys coexist: the new choice landed AND the stranger survived. An earlier review pass
+    // caught a shallow write that dropped it, which is why this is pinned at the browser level.
+    expect(after.appearance?.accent).toBe('violet')
+    expect(after.taskTable?.expandedColumns?.reference).toBe(false)
+    expect(after.taskTable?.expandedColumns?.workflow).toBe(false)
+  })
+
+  it('renders the same card fields below md whatever the desktop fold choices are', () => {
+    // Workflow, Branch and Reference are all folded on the desktop at this point.
+    browser.setViewport(MOBILE.width, MOBILE.height)
+    browser.goto(`${baseUrl}/p/${bootProject}/`)
+    browser.waitForFunction(`document.querySelector('[data-slot="task-card"]') !== null`)
+
+    const withFolds = cardText()
+    // The card is the mobile presentation — the table is in the DOM but laid out away.
+    expect(browser.count('[data-slot="task-card"]')).toBe(1)
+    expect(browser.evaluate(`getComputedStyle(document.querySelector('${TABLE}')).display`)).toBe('none')
+    // Folding is a DESKTOP density choice; the card must still carry the run's real fields.
+    expect(withFolds).toContain('cez/fold-columns-fixture')
+    expect(withFolds).toContain('128')
+    browser.screenshot(`${artifactsDir}/task-columns-mobile-cards.png`)
+
+    // Expand everything on the desktop, then come back: the card must not have moved.
+    browser.setViewport(DESKTOP.width, DESKTOP.height)
+    openTasks()
+    for (const id of ['workflow', 'reference', 'branch']) {
+      browser.click(`${th(id)} button`)
+      browser.waitForFunction(`document.querySelector('${th(id)}[data-folded="true"]') === null`)
+    }
+    expect(foldedHeaderIds()).toEqual([])
+
+    browser.setViewport(MOBILE.width, MOBILE.height)
+    browser.goto(`${baseUrl}/p/${bootProject}/`)
+    browser.waitForFunction(`document.querySelector('[data-slot="task-card"]') !== null`)
+    expect(cardText()).toBe(withFolds)
+  })
+})

--- a/packages/web/e2e/task-columns.e2e.ts
+++ b/packages/web/e2e/task-columns.e2e.ts
@@ -134,6 +134,36 @@ async function waitForUiState(check: (state: UiState) => boolean, what: string):
   throw new Error(`cezar e2e: ${uiStateFile} never showed ${what}`)
 }
 
+/**
+ * A direct API write, retried past a reset keep-alive socket.
+ *
+ * Not defensive padding — this suite reliably hits it. Node's `fetch` pools connections and will
+ * not retry a request it lost mid-flight, while the server is free to close an idle keep-alive
+ * socket after a few seconds. Whole tests here go by driving only the BROWSER, so Node's pooled
+ * socket sits untouched the entire time and the next direct call lands on a half-closed one:
+ * `ECONNRESET`, which says nothing about the app. `getRun` in `queued-stack.e2e.ts` retries for
+ * the same reason. Without this the spec passes only when the run finishes inside the keep-alive
+ * window — which is exactly the sort of green that turns red in CI.
+ */
+async function putUiState(patch: Record<string, unknown>): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const response = await fetch(`${baseUrl}/api/v1/workspace/ui-state`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(patch),
+      })
+      if (!response.ok) throw new Error(`PUT /workspace/ui-state answered ${response.status}`)
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise((r) => setTimeout(r, 200))
+    }
+  }
+  throw lastError
+}
+
 /** Open the Tasks overview and wait until the table is both rendered and interactive.
  *
  *  The `disabled` wait is not ceremony: the header toggles are disabled while the workspace
@@ -162,6 +192,22 @@ function foldedHeaderIds(): string[] {
   return browser.evaluate(
     `[...document.querySelectorAll('${TABLE} thead th[data-folded="true"]')].map((el) => el.dataset.columnId)`,
   ) as string[]
+}
+
+/** Drive the named columns to `folded`, clicking only the ones that are not there already.
+ *
+ *  Idempotent on purpose: a toggle blindly clicked into the state it already holds flips it the
+ *  WRONG way, and the wait that follows then hangs for the full provider timeout — a 25-second
+ *  failure that reads like a product hang and is really just an assumption about test order. */
+function setFolded(ids: readonly string[], folded: boolean): void {
+  for (const id of ids) {
+    const isFolded = browser.count(`${th(id)}[data-folded="true"]`) === 1
+    if (isFolded === folded) continue
+    browser.click(`${th(id)} button`)
+    browser.waitForFunction(
+      `document.querySelector('${th(id)}[data-folded="true"]') ${folded ? '!==' : '==='} null`,
+    )
+  }
 }
 
 /** `textContent`, not the provider's `get text`: the latter returns *rendered* text, so the card's
@@ -257,12 +303,7 @@ describe('foldable Tasks-table columns against a live cezar (#822)', () => {
 
   it('preserves an unrelated ui-state sibling when a column is toggled', async () => {
     // Write a preference this feature knows nothing about, through the same endpoint the app uses.
-    const response = await fetch(`${baseUrl}/api/v1/workspace/ui-state`, {
-      method: 'PUT',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ appearance: { accent: 'violet' } }),
-    })
-    expect(response.ok).toBe(true)
+    await putUiState({ appearance: { accent: 'violet' } })
     await waitForUiState((s) => s.appearance?.accent === 'violet', 'appearance.accent === violet')
 
     // Reload so the client's cache holds the authoritative state including that sibling — the
@@ -285,7 +326,12 @@ describe('foldable Tasks-table columns against a live cezar (#822)', () => {
   })
 
   it('renders the same card fields below md whatever the desktop fold choices are', () => {
-    // Workflow, Branch and Reference are all folded on the desktop at this point.
+    // Establish the folded desktop state explicitly rather than inheriting whatever the earlier
+    // tests left — this assertion is about the card, so it must not also be a test of test order.
+    const foldable = ['workflow', 'branch', 'reference'] as const
+    openTasks()
+    setFolded(foldable, true)
+
     browser.setViewport(MOBILE.width, MOBILE.height)
     browser.goto(`${baseUrl}/p/${bootProject}/`)
     browser.waitForFunction(`document.querySelector('[data-slot="task-card"]') !== null`)
@@ -302,10 +348,7 @@ describe('foldable Tasks-table columns against a live cezar (#822)', () => {
     // Expand everything on the desktop, then come back: the card must not have moved.
     browser.setViewport(DESKTOP.width, DESKTOP.height)
     openTasks()
-    for (const id of ['workflow', 'reference', 'branch']) {
-      browser.click(`${th(id)} button`)
-      browser.waitForFunction(`document.querySelector('${th(id)}[data-folded="true"]') === null`)
-    }
+    setFolded(foldable, false)
     expect(foldedHeaderIds()).toEqual([])
 
     browser.setViewport(MOBILE.width, MOBILE.height)

--- a/packages/web/e2e/task-columns.e2e.ts
+++ b/packages/web/e2e/task-columns.e2e.ts
@@ -270,6 +270,10 @@ describe('foldable Tasks-table columns against a live cezar (#822)', () => {
   })
 
   it('folding Workflow measurably shrinks the column, not just its attribute', () => {
+    // State the precondition instead of assuming it. A toggle clicked from the wrong state folds
+    // the other way and the wait below then burns the full 25s provider timeout — this turns that
+    // into an instant, legible failure that names the actual problem.
+    expect(browser.count(`${th('workflow')}[data-folded="true"]`)).toBe(0)
     const expandedWidth = headerWidth('workflow')
 
     browser.click(`${th('workflow')} button`)
@@ -311,6 +315,9 @@ describe('foldable Tasks-table columns against a live cezar (#822)', () => {
     openTasks()
     browser.waitForFunction(`document.documentElement.dataset.accent === 'violet'`)
 
+    // Same precondition discipline as the fold test: this click must be a fold, not a coin flip on
+    // whatever the earlier tests left behind.
+    expect(browser.count(`${th('reference')}[data-folded="true"]`)).toBe(0)
     browser.click(`${th('reference')} button`)
     browser.waitForFunction(`document.querySelector('${th('reference')}[data-folded="true"]') !== null`)
 


### PR DESCRIPTION
## Summary

Adds the browser-level e2e spec that PR #743 left as follow-up work. The foldable Tasks-table
columns are currently exercised only in jsdom — which does no layout at all — so nothing proved
that a folded column is actually *narrower*, that the choice survives a reload, or that persisting
it preserves unrelated `ui-state.json` siblings.

Closes #822

## What it covers

`packages/web/e2e/task-columns.e2e.ts`, five tests, mapping to the issue's scenario:

| Issue point | Assertion |
|---|---|
| 2 | Shipped defaults: `th[data-column-id="branch"][data-folded="true"]`, no other foldable header folded, and no `button` inside the Status and Task headers |
| 3 | Folding Workflow sets `data-folded` / `aria-pressed="false"` **and measurably shrinks the column** (`getBoundingClientRect().width`) |
| 4 | The fold survives a reload, and `$CEZ_HOME/ui-state.json` really holds `taskTable.expandedColumns.workflow === false` |
| 5 | An unrelated `appearance.accent` written first still coexists with the column state after a toggle — the sibling-preservation regression an earlier review pass caught as a blocker |
| 7 | Below `md` the card list renders the same fields whatever the desktop fold choices are |

The spec boots its own cezar over a throwaway `dataRoot` with a pinned fixture `runs.json`, the way
`quick-list.e2e.ts` does. Two reasons: the run store reads `runs.json` **once, at startup**, so a
task rich enough to render every column can only be seeded before boot; and `fixtureServeEnv` pins
`CEZ_HOME` inside that `dataRoot`, which is a stronger isolation than the shared `.ai/qa/cez-home`
— this suite mutates `ui-state.json`, and `settings-appearance.e2e.ts` save/restores that same
file. It runs under the existing `npm run test:e2e` glob; no new runner, no new CI wiring.

## Scope — point 6 is deliberately excluded

Scenario point 6 (a queued run present while CPU and Mem are both folded, asserting the two columns
stay narrow) is **not** in this PR. It pins the defect tracked in #821, which is being fixed in
parallel on #861, so that assertion belongs with that fix rather than racing it here. **Acceptance
on #822 is therefore partial on that one point**; the three acceptance criteria are otherwise met.

## Verification

- The new spec: **5/5 green, three consecutive runs** (13.6s / 20.9s / 18.0s), and green inside the
  full suite.
- **Mutation-checked.** Dropping the folded `42px` from the `colgroup` and rebuilding turns the
  width assertion red — the shrink falls to 15.42px against a `> 20` floor. The assertion guards
  what it claims to.
- **Two flakes were found and fixed before this landed, both in the spec, neither in the app.** A
  direct API write was landing on a keep-alive socket the server had already closed (`ECONNRESET`),
  so the spec passed *only* when the whole run finished inside the ~5s keep-alive window — the
  first green run was 6.5s and hid it. And the card-parity test inherited the fold state earlier
  tests happened to leave behind, where a toggle clicked into the state it already held flipped it
  the wrong way and hung for the full 25s provider timeout.
- Validation gate: `typecheck`, `test`, `test:unit`, `build`, `test:package` — all green.
- ⚠️ **`npm run test:e2e` as a whole is red on this machine, and was already red without this
  change.** With the new spec: 11 failed files / 30 failed tests. Baseline in the same session with
  the new spec temporarily moved out of the glob: 11 failed files / 31 failed tests. The failing
  set is pre-existing and unstable between runs (`workflows.e2e.ts` and `settings-monitoring.e2e.ts`
  swap places); `task-columns.e2e.ts` appears in neither list. Flagging it rather than presenting a
  red suite as a pass.

Tracking plan: `.ai/runs/2026-08-11-browser-e2e-foldable-task-columns.md`
