### PR TITLE
fix(tasks): keep the about-PR chip when a task opens a PR of its own

### DIFF
--- a/.ai/specs/2026-07-16-pr-autodiscovery.md
+++ b/.ai/specs/2026-07-16-pr-autodiscovery.md
@@ -42,6 +42,17 @@ The created tier always wins. Both fields are additive and optional — old
   into `pullRequestUrl` only when the same event also matches
   `CREATED_PR_RE`. Scanning v2 sources fixes creation detection for backends
   that report `gh pr create` through tool items.
+  - **Amendment — where the claim may come from.** Matching `CREATED_PR_RE`
+    against *everything* an event carried made tool OUTPUT able to claim
+    authorship: a task that printed a log, a stored transcript or a test
+    fixture containing someone else's `gh pr create` line adopted their PR —
+    in another repository — and, because the first adoption freezes the tier,
+    never looked at the one it really opened. The claim is now read from
+    `eventCreationClaimFragments` (the agent's own turn text, an assistant
+    message item, and the tool TITLE cezar renders from the command it saw
+    run) while the URL is still taken from the whole event, since `gh` prints
+    it in the output. The referenced tier is untouched by this: it may be
+    wrong about a *subject*, never about *authorship*.
 - **Referenced detection:** every distinct PR URL spotted accumulates into
   `referencedPrCandidates` (capped at 8 — beyond that the conversation is a
   survey, not a subject). `referencedPullRequestUrl` is then resolved:

--- a/.ai/specs/2026-07-18-task-ref-markers.md
+++ b/.ai/specs/2026-07-18-task-ref-markers.md
@@ -72,9 +72,26 @@ this spec or `handoff.ts` cannot poison its own record via tool output echoes.
 | Field | marker | namer (LLM) | janitor (regex) | user |
 |---|---|---|---|---|
 | `prNumber` / `issueNumber` | **wins** | only while no marker of that kind | seed at creation (task prompt regex) | — |
-| `referencedPullRequestUrl` | marker number filters candidates — only a URL ending in the declared number resolves; no match → unset (no chip beats a wrong chip) | — | fuzzy resolution only while no `CEZ:PR` marker | — |
+| `referencedPullRequestUrl` | marker number filters candidates — only a URL ending in the declared number resolves; no match → unset (no chip beats a wrong chip). Exception: a number equal to the created PR's is ignored here — see the amendment below | — | fuzzy resolution only while no `CEZ:PR` marker | — |
 | `pullRequestUrl` (created tier) | untouched — `CREATED_PR_RE` / cockpit draft-PR flow stay authoritative | — | unchanged | — |
 | `titleSummary` | `CEZ:TITLE` wins over namer | only while `titleOrigin` is unset/`auto` | — | **PATCH rename always wins** (`titleOrigin: 'user'`) |
