### PR TITLE
docs: disambiguate cezar (OSS) from <SAAS_NAME>

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ and a run never stops to ask; it just finishes. Leave it on a VPS and you get
 a dev team that's *always on* — a mobile-friendly cockpit you can check from
 your phone, working your backlog while you're away.
 
+*This is **cezar** — the open-source, single-user, local-first cockpit you run
+yourself (`npx cezar-cli`) — **not** `<SAAS_NAME>`, the separate hosted team SaaS.*
+
 [A look inside](#a-look-inside) · [What cezar does best](#what-cezar-does-best) · [What it solves](#what-it-solves) · [Who it's for](#who-its-for) · [Quick start](#quick-start) · [How it works](#how-it-works) · [Core concepts](#core-concepts) · [Cockpit tour](#cockpit-tour) · [Agent backends](#coding-agent-backends) · [Remote access](#remote-access-host-cezar-on-a-server)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -831,14 +834,20 @@ Every module is meant to be read in one sitting.
 
 ---
 
-## Relationship to cezar (the SaaS)
+## cezar (this repo) vs. `<SAAS_NAME>` (the team SaaS)
 
-cez is the radically-simple, single-user sibling of
-[**cezar**](https://github.com/comerito/cezar) — the team SaaS cockpit for
-running agents across the whole GitHub issue lifecycle (auto-triage, webhooks,
-Supabase, multi-repo). Same core ideas — agent runner, skills, declarative
-workflows, a live run cockpit — with none of the accounts, database or cloud.
-Start here; graduate to cezar when a team needs shared visibility.
+**This repo is cezar** — the open-source, single-user, local-first cockpit you
+just installed as `cezar-cli`. It runs entirely on your own machine, under your
+own CLI logins: no accounts, no database, no cloud.
+
+`<SAAS_NAME>` is a different product: a hosted, multi-user team SaaS cockpit that
+runs agents across the whole GitHub issue lifecycle (auto-triage, webhooks,
+Supabase, multi-repo). It shares cezar's core ideas — agent runner, skills,
+declarative workflows, a live run cockpit — but it is a team service rather than
+a local tool, and it has no public repository to link to at the time of writing.
+
+Start with cezar; look at `<SAAS_NAME>` when a team needs shared, hosted
+visibility.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ and a run never stops to ask; it just finishes. Leave it on a VPS and you get
 a dev team that's *always on* — a mobile-friendly cockpit you can check from
 your phone, working your backlog while you're away.
 
-*This is **cezar** — the open-source, single-user, local-first cockpit you run
-yourself (`npx cezar-cli`) — **not** `<SAAS_NAME>`, the separate hosted team SaaS.*
-
 [A look inside](#a-look-inside) · [What cezar does best](#what-cezar-does-best) · [What it solves](#what-it-solves) · [Who it's for](#who-its-for) · [Quick start](#quick-start) · [How it works](#how-it-works) · [Core concepts](#core-concepts) · [Cockpit tour](#cockpit-tour) · [Agent backends](#coding-agent-backends) · [Remote access](#remote-access-host-cezar-on-a-server)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -831,23 +828,6 @@ the server, **Zod** at every boundary, **YAML** for workflows, and a **React 19 
 Vite + Tailwind v4 + shadcn/ui** cockpit shipped pre-built in `packages/cezar/web/dist/` — the
 published package carries the built app, so `npx` users never run a bundler.
 Every module is meant to be read in one sitting.
-
----
-
-## cezar (this repo) vs. `<SAAS_NAME>` (the team SaaS)
-
-**This repo is cezar** — the open-source, single-user, local-first cockpit you
-just installed as `cezar-cli`. It runs entirely on your own machine, under your
-own CLI logins: no accounts, no database, no cloud.
-
-`<SAAS_NAME>` is a different product: a hosted, multi-user team SaaS cockpit that
-runs agents across the whole GitHub issue lifecycle (auto-triage, webhooks,
-Supabase, multi-repo). It shares cezar's core ideas — agent runner, skills,
-declarative workflows, a live run cockpit — but it is a team service rather than
-a local tool, and it has no public repository to link to at the time of writing.
-
-Start with cezar; look at `<SAAS_NAME>` when a team needs shared, hosted
-visibility.
 
 ---
 


### PR DESCRIPTION
## What

The README's "Relationship to cezar (the SaaS)" section opened with **"cez is the radically-simple, single-user sibling of cezar"** — leftover from an earlier product name. A first-time reader could not tell which of the two products they had just installed.

This rewrites that section and adds a one-line disambiguator near the top. **README.md only** — no code, no renames.

## Changes

- **Rewrote the section**, renamed the heading to `## cezar (this repo) vs. <SAAS_NAME> (the team SaaS)`. It now states in the first sentence that **this repo is cezar** — the open-source, single-user, local-first tool — and refers to the separate hosted product as `<SAAS_NAME>` throughout, so the two never share a bare "cezar".
- **Dropped the `github.com/comerito/cezar` link.** It returns 404 (HTML page and API alike), so the SaaS is described in prose instead.
- **Added a one-sentence "what this is / what it is not" line** above the badges.

`<SAAS_NAME>` is kept as a literal placeholder per the brief — no name was invented. It is wrapped in backticks because a bare `<SAAS_NAME>` is parsed as an unknown HTML tag and stripped by GitHub's Markdown sanitizer, which would render it invisible.

## Deliberately left alone

`cez` appears in two other roles that are both correct and untouched:

- **Shell alias** — `cez` ships alongside `cezar` and `cezar-cli` (Quick start, Local development, `package.json` `bin`, `BACKWARD_COMPATIBILITY.md`).
- **Code identifier** — `~/.cache/cez/`, the `cez/<id8>` branch prefix, `cez-theme` / `cez-accent` / `cez-new-task-draft` localStorage keys, `CEZ_*` env vars, `cez-*` test temp-dir prefixes.

A repo-wide audit (985 tracked files; excluding `dist/`, `node_modules/`, lockfiles) found **no other product-name misuse**. Checked: `docs/**`, `package.json` (+ `alias-cezar/`), the CLI `--help` and skills banner, the cockpit source under `web/app/`, `AGENTS.md`, `BACKWARD_COMPATIBILITY.md`, and `.github/` — all already correct. There is no `CONTRIBUTING.md` and no issue/PR templates in this repo. `.ai/specs/**` and `.ai/runs/**` do use the old name in places, but they are historical design records and run logs, so they were left as written history.

## Note: two identifiers in the brief do not exist

`VITE_CEZ_API_BASE` and `<meta name="cez-api-base">` were listed as README mentions to verify, but they appear **nowhere in the repo** — not in the README, not in any source file. The cockpit resolves its API base via `web/app/src/api/project-scope.ts`, and `web/app/index.html` carries only `charset` and `viewport` meta tags. Reporting only; no code changed.

The other two identifiers verified clean: `~/.cache/cez/` matches `src/skills-remote.ts:155`, and `cez/<id8>` matches `src/git-worktree.ts:45`.

## Test plan

Docs-only; no behaviour change. Rendered-Markdown check: heading renders, both `<SAAS_NAME>` placeholders are visible, and the top-of-README line sits above the badges. No incoming links referenced the old `#relationship-to-cezar-the-saas` anchor (verified across all tracked files), and the table-of-contents line never listed this section, so no anchor updates were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)