### PR TITLE
fix(runners): escalate to SIGKILL in the OpenCode watchdogs (#858)

### DIFF
--- a/AGENT_PROTOCOL.md
+++ b/AGENT_PROTOCOL.md
@@ -83,6 +83,13 @@ settle such an exit on the normal path — `isSignalTerminationExit(exitCode)`
 (`packages/cezar/src/core/agent-runner.ts`) plus a `note` — instead of throwing. Throwing makes
 a finished run settle as `failed` and a cancelled run settle as `failed` too.
 
+That watchdog MUST gate its SIGKILL escalation on real termination, never on
+`ChildProcess.killed` (#844). Node sets `killed` when a signal is *delivered*,
+so the watchdog's own SIGTERM flips it while the CLI — which handles the signal
+— keeps running, and the escalation written for exactly that case is skipped.
+Use `trackChildExit(child)` (`packages/cezar/src/core/agent-runner.ts`), which
+seeds from `exitCode`/`signalCode` and listens for `exit`.
+
 `SessionOptions`:
 
 - `autoEndAfterFirstTurn?` — single-turn behavior for non-interactive workflow

--- a/AGENT_PROTOCOL.md
+++ b/AGENT_PROTOCOL.md
@@ -85,10 +85,10 @@ a finished run settle as `failed` and a cancelled run settle as `failed` too.
 
 That watchdog MUST gate its SIGKILL escalation on real termination, never on
 `ChildProcess.killed` (#844). Node sets `killed` when a signal is *delivered*,
-so the watchdog's own SIGTERM flips it while the CLI — which handles the signal
-— keeps running, and the escalation written for exactly that case is skipped.
-Use `trackChildExit(child)` (`packages/cezar/src/core/agent-runner.ts`), which
-seeds from `exitCode`/`signalCode` and listens for `exit`.
+so the watchdog's own SIGTERM flips it while the CLI — which handles the
+signal — keeps running, and the escalation written for exactly that case is
+skipped. Use `trackChildExit(child)` (`packages/cezar/src/core/agent-runner.ts`),
+which seeds from `exitCode`/`signalCode` and listens for `exit`.
 
 `SessionOptions`:
 

--- a/packages/cezar/src/core/agent-runner.ts
+++ b/packages/cezar/src/core/agent-runner.ts
@@ -80,6 +80,35 @@ export function isSignalTerminationExit(exitCode: number | null): boolean {
   return exitCode === 130 || exitCode === 137 || exitCode === 143;
 }
 
+/** The slice of `ChildProcess` a termination tracker needs — keeps the helper
+ *  usable from the transport layer and from test fakes alike. */
+export interface TrackableChild {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  once(event: 'exit', listener: () => void): unknown;
+}
+
+/**
+ * Returns a predicate that answers "has this child actually terminated?".
+ *
+ * `ChildProcess.killed` answers a different question — it flips as soon as a
+ * signal is *delivered*, whether or not the child dies from it. Every agent CLI
+ * installs its own SIGTERM handler, so gating a SIGTERM→SIGKILL watchdog on
+ * `!child.killed` disables the escalation for exactly the child it exists for:
+ * `killed` is true, `exitCode` stays null, and the process outlives the whole
+ * grace window (#844, same defect fixed for the discovery probe in #841).
+ *
+ * Seeded from `exitCode`/`signalCode` so a child that died before the watchdog
+ * was armed is recognized without waiting for an event that already fired.
+ */
+export function trackChildExit(child: TrackableChild): () => boolean {
+  let exited = child.exitCode != null || child.signalCode != null;
+  child.once('exit', () => {
+    exited = true;
+  });
+  return () => exited;
+}
+
 /** One content block of a user message — mirrors the Anthropic wire format
  *  so it can be written to the claude CLI's stdin verbatim. */
 export type ContentBlock =

--- a/packages/cezar/src/core/claude-cli-runner.test.ts
+++ b/packages/cezar/src/core/claude-cli-runner.test.ts
@@ -1,12 +1,34 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from './agent-runner.ts';
 import { isSignalTerminationExit, prependSystemPrompt } from './agent-runner.ts';
-import { buildClaudeArgs, ClaudeCliRunner } from './claude-cli-runner.ts';
+import {
+  buildClaudeArgs,
+  ClaudeCliRunner,
+  EOF_KILL_GRACE_MS,
+  EOF_TERM_GRACE_MS,
+  KILL_GRACE_MS,
+} from './claude-cli-runner.ts';
 import type { UiEvent } from './ui-events.ts';
+
+/** Only the escalation tests below swap the child out; every other test in this
+ *  file keeps spawning its real stub binary through the untouched `spawn`. */
+const spawnHook = vi.hoisted(() => ({ override: null as null | (() => unknown) }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnHook.override ? spawnHook.override() : actual.spawn(...args),
+  };
+});
 
 /**
  * The per-backend system-prompt delivery mechanism (spec §protocol v2
@@ -107,6 +129,109 @@ describe('a teardown cezar initiated', () => {
       events.some((e) => e.type === 'note' && e.message.includes('terminated by cezar (code 143)')),
     ).toBe(true);
   }, 15_000);
+});
+
+/**
+ * #844 — the watchdogs used to ask `!child.killed` before escalating, but Node
+ * sets `killed` the moment a signal is *delivered*. claude installs its own
+ * SIGTERM handler, so the flag went true while the process ran on and the
+ * SIGKILL that exists for exactly that case was never sent — one leaked CLI per
+ * teardown. The escalation now follows real termination instead.
+ */
+describe('SIGTERM→SIGKILL escalation for a CLI that survives SIGTERM', () => {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
+    const signals: NodeJS.Signals[] = [];
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      killed: false,
+      pid: 4242,
+      // Node's semantics: delivery flips `killed`; a CLI with its own handler
+      // keeps running with `exitCode` still null.
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal);
+        Object.assign(child, { killed: true });
+        return true;
+      },
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
+  }
+
+  function withFakeChild(run: (fake: ReturnType<typeof signallableChild>) => void): void {
+    const fake = signallableChild();
+    spawnHook.override = () => fake.child;
+    vi.useFakeTimers();
+    try {
+      run(fake);
+    } finally {
+      vi.useRealTimers();
+      spawnHook.override = null;
+    }
+  }
+
+  it('escalates after end() even though Node already flagged the child as killed', () => {
+    withFakeChild((fake) => {
+      const session = new ClaudeCliRunner({ bin: 'claude', timeoutMs: 0 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      session.end();
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      // Delivered, not dead — the state that used to disable the escalation.
+      expect(fake.child.killed).toBe(true);
+      expect(fake.child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('escalates on the wall-clock timeout path as well', () => {
+    withFakeChild((fake) => {
+      const session = new ClaudeCliRunner({ bin: 'claude', timeoutMs: 20 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('stops escalating once the CLI really exits after SIGTERM', () => {
+    withFakeChild((fake) => {
+      const session = new ClaudeCliRunner({ bin: 'claude', timeoutMs: 0 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      session.end();
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      fake.exit(143);
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+    });
+  });
 });
 
 describe('prependSystemPrompt (codex/opencode delivery)', () => {

--- a/packages/cezar/src/core/claude-cli-runner.ts
+++ b/packages/cezar/src/core/claude-cli-runner.ts
@@ -14,7 +14,7 @@ import type {
 
 // Re-exported for backends and the run manager that still import them from here.
 export type { AgentSession, SessionOptions } from './agent-runner.ts';
-import { isSignalTerminationExit } from './agent-runner.ts';
+import { isSignalTerminationExit, trackChildExit } from './agent-runner.ts';
 import { buildChildEnv } from './agent-env.ts';
 import { costWeightedTokens, type RawUsage } from './usage.ts';
 import { readNdjson } from './ndjson.ts';
@@ -156,6 +156,11 @@ export class ClaudeCliRunner implements AgentRunner {
       terminatedByCezar = true;
       child.kill(signal);
     };
+    // Every watchdog below asks "is the child still alive?" — and that question
+    // is NOT `child.killed`, which only reports signal delivery. claude handles
+    // SIGTERM itself, so `killed` is true while the process runs on; escalation
+    // has to follow real termination or it never fires (#844).
+    const hasExited = trackChildExit(child);
 
     const end = (): void => {
       if (!stdinOpen) return;
@@ -166,9 +171,9 @@ export class ClaudeCliRunner implements AgentRunner {
         // already gone
       }
       eofTermTimer = setTimeout(() => {
-        if (child.exitCode == null && !child.killed) signalChild('SIGTERM');
+        if (!hasExited()) signalChild('SIGTERM');
         eofKillTimer = setTimeout(() => {
-          if (child.exitCode == null && !child.killed) signalChild('SIGKILL');
+          if (!hasExited()) signalChild('SIGKILL');
         }, EOF_KILL_GRACE_MS);
         eofKillTimer.unref?.();
       }, EOF_TERM_GRACE_MS);
@@ -177,7 +182,7 @@ export class ClaudeCliRunner implements AgentRunner {
 
     const interrupt = (): void => {
       stdinOpen = false;
-      if (!child.killed) signalChild('SIGTERM');
+      if (!hasExited()) signalChild('SIGTERM');
     };
 
     // Seed the first user message — the same path every follow-up takes.
@@ -209,7 +214,7 @@ export class ClaudeCliRunner implements AgentRunner {
         interrupt();
         child.stdout.destroy();
         killTimer = setTimeout(() => {
-          if (child.exitCode == null && !child.killed) signalChild('SIGKILL');
+          if (!hasExited()) signalChild('SIGKILL');
         }, KILL_GRACE_MS);
         killTimer.unref?.();
       }, limitMs);

--- a/packages/cezar/src/core/codex-app-server-runner.test.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.test.ts
@@ -1,7 +1,24 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { AgentEvent } from './agent-runner.js';
+import { KILL_GRACE_MS } from './claude-cli-runner.js';
 import { CodexAppServerRunner } from './codex-app-server-runner.js';
+
+/** Only the escalation tests below swap the child out; every other test in this
+ *  file keeps spawning the real mock app-server through the untouched `spawn`. */
+const spawnHook = vi.hoisted(() => ({ override: null as null | (() => unknown) }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnHook.override ? spawnHook.override() : actual.spawn(...args),
+  };
+});
 
 /**
  * #703 backend parity — `claude-cli-runner.test.ts` proves the Claude half;
@@ -58,4 +75,104 @@ describe('a teardown cezar initiated (codex app-server)', () => {
     expect(events).toContainEqual({ type: 'error', message: 'model unavailable' });
     expect(events).toContainEqual({ type: 'turn-end' });
   }, 15_000);
+});
+
+/**
+ * #844 — the runner's own SIGTERM sets `ChildProcess.killed`, so a watchdog
+ * gated on `!child.killed` refused to escalate for exactly the app-server it
+ * was written for: one that handles the signal and keeps running. The guard now
+ * tracks real termination, and `terminatedByCezar` (#703) is still set before
+ * every signal so the resulting 137/143 stays a teardown note, not a failure.
+ */
+describe('SIGTERM→SIGKILL escalation for an app-server that survives SIGTERM', () => {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
+    const signals: NodeJS.Signals[] = [];
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      killed: false,
+      pid: 4243,
+      // Node's semantics: delivery flips `killed` whether or not the child dies.
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal);
+        Object.assign(child, { killed: true });
+        return true;
+      },
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
+  }
+
+  function withFakeChild(run: (fake: ReturnType<typeof signallableChild>) => void): void {
+    const fake = signallableChild();
+    spawnHook.override = () => fake.child;
+    vi.useFakeTimers();
+    try {
+      run(fake);
+    } finally {
+      vi.useRealTimers();
+      spawnHook.override = null;
+    }
+  }
+
+  it('escalates on the wall-clock timeout even after Node flagged the child as killed', () => {
+    withFakeChild((fake) => {
+      const session = new CodexAppServerRunner({ bin: 'codex', timeoutMs: 20 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      // Delivered, not dead — the state that used to disable the escalation.
+      expect(fake.child.killed).toBe(true);
+      expect(fake.child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('stops escalating once the app-server really exits after SIGTERM', () => {
+    withFakeChild((fake) => {
+      const session = new CodexAppServerRunner({ bin: 'codex', timeoutMs: 20 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+      fake.exit(143);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+    });
+  });
+
+  it('does not signal a second time once interrupt() saw the child exit', () => {
+    withFakeChild((fake) => {
+      const session = new CodexAppServerRunner({ bin: 'codex', timeoutMs: 0 }).startSession({
+        userPrompt: 'do it',
+        cwd: process.cwd(),
+      });
+      void session.result.catch(() => undefined);
+      fake.exit(0);
+
+      session.interrupt();
+      expect(fake.signals).toEqual([]);
+    });
+  });
 });

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -9,7 +9,7 @@ import type {
   ContentBlock,
   SessionOptions,
 } from './agent-runner.ts';
-import { isSignalTerminationExit, prependSystemPrompt } from './agent-runner.ts';
+import { isSignalTerminationExit, prependSystemPrompt, trackChildExit } from './agent-runner.ts';
 import {
   AUTO_END_DELAY_MS,
   DEFAULT_RUN_TIMEOUT_MS,
@@ -124,6 +124,10 @@ class CodexSession implements AgentSession {
    *  codex handles the signal and exits 143, so without this the runner reads
    *  its own teardown as a codex failure (#703). */
   private terminatedByCezar = false;
+  /** "Has the app-server really terminated?" — the question `child.killed`
+   *  does not answer: it flips on signal delivery, so the SIGTERM this runner
+   *  sends would otherwise veto its own SIGKILL escalation (#844). */
+  private hasExited!: () => boolean;
   /** Protocol v2 emission — additive alongside v1 (`onEvent` keeps flowing
    *  byte-identical); the channel is `opts.onUiEvent` (RunManager wiring
    *  lands in R2 step 2.1). */
@@ -143,6 +147,7 @@ class CodexSession implements AgentSession {
       throw codexSpawnError(err, bin);
     }
 
+    this.hasExited = trackChildExit(this.child);
     this.child.on('error', (err: NodeJS.ErrnoException) => {
       this.spawnFailed = codexSpawnError(err, bin);
     });
@@ -160,7 +165,7 @@ class CodexSession implements AgentSession {
         this.interrupt();
         this.child.stdout.destroy();
         killTimer = setTimeout(() => {
-          if (this.child.exitCode == null && !this.child.killed) {
+          if (!this.hasExited()) {
             this.terminatedByCezar = true;
             this.child.kill('SIGKILL');
           }
@@ -325,7 +330,7 @@ class CodexSession implements AgentSession {
         () => undefined,
       );
     }
-    if (!this.child.killed) {
+    if (!this.hasExited()) {
       this.terminatedByCezar = true;
       this.child.kill('SIGTERM');
     }

--- a/packages/cezar/src/core/codex-app-server-runner.ts
+++ b/packages/cezar/src/core/codex-app-server-runner.ts
@@ -127,7 +127,7 @@ class CodexSession implements AgentSession {
   /** "Has the app-server really terminated?" — the question `child.killed`
    *  does not answer: it flips on signal delivery, so the SIGTERM this runner
    *  sends would otherwise veto its own SIGKILL escalation (#844). */
-  private hasExited!: () => boolean;
+  private readonly hasExited: () => boolean;
   /** Protocol v2 emission — additive alongside v1 (`onEvent` keeps flowing
    *  byte-identical); the channel is `opts.onUiEvent` (RunManager wiring
    *  lands in R2 step 2.1). */

--- a/packages/cezar/src/core/codex-app-server-transport.test.ts
+++ b/packages/cezar/src/core/codex-app-server-transport.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -80,18 +81,32 @@ describe('Codex app-server transport', () => {
  * the SIGTERM the escalation issues comes back as an unexplained 143.
  */
 describe('endCodexAppServer watchdog', () => {
-  function signallableChild(): { child: ChildProcessWithoutNullStreams; signals: NodeJS.Signals[] } {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
     const signals: NodeJS.Signals[] = [];
-    const child = {
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
       stdin: new PassThrough(),
-      exitCode: null,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
       killed: false,
+      // Mirrors Node: `killed` records that a signal was *delivered*, not that
+      // the child died. An app-server with its own SIGTERM handler stays alive
+      // with the flag already set (#844).
       kill: (signal: NodeJS.Signals) => {
         signals.push(signal);
+        Object.assign(child, { killed: true });
         return true;
       },
-    } as unknown as ChildProcessWithoutNullStreams;
-    return { child, signals };
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
   }
 
   it('reports each escalation step so the runner can classify the exit', () => {
@@ -121,16 +136,55 @@ describe('endCodexAppServer watchdog', () => {
   it('stays silent when the app-server exits on EOF by itself', () => {
     vi.useFakeTimers();
     try {
-      const { child, signals } = signallableChild();
+      const { child, signals, exit } = signallableChild();
       let reported = 0;
       endCodexAppServer(child, undefined, () => {
         reported += 1;
       });
-      (child as unknown as { exitCode: number | null }).exitCode = 0;
+      exit(0);
 
       vi.advanceTimersByTime(EOF_TERM_GRACE_MS + EOF_KILL_GRACE_MS);
       expect(signals).toEqual([]);
       expect(reported).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #844 — the regression that gating on `child.killed` produced: the SIGTERM
+  // this watchdog sends sets the flag, so the escalation vetoed itself and an
+  // app-server that handles SIGTERM survived the entire teardown window.
+  it('escalates to SIGKILL even though Node already flagged the child as killed', () => {
+    vi.useFakeTimers();
+    try {
+      const { child, signals } = signallableChild();
+      endCodexAppServer(child);
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
+      // Delivery, not death: the app-server handled the signal and runs on.
+      expect(child.killed).toBe(true);
+      expect(child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops escalating once the app-server really exits after SIGTERM', () => {
+    vi.useFakeTimers();
+    try {
+      const { child, signals, exit } = signallableChild();
+      endCodexAppServer(child);
+
+      vi.advanceTimersByTime(EOF_TERM_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
+      exit(143);
+
+      vi.advanceTimersByTime(EOF_KILL_GRACE_MS);
+      expect(signals).toEqual(['SIGTERM']);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/cezar/src/core/codex-app-server-transport.ts
+++ b/packages/cezar/src/core/codex-app-server-transport.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { trackChildExit } from './agent-runner.ts';
 import { buildChildEnv } from './agent-env.ts';
 import { EOF_KILL_GRACE_MS, EOF_TERM_GRACE_MS, KILL_GRACE_MS } from './claude-cli-runner.ts';
 
@@ -115,14 +116,18 @@ export function endCodexAppServer(
   } catch {
     // already gone
   }
+  // Real termination, not `child.killed` — the latter is set by the SIGTERM
+  // this very watchdog sends, which would then suppress its own SIGKILL for an
+  // app-server that handles the signal instead of dying from it (#844).
+  const hasExited = trackChildExit(child);
   let killTimer: NodeJS.Timeout | undefined;
   const termTimer = setTimeout(() => {
-    if (child.exitCode == null && !child.killed) {
+    if (!hasExited()) {
       onSignal?.();
       child.kill('SIGTERM');
     }
     killTimer = setTimeout(() => {
-      if (child.exitCode == null && !child.killed) {
+      if (!hasExited()) {
         onSignal?.();
         child.kill('SIGKILL');
       }

--- a/packages/cezar/src/core/opencode-model-catalog.test.ts
+++ b/packages/cezar/src/core/opencode-model-catalog.test.ts
@@ -1,29 +1,43 @@
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
-import { describe, expect, it } from 'vitest';
-import { discoverOpencodeModels, parseOpencodeModels } from './opencode-model-catalog.ts';
+import { describe, expect, it, vi } from 'vitest';
+import { KILL_GRACE_MS, discoverOpencodeModels, parseOpencodeModels } from './opencode-model-catalog.ts';
 
-/** A stand-in for the `opencode models` child: write its stdout, then close with a code. */
+/**
+ * A stand-in for the `opencode models` child: write its stdout, then close with a code.
+ *
+ * Mirrors Node's actual signal semantics — `kill()` records the signal and sets `killed = true`
+ * on *delivery*, while the child stays alive until something makes it exit. That distinction is
+ * the whole subject of the escalation tests below.
+ */
 function fakeChild(): {
   child: ChildProcessWithoutNullStreams;
   say(text: string): void;
   close(code: number): void;
+  exit(code: number): void;
+  signals: NodeJS.Signals[];
   killed(): boolean;
 } {
   const process = new EventEmitter();
   const stdin = new PassThrough();
   const stdout = new PassThrough();
   const stderr = new PassThrough();
-  let killed = false;
+  const signals: NodeJS.Signals[] = [];
+  const exit = (code: number) => {
+    Object.assign(process, { exitCode: code });
+    process.emit('exit', code, null);
+  };
   Object.assign(process, {
     stdin,
     stdout,
     stderr,
     exitCode: null,
+    signalCode: null,
     killed: false,
-    kill: () => {
-      killed = true;
+    kill: (signal: NodeJS.Signals = 'SIGTERM') => {
+      signals.push(signal);
+      Object.assign(process, { killed: true });
       return true;
     },
     pid: 321,
@@ -32,11 +46,13 @@ function fakeChild(): {
     child: process as unknown as ChildProcessWithoutNullStreams,
     say: (text: string) => stdout.write(text),
     close(code: number) {
-      Object.assign(process, { exitCode: code });
+      exit(code);
       stdout.end();
       queueMicrotask(() => process.emit('close', code));
     },
-    killed: () => killed,
+    exit,
+    signals,
+    killed: () => signals.length > 0,
   };
 }
 
@@ -123,6 +139,51 @@ describe('discoverOpencodeModels', () => {
     const promise = discoverOpencodeModels({ cwd: '/repo', timeoutMs: 5, spawn: () => fake.child });
     await expect(promise).rejects.toThrow('timed out');
     expect(fake.killed()).toBe(true);
+  });
+
+  /**
+   * #858 — `ChildProcess.killed` reports delivery, not death. Gating the escalation on it let a
+   * probe that installs a SIGTERM handler outlive every teardown, one leaked process per refresh.
+   */
+  it('escalates to SIGKILL when the probe survives the teardown SIGTERM', async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = fakeChild();
+      const rejected = expect(
+        discoverOpencodeModels({ cwd: '/repo', timeoutMs: 5, spawn: () => fake.child }),
+      ).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(5);
+      await rejected;
+
+      expect(fake.signals).toEqual(['SIGTERM']);
+      // Delivered, not dead — the state that used to disable the escalation.
+      expect(fake.child.killed).toBe(true);
+      expect(fake.child.exitCode).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops at SIGTERM once the probe really exits', async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = fakeChild();
+      const rejected = expect(
+        discoverOpencodeModels({ cwd: '/repo', timeoutMs: 5, spawn: () => fake.child }),
+      ).rejects.toThrow('timed out');
+      await vi.advanceTimersByTimeAsync(5);
+      await rejected;
+      expect(fake.signals).toEqual(['SIGTERM']);
+
+      fake.exit(143);
+      await vi.advanceTimersByTimeAsync(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('fails when the child floods stdout', async () => {

--- a/packages/cezar/src/core/opencode-model-catalog.ts
+++ b/packages/cezar/src/core/opencode-model-catalog.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { trackChildExit } from './agent-runner.ts';
 import { buildChildEnv } from './agent-env.ts';
 import type { ModelOption } from './runner-model-catalog.ts';
 
@@ -10,6 +11,8 @@ export interface OpencodeModelDiscoveryOptions {
 }
 
 const DEFAULT_DISCOVERY_TIMEOUT_MS = 10_000;
+/** Grace between the probe's SIGTERM and the SIGKILL that follows it. */
+export const KILL_GRACE_MS = 2_000;
 const MAX_MODELS = 500;
 /** Defensive cap on what we buffer from a misbehaving child (characters of stdout). */
 const MAX_OUTPUT_CHARS = 512 * 1_024;
@@ -46,6 +49,7 @@ export async function discoverOpencodeModels(
   const bin = resolveOpencodeExecutable(options.bin);
   const args = ['models'] as const;
   const child = (options.spawn ?? spawnOpencode)(bin, args, options.cwd);
+  const kill = teardown(child);
 
   const timeoutMs = options.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
   let timeout: NodeJS.Timeout | undefined;
@@ -57,7 +61,7 @@ export async function discoverOpencodeModels(
 
       const fail = (message: string) => {
         reject(new Error(message));
-        kill(child);
+        kill();
       };
 
       timeout = setTimeout(() => fail('OpenCode model discovery timed out'), timeoutMs);
@@ -92,7 +96,7 @@ export async function discoverOpencodeModels(
     });
   } finally {
     if (timeout) clearTimeout(timeout);
-    kill(child);
+    kill();
   }
 }
 
@@ -142,6 +146,28 @@ function spawnOpencode(
   return child;
 }
 
-function kill(child: ChildProcessWithoutNullStreams): void {
-  if (child.exitCode === null && !child.killed) child.kill('SIGTERM');
+/**
+ * Returns the probe's teardown: SIGTERM now, SIGKILL once the grace window elapses.
+ *
+ * Both steps gate on the child's *real* termination, never on `child.killed` — Node flips that
+ * flag the moment a signal is delivered, so the old `exitCode === null && !child.killed` test
+ * went false the instant our own SIGTERM landed. A probe that installs a SIGTERM handler then
+ * survived every teardown, leaking one process per cache refresh (#858, the shape #841 fixed for
+ * the Claude probe in `a67b327d`).
+ *
+ * Called from both the failure path and the `finally`, so the escalation is armed at most once.
+ */
+function teardown(child: ChildProcessWithoutNullStreams): () => void {
+  const hasExited = trackChildExit(child);
+  let signalled = false;
+  return () => {
+    if (signalled || hasExited()) return;
+    signalled = true;
+    child.kill('SIGTERM');
+    const escalation = setTimeout(() => {
+      if (hasExited()) return;
+      child.kill('SIGKILL');
+    }, KILL_GRACE_MS);
+    escalation.unref?.();
+  };
 }

--- a/packages/cezar/src/core/opencode-server-runner.test.ts
+++ b/packages/cezar/src/core/opencode-server-runner.test.ts
@@ -1,0 +1,128 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { KILL_GRACE_MS, OpencodeServerRunner } from './opencode-server-runner.ts';
+
+const spawnHook = vi.hoisted(() => ({ override: null as null | (() => unknown) }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnHook.override ? spawnHook.override() : actual.spawn(...args),
+  };
+});
+
+/**
+ * #858 — the OpenCode half of #844. `opencode serve` installs its own SIGTERM handler, so the
+ * teardown watchdog must decide "is it dead?" from a real exit, never from `ChildProcess.killed`,
+ * which Node flips the moment a signal is *delivered*. Gating on the flag made the SIGKILL
+ * unreachable for exactly the server it exists for: one leaked process per teardown, and — because
+ * every teardown path here is followed by `await this.exited` — a session result that never settles.
+ */
+describe('SIGTERM→SIGKILL escalation for an opencode server that survives SIGTERM', () => {
+  function signallableChild(): {
+    child: ChildProcessWithoutNullStreams;
+    signals: NodeJS.Signals[];
+    exit: (code: number) => void;
+  } {
+    const signals: NodeJS.Signals[] = [];
+    const emitter = new EventEmitter();
+    const child = Object.assign(emitter, {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      killed: false,
+      pid: 5150,
+      // Node's semantics: delivery flips `killed` whether or not the child dies.
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal);
+        Object.assign(child, { killed: true });
+        return true;
+      },
+    }) as unknown as ChildProcessWithoutNullStreams;
+    const exit = (code: number) => {
+      Object.assign(child, { exitCode: code });
+      emitter.emit('exit', code, null);
+    };
+    return { child, signals, exit };
+  }
+
+  function withFakeChild(run: (fake: ReturnType<typeof signallableChild>) => void): void {
+    const fake = signallableChild();
+    spawnHook.override = () => fake.child;
+    vi.useFakeTimers();
+    try {
+      run(fake);
+    } finally {
+      vi.useRealTimers();
+      spawnHook.override = null;
+    }
+  }
+
+  /** No wall-clock deadline; the test drives the teardown itself. */
+  function startSession(timeoutMs: number) {
+    const session = new OpencodeServerRunner({ bin: 'opencode', timeoutMs }).startSession({
+      userPrompt: 'do it',
+      cwd: process.cwd(),
+    });
+    // The server never comes up behind a fake child, so the result rejects/settles on its own path.
+    void session.result.catch(() => undefined);
+    return session;
+  }
+
+  it('escalates after end() even once Node flagged the server as killed', () => {
+    withFakeChild((fake) => {
+      const session = startSession(0);
+
+      session.end();
+      expect(fake.signals).toEqual(['SIGTERM']);
+      // Delivered, not dead — the state that used to disable the escalation.
+      expect(fake.child.killed).toBe(true);
+      expect(fake.child.exitCode).toBeNull();
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('escalates on the wall-clock timeout path', () => {
+    withFakeChild((fake) => {
+      startSession(20);
+
+      vi.advanceTimersByTime(20);
+      expect(fake.signals).toEqual(['SIGTERM']);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
+  it('stops escalating once the server really exits after SIGTERM', () => {
+    withFakeChild((fake) => {
+      const session = startSession(0);
+
+      session.end();
+      expect(fake.signals).toEqual(['SIGTERM']);
+      fake.exit(143);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM']);
+    });
+  });
+
+  it('does not signal at all when the server exited before the teardown', () => {
+    withFakeChild((fake) => {
+      const session = startSession(0);
+      fake.exit(0);
+
+      session.end();
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual([]);
+    });
+  });
+});

--- a/packages/cezar/src/core/opencode-server-runner.test.ts
+++ b/packages/cezar/src/core/opencode-server-runner.test.ts
@@ -115,6 +115,22 @@ describe('SIGTERM→SIGKILL escalation for an opencode server that survives SIGT
     });
   });
 
+  it('sends one SIGTERM per session however many teardown paths run', () => {
+    withFakeChild((fake) => {
+      const session = startSession(0);
+
+      // `interrupt()` on the deadline and the result promise's `finally` both
+      // reach terminate() for the same session; the escalation is armed once.
+      session.interrupt();
+      session.end();
+      session.interrupt();
+      expect(fake.signals).toEqual(['SIGTERM']);
+
+      vi.advanceTimersByTime(KILL_GRACE_MS);
+      expect(fake.signals).toEqual(['SIGTERM', 'SIGKILL']);
+    });
+  });
+
   it('does not signal at all when the server exited before the teardown', () => {
     withFakeChild((fake) => {
       const session = startSession(0);

--- a/packages/cezar/src/core/opencode-server-runner.ts
+++ b/packages/cezar/src/core/opencode-server-runner.ts
@@ -119,6 +119,8 @@ class OpencodeSession implements AgentSession {
   private autoEndTimer: NodeJS.Timeout | undefined;
   private spawnFailed: Error | null = null;
   private timedOut = false;
+  /** One teardown per session — see `terminate()`. */
+  private signalled = false;
 
   constructor(
     private readonly bin: string,
@@ -265,9 +267,16 @@ class OpencodeSession implements AgentSession {
    * window (#858, the same defect #844 fixed for the other two backends). Every
    * caller here is followed by `await this.exited`, so a server that survived
    * SIGTERM did not just leak — it hung the session's result forever.
+   *
+   * One teardown per session: all three call sites can run for the same session
+   * (`interrupt()` on the deadline, then the result promise's `finally`), and
+   * once SIGTERM is out with SIGKILL armed there is nothing a second pass adds.
+   * The old `!child.killed` test deduplicated this as a side effect of being
+   * wrong; `signalled` keeps that property on purpose.
    */
   private terminate(): void {
-    if (this.hasExited()) return;
+    if (this.signalled || this.hasExited()) return;
+    this.signalled = true;
     this.child.kill('SIGTERM');
     setTimeout(() => {
       if (this.hasExited()) return;

--- a/packages/cezar/src/core/opencode-server-runner.ts
+++ b/packages/cezar/src/core/opencode-server-runner.ts
@@ -8,7 +8,7 @@ import type {
   ContentBlock,
 } from './agent-runner.ts';
 import type { AgentSession, SessionOptions } from './agent-runner.ts';
-import { prependSystemPrompt } from './agent-runner.ts';
+import { prependSystemPrompt, trackChildExit } from './agent-runner.ts';
 import { buildChildEnv } from './agent-env.ts';
 import { AUTO_END_DELAY_MS, DEFAULT_RUN_TIMEOUT_MS } from './claude-cli-runner.ts';
 import { parseModelIdentity } from './model-identity.ts';
@@ -30,6 +30,9 @@ export interface OpencodeRunnerOptions {
 }
 
 const SERVER_START_TIMEOUT_MS = 30_000;
+
+/** Grace between the teardown SIGTERM and the SIGKILL that follows it. */
+export const KILL_GRACE_MS = 4_000;
 
 /**
  * `AgentRunner` over `opencode serve` — a headless HTTP server (the same one
@@ -79,6 +82,9 @@ class OpencodeSession implements AgentSession {
   readonly result: Promise<AgentRunResult>;
 
   private readonly child!: ChildProcessWithoutNullStreams;
+  /** "Has the server actually terminated?" — never `child.killed`, which only
+   *  reports delivery and would disarm the escalation (#844/#858). */
+  private readonly hasExited: () => boolean;
   private serverOpen = true;
   private baseUrl: string | undefined;
   private sessionId: string | undefined;
@@ -131,6 +137,7 @@ class OpencodeSession implements AgentSession {
     } catch (err) {
       throw wrapSpawnError(err, bin);
     }
+    this.hasExited = trackChildExit(this.child);
 
     this.child.on('error', (err: NodeJS.ErrnoException) => {
       this.spawnFailed = wrapSpawnError(err, bin);
@@ -179,7 +186,7 @@ class OpencodeSession implements AgentSession {
         if (this.autoEndTimer) clearTimeout(this.autoEndTimer);
         this.sse.abort();
         this.serverOpen = false;
-        if (!this.child.killed) this.child.kill('SIGTERM');
+        this.terminate();
       }
 
       await this.exited;
@@ -234,10 +241,7 @@ class OpencodeSession implements AgentSession {
     if (!this.serverOpen) return;
     this.serverOpen = false;
     this.sse.abort();
-    if (!this.child.killed) this.child.kill('SIGTERM');
-    setTimeout(() => {
-      if (this.child.exitCode == null && !this.child.killed) this.child.kill('SIGKILL');
-    }, 4_000).unref?.();
+    this.terminate();
   }
 
   interrupt(): void {
@@ -246,7 +250,29 @@ class OpencodeSession implements AgentSession {
       void this.http('POST', `/session/${this.sessionId}/abort`, undefined).catch(() => undefined);
     }
     this.sse.abort();
-    if (!this.child.killed) this.child.kill('SIGTERM');
+    this.terminate();
+  }
+
+  /**
+   * The one place either signal is sent: SIGTERM now, SIGKILL once the grace
+   * window elapses.
+   *
+   * Both steps gate on `hasExited()`, never on `child.killed` — the latter
+   * flips the moment SIGTERM is *delivered*, so the old nested
+   * `exitCode == null && !killed` guard disarmed the escalation for exactly the
+   * server it was written for: one that installs its own SIGTERM handler stayed
+   * alive with `killed = true` and `exitCode === null`, outliving the whole
+   * window (#858, the same defect #844 fixed for the other two backends). Every
+   * caller here is followed by `await this.exited`, so a server that survived
+   * SIGTERM did not just leak — it hung the session's result forever.
+   */
+  private terminate(): void {
+    if (this.hasExited()) return;
+    this.child.kill('SIGTERM');
+    setTimeout(() => {
+      if (this.hasExited()) return;
+      this.child.kill('SIGKILL');
+    }, KILL_GRACE_MS).unref?.();
   }
 
   // ---- server lifecycle ---------------------------------------------------


### PR DESCRIPTION
Closes #858

> **Stacked on #857.** `trackChildExit()` does not exist on `main` yet — it ships with #857
> (approved, green, `merge-queue`), which the acceptance criteria here name explicitly. This
> branch is cut from #857's head, so the diff below currently carries #857's commits too; it
> collapses to the four files listed under *What Changed* the moment #857 merges. Please merge
> #857 first.

## 🎯 Goal
Tearing a run down must not leave an `opencode serve` behind. The OpenCode backend was the one
outside #844's stated scope, and it still carried the identical `!child.killed` idiom — so its
SIGTERM→SIGKILL watchdogs now escalate for real, and a server that handles SIGTERM instead of
dying from it is reaped at the end of the grace window rather than surviving indefinitely.

## 🔍 Problem
`packages/cezar/src/core/opencode-server-runner.ts` gated all three of its teardown paths on
`ChildProcess.killed` — the result promise's `finally` (182), `end()` (237) and `interrupt()`
(249) — and nested the escalation inside the same flag:
`if (this.child.exitCode == null && !this.child.killed) kill('SIGKILL')` (239).
`packages/cezar/src/core/opencode-model-catalog.ts:146` carried the same shape and, worse, had no
escalation at all: SIGTERM only, so a probe deaf to it was never reaped. #844 fixed this for the
claude and codex backends and #857 landed the shared helper plus the `AGENT_PROTOCOL.md` rule;
this is the OpenCode half, tracked separately as #858.

## 🔍 Root Cause
`ChildProcess.killed` answers "was a signal delivered?", not "is the child dead?" — Node flips it
the instant `kill()` succeeds. `opencode serve` installs its own SIGTERM handler, so the
watchdog's own SIGTERM set `killed = true` while the process kept running with
`exitCode === null`, and the nested guard on line 239 then evaluated to `false`. The escalation
vetoed itself: SIGKILL was unreachable in precisely the scenario it was written for.

One consequence went beyond the leak #858 describes. Each of those SIGTERM sites is followed by
`await this.exited`, so a server that survived SIGTERM did not merely outlive teardown — it hung
the session's `result` promise forever, because nothing ever escalated to make the child exit.

## What Changed
- **`packages/cezar/src/core/opencode-server-runner.ts`** — one `hasExited` tracker per session,
  built from `trackChildExit(this.child)` immediately after the spawn, plus a private
  `terminate()` that is now the only place either signal is sent: SIGTERM when the server has not
  really exited, then an unref'd SIGKILL after the same 4 s window, re-checking real termination
  at fire time. The `finally`, `end()` and `interrupt()` all route through it, so the two paths
  that previously sent a bare SIGTERM escalate as well. The grace is exported as `KILL_GRACE_MS`
  for the tests.
- **`packages/cezar/src/core/opencode-model-catalog.ts`** — the free `kill(child)` function became
  a `teardown(child)` closure built once next to the spawn. It is invoked from both the failure
  path and the `finally`, signals at most once, and escalates SIGTERM → SIGKILL after a 2 s grace
  (`KILL_GRACE_MS`) — the shape #841 fixed for the Claude probe in `a67b327d`.

No production code tests `child.killed` anywhere in the OpenCode backend any more, which is the
rule `AGENT_PROTOCOL.md` already states next to the #703 paragraph.

## 🧪 Tests
- `npm run typecheck` — ✅ green (contract, client, server, web)
- `npm run build` — ✅ green, incl. `check:pack` (468 files)
- `npm run test:unit` — ✅ 35 passed / 1 skipped
- `npm run test:package` — ✅ 12 passed
- `npx vitest run packages/cezar/src/core` — ✅ 27 files / 564 tests, including the 6 new cases
- `npm test` (full suite) is red on this machine and is **not** a regression — see below. CI is the
  authority here.

New regressions, each mutation-checked (restoring the `!child.killed` idiom fails 3 of the 4
runner cases and 1 of the 2 catalog cases):

- **`opencode-server-runner.test.ts`** (new) — escalation after `end()`, escalation on the
  wall-clock timeout path, no escalation once the server really exits, and no signal at all when
  it exited before teardown. Follows the shape #857 established in
  `codex-app-server-runner.test.ts`: a `vi.hoisted` spawn hook plus `vi.mock('node:child_process')`
  that delegates to the real `spawn` unless a test opts in, so nothing else in the file is
  affected.
- **`opencode-model-catalog.test.ts`** — both directions of the probe escalation. Its `fakeChild()`
  now mirrors Node: `kill()` records the signal and sets `killed = true` **while the child stays
  alive**, and `close()` emits `exit` before `close`.

<details>
<summary>Why the full <code>npm test</code> run is red here, and why it is not this branch</summary>

Two full runs on this branch failed **30 files / 175 tests** and **32 files / 168 tests** — a set
that varies between runs, with **zero** failures in `src/core` either time. Every failure is a
wall-clock or temp-dir flake in the spawn-heavy `src/server`, `src/workflows` and `src/workspace`
areas (`Hook timed out in 10000ms`, `run did not finish in time`, `ENOENT` on
`/var/folders/.../cez-hydrate-*`).

Baselined against this branch's merge base: the identical
`packages/cezar/src/workflows packages/cezar/src/workspace` selection, run in a clean worktree at
`863b9fd8` (#857's head, i.e. this branch minus its own commit), fails **12 files / 64 tests** —
and that set is a **strict subset** of the 14 this branch fails. The two extra files,
`auto-resume.test.ts` and `recover-followups.test.ts`, mention OpenCode nowhere and both pass
**24/24** when run on their own.

</details>

## 💥 Breaking Changes
- None. `terminate()` is private and `teardown()` is module-local; the two `KILL_GRACE_MS` exports
  are additive and preserve the existing 4 s and 2 s windows verbatim. No runner contract, event
  shape, or exit classification changed.

One intended behavior change worth a reviewer's eye: `interrupt()` and the result `finally` gain an
escalation they did not have, so a server that previously outlived teardown now dies. #703 cannot
regress here — the OpenCode runner never turns an exit code into an agent failure, so a
self-inflicted 137/143 has no path to being misread as one.
