### PR TITLE
fix(test-env): prove instance identity before reuse and teardown (#898)

### DIFF
--- a/.ai/scripts/test-env-down.sh
+++ b/.ai/scripts/test-env-down.sh
@@ -4,6 +4,9 @@
 # history:
 #   2026-07-14 generated — mirrors test-env-up.sh; no services to remove, so this
 #             only stops the app PID this repo started and marks the descriptor stopped.
+#   2026-08-17 prove the recorded PID is still this worktree's server before signalling
+#             it, and clear the PID on stop — a descriptor outlives reboots, so its PID
+#             number is routinely recycled onto an unrelated process (#898).
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
@@ -22,6 +25,28 @@ pid=$(node -e '
     if (d.startedByThisRepo && d.app && d.app.pid) process.stdout.write(String(d.app.pid));
   } catch { /* corrupt descriptor → nothing safe to stop */ }
 ' "$ENV_DESCRIPTOR" 2>/dev/null || true)
+
+# The process fingerprint, duplicated from test-env-up.sh on purpose: these two are
+# deliberately standalone entrypoints, and the guard has to hold in both. `startedByThisRepo`
+# cannot carry it — up writes it as the literal true on every boot — and a bare `kill -0`
+# only proves *some* process holds that number. start_app launches
+# `node packages/cezar/dist/index.js … --repo $REPO_ROOT`, which names this worktree alone;
+# the match is anchored at end-of-argv (or a space) so the main checkout cannot claim a
+# worktree's server, `<root>` being a prefix of `<root>/.ai/cezar/worktrees/<id>`.
+is_our_server() {
+  [ -n "${1:-}" ] || return 1
+  cmd=$(ps -ww -o command= -p "$1" 2>/dev/null || true)
+  case "$cmd" in
+    *"packages/cezar/dist/index.js"*"--repo $REPO_ROOT") return 0 ;;
+    *"packages/cezar/dist/index.js"*"--repo $REPO_ROOT "*) return 0 ;;
+  esac
+  return 1
+}
+
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && ! is_our_server "$pid"; then
+  log "descriptor pid $pid is not this worktree's server — leaving it alone"
+  pid=
+fi
 
 # Only ever stop what this repo started; safe to run twice.
 if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
@@ -43,6 +68,10 @@ node -e '
   try {
     const d = JSON.parse(fs.readFileSync(f, "utf8"));
     d.status = "stopped";
+    // Defence in depth: a cleanly stopped descriptor must not nominate any PID at all.
+    // (The identity guards above still matter — a crashed run leaves status "running"
+    // with a dead PID, and this line never gets to run.)
+    if (d.app) d.app.pid = null;
     fs.writeFileSync(f, JSON.stringify(d, null, 2) + "\n");
   } catch { /* leave a corrupt descriptor alone — up will treat it as stale */ }
 ' "$ENV_DESCRIPTOR"