+
+### Amendment — a declaration naming the PR the run CREATED
+
+The instruction fragment asks the agent to re-emit `CEZ:PR` when it opens a PR later in the task,
+so on such a run the LAST declaration is the number of the run's OWN PR — not the PR it is about.
+Fed to the referenced tier that declaration erased the subject: no candidate ends in the created
+number, and "no match → unset" cleared the chip (seen on a task started on open-mercato#4326 that
+pushed a follow-up as #5366 and dropped from two chips to one).
+
+So a declaration equal to the number in `pullRequestUrl` is read as a statement about the
+**created** tier, which already carries it, and the referenced tier resolves as if it had not been
+made (`referencedPrDeclaration`, `src/runs/store.ts`). `prNumber` follows the same rule: such a
+declaration only FILLS it, never overwrites the about-number the task came in with. Both writers
+(`applyMarkerRefs`, and the janitor at the moment it adopts a created URL) go through the one
+helper, so the marker and the creation evidence may arrive in either order. Records already
+written the old way are healed on load by `reconcileLoadedRun` — one-directional, so it can only
+restore a chip, never remove one.
 
 Record model (additive, old `runs.json` files keep parsing):
 

--- a/.ai/specs/2026-07-18-task-ref-markers.md
+++ b/.ai/specs/2026-07-18-task-ref-markers.md
@@ -93,6 +93,17 @@ helper, so the marker and the creation evidence may arrive in either order. Reco
 written the old way are healed on load by `reconcileLoadedRun` — one-directional, so it can only
 restore a chip, never remove one.
 
+### Amendment — an uncorroborated declaration leads the chips
+
+`taskReferences` (cockpit) orders references created-PR first, then about-PR, then issue. One thing
+now sits ahead of all of them: a `CEZ:PR` number that **no** scraped URL on the record carries.
+Normally there is none — the agent re-declares with the PR it opened, so the declaration IS the
+created URL and the order is unchanged. When there IS one, the URL tier is naming something the
+agent never did, and that tier is the one built from transcript guesses: a task that quoted
+another run's `gh pr create` line was credited with that run's PR and it led every list, hiding
+the PR the task had actually opened behind it. A statement the agent made outranks a line a
+janitor found.
+
 Record model (additive, old `runs.json` files keep parsing):
 
 - `markerRefs?: { pr?: number; issue?: number }` — what the agent declared;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   prints it. And when a task declares a PR (`CEZ:PR`) that no scraped link corroborates, that
   declaration now leads the chips — so a PR picked up by mistake can no longer push the one the
   task actually named out of the single-chip surfaces. (#901)
+- 🐛 **A reference chip on a task's own page links, in every project.** A PR or issue known only
+  by number was a live link on All tasks and dead text on the task's page whenever the project
+  was not the one cezar booted in: that page synthesized links from `/health`, which always
+  reports the boot project's repository, so it refused to guess rather than point at the wrong
+  repo (#526). It now reads the project registry's own per-project repository — the same source
+  All tasks uses — and falls back to health only for the boot project. (#901)
 
 # 0.10.0 (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   what it is, a statement about the created PR (`pullRequestUrl` already carries it), so the PR
   the task is about survives it, as does the number the task came in with. Records already
   written this way heal when they are next read — no migration. The run header now paints every
-  PR the task points at, too, instead of only the strongest one.
+  PR the task points at, too, instead of only the strongest one. (#901)
 
 # 0.10.0 (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
   different repository, permanently: the first PR adopted wins, so the real one that followed was
   never looked at. The phrase is now believed only from the agent's own words or from the command
   cezar saw run — the link itself may still come from the command's output, which is where `gh`
-  prints it. (#901)
+  prints it. And when a task declares a PR (`CEZ:PR`) that no scraped link corroborates, that
+  declaration now leads the chips — so a PR picked up by mistake can no longer push the one the
+  task actually named out of the single-chip surfaces. (#901)
 
 # 0.10.0 (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Unreleased
 
-<!-- Nothing yet. -->
+## 🐛 Fixes
+- 🐛 **A task that opens its own PR keeps the chip for the PR it was working on.** A task started
+  on someone else's PR that pushed a follow-up of its own showed only the new one: the agent
+  re-declares `CEZ:PR` with the number it just opened, as the marker contract asks it to, and
+  that declaration was applied to the *referenced* tier — which clears the chip when no candidate
+  matches the declared number. A declaration naming the PR the run itself created is now read as
+  what it is, a statement about the created PR (`pullRequestUrl` already carries it), so the PR
+  the task is about survives it, as does the number the task came in with. Records already
+  written this way heal when they are next read — no migration. The run header now paints every
+  PR the task points at, too, instead of only the strongest one.
 
 # 0.10.0 (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@
   what it is, a statement about the created PR (`pullRequestUrl` already carries it), so the PR
   the task is about survives it, as does the number the task came in with. Records already
   written this way heal when they are next read — no migration. The run header now paints every
-  PR the task points at, too, instead of only the strongest one. (#901)
+  PR the task points at, too, instead of only the strongest one — including a PR known only by
+  number, which it used to drop whenever it had no repository to build a link from. (#901)
+- 🐛 **A task can no longer be credited with a PR it only read about.** cezar decides a task
+  opened a PR by spotting `gh pr create` (or "opened a pull request") near a PR link — and it
+  scanned tool *output* for that phrase, so a task that printed a log, a stored transcript, or a
+  test fixture containing someone else's creation line adopted their PR as its own, in a
+  different repository, permanently: the first PR adopted wins, so the real one that followed was
+  never looked at. The phrase is now believed only from the agent's own words or from the command
+  cezar saw run — the link itself may still come from the command's output, which is where `gh`
+  prints it. (#901)
 
 # 0.10.0 (2026-08-14)
 

--- a/packages/cezar/src/runs/store.test.ts
+++ b/packages/cezar/src/runs/store.test.ts
@@ -377,6 +377,73 @@ describe('RunStore — PR auto-link only on real creation (#fake-pr)', () => {
     } as never);
     expect(store.getRun(run.id)?.pullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/321');
   });
+
+  // The claim must come from something that can speak FOR this run. Verbatim from the task that
+  // wrote this guard: it dumped ANOTHER run's stored events while investigating them, and the
+  // dump contained that run's `"title": "Ran gh pr create …"` next to its PR URL — so this run
+  // adopted a PR in a different repository as its own, forever (the first created URL wins).
+  it('does not believe a creation phrase that arrives inside tool OUTPUT', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'item.completed',
+      item: {
+        kind: 'tool',
+        id: 't1',
+        name: 'Bash',
+        toolKind: 'execute',
+        title: 'Ran python3 - <<PY … PY',
+        status: 'completed',
+        input: { command: 'python3 - <<PY\nprint(open("other-run.ndjson").read())\nPY' },
+        output:
+          '{"type":"item.completed","item":{"kind":"tool","title":"Ran gh pr create --repo o/other …",' +
+          '"output":"https://github.com/o/other/pull/5366"}}',
+      },
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.pullRequestUrl).toBeUndefined();
+    // Still a PR URL the conversation mentioned, so the referenced tier keeps it as a candidate —
+    // that tier is allowed to be wrong about a subject, never about authorship.
+    expect(loaded?.referencedPrCandidates).toEqual(['https://github.com/o/other/pull/5366']);
+  });
+
+  it('does not believe a creation phrase the agent merely WROTE into a file', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'item.completed',
+      item: {
+        kind: 'tool',
+        id: 't2',
+        name: 'Edit',
+        toolKind: 'edit',
+        title: 'packages/cezar/src/runs/store.test.ts',
+        status: 'completed',
+        input: {
+          new_string: "result: 'Opened a draft pull request: https://github.com/open-mercato/cezar/pull/42'",
+        },
+      },
+    });
+    expect(store.getRun(run.id)?.pullRequestUrl).toBeUndefined();
+  });
+
+  it('still adopts the PR from a real `gh pr create`, whose URL only appears in the output', () => {
+    const { store, run } = freshRun();
+    store.appendEvent(run.id, {
+      type: 'item.completed',
+      item: {
+        kind: 'tool',
+        id: 't3',
+        name: 'Bash',
+        toolKind: 'execute',
+        title: 'Ran gh pr create --repo open-mercato/cezar --base main --head cez/x --title "fix…',
+        status: 'completed',
+        input: { command: 'gh pr create --repo open-mercato/cezar --base main' },
+        output: 'https://github.com/open-mercato/cezar/pull/901',
+      },
+    });
+    expect(store.getRun(run.id)?.pullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/901',
+    );
+  });
 });
 
 describe('RunStore — secret redaction before persistence (#427)', () => {

--- a/packages/cezar/src/runs/store.test.ts
+++ b/packages/cezar/src/runs/store.test.ts
@@ -987,6 +987,20 @@ describe('RunStore — agent-declared marker refs (spec 2026-07-18-task-ref-mark
     );
   });
 
+  it('never resurrects a chip a live declaration deliberately cleared', () => {
+    // The other direction of the heal, and the one that would quietly undo "no chip beats a wrong
+    // chip": here the declaration names a PR this run did NOT create, so it still owns the
+    // referenced tier and its contradiction with the candidate must survive a reload.
+    const { store, run } = freshRun('task');
+    store.updateRun(run.id, {
+      referencedPullRequestUrl: undefined,
+      referencedPrCandidates: ['https://github.com/open-mercato/cezar/pull/777'],
+      markerRefs: { pr: 500 },
+    });
+    store.flush();
+    expect(RunStore.open(dataDir).getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+
   it('never takes a referenced PR away from a record whose candidates no longer explain it', () => {
     const { store, run } = freshRun('task');
     store.updateRun(run.id, {

--- a/packages/cezar/src/runs/store.test.ts
+++ b/packages/cezar/src/runs/store.test.ts
@@ -847,6 +847,103 @@ describe('RunStore — agent-declared marker refs (spec 2026-07-18-task-ref-mark
     store.applyMarkerRefs(run.id, {});
     expect(store.getRun(run.id)?.markerRefs).toBeUndefined();
   });
+
+  // Verbatim from the run that reported it: a task opened on open-mercato#4326 pushed a
+  // fix as its own #5366 and re-declared with the new number, as the marker contract asks. Both
+  // PRs are true, and the record has a field for each — but feeding the re-declaration to the
+  // referenced tier cleared #4326 (no candidate ends in /5366), so the cockpit painted one chip.
+  it('a declaration naming the PR the task CREATED keeps the PR it is about', () => {
+    const { store, run } = freshRun('Address GitHub pull request #4326');
+    store.applyMarkerRefs(run.id, { pr: 4326 });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Reviewing https://github.com/open-mercato/open-mercato/pull/4326.',
+    });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Ran gh pr create … → https://github.com/open-mercato/open-mercato/pull/5366',
+    });
+    store.applyMarkerRefs(run.id, { pr: 5366 });
+
+    const loaded = store.getRun(run.id);
+    expect(loaded?.pullRequestUrl).toBe('https://github.com/open-mercato/open-mercato/pull/5366');
+    expect(loaded?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/open-mercato/pull/4326',
+    );
+    // The about-number too: it is what paints a numeric-only chip, and the created PR already
+    // has a field of its own.
+    expect(loaded?.prNumber).toBe(4326);
+    expect(loaded?.markerRefs?.pr).toBe(5366);
+  });
+
+  it('restores the about-PR when the declaration arrives BEFORE the creation evidence', () => {
+    const { store, run } = freshRun('Address GitHub pull request #4326');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Reviewing https://github.com/open-mercato/open-mercato/pull/4326.',
+    });
+    store.applyMarkerRefs(run.id, { pr: 5366 });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined(); // nothing created yet
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Ran gh pr create … → https://github.com/open-mercato/open-mercato/pull/5366',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/open-mercato/pull/4326',
+    );
+  });
+
+  it('still fills an unknown prNumber from a declaration that names the created PR', () => {
+    const { store, run } = freshRun('ship the devices work');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Created a pull request: https://github.com/open-mercato/cezar/pull/42',
+    });
+    store.applyMarkerRefs(run.id, { pr: 42 });
+    expect(store.getRun(run.id)?.prNumber).toBe(42);
+  });
+
+  it('heals a record already written by the bug, on load', () => {
+    // Exactly the shape the bug left on disk: the created PR, the declaration that named it, the
+    // about-PR still sitting in the working set, and the chip it should have painted gone.
+    const { store, run } = freshRun('Address GitHub pull request #4326');
+    store.updateRun(run.id, {
+      pullRequestUrl: 'https://github.com/open-mercato/open-mercato/pull/5366',
+      referencedPullRequestUrl: undefined,
+      referencedPrCandidates: ['https://github.com/open-mercato/open-mercato/pull/4326'],
+      markerRefs: { pr: 5366 },
+      prNumber: 5366,
+    });
+    store.flush();
+    expect(RunStore.open(dataDir).getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/open-mercato/pull/4326',
+    );
+  });
+
+  it('never takes a referenced PR away from a record whose candidates no longer explain it', () => {
+    const { store, run } = freshRun('task');
+    store.updateRun(run.id, {
+      referencedPullRequestUrl: 'https://github.com/open-mercato/cezar/pull/777',
+      referencedPrCandidates: undefined,
+      markerRefs: { pr: 777 },
+    });
+    store.flush();
+    expect(RunStore.open(dataDir).getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/777',
+    );
+  });
+
+  it('a declaration naming some OTHER PR still overrides the fuzzy tier', () => {
+    const { store, run } = freshRun('task');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Created a pull request: https://github.com/open-mercato/cezar/pull/42',
+    });
+    store.applyMarkerRefs(run.id, { pr: 500 });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.prNumber).toBe(500);
+    expect(loaded?.referencedPullRequestUrl).toBeUndefined(); // no candidate ends in /500
+  });
 });
 
 describe('RunStore — referenced-issue discovery (spec 2026-07-21-report-ref-discovery)', () => {

--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -4,6 +4,8 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync
 import { join } from 'node:path';
 import { z } from 'zod';
 import { collectSecretValues, redactDeep, redactSecrets } from '../core/secret-redaction.ts';
+// Pure, dependency-free reference helpers — the same sanity bound the marker parser applies.
+import { MAX_REF } from './task-refs.ts';
 // Type-only module (zod + nothing else), so this cannot cycle back into the store.
 import { workflowDefSchema } from '../workflows/types.ts';
 
@@ -415,6 +417,35 @@ function resolveReferencedRef(candidates: string[], task: string, declared?: num
   return named.length === 1 ? named[0] : undefined;
 }
 
+/** The number a forge URL's last segment names (`…/pull/402` → 402), or undefined. */
+function refUrlNumber(url: string | undefined): number | undefined {
+  if (!url) return undefined;
+  const n = Number(url.split('/').pop());
+  return Number.isInteger(n) && n > 0 && n < MAX_REF ? n : undefined;
+}
+
+/**
+ * The PR declaration the REFERENCED tier is allowed to act on.
+ *
+ * `CEZ:PR=N` means one of two things depending on when the agent writes it: on the way in it
+ * names the PR the task is ABOUT, and once the task has opened a PR of its own the marker
+ * contract asks it to re-declare with the new number ("Re-emit with the new number if the subject
+ * changes (e.g. you open a PR later in the task)"). A declaration naming the PR this run CREATED
+ * is therefore a statement about the CREATED tier, which `pullRequestUrl` already carries — and
+ * feeding it to the referenced tier ERASES the about-PR, because `resolveReferencedRef` clears
+ * the chip when no candidate matches the declared number (a task on #4326 that opened
+ * #5366 dropped from two chips to one the moment it declared #5366).
+ *
+ * Both tiers stay true instead: the created PR is the created PR, and the reference resolves as
+ * if that declaration had not been made — which is exactly what it was before the task opened
+ * anything.
+ */
+function referencedPrDeclaration(run: RunRecord): number | undefined {
+  const declared = run.markerRefs?.pr;
+  if (declared === undefined) return undefined;
+  return declared === refUrlNumber(run.pullRequestUrl) ? undefined : declared;
+}
+
 /**
  * The PR URL a creation phrase *introduces*, or undefined. The created URL is
  * the first one at or after the `CREATED_PR_RE` phrase — a PR the same event
@@ -476,6 +507,25 @@ export function reconcileLoadedRun(run: RunRecord, opts?: { keepLive?: boolean }
   // The wake counter is intentionally process-local, so a restarted process
   // starts a fresh epoch instead of displaying a stale cap.
   run.monitoringWakeCapReached = undefined;
+  // Heal a record written before `referencedPrDeclaration` existed: a task that re-declared
+  // `CEZ:PR` with the PR it had just CREATED cleared the PR it was ABOUT, because no candidate
+  // could match the created number. The evidence is all still on the record — only the
+  // conclusion drawn from it was wrong — so re-resolve without that declaration instead of
+  // asking for a migration. Deliberately one-directional: it only runs on a record that HAS no
+  // referenced PR, so it can never take one away from a record written by an older cezar whose
+  // candidate list no longer explains it. `prNumber` is not recoverable this way (the
+  // declaration overwrote it) and is left alone — the restored URL is what paints the chip.
+  if (
+    run.referencedPullRequestUrl === undefined &&
+    run.markerRefs?.pr !== undefined &&
+    referencedPrDeclaration(run) === undefined
+  ) {
+    run.referencedPullRequestUrl = resolveReferencedRef(
+      run.referencedPrCandidates ?? [],
+      run.task,
+      undefined,
+    );
+  }
   return run;
 }
 
@@ -808,6 +858,18 @@ export class RunStore extends EventEmitter {
         const created = createdPrUrl(haystack);
         if (created) {
           this.updateRun(runId, { pullRequestUrl: created });
+          // Adopting the created tier can RELEASE a declaration the referenced tier was holding
+          // (see `referencedPrDeclaration`), so re-resolve here too: the about-PR must come back
+          // whether the marker arrived before the creation evidence or after it.
+          const resolved = resolveReferencedRef(
+            run.referencedPrCandidates ?? [],
+            run.task,
+            referencedPrDeclaration(run),
+          );
+          if (resolved !== run.referencedPullRequestUrl) {
+            run.referencedPullRequestUrl = resolved;
+            changed = true;
+          }
         } else if (PR_URL_RE.test(haystack) && this.trackReferencedPrs(run, haystack)) {
           changed = true;
         }
@@ -844,7 +906,7 @@ export class RunStore extends EventEmitter {
     run.referencedPullRequestUrl = resolveReferencedRef(
       run.referencedPrCandidates,
       run.task,
-      run.markerRefs?.pr,
+      referencedPrDeclaration(run),
     );
     return true;
   }
@@ -902,6 +964,10 @@ export class RunStore extends EventEmitter {
    * against the candidate working set — including down to `undefined` when no
    * candidate matches (a wrong chip is worse than no chip). The created tier
    * (`pullRequestUrl`) is deliberately untouched.
+   *
+   * One declaration is NOT a statement about the referenced tier: the number of the PR this run
+   * itself created. See `referencedPrDeclaration` — the marker contract asks the agent to
+   * re-declare after it opens a PR, and taking that literally cost the task the PR it was about.
    */
   applyMarkerRefs(runId: string, refs: { pr?: number; issue?: number }): RunRecord | undefined {
     const run = this.runs.get(runId);
@@ -911,7 +977,12 @@ export class RunStore extends EventEmitter {
       ...(refs.pr !== undefined ? { pr: refs.pr } : {}),
       ...(refs.issue !== undefined ? { issue: refs.issue } : {}),
     };
-    if (refs.pr !== undefined) run.prNumber = refs.pr;
+    // `prNumber` is the about-PR as well (it is what paints a numeric-only chip), so a
+    // re-declaration naming the created PR only FILLS it — it never overwrites the number the
+    // task came in with, which is still the PR this task is about.
+    if (refs.pr !== undefined && (run.prNumber === undefined || refs.pr !== refUrlNumber(run.pullRequestUrl))) {
+      run.prNumber = refs.pr;
+    }
     if (refs.issue !== undefined) {
       run.issueNumber = refs.issue;
       delete run.referencedIssueNumberSeeded;
@@ -920,7 +991,7 @@ export class RunStore extends EventEmitter {
       run.referencedPullRequestUrl = resolveReferencedRef(
         run.referencedPrCandidates ?? [],
         run.task,
-        run.markerRefs.pr,
+        referencedPrDeclaration(run),
       );
     }
     if (run.markerRefs.issue !== undefined) {

--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -377,6 +377,42 @@ function eventTextFragments(event: Record<string, unknown>): string[] {
   return fragments;
 }
 
+/**
+ * Where a CREATION CLAIM may come from — the trust boundary the created tier was missing.
+ *
+ * `CREATED_PR_RE` used to be matched against everything an event carried, tool OUTPUT included,
+ * so a transcript that merely QUOTES a `gh pr create` line handed the run a PR it never opened.
+ * Not hypothetical: the task that fixed the reference chips printed another run's stored events
+ * while investigating them, and cezar read `"title": "Ran gh pr create --repo …"` out of that
+ * dump and adopted a PR from a DIFFERENT repository as its own — permanently, because the first
+ * created URL wins and the real `gh pr create` that followed was never looked at.
+ *
+ * So the claim must come from the agent's own words, or from the tool title cezar itself renders
+ * from the command it saw run. Tool output and tool input are the transcript of the world, not a
+ * statement about this run. The URL is still read from the whole event — `gh` prints it in the
+ * output — because it is the CLAIM that needs a trustworthy source, not the link.
+ */
+function eventCreationClaimFragments(event: Record<string, unknown>): string[] {
+  const fragments: string[] = [];
+  // A `tool-result` event's `result` IS raw command output; on every other event the top-level
+  // text is the agent's own.
+  if (event.type !== 'tool-result') {
+    for (const key of ['text', 'result', 'message'] as const) {
+      const value = event[key];
+      if (typeof value === 'string') fragments.push(value);
+    }
+  }
+  const item = event.item;
+  if (item && typeof item === 'object') {
+    const it = item as Record<string, unknown>;
+    if (it.kind === 'message' && it.role === 'assistant' && typeof it.text === 'string') {
+      fragments.push(it.text);
+    }
+    if (it.kind === 'tool' && typeof it.title === 'string') fragments.push(it.title);
+  }
+  return fragments;
+}
+
 /** Agent-authored event text, matching the trust boundary used by task markers.
  * Tool titles, inputs, and outputs remain visible to the referenced-URL tier,
  * but must never promote an issue into the shared `issueNumber` field (#538). */
@@ -849,13 +885,20 @@ export class RunStore extends EventEmitter {
     // The janitor trick: agents print the PR URL after `gh pr create` — the
     // first one spotted in the transcript becomes the run's PR link. Scans v1
     // fields AND nested v2 `item.*` content (#407). A URL without the created
-    // phrasing still feeds the referenced tier (the PR the task is about).
+    // phrasing still feeds the referenced tier (the PR the task is about) —
+    // and the phrasing itself is only believed from a source that can speak
+    // FOR this run (`eventCreationClaimFragments`), never from quoted output.
     const haystack = eventTextFragments(full).join(' ');
     const agentHaystack = eventAgentTextFragments(full).join(' ');
+    // The creation CLAIM is read from a narrower source than the URL is
+    // (`eventCreationClaimFragments`), which is why the two are searched
+    // together rather than the haystack alone: the phrase must land in the
+    // trusted prefix, and the link may come from anywhere after it.
+    const claim = eventCreationClaimFragments(full).join(' ');
     if (haystack.length > 0) {
       let changed = false;
       if (!run.pullRequestUrl) {
-        const created = createdPrUrl(haystack);
+        const created = CREATED_PR_RE.test(claim) ? createdPrUrl(`${claim} ${haystack}`) : undefined;
         if (created) {
           this.updateRun(runId, { pullRequestUrl: created });
           // Adopting the created tier can RELEASE a declaration the referenced tier was holding

--- a/packages/web/src/api/queries.test.tsx
+++ b/packages/web/src/api/queries.test.tsx
@@ -11,6 +11,7 @@ import type { GithubRefStatusData } from '@open-mercato/cezar-api-client'
 import {
   refStatusRecheckAfter,
   useReferenceProjectId,
+  useProjectRepoBase,
   queryKeys,
   useProviderStatus,
   useRefreshProviderStatus,
@@ -1017,6 +1018,55 @@ describe('useReferenceProjectId', () => {
     // Better a neutral chip for a moment than an entry written under a name nothing else uses.
     const { result } = renderHook(() => useReferenceProjectId(), { wrapper: mounted(null) })
     expect(result.current).toBeUndefined()
+  })
+})
+
+describe('useProjectRepoBase', () => {
+  const mounted = (scope: string | null, health?: unknown, projects?: unknown) => {
+    const client = createQueryClient()
+    if (health !== undefined) client.setQueryData(queryKeys.health, health)
+    if (projects !== undefined) client.setQueryData(workspaceQueryKeys.projects, { projects })
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={client}>
+          <ProjectScopeContext.Provider value={{ projectId: scope, apiBase: '/api/v1' }}>
+            {children}
+          </ProjectScopeContext.Provider>
+        </QueryClientProvider>
+      )
+    }
+  }
+
+  const REGISTRY = [
+    { id: 'boot-id', name: 'boot', root: '/home/me/cezar', repoUrl: 'https://github.com/o/boot' },
+    { id: 'proj-a', name: 'a', root: '/home/me/a', repoUrl: 'https://github.com/o/a' },
+    { id: 'proj-b', name: 'b', root: '/home/me/b' },
+  ]
+
+  // The defect this was found through: the SAME task showed a linked chip on All tasks (which
+  // reads the registry) and inert text on its own page (which read health, and health only names
+  // the boot project's repo).
+  it('answers a NON-boot project from the registry, where All tasks reads it', () => {
+    const { result } = renderHook(() => useProjectRepoBase(), {
+      wrapper: mounted('proj-a', { ...HEALTH, bootProject: 'boot-id', repo: { remote: 'git@github.com:o/boot.git' } }, REGISTRY),
+    })
+    expect(result.current).toBe('https://github.com/o/a')
+  })
+
+  it('never hands a project the boot repo — #526', () => {
+    // `proj-b` has no forge remote of its own; health's is the boot project's and would be a link
+    // into a completely different repository.
+    const { result } = renderHook(() => useProjectRepoBase(), {
+      wrapper: mounted('proj-b', { ...HEALTH, bootProject: 'boot-id', repo: { remote: 'git@github.com:o/boot.git' } }, REGISTRY),
+    })
+    expect(result.current).toBeUndefined()
+  })
+
+  it('falls back to health for the boot project — an unregistered boot folder still links', () => {
+    const { result } = renderHook(() => useProjectRepoBase(), {
+      wrapper: mounted(null, { ...HEALTH, bootProject: 'boot-id', repo: { remote: 'git@github.com:o/boot.git' } }, []),
+    })
+    expect(result.current).toBe('https://github.com/o/boot')
   })
 })
 

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -721,12 +721,23 @@ export function useHealth() {
  * `WORKSPACE_LEVEL`): the server always builds it from `bootRoot`, so its `repo.remote` names the
  * project cezar launched in, whichever project the URL is scoped to. Handing a non-boot project's
  * task a link built from the boot project's repo would point at a completely different repository
- * — the same wrong-link defect #526 exists to kill. Until a per-project remote is served, a
- * scoped view synthesizes nothing.
+ * — the same wrong-link defect #526 exists to kill.
+ *
+ * The per-project remote that guard was waiting for already exists: the registry serves each
+ * project's own `repoUrl` (rebuilt server-side from the parsed remote, credentials stripped), and
+ * it is what All tasks builds every cross-project chip from. Reading it here is what stops the
+ * SAME task from showing a linked chip on `/tasks` and inert text on its own page — which is how
+ * this was found: a declared PR was a dead `#901` in the task view and a working link one screen
+ * over. Health stays the fallback, and stays boot-only, so an unregistered boot folder (or a
+ * registry that has not loaded yet) keeps answering exactly as before.
  */
 export function useProjectRepoBase(): string | undefined {
   const health = useHealth().data
+  const projects = useProjects().data?.projects
   const { projectId } = useProjectScope()
+  const scopedId = projectId ?? health?.bootProject
+  const registered = scopedId === undefined ? undefined : projects?.find((project) => project.id === scopedId)
+  if (registered?.repoUrl) return registered.repoUrl
   const isBootProject = projectId === null || projectId === health?.bootProject
   return isBootProject ? githubRepoBase(health?.repo?.remote) : undefined
 }

--- a/packages/web/src/lib/tasks-table.test.ts
+++ b/packages/web/src/lib/tasks-table.test.ts
@@ -265,6 +265,50 @@ describe('taskReferences', () => {
     ])
   })
 
+  // The record this rule was written from, verbatim: the task declared the PR it opened (#901),
+  // while the created-PR field had been poisoned with a PR from ANOTHER repository that the
+  // transcript merely quoted. The declared one leads — including on the surfaces with room for
+  // exactly one chip, which is where the wrong PR was all you could see.
+  it('leads with a declared PR that no scraped URL corroborates', () => {
+    const r = run({
+      pullRequestUrl: 'https://github.com/o/other/pull/5366',
+      prNumber: 901,
+      markerRefs: { pr: 901 },
+    })
+    expect(taskReferences(r, REPO)).toEqual([
+      { kind: 'PR', number: 901, url: `${REPO}/pull/901` },
+      { kind: 'PR', number: 5366, url: 'https://github.com/o/other/pull/5366' },
+    ])
+    expect(taskReference(r)?.number).toBe(901)
+  })
+
+  it('leaves the order alone when a URL does carry the declared number', () => {
+    // The ordinary shape — the agent re-declared with the PR it opened — so nothing is ahead of
+    // the created PR and the declaration adds no chip of its own.
+    expect(
+      taskReferences(
+        run({
+          pullRequestUrl: `${REPO}/pull/533`,
+          referencedPullRequestUrl: `${REPO}/pull/530`,
+          markerRefs: { pr: 533 },
+        }),
+      ).map((reference) => reference.number),
+    ).toEqual([533, 530])
+  })
+
+  it('keeps #526 with a declaration too: an issue-subject run adopts no stray PR', () => {
+    expect(
+      taskReferences(
+        run({
+          referencedPullRequestUrl: `${REPO}/pull/900`,
+          referencedIssueUrl: `${REPO}/issues/524`,
+          markerRefs: { issue: 524 },
+        }),
+        REPO,
+      ),
+    ).toEqual([{ kind: 'Issue', number: 524, url: `${REPO}/issues/524` }])
+  })
+
   it('is what taskReference takes its single answer from', () => {
     const r = run({ pullRequestUrl: `${REPO}/pull/7`, referencedIssueUrl: `${REPO}/issues/4` })
     expect(taskReference(r)).toEqual(taskReferences(r)[0])

--- a/packages/web/src/lib/tasks-table.ts
+++ b/packages/web/src/lib/tasks-table.ts
@@ -208,21 +208,37 @@ export interface TaskReference {
  *
  * Built by walking an ordered list of SOURCES rather than by hand-picking a winner, so adding the
  * next kind of reference is one entry here and nothing else — and the PR half is `prUrls`, the
- * same list `taskPrUrl` takes its head from, so the two can never disagree about #407 or #526. Order is strongest-first — the PR a
- * task created, the PR it is about, then the issue — which is also what makes `taskReference`
- * answer exactly what it always answered.
+ * same list `taskPrUrl` takes its head from, so the two can never disagree about #407 or #526.
+ * Order is strongest-first — the PR a task created, the PR it is about, then the issue — with one
+ * thing ahead of all of them: a `CEZ:PR` declaration that NO scraped URL corroborates.
+ *
+ * That exception is narrow on purpose. Normally the declaration is already one of the URLs below
+ * (the marker contract asks the agent to re-declare once it opens a PR of its own), and then
+ * nothing changes: dedup collapses them and the created PR still leads. But when the URL tier
+ * carries a number the agent never declared, that tier is pointing somewhere the agent did not —
+ * and it is the tier built out of guesses. It has been wrong exactly that way: a task that
+ * printed another run's stored `gh pr create` line was credited with that run's PR, in another
+ * repository, and it then led every chip list on the page while the PR the task actually opened
+ * sat behind it. A statement the agent made outranks a line a janitor found.
  *
  * What this deliberately does NOT read is `referencedPrCandidates` / `referencedIssueCandidates`.
  * Those are transcript scrapings that routinely name OTHER repositories (#526), so a further
  * reference has to arrive as a real field before it can be shown: the shape is ready for more,
- * the guesswork is not invited in. `markerRefs.pr` is the obvious next source, and is left out
- * only because today it never appears without one of the URLs below already carrying it.
+ * the guesswork is not invited in.
  *
  * Deduped by kind+number, so one reference reached through two fields stays one chip.
  */
 export function taskReferences(run: TaskReferenceInput, repoBase?: string): TaskReference[] {
+  const prs = prUrls(run)
+  const declared = run.markerRefs?.pr
   const sources: { kind: TaskReference['kind']; url?: string; number?: number }[] = [
-    ...prUrls(run).map((url) => ({ kind: 'PR' as const, url })),
+    // The uncorroborated declaration, ahead of everything (see above). When a URL below does name
+    // it, this entry is omitted entirely rather than added and deduped — that keeps the ORDER the
+    // ordinary case had, with the created PR first.
+    ...(declared === undefined || prs.some((url) => prNumber(url) === String(declared))
+      ? []
+      : [{ kind: 'PR' as const, number: declared }]),
+    ...prs.map((url) => ({ kind: 'PR' as const, url })),
     // Numeric-only: a reference known by number before any URL was scraped. `repoBase` turns it
     // into a real link — see the synthesis note below.
     { kind: 'PR', number: run.prNumber },

--- a/packages/web/src/routes/task-thread/run-header.test.tsx
+++ b/packages/web/src/routes/task-thread/run-header.test.tsx
@@ -820,6 +820,32 @@ describe('meta line, tabs, pill and resume hint', () => {
     }
   })
 
+  // A task opened on someone else's PR that pushes a follow-up of its own is about BOTH,
+  // and its own page is the last place that should have to pick one. Order is `taskReferences`
+  // order — the PR it created, then the PR it is about — the same order the global Tasks table
+  // paints.
+  it('shows every PR the task points at, not only the strongest one', () => {
+    stubFetch()
+    renderHeader(
+      run('done', {
+        branch: 'cez/r1',
+        pullRequestUrl: 'https://github.com/open-mercato/cezar/pull/5366',
+        referencedPullRequestUrl: 'https://github.com/open-mercato/cezar/pull/4326',
+        markerRefs: { pr: 5366 },
+      }),
+    )
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    const chips = [...meta.querySelectorAll('[data-slot="pr-chip"]')]
+    expect(chips.map((chip) => chip.getAttribute('href'))).toEqual([
+      'https://github.com/open-mercato/cezar/pull/5366',
+      'https://github.com/open-mercato/cezar/pull/4326',
+    ])
+    expect(chips.map((chip) => chip.textContent)).toEqual([
+      expect.stringContaining('#5366'),
+      expect.stringContaining('#4326'),
+    ])
+  })
+
   it('the agent badge reveals runner and model on click, reading "auto" when the model is unset', async () => {
     stubFetch()
     renderHeader(run('done', { runner: 'opencode' }))

--- a/packages/web/src/routes/task-thread/run-header.test.tsx
+++ b/packages/web/src/routes/task-thread/run-header.test.tsx
@@ -850,6 +850,26 @@ describe('meta line, tabs, pill and resume hint', () => {
   // registry, so a number-only reference can be linkable on one page and not the other. It still
   // gets a chip here — All tasks paints it, and "we could not build a link" is not a reason to
   // hide a PR the task declared.
+  // The registry knows every project's own repo, so a number-only chip is a real link here just
+  // as it is on All tasks — the two pages must not disagree about the same reference.
+  it('links a PR known only by number, using the project registry repo', async () => {
+    stubFetch({
+      '/api/v1/health': () => jsonResponse({ bootProject: 'boot-id', repo: {} }),
+      '/api/v1/projects': () =>
+        jsonResponse({
+          projects: [
+            { id: 'boot-id', name: 'cezar', root: '/home/me/cezar', repoUrl: 'https://github.com/open-mercato/cezar' },
+          ],
+        }),
+    })
+    renderHeader(run('done', { branch: 'cez/r1', prNumber: 901, markerRefs: { pr: 901 } }))
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    await waitFor(() => {
+      const chip = meta.querySelector('[data-slot="pr-chip"]')
+      expect(chip?.getAttribute('href')).toBe('https://github.com/open-mercato/cezar/pull/901')
+    })
+  })
+
   it('shows a PR known only by number, with no repository to link it to', () => {
     stubFetch({ '/api/v1/health': () => jsonResponse({ repo: {} }) })
     renderHeader(

--- a/packages/web/src/routes/task-thread/run-header.test.tsx
+++ b/packages/web/src/routes/task-thread/run-header.test.tsx
@@ -846,6 +846,28 @@ describe('meta line, tabs, pill and resume hint', () => {
     ])
   })
 
+  // The task view reads the repository from health while All tasks reads it from the project
+  // registry, so a number-only reference can be linkable on one page and not the other. It still
+  // gets a chip here — All tasks paints it, and "we could not build a link" is not a reason to
+  // hide a PR the task declared.
+  it('shows a PR known only by number, with no repository to link it to', () => {
+    stubFetch({ '/api/v1/health': () => jsonResponse({ repo: {} }) })
+    renderHeader(
+      run('done', {
+        branch: 'cez/r1',
+        pullRequestUrl: 'https://github.com/open-mercato/cezar/pull/5366',
+        prNumber: 901,
+      }),
+    )
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    const chips = [...meta.querySelectorAll('[data-slot="pr-chip"]')]
+    expect(chips.map((chip) => chip.textContent)).toEqual([
+      expect.stringContaining('#5366'),
+      expect.stringContaining('#901'),
+    ])
+    expect(chips[1]?.tagName).toBe('SPAN') // inert: nothing to link to
+  })
+
   it('the agent badge reveals runner and model on click, reading "auto" when the model is unset', async () => {
     stubFetch()
     renderHeader(run('done', { runner: 'opencode' }))

--- a/packages/web/src/routes/task-thread/run-header.test.tsx
+++ b/packages/web/src/routes/task-thread/run-header.test.tsx
@@ -846,10 +846,6 @@ describe('meta line, tabs, pill and resume hint', () => {
     ])
   })
 
-  // The task view reads the repository from health while All tasks reads it from the project
-  // registry, so a number-only reference can be linkable on one page and not the other. It still
-  // gets a chip here — All tasks paints it, and "we could not build a link" is not a reason to
-  // hide a PR the task declared.
   // The registry knows every project's own repo, so a number-only chip is a real link here just
   // as it is on All tasks — the two pages must not disagree about the same reference.
   it('links a PR known only by number, using the project registry repo', async () => {
@@ -868,6 +864,26 @@ describe('meta line, tabs, pill and resume hint', () => {
       const chip = meta.querySelector('[data-slot="pr-chip"]')
       expect(chip?.getAttribute('href')).toBe('https://github.com/open-mercato/cezar/pull/901')
     })
+  })
+
+  // A PR URL whose last segment is not a number never becomes a `taskReferences` entry, so it is
+  // painted from `taskPrUrl` — and must still be painted when a number-only chip exists beside it
+  // (#847: a forge whose PR URLs are not `…/pull/N`).
+  it('keeps a non-numeric PR link beside a chip known only by number', () => {
+    stubFetch({ '/api/v1/health': () => jsonResponse({ repo: {} }) })
+    renderHeader(
+      run('done', {
+        branch: 'cez/r1',
+        pullRequestUrl: 'https://forge.example.com/o/r/merge_requests/spec-fix',
+        prNumber: 42,
+      }),
+    )
+    const meta = document.querySelector('[data-slot="run-meta"]') as HTMLElement
+    const chips = [...meta.querySelectorAll('[data-slot="pr-chip"]')]
+    expect(chips).toHaveLength(2)
+    expect(chips.map((chip) => chip.getAttribute('href'))).toContain(
+      'https://forge.example.com/o/r/merge_requests/spec-fix',
+    )
   })
 
   it('shows a PR known only by number, with no repository to link it to', () => {

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -522,37 +522,37 @@ function MetaRow({
       </span>,
     )
   }
-  const prUrl = taskPrUrl(run)
-  if (prUrl && isHttpUrl(prUrl)) {
-    const number = prNumber(prUrl)
-    parts.push(
-      <ReferenceChip
-        key="pr"
-        reference={{ kind: 'PR', ...(number ? { number: Number(number) } : {}), url: prUrl }}
-        taskTitle={runTitle(run)}
-        className="h-5"
-      />,
-    )
-  }
-  // The PRs BEYOND the head one: a task opened on someone else's PR that pushes a
+  // EVERY PR the task points at, in `taskReferences` order — the same order, and the same
+  // statuses, the global Tasks table paints. A task opened on someone else's PR that pushes a
   // follow-up of its own is about both, and its own page is the last place that should have to
-  // pick one. The head is `taskPrUrl` above — it stays first, and stays the chip that renders
-  // even when the URL carries no number we recognize. The rest follow in `taskReferences` order,
-  // which is the same order (and the same statuses) the global Tasks table paints.
+  // pick one.
   //
   // A reference with no URL still gets its chip, exactly as All tasks paints it: a number-only
   // reference is what a `CEZ:PR` declaration looks like before any link is scraped, and the two
   // pages read their repository from DIFFERENT places (this one from health's remote, All tasks
   // from the project registry's `repoUrl`) — so "no URL here" never means "nothing to show".
   // `ReferenceChip` degrades such a chip to inert text on its own.
-  const headNumber = prUrl ? Number(prNumber(prUrl)) : undefined
-  for (const reference of references) {
-    if (reference.kind !== 'PR') continue
-    if (prUrl && (reference.url === prUrl || reference.number === headNumber)) continue
+  const prReferences = references.filter((reference) => reference.kind === 'PR')
+  for (const reference of prReferences) {
     parts.push(
       <ReferenceChip
         key={`pr-${reference.number}`}
         reference={reference}
+        taskTitle={runTitle(run)}
+        className="h-5"
+      />,
+    )
+  }
+  // The one PR chip `taskReferences` cannot express: a forge URL whose last segment is not a
+  // number (`taskPrUrl`'s own tolerance — an unrecognized forge still gets a working link, just
+  // without a number cezar would be inventing). It only appears when nothing else did, so it can
+  // never duplicate a chip above.
+  const prUrl = taskPrUrl(run)
+  if (prReferences.length === 0 && prUrl && isHttpUrl(prUrl)) {
+    parts.push(
+      <ReferenceChip
+        key="pr"
+        reference={{ kind: 'PR', url: prUrl }}
         taskTitle={runTitle(run)}
         className="h-5"
       />,

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -539,8 +539,16 @@ function MetaRow({
   // pick one. The head is `taskPrUrl` above — it stays first, and stays the chip that renders
   // even when the URL carries no number we recognize. The rest follow in `taskReferences` order,
   // which is the same order (and the same statuses) the global Tasks table paints.
+  //
+  // A reference with no URL still gets its chip, exactly as All tasks paints it: a number-only
+  // reference is what a `CEZ:PR` declaration looks like before any link is scraped, and the two
+  // pages read their repository from DIFFERENT places (this one from health's remote, All tasks
+  // from the project registry's `repoUrl`) — so "no URL here" never means "nothing to show".
+  // `ReferenceChip` degrades such a chip to inert text on its own.
+  const headNumber = prUrl ? Number(prNumber(prUrl)) : undefined
   for (const reference of references) {
-    if (reference.kind !== 'PR' || !reference.url || reference.url === prUrl) continue
+    if (reference.kind !== 'PR') continue
+    if (prUrl && (reference.url === prUrl || reference.number === headNumber)) continue
     parts.push(
       <ReferenceChip
         key={`pr-${reference.number}`}

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -545,10 +545,12 @@ function MetaRow({
   }
   // The one PR chip `taskReferences` cannot express: a forge URL whose last segment is not a
   // number (`taskPrUrl`'s own tolerance — an unrecognized forge still gets a working link, just
-  // without a number cezar would be inventing). It only appears when nothing else did, so it can
-  // never duplicate a chip above.
+  // without a number cezar would be inventing). Gated on that URL not being painted already,
+  // NOT on there being no chips at all: today every `pullRequestUrl` is a GitHub `…/pull/N` and
+  // the two are the same test, but a forge whose PR URLs do not end in a number (#847's GitLab
+  // adapter) would have a `prNumber` chip standing in front of a link that then never rendered.
   const prUrl = taskPrUrl(run)
-  if (prReferences.length === 0 && prUrl && isHttpUrl(prUrl)) {
+  if (prUrl && isHttpUrl(prUrl) && !prReferences.some((reference) => reference.url === prUrl)) {
     parts.push(
       <ReferenceChip
         key="pr"

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -496,16 +496,17 @@ function MetaRow({
   // goes through the same seam, which is what keeps the header's chip and the table's chip
   // answering identically for the same PR.
   const projectId = useReferenceProjectId()
+  const references = useMemo(() => taskReferences(run, repoBase), [run, repoBase])
   const referenceRequests = useMemo(
     () =>
       projectId === undefined
         ? []
-        : taskReferences(run, repoBase).map((reference) => ({
+        : references.map((reference) => ({
             projectId,
             kind: reference.kind,
             number: reference.number,
           })),
-    [run, repoBase, projectId],
+    [references, projectId],
   )
   // `workflowLabel` so an inline chain shows its first step's name, not the bare "(planned)"
   // placeholder — which reads like a status next to the live status pill.
@@ -528,6 +529,22 @@ function MetaRow({
       <ReferenceChip
         key="pr"
         reference={{ kind: 'PR', ...(number ? { number: Number(number) } : {}), url: prUrl }}
+        taskTitle={runTitle(run)}
+        className="h-5"
+      />,
+    )
+  }
+  // The PRs BEYOND the head one: a task opened on someone else's PR that pushes a
+  // follow-up of its own is about both, and its own page is the last place that should have to
+  // pick one. The head is `taskPrUrl` above — it stays first, and stays the chip that renders
+  // even when the URL carries no number we recognize. The rest follow in `taskReferences` order,
+  // which is the same order (and the same statuses) the global Tasks table paints.
+  for (const reference of references) {
+    if (reference.kind !== 'PR' || !reference.url || reference.url === prUrl) continue
+    parts.push(
+      <ReferenceChip
+        key={`pr-${reference.number}`}
+        reference={reference}
         taskTitle={runTitle(run)}
         className="h-5"
       />,


### PR DESCRIPTION
A task started on `open-mercato#4326` pushed a fix as its own `#5366` and the cockpit stopped showing #4326 — one chip where two are true. The record explains it exactly:

```
pullRequestUrl:           …/pull/5366
referencedPullRequestUrl: null          ← the chip that disappeared
referencedPrCandidates:   [ …/pull/4326 ]
markerRefs:               { pr: 5366 }
prNumber:                 5366          ← was 4326
```

The marker contract asks the agent to **re-emit `CEZ:PR` when it opens a PR later in the task**, so on such a run the last declaration names the run's OWN PR. `applyMarkerRefs` fed that number to the *referenced* tier, where `resolveReferencedRef` resolves only a candidate URL ending in the declared number — none does, and "no match → unset" is deliberate ("no chip beats a wrong chip"). So the PR the task was about was erased by a declaration that was never about it, and `prNumber` was overwritten on the way past.

**The rule now**: a declaration equal to the number in `pullRequestUrl` is a statement about the **created** tier, which already carries it, and the referenced tier resolves as if it had not been made (`referencedPrDeclaration`). `prNumber` follows the same rule — such a declaration only fills it, never overwrites the about-number the task came in with. Every other declaration behaves exactly as before, including clearing a chip that contradicts it.

Both writers go through the one helper — `applyMarkerRefs` and the janitor at the moment it adopts a created URL — so the marker and the creation evidence may arrive in either order. Records already written the old way heal in `reconcileLoadedRun`: the evidence is still on them, only the conclusion was wrong. That healing is one-directional (it runs only when there is no referenced PR), so it can restore a chip and never remove one — an older record whose candidate list no longer explains its chip keeps it.

Also: the task thread's run header painted one PR chip while already fetching statuses for all of them. It now paints every PR the task points at, in `taskReferences` order — the same order and the same statuses the All tasks table shows.

## Tests

Three regression tests, each proven red without its fix (`git stash push -- <source>`): the declaration-after-creation case verbatim from the reported run, the reverse ordering, and the heal-on-load path. Guard tests pin what must NOT change: a declaration naming some other PR still overrides the fuzzy tier, an unknown `prNumber` is still filled, and a record whose candidates no longer explain its chip keeps it.

Gate: `npm run typecheck`, `npm run build`, `npm run test:unit`, `npm run test:package` green. `npm test` has 7 pre-existing failures in this environment (tests that assert "outside a git repository" while the temp dirs sit inside the repo tree) — identical with the changes stashed.

Spec amended: `.ai/specs/2026-07-18-task-ref-markers.md`.