### PR TITLE
fix(cockpit): open another project's task without a 404

### DIFF
--- a/packages/web/src/api/project-scope-context.test.tsx
+++ b/packages/web/src/api/project-scope-context.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render } from '@testing-library/react'
-import { useEffect } from 'react'
+import { StrictMode, useEffect } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { ProjectScopeProvider, useProjectScope } from './project-scope-context'
@@ -82,6 +82,60 @@ describe('ProjectScopeProvider', () => {
       <ProjectScopeProvider projectId="b">
         <MountProbe key="b" />
       </ProjectScopeProvider>,
+    )
+    expect(seen).toEqual(['a', 'b'])
+  })
+
+  // #task-detail-404: the same rule under StrictMode's simulated remount, which is what a soft
+  // navigation into another project's task hits in dev — the provider and the (lazily-loaded,
+  // by then warm) thread mount in ONE commit, so the double-invoke's destroys include this
+  // provider's own reset. A passive reset landed between it and the re-created child effects,
+  // and the thread's very first `/runs/:id` went out unprefixed: a 404 the boot project honestly
+  // answers, cached under the correctly-scoped key, so only a reload cleared it.
+  it('never dips back to unscoped through StrictMode’s remount of a fresh subtree', () => {
+    const seen: (string | null)[] = []
+    function MountProbe() {
+      useEffect(() => {
+        seen.push(getApiScope())
+      }, [])
+      return null
+    }
+
+    render(
+      <StrictMode>
+        <ProjectScopeProvider projectId="a">
+          <MountProbe />
+        </ProjectScopeProvider>
+      </StrictMode>,
+    )
+    expect(seen).toEqual(['a', 'a'])
+  })
+
+  // Two provider INSTANCES in one commit — leaving a project area for another (the global Tasks
+  // page's rows, the sidebar's cross-project task links). The departing one's cleanup must not
+  // land between the arriving one's render and its children's first requests.
+  it('never dips back to unscoped when one provider replaces another in a single commit', () => {
+    const seen: (string | null)[] = []
+    function MountProbe() {
+      useEffect(() => {
+        seen.push(getApiScope())
+      }, [])
+      return null
+    }
+
+    const view = render(
+      <div>
+        <ProjectScopeProvider key="a" projectId="a">
+          <MountProbe />
+        </ProjectScopeProvider>
+      </div>,
+    )
+    view.rerender(
+      <div>
+        <ProjectScopeProvider key="b" projectId="b">
+          <MountProbe />
+        </ProjectScopeProvider>
+      </div>,
     )
     expect(seen).toEqual(['a', 'b'])
   })

--- a/packages/web/src/api/project-scope-context.tsx
+++ b/packages/web/src/api/project-scope-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, type ReactNode } from 'react'
+import { createContext, useContext, useLayoutEffect, useMemo, type ReactNode } from 'react'
 
 import { API_PREFIX, getApiScope, setApiScope } from '@open-mercato/cezar-api-client'
 
