### PR TITLE
feat(release): nightly npm publishes of main under the `nightly` dist-tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # `lts/*` — the current Node LTS, whatever it is on the day the job runs, so
+      # the gate follows the release line users actually install on instead of
+      # freezing on a version that quietly ages out of support. The floor stays the
+      # root manifest's `engines.node`; this is the ceiling we verify against.
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: lts/*
           cache: npm
 
       - name: Install dependencies
@@ -89,12 +93,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: lts/*
           cache: npm
           registry-url: https://registry.npmjs.org
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,151 @@
+name: Nightly
+
+# Publishes `main`'s tip to npm under the `nightly` dist-tag, every day.
+#
+# A third channel alongside the two in docs/publishing.md: previews follow a PR or
+# `develop`, stable `latest` is owner-driven and manual — neither gives you "what is
+# on the trunk right now" without hunting for a run number. `npx cezar-cli@nightly`
+# does. Like every snapshot it publishes a PRERELEASE version under an explicit
+# dist-tag, so it can never become the default install.
+on:
+  schedule:
+    # 03:17 UTC — off the hour, where Actions' scheduled-run queue is least congested.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Publish even if main has not moved since the last nightly'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel mid-publish: an interrupted run could leave the scoped package on
+  # the registry without its alias.
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    name: Publish nightly to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # A scheduled run always uses the default branch; this also pins the manual
+    # dispatch to main, so a nightly can never be cut from a feature branch.
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write # npm provenance attestation
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: the default shallow clone has no commit dates to compare,
+          # so the "did main move?" check below would see an empty log every night.
+          fetch-depth: 0
+
+      # Nothing merged since yesterday's run means tonight's build is byte-identical
+      # to the one already tagged `nightly` — publishing it again would only add a
+      # version nobody can tell apart. A manual dispatch skips this check by default:
+      # if someone asked for a nightly from the Actions tab, they want one.
+      - name: Decide whether to publish
+        id: decide
+        env:
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "Forced by manual dispatch — publishing."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COMMITS=$(git log --since="24 hours ago" --oneline HEAD | wc -l | tr -d ' ')
+          if [ "$COMMITS" -eq 0 ]; then
+            echo "No commits on main in the last 24h — skipping tonight's publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$COMMITS commit(s) on main in the last 24h — publishing."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # `lts/*` like every other workflow here: a nightly is built and verified on
+      # the Node release line users are actually on that day (see ci.yml).
+      - name: Set up Node.js
+        if: steps.decide.outputs.publish == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        if: steps.decide.outputs.publish == 'true'
+        run: npm ci
+
+      # A nightly is an installable build, not a preview of a proposal — it carries
+      # the same gate as a release. main is protected and every commit on it passed
+      # ci.yml already, but the trunk can still go red through the calendar alone (a
+      # dependency's new major, an expired fixture), and a broken `@nightly` is worse
+      # than a missing one.
+      - name: Verify before publishing
+        if: steps.decide.outputs.publish == 'true'
+        run: |
+          npm run typecheck
+          npm run test:unit
+          npm test
+
+      - name: Build application
+        if: steps.decide.outputs.publish == 'true'
+        run: npm run build
+
+      - name: Run packaged CLI E2E tests
+        if: steps.decide.outputs.publish == 'true'
+        run: npm run test:package
+
+      - name: Publish nightly
+        id: nightly
+        if: steps.decide.outputs.publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The channel is requested BY NAME, never inferred from the event — that is
+          # what keeps any other workflow_dispatch from cutting a nightly by accident.
+          CEZ_RELEASE_CHANNEL: nightly
+        run: node scripts/release-snapshot.mjs
+
+      # `always()` so a skipped night still explains itself, but only once the
+      # decision actually ran — a job that died before it has nothing to report.
+      - name: Write workflow summary
+        if: always() && steps.decide.outputs.publish != ''
+        env:
+          PUBLISH: ${{ steps.decide.outputs.publish }}
+          ATTEMPTED: ${{ steps.nightly.outputs.attempted }}
+          RESULT: ${{ steps.nightly.outputs.result }}
+        run: |
+          if [ "$PUBLISH" != "true" ]; then
+            {
+              echo "## 🌙 Nightly skipped"
+              echo ""
+              echo "\`main\` has not moved in the last 24 hours — the current \`nightly\` tag is already this build."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [ "$ATTEMPTED" != "true" ]; then
+            echo "## 🌙 Nightly did not publish (see the job log)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node - <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          const r = JSON.parse(process.env.RESULT);
+          console.log(`## 🌙 Nightly ${r.dryRun ? 'dry run (NPM_TOKEN not configured)' : 'published'}`);
+          console.log('');
+          console.log(`- Version: \`${r.version}\``);
+          console.log(`- Dist-tag: \`${r.distTag}\``);
+          console.log(`- Packages: \`${r.aliasName}\` → \`${r.rootName}\` → \`${r.apiClientName}\``);
+          console.log('');
+          console.log('```bash');
+          console.log(`npx ${r.aliasName}@nightly          # always the latest nightly`);
+          for (const line of r.installLines) console.log(line);
+          console.log('```');
+          EOF

--- a/.github/workflows/npm-preview-cleanup.yml
+++ b/.github/workflows/npm-preview-cleanup.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The PR's merge ref may already be gone for a closed PR, and package
           # names should come from the trunk anyway — not from the PR's code.
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: lts/*
           registry-url: https://registry.npmjs.org
 
       - name: Remove dist-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,14 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: lts/*
           cache: npm
           registry-url: https://registry.npmjs.org
 

--- a/README.md
+++ b/README.md
@@ -169,22 +169,47 @@ CLIs you are already logged into, `claude` by default.
 > instead of the real CLI — the whole cockpit works with no `claude` login, so
 > you can explore runs, diffs, variants and the review gate offline.
 
+### Nightly builds — help us shape cezar 🌙
+
+Every night we publish the trunk to npm, so the features landing in the next
+release are one command away:
+
+```bash
+npx cezar-cli@nightly      # everything merged as of last night
+```
+
+**Come build this with us.** cezar is shaped by the people who run it on real
+repos: if you try a nightly and something feels wrong — a workflow that stalls, a
+diff that reads badly, a runner that should exist — [open an
+issue](https://github.com/open-mercato/cezar/issues) and tell us. That feedback,
+early, is worth more than a bug report six weeks after a release, and it is how
+most of the features here got their final shape.
+
+**Know what you're installing.** A nightly is verified (typecheck, unit suites,
+packaged-CLI e2e — the same gate a release runs) but it is *not* a release: it
+can be rough, a flag or a screen may change under you, and something occasionally
+breaks in a way no test caught. Nothing is at risk beyond your patience — every
+task runs in its own git worktree and cezar never auto-merges — but if you need a
+boring day, stay on the stable release. Pin a nightly you liked with its exact
+version (`npx cezar-cli@0.9.2-nightly.20260813.126` — the cockpit prints the
+version it booted, and the date in it tells you how old the build is), and drop
+back to stable any time with a plain `npx cezar-cli`.
+
 ### Preview builds
 
-Every green CI run publishes an installable npm snapshot
-([how it works](docs/publishing.md)), so you can try unreleased code without
-cloning anything:
+Every green CI run also publishes an installable npm snapshot
+([how it works](docs/publishing.md)), so you can try code that has not even
+merged yet:
 
 ```bash
 npx cezar-cli@develop      # current develop head
-npx cezar-cli@main         # current main head (ahead of the latest stable release)
 ```
 
 Every pull request gets its own preview too — the CI bot posts a sticky comment
 on the PR with the exact pinned version to copy-paste
-(`npx cezar-cli@<version>-pr<N>.<run>`). Previews are prerelease versions under
-their own dist-tags; a plain `npx cezar-cli` always resolves to the latest
-stable release.
+(`npx cezar-cli@<version>-pr<N>.<run>`). Nightlies and previews are all
+prerelease versions under their own dist-tags; a plain `npx cezar-cli` always
+resolves to the latest stable release.
 
 ---
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -10,6 +10,9 @@ How cezar reaches npm. Two paths, deliberately separate
 - **Previews** are **CI-driven**: the `publish-snapshot` job in
   [`ci.yml`](../.github/workflows/ci.yml) publishes a snapshot of every package
   after a fully green `verify` run — on `develop` pushes and same-repo PRs only.
+- **Nightlies** are **clock-driven**: [`nightly.yml`](../.github/workflows/nightly.yml)
+  cuts `main`'s tip every night under the `nightly` dist-tag, so `npx cezar-cli@nightly`
+  is always the trunk. Also runnable on demand from the Actions tab.
 
 Three packages are in the release, always at the same version; two of them ship:
 
@@ -53,13 +56,44 @@ with `--tag latest --provenance`, commits the bump, tags `v<version>`, and cuts 
 GitHub Release. It's gated behind the `production` environment, so a release can
 require reviewer approval. Without `NPM_TOKEN` it degrades to a loud dry run.
 
+## Nightlies
+
+Every night at **03:17 UTC**, [`nightly.yml`](../.github/workflows/nightly.yml)
+verifies `main` (typecheck, unit suites, build, packaged-CLI e2e — the same gate
+a release runs) and publishes it under the `nightly` dist-tag:
+
+```bash
+npx cezar-cli@nightly              # whatever is on main as of last night
+npx cezar-cli@0.1.5-nightly.20260813.126   # that exact night, forever
+```
+
+The version is named after the **day it was cut** — `<base>-nightly.<YYYYMMDD>.<run_number>`
+— so the version list reads as a calendar and a user can tell how old their build
+is without looking anything up. The run number trails the date so an on-demand cut
+never collides with the scheduled one; both are numeric semver identifiers, so the
+ordering stays chronological.
+
+**Manual runs:** Actions → Nightly → *Run workflow* (from `main`). It publishes
+immediately, even if nothing has merged since the last one — that's what the
+`force` input defaults to. A *scheduled* run skips itself when `main` has not moved
+in 24 hours, because that build is already the one tagged `nightly`.
+
+The channel is requested **by name** (`CEZ_RELEASE_CHANNEL=nightly`), never inferred
+from the event, so no other workflow's manual dispatch can cut a nightly by accident;
+`computeSnapshot` additionally re-checks that the ref is `main`. Nightlies are
+prereleases under an explicit dist-tag like every other snapshot — they can never
+become the default install.
+
 ## Preview channels
 
 | Event | Version (example) | dist-tag | Install |
 |---|---|---|---|
 | same-repo PR, CI green | `0.1.5-pr482.123` | `pr-482` | `npx cezar-cli@0.1.5-pr482.123` |
 | push to `develop` | `0.1.5-develop.124` | `develop` | `npx cezar-cli@develop` |
-| push to `main` | `0.1.5-main.125` | `main` | `npx cezar-cli@main` |
+| nightly cut of `main` | `0.1.5-nightly.20260813.126` | `nightly` | `npx cezar-cli@nightly` |
+
+A push to `main` publishes **nothing**: the trunk reaches npm through the nightly
+above, or through an owner-driven stable release — never straight off a merge.
 
 Version scheme: `<base>-<channel>.<run_number>`, with `.<run_attempt>` appended
 on re-runs so no publish ever collides. Prerelease versions under explicit
@@ -88,6 +122,7 @@ prereleases are inert).
 | `packages/cezar/src/release/manifests.ts` | the shared stamper: which manifests exist, and how each pins the next (unit-tested) |
 | `scripts/release-snapshot.mjs` | orchestrator: stamps manifests, `npm publish --tag <channel> --provenance`, emits result JSON (`--dry-run` supported; e2e-tested) |
 | `ci.yml` → `publish-snapshot` | gate (`needs: verify`), same-repo guard, provenance permissions, sticky PR comment, step summary |
+| `nightly.yml` | the 03:17 UTC cron + manual dispatch: main-only guard, "did main move?" check, full verify, then the same orchestrator with `CEZ_RELEASE_CHANNEL=nightly` |
 | `npm-preview-cleanup.yml` | dist-tag removal on PR close |
 
 Guards: the job runs only for pushes and same-repo PRs (fork PRs get no

--- a/packages/cezar/src/release/snapshot.test.ts
+++ b/packages/cezar/src/release/snapshot.test.ts
@@ -56,6 +56,57 @@ describe('computeSnapshot', () => {
     expect(computeSnapshot({ ...base, eventName: 'schedule' })).toBeNull();
   });
 
+  describe('nightly', () => {
+    const nightly: SnapshotContext = {
+      ...base,
+      eventName: 'schedule',
+      refName: 'main',
+      prNumber: undefined,
+      requestedChannel: 'nightly',
+      nightlyDate: '20260813',
+    };
+
+    it('cuts main under the nightly dist-tag, dated and run-numbered', () => {
+      expect(computeSnapshot(nightly)).toEqual({
+        channel: 'nightly',
+        // Date first so the versions sort chronologically and a user can read the
+        // age of their build; run number second so a same-day re-cut never collides.
+        version: '0.1.5-nightly.20260813.123',
+        distTag: 'nightly',
+      });
+    });
+
+    it('cuts one on demand too — a manual dispatch of the nightly workflow', () => {
+      expect(computeSnapshot({ ...nightly, eventName: 'workflow_dispatch' })?.distTag).toBe('nightly');
+    });
+
+    it('is reachable only by asking for it by name, never from the event alone', () => {
+      // A workflow_dispatch or schedule that did NOT request the channel (ci.yml's
+      // manual trigger, say) must publish nothing.
+      expect(computeSnapshot({ ...nightly, requestedChannel: undefined })).toBeNull();
+      // ...and an unrecognised request is a no-op, not a fallback to another channel.
+      expect(computeSnapshot({ ...nightly, requestedChannel: 'nghtly' })).toBeNull();
+      expect(computeSnapshot({ ...base, requestedChannel: 'latest' })).toBeNull();
+    });
+
+    it('cuts only from main, and only from a schedule or a dispatch', () => {
+      expect(computeSnapshot({ ...nightly, refName: 'develop' })).toBeNull();
+      expect(computeSnapshot({ ...nightly, refName: 'release/0.1.x' })).toBeNull();
+      expect(computeSnapshot({ ...nightly, eventName: 'push' })).toBeNull();
+      expect(computeSnapshot({ ...nightly, eventName: 'pull_request' })).toBeNull();
+    });
+
+    it('refuses to publish without a well-formed date', () => {
+      expect(computeSnapshot({ ...nightly, nightlyDate: undefined })).toBeNull();
+      expect(computeSnapshot({ ...nightly, nightlyDate: '2026-08-13' })).toBeNull();
+      expect(computeSnapshot({ ...nightly, nightlyDate: '260813' })).toBeNull();
+    });
+
+    it('appends the run attempt on a re-run, like every other channel', () => {
+      expect(computeSnapshot({ ...nightly, runAttempt: 2 })?.version).toBe('0.1.5-nightly.20260813.123.2');
+    });
+  });
+
   it('appends the run attempt only on re-runs, so no publish ever collides', () => {
     expect(computeSnapshot({ ...base, runAttempt: 1 })?.version).toBe('0.1.5-pr482.123');
     expect(computeSnapshot({ ...base, runAttempt: undefined })?.version).toBe('0.1.5-pr482.123');
@@ -71,6 +122,14 @@ describe('computeSnapshot', () => {
     const events: SnapshotContext[] = [
       base,
       { ...base, eventName: 'push', refName: 'develop', prNumber: undefined },
+      {
+        ...base,
+        eventName: 'schedule',
+        refName: 'main',
+        prNumber: undefined,
+        requestedChannel: 'nightly',
+        nightlyDate: '20260813',
+      },
     ];
     for (const ctx of events) {
       const plan = computeSnapshot(ctx);

--- a/packages/cezar/src/release/snapshot.ts
+++ b/packages/cezar/src/release/snapshot.ts
@@ -16,11 +16,22 @@ import { stampManifestSet, type ReleaseManifests as ReleaseManifestSet } from '.
 
 /** The CI facts the decision needs, straight from GitHub Actions' env/event. */
 export interface SnapshotContext {
-  /** `GITHUB_EVENT_NAME` — only `pull_request` and `push` ever publish. */
+  /** `GITHUB_EVENT_NAME` — `pull_request` and `push` publish previews; `schedule`
+   *  and `workflow_dispatch` publish only the explicitly requested nightly. */
   eventName: string;
   /** `GITHUB_REF_NAME` for push events — only `develop` publishes a snapshot;
-   *  `main` is reserved for owner-driven stable releases (see stable.ts). */
+   *  `main` is reserved for owner-driven stable releases (see stable.ts) and for
+   *  the nightly channel below, which never moves `latest` either. */
   refName: string;
+  /** `CEZ_RELEASE_CHANNEL` — a channel asked for by name rather than derived from
+   *  the event. Only `.github/workflows/nightly.yml` sets it (to `nightly`); every
+   *  other caller leaves it empty and gets the event-derived channel. Opt-in by
+   *  name is what keeps a `workflow_dispatch` of ci.yml from cutting a nightly by
+   *  accident — the event alone is not enough. */
+  requestedChannel?: string;
+  /** `YYYYMMDD` (UTC) of the day a nightly is cut — the nightly version is named
+   *  after its date. Required for the nightly channel, ignored by every other. */
+  nightlyDate?: string;
   /** PR number for pull_request events; absent/invalid → no publish. */
   prNumber?: number;
   /** `owner/name` of the PR head repo — fork PRs (≠ `repo`) never publish. */
@@ -51,14 +62,34 @@ export function computeSnapshot(ctx: SnapshotContext): SnapshotPlan | null {
   const attempt = ctx.runAttempt !== undefined && Number.isInteger(ctx.runAttempt) && ctx.runAttempt > 1
     ? `.${ctx.runAttempt}`
     : '';
+  // A nightly is named after the day it was cut — `0.1.5-nightly.20260813.126` —
+  // so `npm view cezar-cli versions` reads as a calendar and a user can tell at a
+  // glance how old their build is. The run number still trails the date, because a
+  // manual re-cut on the same day must not collide with the scheduled one. Both are
+  // plain numeric semver identifiers, so the ordering stays chronological.
+  const nightly = channel.channel === 'nightly';
+  if (nightly && !/^\d{8}$/.test(ctx.nightlyDate ?? '')) return null;
+  const stamp = nightly ? `${ctx.nightlyDate}.${ctx.runNumber}` : `${ctx.runNumber}`;
   return {
     channel: channel.channel,
-    version: `${ctx.baseVersion}-${channel.channel}.${ctx.runNumber}${attempt}`,
+    version: `${ctx.baseVersion}-${channel.channel}.${stamp}${attempt}`,
     distTag: channel.distTag,
   };
 }
 
 function resolveChannel(ctx: SnapshotContext): { channel: string; distTag: string } | null {
+  // A named channel wins over the event-derived ones, and is the ONLY way to reach
+  // nightly — asked for explicitly by nightly.yml, never inferred from an event.
+  // An unrecognised name publishes nothing rather than silently falling back: a
+  // typo in a workflow should be a no-op, not a publish under the wrong tag.
+  if (ctx.requestedChannel) {
+    if (ctx.requestedChannel !== 'nightly') return null;
+    // Nightly cuts main's tip — on the schedule, or on demand from the Actions tab
+    // when someone needs a fresh build before the next night.
+    if (ctx.eventName !== 'schedule' && ctx.eventName !== 'workflow_dispatch') return null;
+    if (ctx.refName !== 'main') return null;
+    return { channel: 'nightly', distTag: 'nightly' };
+  }
   if (ctx.eventName === 'pull_request') {
     const n = ctx.prNumber;
     if (n === undefined || !Number.isInteger(n) || n <= 0) return null;

--- a/packages/cezar/test/e2e/release-snapshot.test.ts
+++ b/packages/cezar/test/e2e/release-snapshot.test.ts
@@ -162,6 +162,52 @@ test('a missing NPM token forces a dry run instead of failing the job', { timeou
   }
 });
 
+test('the nightly channel stamps a dated version and publishes under the nightly tag', { timeout: 120_000 }, async () => {
+  const root = await makeFixture();
+  try {
+    await writeFile(join(root, 'github-output.txt'), '');
+    await runScript(
+      root,
+      {
+        GITHUB_EVENT_NAME: 'schedule',
+        GITHUB_REF_NAME: 'main',
+        GITHUB_REPOSITORY: 'open-mercato/cezar',
+        GITHUB_RUN_NUMBER: '12',
+        CEZ_RELEASE_CHANNEL: 'nightly',
+        // Pinned so the assertion below is not a race with the wall clock.
+        NIGHTLY_DATE: '20260813',
+      },
+      ['--dry-run'],
+    );
+
+    const aliasPkg = await readPkg(root, 'alias-cezar');
+    assert.equal(aliasPkg.version, '0.9.9-nightly.20260813.12');
+    assert.deepEqual(aliasPkg.dependencies, { '@scope/fake-root': '0.9.9-nightly.20260813.12' });
+    const output = await readFile(join(root, 'github-output.txt'), 'utf8');
+    assert.match(output, /^attempted=true$/m);
+    assert.match(output, /"distTag":"nightly"/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('the same schedule event without the channel request publishes nothing', { timeout: 60_000 }, async () => {
+  const root = await makeFixture();
+  try {
+    await writeFile(join(root, 'github-output.txt'), '');
+    await runScript(root, {
+      GITHUB_EVENT_NAME: 'schedule',
+      GITHUB_REF_NAME: 'main',
+      GITHUB_REPOSITORY: 'open-mercato/cezar',
+      GITHUB_RUN_NUMBER: '13',
+    });
+    assert.equal((await readPkg(root, 'packages', 'cezar')).version, '0.9.9');
+    assert.match(await readFile(join(root, 'github-output.txt'), 'utf8'), /^attempted=false$/m);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('a non-publishable event exits 0 without touching the manifests', { timeout: 60_000 }, async () => {
   const root = await makeFixture();
   try {

--- a/scripts/release-snapshot.mjs
+++ b/scripts/release-snapshot.mjs
@@ -4,6 +4,10 @@
 // `publish-snapshot` job after `npm run build` (spec
 // .ai/specs/2026-07-18-npm-preview-publish.md, #482).
 //
+// Also the engine behind the nightly channel (.github/workflows/nightly.yml):
+// same stamping and same publish order, reached by setting CEZ_RELEASE_CHANNEL=nightly
+// rather than by the event — see resolveChannel in src/release/snapshot.ts.
+//
 // Reads the CI facts from GitHub Actions' env, decides via computeSnapshot,
 // stamps every manifest in the release set (intra-release dependencies pinned
 // exact), publishes the non-`private` ones in DEPENDENCY ORDER — api-client,
@@ -76,9 +80,14 @@ const manifests = {
 };
 
 const prNumberRaw = process.env.PR_NUMBER ?? '';
+// The nightly channel is named after the UTC day it was cut. Overridable via env so
+// the e2e suite can assert an exact version instead of the wall clock.
+const nightlyDate = process.env.NIGHTLY_DATE || new Date().toISOString().slice(0, 10).replaceAll('-', '');
 const plan = computeSnapshot({
   eventName: process.env.GITHUB_EVENT_NAME ?? '',
   refName: process.env.GITHUB_REF_NAME ?? '',
+  requestedChannel: process.env.CEZ_RELEASE_CHANNEL || undefined,
+  nightlyDate,
   prNumber: /^\d+$/.test(prNumberRaw) ? Number(prNumberRaw) : undefined,
   headRepo: process.env.PR_HEAD_REPO || undefined,
   repo: process.env.GITHUB_REPOSITORY || undefined,


### PR DESCRIPTION
Adds `.github/workflows/nightly.yml`: at 03:17 UTC it verifies `main` (typecheck, unit suites, build, packaged-CLI e2e) and publishes it under the `nightly` dist-tag, so `npx cezar-cli@nightly` is always the trunk — a scheduled run skips itself when `main` has not moved in 24h, while a manual dispatch from the Actions tab publishes unconditionally.

It reuses `scripts/release-snapshot.mjs` rather than adding a second orchestrator: `computeSnapshot` gains a `nightly` channel that is reachable only by asking for it by name (`CEZ_RELEASE_CHANNEL=nightly`) and only from `main`, so no other `workflow_dispatch` can cut one by accident, and versions are date-first (`0.9.2-nightly.20260813.126`) so the version list reads as a calendar and a same-day re-cut never collides.

Also across every workflow: `node-version: lts/*` so CI follows the Node release line users are actually on instead of freezing on 20, and `actions/checkout` bumped to v7.0.1 (`setup-node` v7.0.0 and `github-script` v9.0.0 were already current).

Covered by 6 new unit cases in `snapshot.test.ts` and 2 orchestrator e2e cases; `docs/publishing.md` documents the new channel and drops a stale claim that pushes to `main` publish anything.