### PR TITLE
fix(server): bound cursorless SSE replay (#882)

### DIFF
--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -49,7 +49,7 @@ What is protected now: **the shape of each route under `/api/v1`**, the three-wa
 - Variants: `GET /api/v1/groups/:groupId`, `POST /api/v1/groups/:groupId/pick`
 - Inbox: `GET /api/v1/todos`, `DELETE /api/v1/todos/:id`, `POST /api/v1/todos/:id/start` — present always, but **gated** on `CEZ_FOLLOWUPS=1` (#471, off by default): the GET degrades to `200 []` and the two mutators answer `409`. The routes themselves must keep existing and must behave exactly as before once the flag is on.
 - Run history: `GET /api/v1/runs/:id/{history,history-context}` (reverse-paged visible events + compact current-state context; boot/default/project aliases remain identical)
-- SSE: `GET /api/v1/events` (boot project), `GET /api/v1/runs/:id/events` (no-query full replay + live; optional opaque `cursor`/`afterSeq` resume, additive data-frame `id`, payload dedup by `seq`), `GET /api/v1/workspace/events` (all projects; workspace-level, never mirrored — see below)
+- SSE: `GET /api/v1/events` (boot project), `GET /api/v1/runs/:id/events` (byte-bounded recent replay + live when no cursor/resume point is supplied; optional opaque `cursor`/`afterSeq` resume, additive data-frame `id`, payload dedup by `seq`; oversized SSE payloads are projected while full NDJSON/history payloads remain intact), `GET /api/v1/workspace/events` (all projects; workspace-level, never mirrored — see below)
   - Legacy `GET /api/v1/events` is **explicitly boot-project-only** and keeps its exact pre-workspace, un-stamped payload shapes (`run` = the bare `RunRecord`, `run-deleted` = `{id}`, `todos` = the bare item array, `usage` filtered to this project's runs, `ping`). Widening it to carry other projects' events, or stamping its payloads with a project id, would be a silent behavioral break for every script reading it — the all-project stream is `/api/v1/workspace/events`, and each project's own stream is `/api/v1/p/:projectId/events` in the same un-stamped shape.
   - `GET /api/v1/workspace/events` reuses the same event names but stamps every payload with the owning `project` id — additively where the legacy payload is an object (`run` grows a `project` key; `run-deleted` becomes `{id, project}`), wrapped where it is not (`todos` → `{project, items}`; `usage` → `{project, usage}`). `usage` is **filtered per project** — one event per project that has live rows, never a stamped whole and never an empty-record clear. Three workspace-only event names exist for the registry/GUI-clone flows: `project-added`, `project-removed`, `checkout-progress` (payloads relayed verbatim from the emitter). The host-wide `provider-status` event is also workspace-only and deliberately **unstamped**: its additive coarse provider row is `{provider, status, hint?, authFailureId?, enabled?}`. It is emitted on a runtime-authentication latch transition, a successful provider enablement change, and a successful incident-safe retry; runtime rows carry the fixed hint and opaque incident id, while enablement/retry rows carry the current `enabled` value. Evolution is additive: a new workspace event name is inert to older consumers, and subscribing never force-instantiates a project (a lazily-built project's events join streams already open).
 - WebSocket: `GET /api/v1/ws` — the topic subscription bus (spec `.ai/specs/2026-07-23-websocket-subscriptions.md`), upgrade-only and workspace-level (single-mount, never mirrored under `/api/v1/p/`). **The path is protected, the frame protocol is not.** The path is what the `packages/cezar/web/dist` bundle and the Vite dev proxy connect to and what the upgrade guard answers `403` on, so moving or removing it is breaking. The frames (`{type:'subscribe'|'unsubscribe',topic}` up; `{type:'event'|'error'|'ping',…}` down) and the topic names are deliberately **internal**: the cockpit bundle ships in lockstep with the server that serves it, there is no cross-version consumer, and unlike `/api/v1/events` nothing outside this repo can have scripted them. Topic names may therefore be added, renamed or dropped freely — but a topic's payload, when it mirrors an HTTP route's shape (`health` does), inherits that route's contract.
@@ -255,6 +255,21 @@ instruction rather than silently.
 - **No deprecation alias**: the flag *is* the migration path — one env var restores the previous
   behavior wholesale, which is what the "keep the old spelling for a minor release" rule exists to
   provide.
+
+## Bounded cursorless run replay (#882), 2026-08-14
+
+The cursorless `GET /api/v1/runs/:id/events` replay is now a byte-bounded recent tail instead of
+the entire persisted transcript. Individual oversized SSE frames are projected to a bounded wire
+form; the append-only NDJSON file and paged history responses retain the full event payload. This
+is an intentional availability-first narrowing of the protected no-query behavior: multi-megabyte
+full replays caused Safari to abort and immediately reconnect, freezing the cockpit before its
+composer could submit. Consumers that need the complete archive must use the paged `history` route;
+reconnects continue from SSE frame ids through `Last-Event-ID`.
+
+Event names, required envelope fields (`seq`, `ts`, `type`), route spellings, cursor semantics, and
+live ordering are unchanged; only an oversized live payload can receive the same SSE-only bounded
+projection. There is no compatibility alias for the unsafe full replay because it would preserve
+the reconnect amplification this change removes.
 
 ## When in doubt
 

--- a/packages/cezar/src/server/route-parity.test.ts
+++ b/packages/cezar/src/server/route-parity.test.ts
@@ -291,6 +291,23 @@ describe('project-route alias parity (unprefixed vs /api/v1/p/<boot> vs /api/v1/
     }
   });
 
+  it('SSE: a cursorless run replay is byte-bounded without rewriting persisted history', async () => {
+    for (let index = 0; index < 40; index += 1) {
+      store.appendEvent(runId, { type: 'note', message: `tail-${index}-${'x'.repeat(100_000)}` });
+    }
+    const oversized = store.appendEvent(runId, { type: 'note', message: `oversized-${'y'.repeat(1_000_000)}` });
+
+    const replay = await sseHead(`/api/v1/runs/${runId}/events`);
+
+    expect(replay.body.length).toBeLessThan(1_600_000);
+    expect(replay.body).not.toContain('tail-0-');
+    expect(replay.body).toContain('tail-39-');
+    expect(replay.body).toContain(`id: ${oversized.seq}`);
+    expect(replay.body).toContain('truncated for SSE');
+    expect(store.readEvents(runId).find(({ seq }) => seq === oversized.seq)?.message)
+      .toBe(oversized.message);
+  });
+
   it('unknown and malformed project ids answer 404 {error}', async () => {
     for (const url of ['/api/v1/p/no-such-project/runs', '/api/v1/p/no-such-project/events']) {
       const res = await apiRequest(app, url);

--- a/packages/cezar/src/server/run-event-replay.test.ts
+++ b/packages/cezar/src/server/run-event-replay.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { RunEvent } from '../runs/store.ts';
+import {
+  MAX_INITIAL_SSE_REPLAY_BYTES,
+  MAX_SSE_EVENT_BYTES,
+  prepareRunEventForSse,
+  selectInitialSseReplay,
+  sseReplayEventBytes,
+} from './run-event-replay.ts';
+
+const event = (seq: number, message: string): RunEvent => ({
+  seq,
+  ts: '2026-08-14T00:00:00.000Z',
+  type: 'note',
+  message,
+});
+
+describe('bounded per-run SSE replay', () => {
+  it('keeps only a byte-bounded contiguous tail for a cursorless initial connection', () => {
+    const events = Array.from({ length: 40 }, (_, index) => event(index + 1, 'x'.repeat(100_000)));
+
+    const replay = selectInitialSseReplay(events);
+
+    expect(replay.length).toBeLessThan(events.length);
+    expect(replay.at(-1)?.seq).toBe(events.at(-1)?.seq);
+    expect(replay.map(({ seq }) => seq)).toEqual(
+      Array.from({ length: replay.length }, (_, index) => events.length - replay.length + index + 1),
+    );
+    expect(replay.reduce((bytes, item) => bytes + sseReplayEventBytes(item), 0))
+      .toBeLessThanOrEqual(MAX_INITIAL_SSE_REPLAY_BYTES);
+  });
+
+  it('preserves the event envelope but bounds a single oversized payload', () => {
+    const original = event(7, 'x'.repeat(MAX_SSE_EVENT_BYTES * 5));
+
+    const prepared = prepareRunEventForSse(original);
+
+    expect(prepared).toMatchObject({ seq: 7, ts: original.ts, type: 'note' });
+    expect(prepared).not.toBe(original);
+    expect(JSON.stringify(prepared)).toContain('truncated for SSE');
+    expect(sseReplayEventBytes(prepared)).toBeLessThanOrEqual(MAX_SSE_EVENT_BYTES);
+    expect(original.message).toHaveLength(MAX_SSE_EVENT_BYTES * 5);
+  });
+});

--- a/packages/cezar/src/server/run-event-replay.ts
+++ b/packages/cezar/src/server/run-event-replay.ts
@@ -1,0 +1,68 @@
+import type { RunEvent } from '../runs/store.ts';
+
+/** Maximum wire footprint of the initial cursorless replay, including SSE framing estimates. */
+export const MAX_INITIAL_SSE_REPLAY_BYTES = 1_500_000;
+/** Maximum wire footprint of one run-event frame. Full payloads remain available through history. */
+export const MAX_SSE_EVENT_BYTES = 256 * 1024;
+
+const MAX_SSE_STRING_CHARS = 64 * 1024;
+const SSE_FRAME_OVERHEAD_BYTES = 128;
+const TRUNCATION_MARKER = '\n… [truncated for SSE; full payload available from run history]';
+
+/** Conservative byte estimate for the id/event/data framing written around one event. */
+export function sseReplayEventBytes(event: RunEvent): number {
+  return Buffer.byteLength(JSON.stringify(event), 'utf8') + SSE_FRAME_OVERHEAD_BYTES;
+}
+
+function truncateLongStrings(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.length <= MAX_SSE_STRING_CHARS
+      ? value
+      : `${value.slice(0, MAX_SSE_STRING_CHARS)}${TRUNCATION_MARKER}`;
+  }
+  if (Array.isArray(value)) return value.map(truncateLongStrings);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nested]) => [key, truncateLongStrings(nested)]),
+  );
+}
+
+/**
+ * Keep ordinary event payloads byte-identical while preventing one persisted tool result from
+ * monopolising (and repeatedly killing) a browser's EventSource connection. The append-only NDJSON
+ * file and paged history responses remain untouched; only the live SSE projection is bounded.
+ */
+export function prepareRunEventForSse(event: RunEvent): RunEvent {
+  const originalBytes = sseReplayEventBytes(event);
+  if (originalBytes <= MAX_SSE_EVENT_BYTES) return event;
+
+  const truncated = truncateLongStrings(event) as RunEvent;
+  if (sseReplayEventBytes(truncated) <= MAX_SSE_EVENT_BYTES) return truncated;
+
+  return {
+    seq: event.seq,
+    ts: event.ts,
+    ...(event.stepId === undefined ? {} : { stepId: event.stepId }),
+    type: event.type,
+    ssePayloadOmitted: true,
+    originalBytes,
+    message: `Event payload omitted from SSE (${originalBytes} bytes; limit ${MAX_SSE_EVENT_BYTES}). Full payload is available from run history.`,
+  };
+}
+
+/**
+ * Project and retain the newest contiguous events that fit the initial replay budget. A client
+ * that needs older events uses the paged history route; reconnects resume from the emitted ids.
+ */
+export function selectInitialSseReplay(events: readonly RunEvent[]): RunEvent[] {
+  const selected: RunEvent[] = [];
+  let selectedBytes = 0;
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = prepareRunEventForSse(events[index]!);
+    const eventBytes = sseReplayEventBytes(event);
+    if (selectedBytes + eventBytes > MAX_INITIAL_SSE_REPLAY_BYTES) break;
+    selected.unshift(event);
+    selectedBytes += eventBytes;
+  }
+  return selected;
+}