@@ -43,6 +43,24 @@ export function useProjectScope(): ProjectScope {
  * the scope *between* the render that set it and the children's mount effects, so the arriving
  * project's very first requests would go out unprefixed and cache under the wrong key. A
  * project change must therefore never run a cleanup — only a real unmount does.
+ *
+ * Both are LAYOUT effects, and that is the second half of the same rule (#task-detail-404). Every
+ * request in this app goes out from a passive effect — TanStack's mount fetch, the EventSource
+ * hooks — and React runs every layout effect in a commit (destroys in the mutation phase, creates
+ * in the layout phase) before any passive one. Passive effects here would leave two windows where
+ * a child fetches with the scope this provider's own cleanup nulled, because a child's create runs
+ * BEFORE its ancestor's:
+ *
+ *   - StrictMode's simulated remount, where the whole subtree's destroys (this reset among them)
+ *     run and then its creates — so a thread mounted in the SAME commit as this provider re-fires
+ *     its query unprefixed. That is a soft navigation into another project's task: 404, cached
+ *     under the correctly-scoped key, and only a reload (where the provider commits with the lazy
+ *     route's Suspense fallback, a commit earlier than the route's own) clears it.
+ *   - a real unmount+mount of two providers in ONE commit (leaving a project area for another),
+ *     where the departing provider's cleanup would land between the arriving one's render and its
+ *     children's fetches.
+ *
+ * As layout effects, the whole dance finishes before the first request of the commit is made.
  */
 export function ProjectScopeProvider({
   projectId,
@@ -53,14 +71,15 @@ export function ProjectScopeProvider({
 }) {
   if (getApiScope() !== projectId) setApiScope(projectId)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setApiScope(projectId)
   }, [projectId])
 
-  // Unmount only — see the note above on why this cannot be the cleanup of the effect above.
-  // Ordering still holds for StrictMode's simulated remount: destroys run before creates, so
-  // the re-created `[projectId]` effect re-asserts the scope after this one nulled it.
-  useEffect(() => () => setApiScope(null), [])
+  // Unmount only — see the note above on why this cannot be the cleanup of the effect above, and
+  // why both are layout effects: destroys run before creates, so the re-created `[projectId]`
+  // effect re-asserts the scope after this one nulled it, and the whole exchange happens in the
+  // layout phase — before the passive effects where every request of the commit is made.
+  useLayoutEffect(() => () => setApiScope(null), [])
 
   const value = useMemo<ProjectScope>(
     // Built from the same prefix the request path uses — the version is one fact, not two.

--- a/packages/web/src/routes/cross-project-task-navigation.test.tsx
+++ b/packages/web/src/routes/cross-project-task-navigation.test.tsx
@@ -1,0 +1,176 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createQueryClient } from '@/api/query-client'
+import type { ProjectsResponse } from '@open-mercato/cezar-api-client'
+import { AppearanceProvider } from '@/components/appearance-provider'
+import { ListViewProvider } from '@/components/list-view'
+import { ThemeProvider } from '@/components/theme-provider'
+import { AppRoutes } from '@/routes'
+
+/**
+ * Opening ANOTHER project's task without a reload (#task-detail-404).
+ *
+ * The rows of the global Tasks page, the sidebar's per-project lists and the ⌘K palette all link
+ * into a project that is not the one the app currently stands in. The thread that arrives must ask
+ * `/api/v1/p/<that project>/runs/:id` — the unscoped spelling reaches the BOOT project, which
+ * honestly answers 404 for a run it does not own, and TanStack caches that error under the
+ * correctly-scoped key, so the thread stays stuck on "Task not found" until a reload.
+ *
+ * Rendered under `StrictMode`, like `main.tsx`: its simulated remount is exactly what broke this.
+ * The provider and the thread mount in ONE commit (soft navigation, thread chunk already loaded),
+ * the double-invoke destroys the provider's scope reset among the subtree's cleanups, and a
+ * PASSIVE reset then landed before the re-created child effects — which is where every request is
+ * made. A reload never showed it: there the provider commits with the lazy route's Suspense
+ * fallback, one commit ahead of the thread's own mount.
+ */
+
+const BOOT = 'boot'
+const RUN_ID = 'r1'
+
+const HEALTH = {
+  version: '0.0.0-test',
+  repoRoot: '/home/u/cezar',
+  repo: null,
+  checks: [],
+  defaultRunner: 'claude',
+  forge: null,
+  capabilities: { localHandoff: true, followups: true, singleProject: false, automations: false },
+  projects: [{ id: BOOT, name: 'cezar' }],
+  bootProject: BOOT,
+}
+
+const REGISTRY: ProjectsResponse = {
+  projects: [
+    { id: BOOT, name: 'cezar', root: '/home/u/cezar', addedAt: '', lastOpenedAt: '', source: 'local', status: 'ok' },
+    { id: 'other', name: 'other-repo', root: '/home/u/other', addedAt: '', lastOpenedAt: '', source: 'local', status: 'ok' },
+  ],
+  bootProject: BOOT,
+  projectsDir: '~/cezar/projects',
+}
+
+/** The row the global Tasks page renders, and the record its thread then reads. */
+const INDEX_ROW = {
+  projectId: 'other',
+  id: RUN_ID,
+  title: 'Do the thing',
+  status: 'done',
+  createdAt: '2026-07-14T10:00:00Z',
+  archived: false,
+  workflow: 'quick-task',
+  seenAt: '2026-07-14T10:06:00Z',
+}
+
+const RUN = {
+  ...INDEX_ROW,
+  task: 'Do the thing',
+  startedAt: '2026-07-14T10:00:00Z',
+  finishedAt: '2026-07-14T10:05:00Z',
+  steps: [],
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+/** The unscoped spelling of every route this task's thread needs — what a stale scope emits. */
+const UNSCOPED = [
+  `/api/v1/runs/${RUN_ID}`,
+  `/api/v1/runs/${RUN_ID}/history`,
+  `/api/v1/runs/${RUN_ID}/history-context`,
+]
+
+let paths: string[] = []
+
+beforeEach(() => {
+  paths = []
+  localStorage.clear()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      paths.push(path)
+      if (path === '/api/v1/health') return json(HEALTH)
+      if (path === '/api/v1/projects') return json(REGISTRY)
+      if (path === '/api/v1/workspace/runs-index') {
+        return json({ runs: [INDEX_ROW], perProjectLimit: 200, truncated: [], referenceStatuses: {} })
+      }
+      if (path === `/api/v1/p/other/runs/${RUN_ID}`) return json(RUN)
+      // What the server really answers when the boot project is asked for another one's run.
+      if (UNSCOPED.includes(path)) return json({ error: 'not found' }, 404)
+      // Everything else stays pending — this file is about which URL goes out, not about data.
+      return new Promise<never>(() => {})
+    }),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+/** The address bar (MemoryRouter keeps it internal) plus the one cross-project jump every
+ *  surface outside the arriving project makes — a plain, explicitly scoped target. */
+function NavigationProbe() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  return (
+    <>
+      <div data-testid="location" data-pathname={location.pathname} />
+      <button onClick={() => navigate(`/p/other/tasks/${RUN_ID}`)}>Open the other project’s task</button>
+    </>
+  )
+}
+
+function renderAt(entry: string) {
+  const client = createQueryClient()
+  render(
+    <StrictMode>
+      <QueryClientProvider client={client}>
+        <ThemeProvider>
+          <AppearanceProvider>
+            <MemoryRouter initialEntries={[entry]}>
+              <ListViewProvider>
+                <AppRoutes />
+                <NavigationProbe />
+              </ListViewProvider>
+            </MemoryRouter>
+          </AppearanceProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </StrictMode>,
+  )
+}
+
+/** Wait for the thread's own request, whichever spelling it chose, then hold both to account. */
+async function expectTheRunWasReadFromItsOwnProject() {
+  await waitFor(() =>
+    expect(document.querySelector('[data-testid="location"]')?.getAttribute('data-pathname')).toBe(
+      `/p/other/tasks/${RUN_ID}`,
+    ),
+  )
+  await waitFor(() => expect(paths.some((path) => path.includes(`/runs/${RUN_ID}`))).toBe(true))
+  expect(paths).toContain(`/api/v1/p/other/runs/${RUN_ID}`)
+  for (const path of UNSCOPED) expect(paths).not.toContain(path)
+  expect(screen.queryByText('Task not found')).toBeNull()
+}
+
+describe('opening another project’s task without a reload', () => {
+  it('reads the run from its own project when the row is clicked on the global Tasks page', async () => {
+    renderAt('/tasks')
+    fireEvent.click(await screen.findByRole('link', { name: 'Do the thing' }))
+    await expectTheRunWasReadFromItsOwnProject()
+  })
+
+  // The regression proper: standing INSIDE a project (the boot one — which mounts unscoped, so a
+  // leaked scope is invisible in the URL) and jumping to another project's task, with the thread
+  // chunk already warm from the case above. Provider and thread mount in the same commit.
+  it('reads the run from its own project when jumping out of the project in view', async () => {
+    renderAt(`/p/${BOOT}/`)
+    fireEvent.click(await screen.findByRole('button', { name: 'Open the other project’s task' }))
+    await expectTheRunWasReadFromItsOwnProject()
+  })
+})


### PR DESCRIPTION
Opening another project's task from the global Tasks page or the sidebar showed "Task not found" until the page was reloaded: the request went to `/api/v1/runs/:id` — the boot project, which honestly 404s a run it does not own — instead of `/api/v1/p/<that project>/runs/:id`.

`ProjectScopeProvider` writes the API scope in passive effects, which run child-before-ancestor, and every request goes out from a passive effect too; when the provider and the thread mount in the same commit (a soft navigation, thread chunk already warm), StrictMode's simulated remount ran the provider's scope reset among the subtree's destroys and the thread re-fired its query before the scope came back — and TanStack cached that 404 under the correctly-scoped key, so only a reload cleared it.

Both scope effects are layout effects now, so the scope is settled before any request of the commit is made; the render-phase write stays, since query keys are computed during render.

Covered by two ordering cases in `project-scope-context.test.tsx` and a new route-level `cross-project-task-navigation.test.tsx` that drives the real navigation under StrictMode — all three fail on the old code.