### PR TITLE
fix(cockpit): keep the sidebar footer inside the column on a nightly version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Unreleased
 
 ### 🐛 Fixes
+- 🐛 **The settings gear and the theme toggle stay inside the sidebar on a nightly build.** A
+  nightly's version is long — `v0.9.2-nightly.20260813.1`, where a release is `v0.9.2` — and the
+  footer chip that shows it refused to give up a single pixel, so on the nightly channel it simply
+  pushed the two buttons beside it out of the sidebar and over the page. The chip now yields the
+  space instead, showing as much of the version as fits and the whole of it on hover, which is what
+  keeps the row inside the column whatever a future version string looks like.
 - 🐛 **The global Tasks page reacts to work happening in other projects.** Every event from a
   project other than the one you were standing in was dropped before it reached any cache, so
   `/tasks` — which is precisely the page that spans every project — heard nothing and ran on its

--- a/packages/web/e2e/smoke.e2e.ts
+++ b/packages/web/e2e/smoke.e2e.ts
@@ -171,6 +171,31 @@ describe('cockpit app shell', () => {
     expect(footerRows.rowCount).toBe(2)
   })
 
+  it('keeps the footer controls inside the 264px column even on a nightly-length version', () => {
+    browser.goto(baseUrl + scoped('/'))
+    browser.waitForFunction(`document.querySelector('[data-slot="version-chip"]') !== null`)
+
+    // The e2e server reports this checkout's own (short) semver, which never overflowed. The
+    // string that DID is the nightly dist-tag of #876 — so write it into the chip and measure
+    // what the real layout engine does with it. Every control in the row but the chip is
+    // `shrink-0`, so before the chip could give, this pushed the gear and the theme toggle
+    // bodily outside the sidebar's right edge instead of clipping anything.
+    const overflow = browser.evaluate(`(() => {
+      const chip = document.querySelector('[data-slot="version-chip"]')
+      const label = chip.querySelector('span:not([data-slot])')
+      label.textContent = 'v0.9.2-nightly.20260813.1'
+      const sidebarRight = document.querySelector('[data-slot="sidebar"]').getBoundingClientRect().right
+      const escaped = [...document.querySelectorAll('[data-slot="sidebar-footer-controls"] > *')]
+        .filter((el) => el.getBoundingClientRect().right > sidebarRight)
+        .map((el) => el.dataset.slot)
+      return { escaped, truncated: label.scrollWidth > Math.ceil(label.getBoundingClientRect().width) }
+    })()`) as { escaped: string[]; truncated: boolean }
+
+    expect(overflow.escaped).toEqual([])
+    // …and the chip absorbed it by clipping its own label, which is where the `title` earns its keep.
+    expect(overflow.truncated).toBe(true)
+  })
+
   it('fills the repo and version chips from the live /api/v1/health', async () => {
     // The server runs against this checkout (a real git repo), so health is real data — the one
     // thing a jsdom test with a mocked fetch cannot prove. Ask it from here rather than inside

--- a/packages/web/src/components/app-shell.test.tsx
+++ b/packages/web/src/components/app-shell.test.tsx
@@ -267,6 +267,31 @@ describe('AppShell', () => {
       expect(chip.getAttribute('data-update-available')).toBe('true')
       expect(chip.querySelector('[data-slot="status-dot"]')).not.toBeNull()
     })
+
+    /* The two-row footer holds only while something in the controls row can give: every icon
+     * button is `shrink-0` (button base class), so a long version string — `0.9.2-nightly.…`,
+     * the nightly dist-tag of #876 — used to push the gear and the toggle outside the 264px
+     * column entirely. jsdom still measures nothing; what it can pin is which item yields. */
+    it('makes the version chip the one control that gives, so a nightly version cannot push the row out', () => {
+      renderShell('/', {
+        version: '0.9.2-nightly.20260813.1',
+        toolsMenu: <button type="button">Tools</button>,
+      })
+      const chip = controls().querySelector('[data-slot="version-chip"]') as HTMLElement
+      expect(chip.className).not.toContain('shrink-0')
+      expect(chip.className).toContain('min-w-0')
+      // The text truncates inside the pill rather than widening it past what the row can hold.
+      const label = chip.querySelector('span:not([data-slot])') as HTMLElement
+      expect(label.className).toContain('truncate')
+      expect(label.textContent).toBe('v0.9.2-nightly.20260813.1')
+      // …and the full string stays legible on hover, since the visible one may be clipped.
+      expect(chip.getAttribute('title')).toBe('v0.9.2-nightly.20260813.1')
+      // Everything else in the row still refuses to shrink — that is what keeps them readable.
+      for (const slot of ['tools-menu', 'global-settings-link', 'theme-toggle']) {
+        const el = controls().querySelector(`[data-slot="${slot}"]`) as HTMLElement
+        expect(el.className).toContain('shrink-0')
+      }
+    })
   })
 
   describe('data slots stay empty rather than showing invented data', () => {
@@ -290,7 +315,9 @@ describe('AppShell', () => {
       it('stays plain while the registry has nothing newer', () => {
         renderShell('/', { version: '1.2.3' })
         expect(chip().getAttribute('data-update-available')).toBeNull()
-        expect(chip().getAttribute('title')).toBeNull()
+        // A tooltip, but one that claims nothing: the chip truncates, so the full version has to
+        // stay reachable on hover even when there is no update to announce.
+        expect(chip().getAttribute('title')).toBe('v1.2.3')
         expect(chip().querySelector('[data-slot="status-dot"]')).toBeNull()
       })
 
@@ -303,7 +330,7 @@ describe('AppShell', () => {
       it('pulses and names the newer version when one exists', () => {
         renderShell('/', { version: '1.2.3', latestVersion: '1.3.0' })
         expect(chip().getAttribute('data-update-available')).toBe('true')
-        expect(chip().getAttribute('title')).toBe('update available: v1.3.0')
+        expect(chip().getAttribute('title')).toBe('v1.2.3 — update available: v1.3.0')
         const dot = chip().querySelector('[data-slot="status-dot"]') as HTMLElement
         expect(dot.getAttribute('data-tone')).toBe('pending')
         expect(dot.className).toContain('animate-pulse')

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -799,6 +799,15 @@ function CommandPaletteHint() {
  * The footer's `v{version}` chip. When the server's npm-registry check found something newer
  * (`latestVersion`, #368), the chip grows a pulsing pending-tone dot and names the version in
  * its tooltip — an affordance, not an alert: updating is optional, so the chrome stays quiet.
+ *
+ * The chip is the controls row's ONE elastic item, and that is load-bearing. Every other control
+ * there is `shrink-0` (the icon buttons inherit it from the button base class), so whatever a
+ * version string costs beyond the column's width has to come out of somewhere — and while this
+ * chip was `shrink-0` too, there was nowhere for it to come from: a nightly version (#876's
+ * dist-tag, some 173px of it) shoved the gear and the theme toggle clean outside the sidebar
+ * rather than clipping anything. Truncating from the tail keeps the half that carries meaning,
+ * the semver, and the `title` keeps the whole string — which is why the tooltip is now there
+ * even with no update to announce.
  */
 function VersionChip({ version, latestVersion }: { version: string; latestVersion: string | null }) {
   const updateAvailable = Boolean(latestVersion && latestVersion !== version)
@@ -806,11 +815,11 @@ function VersionChip({ version, latestVersion }: { version: string; latestVersio
     <span
       data-slot="version-chip"
       data-update-available={updateAvailable ? 'true' : undefined}
-      title={updateAvailable ? `update available: v${latestVersion}` : undefined}
-      className="flex shrink-0 items-center gap-1 rounded-full border border-border px-1.5 py-px font-mono text-[10px] font-medium text-soft-foreground"
+      title={updateAvailable ? `v${version} — update available: v${latestVersion}` : `v${version}`}
+      className="flex min-w-0 items-center gap-1 rounded-full border border-border px-1.5 py-px font-mono text-[10px] font-medium text-soft-foreground"
     >
-      {updateAvailable ? <StatusDot tone="pending" pulse className="size-[5px]" /> : null}
-      v{version}
+      {updateAvailable ? <StatusDot tone="pending" pulse className="size-[5px] shrink-0" /> : null}
+      <span className="truncate">v{version}</span>
     </span>
   )
 }


### PR DESCRIPTION
## 🎯 Goal

The sidebar's footer controls must stay inside the sidebar. On the `nightly` dist-tag (#876) they did not: the settings gear and the theme toggle were pushed bodily out of the 264px column and painted over the page behind it.

## 🔍 Problem

#702 replaced the footer's single wrapping row with two deliberate rows, which is the right shape — but every control in the second row is `shrink-0`. The three icon buttons inherit it from the `button` base class, and `VersionChip` carried it explicitly. So the row had no elastic member at all: whatever the version string cost beyond the column's width had to come out of somewhere, and there was nowhere for it to come from.

That was invisible for as long as the chip read `v0.9.2` — 55px, and the row fit with room to spare. #876 then started publishing `main` under a date-first nightly version, and `v0.9.2-nightly.20260813.1` measures ~173px. Measured in Chrome at the 264px column:

| control | right edge before | sidebar edge |
|---|---|---|
| version chip | 271 | 264 |
| settings gear | 307 | 264 |
| theme toggle | 345 | 264 |

Nothing clipped, because nothing in the chain sets `overflow: hidden` — the two buttons simply rendered outside the sidebar, on top of the routed view.

## 🔍 Root Cause

`min-width: auto` is what usually saves a flex row like this: an item shrinks to its min-content and the row stays put. `shrink-0` opts out of that entirely, and with every child opted out the row's used width is just the sum of its items — free to exceed the container. `flex-wrap` would not have helped either (#702 removed it for good reason): a single item wider than the line still overflows it.

## What Changed

**`packages/web/src/components/app-shell.tsx`** — `VersionChip` becomes the controls row's one elastic item:

- `shrink-0` → `min-w-0`, so the chip is what yields when the row is over budget.
- The label moves into a `truncate` span, so the chip clips its own text instead of widening the row. Truncating from the tail keeps the half that carries meaning — `v0.9.2-…` — and drops the build stamp, which is the noise.
- `title` now carries the full version **always**, not only when an update is available: the visible text may be clipped, so the tooltip is where the whole string has to stay reachable. When there is an update it reads `v0.9.2 — update available: v0.9.3`, so the running version is named there too rather than being replaced by the newer one.
- The pulsing update dot gains `shrink-0` — it is 5px of signal and must not be the thing that gives.

No layout classes on the row or the footer changed; the two-row structure #702 established is untouched. Nothing else in the sidebar was in scope.

## 🧪 Tests

Verified against `origin/main` @ `6a97d0ff` with a forced clean rebuild:

- `npm run typecheck` — ✅ green (contract, client, server, web)
- `packages/web/src/components/app-shell.test.tsx` — ✅ 78 passed
- `packages/web/e2e/smoke.e2e.ts` — ✅ 20 passed / 1 skipped

**New regressions:**

- **`app-shell.test.tsx`** — jsdom measures nothing, so this pins *which item yields*: the chip has `min-w-0` and not `shrink-0`, its label truncates, its `title` is the whole version, and the other three controls still refuse to shrink. Two existing `title` assertions updated for the always-on tooltip.
- **`smoke.e2e.ts`** — the one that would actually have caught this. It writes a nightly-length version into the live chip and asserts, through a real layout engine, that no child of `sidebar-footer-controls` has a right edge past the sidebar's, and that the chip absorbed it by clipping. **Mutation-checked:** restoring `shrink-0` + dropping `truncate` and rebuilding fails it (`escaped: ['global-settings-link', 'theme-toggle']`); the fix turns it green.

**Manual verification** in Chrome on the rebuilt app, across every width the sidebar can be (#788 makes it resizable, 264–420):

| sidebar | escaped controls | chip |
|---|---|---|
| 264px (min / default) | none — toggle ends at 249 | clips to `v0.9.2-…` |
| 420px (max) | none | full `v0.9.2-nightly.20260813.1`, no clipping |
| 264px mobile drawer @ 390px viewport | none | clips |

The chip gives up only what it must — widen the sidebar and the whole version comes back on its own.

## 💥 Breaking Changes

- None. Presentational only; no prop, `data-slot` or API surface changed. The chip's `textContent` is still exactly `v{version}`, so `smoke.e2e.ts`'s existing health-chip assertion and the `waitForFunction` guards in `new-task.e2e.ts` / `github.e2e.ts` are unaffected.

## Note on the suite

The broad e2e failures in my worktree (`agents-dock`, `github`, `inbox`, ~20 more files) are pre-existing and environmental, not from this change — `agents-dock.e2e.ts` fails 4/4 identically on a pristine `origin/main` checkout on this machine. `smoke.e2e.ts` is green on both. CI is the authority.