--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -92,6 +92,7 @@ import type { RunManager } from '../workflows/run.ts';
 import { removeWorktree, worktreeDiff, worktreeDiffStat, worktreeSizeBytes } from '../git-worktree.ts';
 import { isReclaimable, reclaimWorktrees } from '../runs/retention.ts';
 import { getBranches, getCommit, getDiff, getLog, getRepoInfo, getStatus } from './git.ts';
+import { prepareRunEventForSse, selectInitialSseReplay } from './run-event-replay.ts';
 import {
   collectChanges,
   collectCommitChanges,
@@ -4556,12 +4557,14 @@ export function createApp(deps: ServerDeps) {
         // (dotted types, persisted snapshots AND ephemeral coalesced deltas)
         // ride `ui-event`, which only v2-aware clients subscribe to.
         // EventSource ignores names it has no listener for.
-        const writeEvent = (event: RunEvent) =>
-          stream.writeSSE({
-            id: String(event.seq),
-            event: isV2WireEventType(event.type) ? 'ui-event' : 'run-event',
-            data: JSON.stringify(event),
+        const writeEvent = (event: RunEvent) => {
+          const wireEvent = prepareRunEventForSse(event);
+          return stream.writeSSE({
+            id: String(wireEvent.seq),
+            event: isV2WireEventType(wireEvent.type) ? 'ui-event' : 'run-event',
+            data: JSON.stringify(wireEvent),
           });
+        };
         const onEvent = (payload: { runId: string; event: RunEvent }) => {
           if (payload.runId !== id) return;
           if (replaying) buffered.push(payload.event);
@@ -4580,7 +4583,12 @@ export function createApp(deps: ServerDeps) {
 
         const replay = query.cursor
           ? await readEventsAfterLiveCursor(eventsPath, query.cursor)
-          : { events: store.readEvents(id), boundarySeq: 0 };
+          : {
+              events: requestedAfter === 0
+                ? selectInitialSseReplay(store.readEvents(id))
+                : store.readEvents(id),
+              boundarySeq: 0,
+            };
         maxSeq = Math.max(maxSeq, replay.boundarySeq);
         for (const event of replay.events) {
           if (event.seq <= maxSeq) continue;


### PR DESCRIPTION
Closes #882

## 🎯 Goal

Keep long run streams usable in Safari and over tunnels by preventing a cursorless EventSource connection from replaying an unbounded multi-megabyte transcript.

## 🔍 Problem

The released 0.9.2 and 0.9.3 servers replay the complete NDJSON transcript on every connection. Measured runs returned between 3.49 MB and 28.6 MB per connection, and individual tool events reached 1.24 MB. Safari aborted during replay, immediately reconnected, and repeated the same transfer until the cockpit stopped accepting input.

## 🔍 Root Cause

PR #739 added progressive history, frame ids, `Last-Event-ID`, and cursor resume on `main`, but intentionally retained `store.readEvents(id)` for the protected no-query path. The history hook also uses that path as its compatibility fallback. Consequently the first cursorless connection still has no network or per-frame bound, and a single oversized persisted tool result can reproduce the reconnect amplification even after resume support ships.

## What Changed

- Added an SSE-only event projection that leaves normal frames byte-identical, truncates long string fields only when a frame exceeds 256 KiB, and falls back to a bounded envelope if an event still exceeds that limit. Persisted NDJSON and paged history payloads remain unchanged.
- Limited the first cursorless replay to a contiguous recent tail with a conservative 1.5 MB wire budget. Reconnects continue to resume through the frame ids already added by #739.
- Added unit coverage for total replay and individual-frame bounds, plus a real route regression proving that old history is omitted from SSE while the persisted oversized event remains intact.
- Updated the protected-contract inventory to document the intentional availability-first narrowing and the history-route migration path for consumers that need the complete archive.

## 🧪 Tests

- Regression proof before implementation: `run-event-replay.test.ts` failed because the bounded replay implementation did not exist.
- `npm test --workspace @open-mercato/cezar -- --run src/server/run-event-replay.test.ts src/server/route-parity.test.ts` — 12 tests passed.
- `npm run typecheck` — passed for contract, API client, server, and web.
- `npm run test:unit` — 35 passed, 1 platform-specific test skipped.
- `npm run build` — passed; package check found 478 files and 85 web assets.
- `npm run test:package` — 15 tests passed.
- Two local full `npm test` runs reached 6,060/6,061 passing tests. The only failures were pre-existing parallel timing flakes in `health-topic.test.ts` / `automations-gate.test.ts`; both affected files pass together in isolation (31/31), and the base commit's exact GitHub CI is green: https://github.com/open-mercato/cezar/actions/runs/31816677977. PR CI remains authoritative for this head.

## 💥 Breaking Changes

The no-query `/api/v1/runs/:id/events` connection now receives a recent byte-bounded tail instead of the complete transcript. Consumers requiring the complete archive must use `/api/v1/runs/:id/history`. Event names, required event envelope fields, route aliases, persisted NDJSON, cursor semantics, sequence ids, and event ordering are unchanged. Oversized live SSE payloads can receive the same bounded wire projection while their full persisted form remains available through history.