--- a/.ai/scripts/test-env-up.sh
+++ b/.ai/scripts/test-env-up.sh
@@ -101,7 +101,7 @@ port_free() {
 
 http_ok() { curl -fsS --max-time 5 "$1" >/dev/null 2>&1; }
 
-# ---- identity — whose instance is this? -------------------------------------
+# ---- identity — whose instance is this? (#898) ------------------------------
 # A PID number and a port say only that *something* is alive and answering; neither
 # says it is OURS. A descriptor outlives reboots (it is gitignored and only ever
 # rewritten, never deleted), so its PID number is routinely recycled onto an unrelated
@@ -425,9 +425,12 @@ write_descriptor() {
       startedByThisRepo: true,
       startScript: ".ai/scripts/test-env-up.sh",
       stopScript: ".ai/scripts/test-env-down.sh",
-      // `repoRoot` is the identity a bare PID number and a port never carry: it is what
-      // the reuse and teardown guards compare against so a recycled PID or a port taken
-      // by another worktree cannot be mistaken for this instance.
+      // `repoRoot` records which checkout this instance belongs to — the one thing a bare
+      // PID number and a port never carry — for descriptor consumers and for debugging.
+      // The guards deliberately do NOT read it back (#898): the descriptor is the artifact
+      // that goes stale, so both derive $REPO_ROOT themselves and compare against that.
+      // Comparing the file against itself would be a no-op, since the same script at the
+      // same path always writes the same value.
       app: { startCommand: cmd, port: Number(port), healthPath: "/api/v1/health", pid: Number(pid), repoRoot },
       services: [],
       credentials: [],

--- a/.ai/scripts/test-env-up.sh
+++ b/.ai/scripts/test-env-up.sh
@@ -15,6 +15,9 @@
 #             imports as missing/unknown and a cached build cannot start without node_modules.
 #   2026-07-30 execute the compound preparation chain through sh -c and stop requiring an
 #             api-client dist artifact that this source-aliased workspace does not produce.
+#   2026-08-17 reuse and teardown prove the instance's identity (process argv + the health
+#             endpoint's repoRoot) instead of trusting a recorded PID number and port, which
+#             a long-lived descriptor outlives and another worktree can inherit (#898).
 set -eu
 
 # ---- project-specific parameters -------------------------------------------
@@ -98,6 +101,48 @@ port_free() {
 
 http_ok() { curl -fsS --max-time 5 "$1" >/dev/null 2>&1; }
 
+# ---- identity — whose instance is this? -------------------------------------
+# A PID number and a port say only that *something* is alive and answering; neither
+# says it is OURS. A descriptor outlives reboots (it is gitignored and only ever
+# rewritten, never deleted), so its PID number is routinely recycled onto an unrelated
+# process, and its port is routinely taken by another worktree's instance. Every kill
+# and every reuse therefore has to prove identity first.
+
+# The process fingerprint: start_app launches `node packages/cezar/dist/index.js …
+# --repo $REPO_ROOT`, which names this worktree and no other. Anchored at the end of
+# argv (or at a space) because an unanchored match would let the main checkout claim a
+# worktree's server — `<root>` is a prefix of `<root>/.ai/cezar/worktrees/<id>`.
+is_our_server() {
+  [ -n "${1:-}" ] || return 1
+  cmd=$(ps -ww -o command= -p "$1" 2>/dev/null || true)
+  case "$cmd" in
+    *"packages/cezar/dist/index.js"*"--repo $REPO_ROOT") return 0 ;;
+    *"packages/cezar/dist/index.js"*"--repo $REPO_ROOT "*) return 0 ;;
+  esac
+  return 1
+}
+
+# The HTTP fingerprint: GET $HEALTH_PATH reports `repoRoot`, the checkout the answering
+# instance was booted with. Compared through realpath because the server derives its root
+# from git (`getRepoInfo`) while this script derives it from its own path, and the two can
+# disagree on symlinked components. Under CEZ_REMOTE health trims the value to a basename
+# (the test env never sets it, but degrade to a basename comparison rather than a false
+# mismatch). Any non-absolute or unreadable answer is a mismatch, never a pass.
+health_repo_root_matches() {
+  node -e '
+    const fs = require("fs"), path = require("path");
+    const [body, expected] = process.argv.slice(1);
+    let root;
+    try { root = JSON.parse(body).repoRoot; } catch { process.exit(1); }
+    if (typeof root !== "string" || root === "") process.exit(1);
+    const real = (p) => { try { return fs.realpathSync(p); } catch { return p; } };
+    const ok = path.isAbsolute(root)
+      ? real(root) === real(expected)
+      : root === path.basename(expected);
+    process.exit(ok ? 0 : 1);
+  ' "$1" "$REPO_ROOT" 2>/dev/null
+}
+
 json_get() { node -e '
   const fs = require("fs");
   try {
@@ -167,12 +212,19 @@ try_reuse() {
   [ "${CEZ_SINGLE_PROJECT:-}" = 1 ] && requested_single_project=true
   [ "$(json_get "$ENV_DESCRIPTOR" environment.singleProject)" = "$requested_single_project" ] || return 1
   [ -n "$pid" ] && [ -n "$url" ] || return 1
-  # A state file is a claim, not proof: the PID must still be alive…
+  # A state file is a claim, not proof: the PID must still be alive and must still be
+  # THIS worktree's server. `kill -0` alone passes on any recycled PID number, which
+  # would then be handed to the teardown/stop path as a kill target.
   kill -0 "$pid" 2>/dev/null || return 1
+  is_our_server "$pid" || { log "descriptor pid $pid is not this worktree's server — rebooting"; return 1; }
   # …and the app must actually answer. Health first (deep: reads config + git),
   # then the app shell, which is what the e2e specs actually load.
-  http_ok "$url$HEALTH_PATH" || return 1
+  health=$(curl -fsS --max-time 5 "$url$HEALTH_PATH" 2>/dev/null) || return 1
   http_ok "$url/" || return 1
+  # An answer on the recorded port is not an answer from OUR instance: another
+  # worktree may have taken the port meanwhile, and attaching to it would test a
+  # different branch's build while reporting it as verified.
+  health_repo_root_matches "$health" || { log "$url serves a different checkout — rebooting"; return 1; }
 
   # Fresh: within TTL and no tracked source newer than startedAt.
   if [ -n "$started" ]; then
@@ -190,15 +242,22 @@ try_reuse() {
 
 teardown_stale() {
   [ -f "$ENV_DESCRIPTOR" ] || return 0
+  # A descriptor already marked stopped has nothing to tear down; its PID field is
+  # only a record of what used to run, so acting on it is pure hazard.
+  [ "$(json_get "$ENV_DESCRIPTOR" status)" = running ] || return 0
   pid=$(json_get "$ENV_DESCRIPTOR" app.pid)
-  own=$(json_get "$ENV_DESCRIPTOR" startedByThisRepo)
-  # Only ever kill what this repo started.
-  if [ -n "$pid" ] && [ "$own" = true ] && kill -0 "$pid" 2>/dev/null; then
-    log "stopping stale instance (pid $pid)"
-    kill "$pid" 2>/dev/null || true
-    sleep 1
-    kill -9 "$pid" 2>/dev/null || true
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null || return 0
+  # Only ever kill what this repo started — proven from the live process, not from
+  # `startedByThisRepo`, which write_descriptor hard-writes as true on every boot and
+  # so can never be false.
+  if ! is_our_server "$pid"; then
+    log "descriptor pid $pid is not this worktree's server — leaving it alone"
+    return 0
   fi
+  log "stopping stale instance (pid $pid)"
+  kill "$pid" 2>/dev/null || true
+  sleep 1
+  kill -9 "$pid" 2>/dev/null || true
 }
 
 # ---- 4. build cache ---------------------------------------------------------
@@ -356,7 +415,7 @@ write_descriptor() {
   [ "${CEZ_SINGLE_PROJECT:-}" = 1 ] && SINGLE_PROJECT=true
   node -e '
     const fs = require("fs");
-    const [out, baseUrl, port, pid, cmd, bInstalled, bCmd, bVer, bNotes, desc, singleProject, platform] = process.argv.slice(1);
+    const [out, baseUrl, port, pid, cmd, bInstalled, bCmd, bVer, bNotes, desc, singleProject, platform, repoRoot] = process.argv.slice(1);
     fs.writeFileSync(out, JSON.stringify({
       version: 1,
       runId: "cezar-" + new Date().toISOString().slice(0, 10) + "-" + pid,
@@ -366,7 +425,10 @@ write_descriptor() {
       startedByThisRepo: true,
       startScript: ".ai/scripts/test-env-up.sh",
       stopScript: ".ai/scripts/test-env-down.sh",
-      app: { startCommand: cmd, port: Number(port), healthPath: "/api/v1/health", pid: Number(pid) },
+      // `repoRoot` is the identity a bare PID number and a port never carry: it is what
+      // the reuse and teardown guards compare against so a recycled PID or a port taken
+      // by another worktree cannot be mistaken for this instance.
+      app: { startCommand: cmd, port: Number(port), healthPath: "/api/v1/health", pid: Number(pid), repoRoot },
       services: [],
       credentials: [],
       environment: { singleProject: singleProject === "true" },
@@ -384,9 +446,10 @@ write_descriptor() {
       notes: "Booted from a production build after npm ci with CEZ_DRY_RUN=1, so workspace links/runtime dependencies are present, the agent CLIs are mocked, and no agent login/network is needed. No backing services. Stop with .ai/scripts/test-env-down.sh. App log: .ai/qa/test-env-app.log.",
     }, null, 2) + "\n");
   ' "$ENV_DESCRIPTOR" "$BASE_URL" "$PORT" "$APP_PID" \
-    "CEZ_DRY_RUN=1 CEZ_HOME=.ai/qa/cez-home node packages/cezar/dist/index.js --port $PORT --no-open" \
+    "CEZ_DRY_RUN=1 CEZ_HOME=.ai/qa/cez-home node packages/cezar/dist/index.js --port $PORT --no-open --repo $REPO_ROOT" \
     "$BROWSER_INSTALLED" "$BROWSER_COMMAND" "$BROWSER_VERSION" "$BROWSER_NOTES" "$BROWSER_DESCRIPTOR" \
-    "$SINGLE_PROJECT" "$(uname -s 2>/dev/null | grep -qi Linux && { grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null && echo wsl2 || echo linux; } || echo darwin)"
+    "$SINGLE_PROJECT" "$(uname -s 2>/dev/null | grep -qi Linux && { grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null && echo wsl2 || echo linux; } || echo darwin)" \
+    "$REPO_ROOT"
 }
 
 # ---- main -------------------------------------------------------------------

--- a/packages/cezar/test/unit/test-env-launcher.test.ts
+++ b/packages/cezar/test/unit/test-env-launcher.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, test } from 'node:test';
@@ -41,7 +44,9 @@ function makeFixture(withSetsid: boolean): { root: string; path: string } {
   writeFileSync(join(root, 'package.json'), '{"private":true}\n');
   writeFileSync(join(root, 'package-lock.json'), '{}\n');
 
-  const commands = ['cat', 'chmod', 'curl', 'date', 'dirname', 'find', 'grep', 'id', 'kill', 'mkdir', 'mv', 'nohup', 'pwd', 'rm', 'sh', 'sleep', 'tail', 'uname'];
+  // `ps` earns its place here: the identity guards read the live process's argv through it,
+  // and a fixture PATH without it would make every guard fail closed and silently pass.
+  const commands = ['cat', 'chmod', 'curl', 'date', 'dirname', 'find', 'grep', 'id', 'kill', 'mkdir', 'mv', 'nohup', 'ps', 'pwd', 'rm', 'sh', 'sleep', 'tail', 'uname'];
   if (withSetsid) commands.push('setsid');
   for (const command of commands) symlinkSync(commandPath(command), join(root, 'bin', command));
   symlinkSync(process.execPath, join(root, 'bin/node'));
@@ -58,9 +63,14 @@ printf '{"name":"zod"}' > node_modules/zod/package.json
 cat > packages/cezar/dist/index.js <<'EOF'
 const http = require('node:http');
 const port = Number(process.argv[process.argv.indexOf('--port') + 1]);
+// The real server reports the checkout it was booted with on the health route, and the
+// launcher's reuse guard compares that against its own root — so the fake has to echo
+// --repo back rather than answer with a shape that carries no identity at all.
+const repoRoot = process.argv[process.argv.indexOf('--repo') + 1];
 http.createServer((req, res) => {
-  res.writeHead(200, { 'content-type': req.url === '/api/health' ? 'application/json' : 'text/html' });
-  res.end(req.url === '/api/health' ? '{"ok":true}' : '<!doctype html>');
+  const health = req.url === '/api/health' || req.url === '/api/v1/health';
+  res.writeHead(200, { 'content-type': health ? 'application/json' : 'text/html' });
+  res.end(health ? JSON.stringify({ ok: true, repoRoot }) : '<!doctype html>');
 }).listen(port, '127.0.0.1');
 EOF
 printf '<!doctype html>' > packages/cezar/web/dist/index.html
@@ -81,11 +91,56 @@ esac
   return { root, path: join(root, 'bin') };
 }
 
-function descriptor(root: string): { baseUrl: string; app: { pid: number } } {
-  return JSON.parse(readFileSync(join(root, '.ai/qa/test-env.json'), 'utf8')) as {
-    baseUrl: string;
-    app: { pid: number };
-  };
+type Descriptor = {
+  status: string;
+  baseUrl: string;
+  startedAt: string;
+  startedByThisRepo: boolean;
+  environment: { singleProject: boolean };
+  browser: { installed: boolean };
+  app: { pid: number | null; repoRoot: string };
+};
+
+function descriptor(root: string): Descriptor {
+  return JSON.parse(readFileSync(join(root, '.ai/qa/test-env.json'), 'utf8')) as Descriptor;
+}
+
+function writeDescriptor(root: string, descriptorToWrite: unknown): void {
+  writeFileSync(join(root, '.ai/qa/test-env.json'), `${JSON.stringify(descriptorToWrite, null, 2)}\n`);
+}
+
+async function freePort(): Promise<number> {
+  return await new Promise((resolvePort, rejectPort) => {
+    const probe = createServer();
+    probe.once('error', rejectPort);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close(() => resolvePort(port));
+    });
+  });
+}
+
+/**
+ * `kill -0` is not enough to prove survival here: these processes are children of the test
+ * runner, and a killed-but-unreaped child is a zombie that `kill -0` still reports as alive.
+ * The child handle is the honest witness — an exit shows up as a code or a signal.
+ */
+async function assertStillRunning(child: ChildProcess, label: string): Promise<void> {
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  assert.equal(child.exitCode, null, `${label} exited with code ${child.exitCode}`);
+  assert.equal(child.signalCode, null, `${label} was signalled with ${child.signalCode}`);
+}
+
+async function waitForHealth(baseUrl: string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      if ((await fetch(`${baseUrl}/api/v1/health`)).ok) return;
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+  assert.fail(`${baseUrl} never became healthy`);
 }
 
 for (const withSetsid of [true, false]) {
@@ -113,7 +168,9 @@ for (const withSetsid of [true, false]) {
       assert.match(cold.stdout, /TEST_ENV_REUSED=0/);
 
       const first = descriptor(fixture.root);
-      launchedPids.add(first.app.pid);
+      const firstPid = first.app.pid;
+      assert.ok(firstPid, 'a cold boot records the live pid');
+      launchedPids.add(firstPid);
       if (withSetsid) {
         const callerPid = Number(readFileSync(callerPidFile, 'utf8').trim());
         try {
@@ -123,20 +180,113 @@ for (const withSetsid of [true, false]) {
         }
         await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
       }
-      assert.equal(process.kill(first.app.pid, 0), true);
+      assert.equal(process.kill(firstPid, 0), true);
       const health = await fetch(`${first.baseUrl}/api/health`).then((response) => response.json());
-      assert.deepEqual(health, { ok: true });
+      assert.deepEqual(health, { ok: true, repoRoot: first.app.repoRoot });
 
       const warm = spawnSync('/bin/sh', [up], { encoding: 'utf8', env, timeout: 20_000 });
       assert.equal(warm.status, 0, warm.stderr);
       assert.match(warm.stdout, /TEST_ENV_REUSED=1/);
-      assert.equal(descriptor(fixture.root).app.pid, first.app.pid);
+      assert.equal(descriptor(fixture.root).app.pid, firstPid);
 
       const stopped = spawnSync('/bin/sh', [down], { encoding: 'utf8', env, timeout: 20_000 });
       assert.equal(stopped.status, 0, stopped.stderr);
       assert.match(stopped.stdout, /TEST_ENV_STATUS=stopped/);
-      assert.throws(() => process.kill(first.app.pid, 0));
-      launchedPids.delete(first.app.pid);
+      assert.throws(() => process.kill(firstPid, 0));
+      // A cleanly stopped descriptor nominates no PID at all, so nothing downstream can
+      // inherit a number that now belongs to somebody else.
+      assert.equal(descriptor(fixture.root).app.pid, null);
+      launchedPids.delete(firstPid);
     },
   );
 }
+
+// ---- instance identity (#898) ----------------------------------------------
+// A PID number and a port prove liveness, never ownership. The descriptor is gitignored
+// and only ever rewritten, so it outlives reboots — after which its PID number is
+// routinely recycled onto an unrelated process and its port is routinely held by another
+// worktree's instance. These cover both halves of that.
+
+test('a descriptor whose PID was recycled onto a foreign process never signals it', async () => {
+  const fixture = makeFixture(hasSetsid);
+  const env = { ...process.env, PATH: fixture.path, TEST_ENV_CACHE_TTL_SECONDS: '600' };
+  const up = join(fixture.root, '.ai/scripts/test-env-up.sh');
+
+  // Stands in for whatever inherited the recorded number after a reboot: a live process
+  // that is emphatically not a cezar server.
+  const bystander = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 300_000)'], { stdio: 'ignore' });
+  const bystanderPid = bystander.pid;
+  assert.ok(bystanderPid, 'the bystander process started');
+  launchedPids.add(bystanderPid);
+
+  mkdirSync(join(fixture.root, '.ai/qa'), { recursive: true });
+  writeDescriptor(fixture.root, {
+    status: 'running',
+    // Nothing answers here — the descriptor is stale in every respect except its liveness signal.
+    baseUrl: 'http://127.0.0.1:1',
+    startedByThisRepo: true,
+    startedAt: new Date().toISOString(),
+    app: { pid: bystanderPid, port: 1, healthPath: '/api/v1/health', repoRoot: fixture.root },
+    environment: { singleProject: false },
+    browser: { installed: true },
+  });
+
+  const boot = spawnSync('/bin/sh', [up], { encoding: 'utf8', env, timeout: 20_000 });
+  assert.equal(boot.status, 0, boot.stderr);
+  assert.match(boot.stdout, /TEST_ENV_REUSED=0/);
+
+  await assertStillRunning(bystander, 'the bystander holding the recycled pid');
+  const booted = descriptor(fixture.root);
+  assert.ok(booted.app.pid, 'a fresh instance booted');
+  assert.notEqual(booted.app.pid, bystanderPid);
+  launchedPids.add(booted.app.pid);
+});
+
+test('an instance from another checkout on the recorded port is not reused as this one', async () => {
+  const fixture = makeFixture(hasSetsid);
+  const env = { ...process.env, PATH: fixture.path, TEST_ENV_CACHE_TTL_SECONDS: '600' };
+  const up = join(fixture.root, '.ai/scripts/test-env-up.sh');
+
+  const cold = spawnSync('/bin/sh', [up], { encoding: 'utf8', env, timeout: 20_000 });
+  assert.equal(cold.status, 0, cold.stderr);
+  assert.match(cold.stdout, /TEST_ENV_REUSED=0/);
+  const ours = descriptor(fixture.root);
+  const oursPid = ours.app.pid;
+  assert.ok(oursPid, 'a cold boot records the live pid');
+  launchedPids.add(oursPid);
+
+  // The guards must not defeat the build cache: an instance this fixture booted is
+  // still recognised as its own and reused.
+  const warm = spawnSync('/bin/sh', [up], { encoding: 'utf8', env, timeout: 20_000 });
+  assert.equal(warm.status, 0, warm.stderr);
+  assert.match(warm.stdout, /TEST_ENV_REUSED=1/);
+
+  // The realistic collision: the recorded PID is still alive and still genuinely ours,
+  // but the recorded port has meanwhile been taken by a different checkout's instance.
+  // Liveness says "reuse"; only identity says otherwise.
+  const foreignRoot = `${fixture.root}-other-worktree`;
+  const foreignPort = await freePort();
+  const foreign = spawn(
+    process.execPath,
+    [join(fixture.root, 'packages/cezar/dist/index.js'), '--port', String(foreignPort), '--no-open', '--repo', foreignRoot],
+    { stdio: 'ignore' },
+  );
+  const foreignPid = foreign.pid;
+  assert.ok(foreignPid, 'the foreign instance started');
+  launchedPids.add(foreignPid);
+  const foreignUrl = `http://127.0.0.1:${foreignPort}`;
+  await waitForHealth(foreignUrl);
+
+  writeDescriptor(fixture.root, { ...ours, baseUrl: foreignUrl, startedAt: new Date().toISOString() });
+
+  const collided = spawnSync('/bin/sh', [up], { encoding: 'utf8', env, timeout: 20_000 });
+  assert.equal(collided.status, 0, collided.stderr);
+  assert.match(collided.stdout, /TEST_ENV_REUSED=0/);
+  await assertStillRunning(foreign, "the other checkout's instance");
+
+  const rebooted = descriptor(fixture.root);
+  assert.ok(rebooted.app.pid, 'a fresh instance booted');
+  assert.notEqual(rebooted.baseUrl, foreignUrl);
+  assert.equal(rebooted.app.repoRoot, ours.app.repoRoot);
+  launchedPids.add(rebooted.app.pid);
+});


### PR DESCRIPTION
Closes #898

## 🎯 Goal
Make the test-env launcher act only on the instance this worktree actually started, so a QA run can no longer `kill -9` an unrelated process or silently verify a different branch's build.

## 🔍 Problem
`.ai/scripts/test-env-up.sh` and `.ai/scripts/test-env-down.sh` decided both *"reuse this instance"* and *"kill this instance"* from liveness signals that never proved the process was theirs: `kill -0 $pid` plus an HTTP 200 on the recorded URL. `.ai/qa/test-env.json` is gitignored and never removed — `down` only rewrote one field — so it outlives reboots and days of process churn, after which the recorded PID number very plausibly belongs to something else. Two failure modes followed, worst first: a `kill -9` of an innocent process, which needs only PID recycling and no second coincidence; and a silent false-green QA run, where the recorded port has meanwhile been taken by another worktree's instance and the run tests a different branch's build while reporting "verified" — the worst possible outcome for a gate whose whole job is to be trustworthy, because it passes *and* leaves evidence claiming it checked.

## 🔍 Root Cause
The descriptor recorded *where* (a URL) and *what number* (a PID), never *who*. `try_reuse()` required `status: running`, `kill -0 $pid`, `curl` OK on the health path and on `/`, TTL freshness, and no source newer than `startedAt` — every one of which a *foreign* process satisfies, because `kill -0` only asks whether some process currently holds that number and the two HTTP probes only ask whether something answers on that port. `teardown_stale()` killed whenever `startedByThisRepo` was true, and `write_descriptor()` writes that field as the literal `true` on every boot, so it could never be false; it also never consulted `status`, so a descriptor left behind by `test-env-down.sh` (which rewrote `status` to `stopped` but kept `app.pid`) still nominated that PID for `kill` and then `kill -9`. `test-env-down.sh` carried the identical pattern.

The identity signal already existed and was simply unused: `GET /api/v1/health` returns `repoRoot`, the checkout path of the answering instance (`packages/cezar/src/server/server.ts:1476`), and `start_app()` launches `node packages/cezar/dist/index.js … --repo "$REPO_ROOT"`, a per-worktree argv fingerprint.

## What Changed
- **`.ai/scripts/test-env-up.sh`** — new `is_our_server()` reads the live process's argv via `ps -ww -o command= -p` and requires *both* `packages/cezar/dist/index.js` and `--repo $REPO_ROOT`. The match is anchored at end-of-argv (or a space) deliberately: an unanchored match would let the main checkout claim a worktree's server, since `<root>` is a prefix of `<root>/.ai/cezar/worktrees/<id>`. New `health_repo_root_matches()` parses `repoRoot` out of the health payload and compares it through `realpath` — the server derives its root from git (`getRepoInfo`) while the script derives it from its own path, and the two can disagree on symlinked components; it degrades to a basename comparison for the `CEZ_REMOTE`-trimmed form, and treats an unreadable or empty answer as a mismatch, never a pass.
- **`try_reuse()`** — now also requires the recorded PID to be this worktree's server *and* the recorded port to be answered by this checkout. Both rejections log a greppable reason in the same shape as the existing `source changed since boot (…)` line.
- **`teardown_stale()`** — gates the kill on `is_our_server` and on `status = running` instead of on `startedByThisRepo`. A PID that is not ours is logged and left alone.
- **`write_descriptor()`** — records `app.repoRoot`, which checkout this instance belongs to, for descriptor consumers and debugging. The guards deliberately do *not* read it back: the descriptor is the artifact that goes stale, so each derives `$REPO_ROOT` itself and compares against that — comparing the file against itself would be a no-op. Its `startCommand` string also regains the `--repo` flag the process has always carried in argv but the descriptor omitted.
- **`.ai/scripts/test-env-down.sh`** — the same guard before signalling (duplicated on purpose: these are deliberately standalone entrypoints), plus `app.pid: null` alongside `status: "stopped"`, so a cleanly stopped descriptor nominates no PID at all. That is defence in depth, not a substitute — a crashed run still leaves `status: running` with a dead PID, which is what the identity guard covers.

Where `ps` is unavailable the guards fail closed: reuse is declined and the kill is skipped, costing a reboot rather than risking a wrong signal.

## 🧪 Tests
- `npm run test:unit` — pass; `npm run build` — pass; `npm run test:package` — pass; `npm run typecheck` — pass.
- `npm test` — 6084 passed / 6 failed. Every one of the 6 reproduces on a clean tree with no changes at all (`directional-usage`, `agents-section`, `todos` watch, two `git-changes` cases) or is flaky under full-suite load (`automations-gate` passes in isolation). None is in the changed area. A further 8 failures seen initially were an artifact of `TMPDIR` pointing inside the git repo, which breaks tests asserting "outside a git repository".
- Three new cases in `packages/cezar/test/unit/test-env-launcher.test.ts`, all red-green proven — they fail on the unfixed scripts and pass on the fixed ones:
  - a descriptor whose PID was recycled onto a foreign process leaves that process running;
  - an instance from another checkout on the recorded port forces `TEST_ENV_REUSED=0` rather than being adopted;
  - a happy-path regression that an instance the fixture booted is still reused (`TEST_ENV_REUSED=1`), so the guards do not defeat the build cache.
- Two supporting fixture changes were load-bearing rather than cosmetic: `ps` joins the fixture's symlinked PATH (without it every guard fails closed and the tests would pass vacuously), and the fake server answers `/api/v1/health` echoing its own `--repo` (the real server reports `repoRoot` there; the fixture previously only special-cased `/api/health`). The survival assertions use `ChildProcess.exitCode`/`signalCode` rather than `kill -0`, which succeeds on a zombie — the first draft of the recycled-PID test passed against the *unfixed* script for exactly that reason.

## 💥 Breaking Changes
None. `BACKWARD_COMPATIBILITY.md` protects the HTTP API surface and the published package; this touches only the generated `.ai/scripts/` test-env entrypoints and their unit test. `.ai/qa/test-env.json` gains one additive field (`app.repoRoot`) and corrects `startCommand` — the file is gitignored, per-worktree, and rewritten on every boot, so no consumer needs a migration. Neither descriptor consumer (`.ai/scripts/e2e.sh`, `packages/web/e2e/agent-browser.ts`) reads `app.pid` or `app.startCommand`.

## Notes for the reviewer
- The issue also asked to correct `app.healthPath` (`/api/health` → `/api/v1/health`) and the hard-coded `platform: "wsl2"`. **Both already landed on `main` in `bbd77e9b` (#739)**, after the issue's analysis was written, so they are not in this diff. Only the `startCommand` omission remained from that family.
- Out of scope, as the issue notes: the bootstrap lock at `.ai/qa/test-env.lock` has the same `kill -0`-only shape for stale-owner recovery, but its consequence is only *waiting* on a foreign PID for up to 300 s rather than signalling it. Worth a follow-up, not worth widening this fix.

