### PR TITLE
fix(release): pin GITHUB_RUN_ATTEMPT so CI re-runs stop failing the snapshot e2e

### DIFF
--- a/packages/cezar/test/e2e/release-snapshot.test.ts
+++ b/packages/cezar/test/e2e/release-snapshot.test.ts
@@ -90,6 +90,14 @@ function runScript(fixtureRoot: string, extraEnv: Record<string, string>, args: 
     GITHUB_OUTPUT: join(fixtureRoot, 'github-output.txt'),
     NODE_AUTH_TOKEN: '',
     GITHUB_ACTIONS: '',
+    // Neutralized for the same reason as the two above: the suite inherits `process.env`, and
+    // under Actions that carries the workflow's OWN run identity. `GITHUB_RUN_ATTEMPT` is the
+    // one that bites, because `computeSnapshot` appends `.${attempt}` whenever it is > 1 — so
+    // on a re-run (attempt 2+) every version the orchestrator stamps here silently grew a
+    // suffix and the hard-coded expectations below missed by it. Pinning the default to the
+    // first attempt makes the suite depend only on what each test passes; a test that wants to
+    // exercise re-run behavior overrides it explicitly via `extraEnv`.
+    GITHUB_RUN_ATTEMPT: '1',
     ...extraEnv,
   };
   return execFile(process.execPath, [script, ...args], { env, maxBuffer: 10 * 1024 * 1024 });
@@ -186,6 +194,36 @@ test('the nightly channel stamps a dated version and publishes under the nightly
     const output = await readFile(join(root, 'github-output.txt'), 'utf8');
     assert.match(output, /^attempted=true$/m);
     assert.match(output, /"distTag":"nightly"/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// The other half of the contract the pinned default above protects: an attempt number the test
+// asks for still reaches the orchestrator and still separates a re-cut from the original, so
+// re-running a nightly cannot try to publish a version npm already has. Passing it explicitly
+// also proves the default is a default and not a hard override.
+test('a nightly re-run stamps the attempt onto the version so it cannot collide', { timeout: 120_000 }, async () => {
+  const root = await makeFixture();
+  try {
+    await writeFile(join(root, 'github-output.txt'), '');
+    await runScript(
+      root,
+      {
+        GITHUB_EVENT_NAME: 'schedule',
+        GITHUB_REF_NAME: 'main',
+        GITHUB_REPOSITORY: 'open-mercato/cezar',
+        GITHUB_RUN_NUMBER: '12',
+        GITHUB_RUN_ATTEMPT: '2',
+        CEZ_RELEASE_CHANNEL: 'nightly',
+        NIGHTLY_DATE: '20260813',
+      },
+      ['--dry-run'],
+    );
+
+    const aliasPkg = await readPkg(root, 'alias-cezar');
+    assert.equal(aliasPkg.version, '0.9.9-nightly.20260813.12.2');
+    assert.deepEqual(aliasPkg.dependencies, { '@scope/fake-root': '0.9.9-nightly.20260813.12.2' });
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

Every **re-run** of the CI workflow fails, on any branch, regardless of the diff. It has been that way since the nightly-publish work landed in #876 (2026-08-13), and it is currently what is holding up #828.

The red step is `Run packaged CLI E2E tests`, with exactly one assertion failing:

```
✖ the nightly channel stamps a dated version and publishes under the nightly tag
  AssertionError: Expected values to be strictly equal:
  + actual   '0.9.9-nightly.20260813.12.2'
  - expected '0.9.9-nightly.20260813.12'
```

That trailing `.2` is the workflow's **run attempt**, and it is there by design: `computeSnapshot` appends `.${runAttempt}` whenever the attempt is greater than 1, so that re-cutting a nightly cannot collide with a version npm already has (`packages/cezar/src/release/snapshot.ts:45-46,62`).

The bug is in the test's environment, not in that behavior. `runScript` spreads `...process.env` into the child, and under Actions that carries the workflow's own run identity. The suite already neutralizes `NODE_AUTH_TOKEN` and `GITHUB_ACTIONS` for exactly this reason, but not `GITHUB_RUN_ATTEMPT` — so on attempt 2 the ambient value leaked into the orchestrator, every version it stamped grew a suffix, and the hard-coded expectations missed by it. Only the nightly test asserts an exact version, so only it goes red; the other three call sites that do not pin the attempt were computing nondeterministic versions too, they just never looked.

Locally the variable is unset, which is why this never reproduces on a developer machine and why the suite looks healthy on attempt 1.

## Fix

`packages/cezar/test/e2e/release-snapshot.test.ts` — pin `GITHUB_RUN_ATTEMPT: '1'` in `runScript`'s base environment, alongside the two neutralizers already there. The suite now depends only on what each test passes in, and a test that wants re-run behavior overrides it explicitly through `extraEnv`.

Fixing it in the shared helper rather than in the one failing test also covers the three other call sites that were latently exposed.

## Tests

- Added `a nightly re-run stamps the attempt onto the version so it cannot collide`, which passes `GITHUB_RUN_ATTEMPT: '2'` explicitly and asserts the `.2` suffix end-to-end through the orchestrator. It pins the behavior the pinned default protects, and proves the default is a default rather than a hard override.
- Verified by mutation: with the `GITHUB_RUN_ATTEMPT: '1'` line removed and `GITHUB_RUN_ATTEMPT=2` in the ambient environment, the suite reproduces the CI failure byte for byte (`actual '0.9.9-nightly.20260813.12.2'`, `expected '0.9.9-nightly.20260813.12'`). With the line restored it passes.
- The suite is green with the ambient variable unset, `=1`, `=2`, and `=3` — 6/6 in each case, where before only the unset/`=1` cases passed.

## Note for #828

This is what is making [that PR's CI](https://github.com/open-mercato/cezar/actions/runs/31896798979) red; the composer diff there is not involved. Worth knowing: clicking "re-run" on #828 will **not** clear it, because a re-run becomes attempt 3 and fails the same assertion with `.3`. Once this merges, #828 needs a rebase (or any fresh run) to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
