### PR TITLE
fix(attachments): stop pasted screenshots going invisible to the agent

### DIFF
--- a/packages/cezar/src/handoff.ts
+++ b/packages/cezar/src/handoff.ts
@@ -152,7 +152,7 @@ Structured question marker: when you are blocked on a decision that is genuinely
 Task reference markers: as soon as you know which GitHub pull request or issue this task is ABOUT (it was named in the task, or you just opened it), declare it by emitting, on its own line in your message text: CEZ:PR=<number> and/or CEZ:ISSUE=<number>. Re-emit with the new number if the subject changes (e.g. you open a PR later in the task). Declare only the task's own subject — never a PR/issue you merely mention, list, or compare against. You may also emit CEZ:TITLE=<terse gerund phrase, max 40 chars, e.g. "implementing comment threads"> once the work has a clearer shape than its current title; cez uses these instead of guessing from the transcript. Put markers in plain message text, never inside a code fence.
 
 ## Pasted attachments
-User-pasted screenshots/files are saved as real files; their absolute paths are listed in the message that carries them. Use those paths when a task needs the file itself (saving, uploading, attaching to issues/PRs); the inline image is for viewing only.`;
+User-pasted screenshots/files are saved as real files; their absolute paths are listed in the message that carries them. Use those paths when a task needs the file itself (saving, uploading, attaching to issues/PRs). Use them to LOOK at an attachment too: read the file whenever the user refers to a screenshot you cannot see inline — the inline copy does not survive later workflow steps, every backend, or a compacted context, but the file on disk does. Never tell the user their attachment did not reach you without opening its path first.`;
 
 export const FOLLOWUP_INSTRUCTIONS = `## Follow-ups (cezar)
 

--- a/packages/cezar/src/workflows/pasted-attachments.test.ts
+++ b/packages/cezar/src/workflows/pasted-attachments.test.ts
@@ -18,12 +18,20 @@ const TINY_PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
 /** The static system-prompt note every agent step gets (#357) — the agent
- *  contract that says "use the on-disk path, the inline image is view-only". */
+ *  contract that says "the on-disk path is the attachment", inline copy or not. */
 describe('HANDOFF_INSTRUCTIONS pasted-attachments note', () => {
   it('tells the agent pasted files are real files with paths, not just inline images', () => {
     expect(HANDOFF_INSTRUCTIONS).toContain('## Pasted attachments');
     expect(HANDOFF_INSTRUCTIONS).toMatch(/saved as real files/);
-    expect(HANDOFF_INSTRUCTIONS).toMatch(/the inline image is for viewing only/);
+  });
+
+  /** The note used to end at "the inline image is for viewing only", which reads as
+   *  "no inline image, no attachment" — the reason agents answered "I can't see your
+   *  screenshot" with the PNG sitting one Read away. */
+  it('tells the agent to open the path instead of reporting it cannot see the attachment', () => {
+    expect(HANDOFF_INSTRUCTIONS).toMatch(/read the file whenever the user refers to a screenshot you cannot see inline/);
+    expect(HANDOFF_INSTRUCTIONS).toMatch(/Never tell the user their attachment did not reach you without opening its path first/);
+    expect(HANDOFF_INSTRUCTIONS).not.toMatch(/the inline image is for viewing only/);
   });
 });
 
@@ -52,8 +60,18 @@ describe('pastedAttachmentsText / pastedAttachmentsNote', () => {
 
   it('tells the agent to operate on the files, not reconstruct them', () => {
     const text = pastedAttachmentsText([{ name: 'pasted-1.png', url: '/api/v1/x', path: '/abs/pasted-1.png' }]);
-    expect(text).toMatch(/operate on these files/);
-    expect(text).toMatch(/do not attempt to reconstruct/);
+    expect(text).toMatch(/Operate on these files/);
+    expect(text).toMatch(/never reconstruct them from the conversation/);
+  });
+
+  /** The note is the ONLY reference to the attachment on every path that loses the
+   *  inline blocks — later workflow steps, codex/opencode's `textOf`, a compacted
+   *  session. Saying only "operate on these files" left an agent that cannot see the
+   *  image with no reason to believe the path would show it one. */
+  it('tells the agent to read a path when no image is visible in the message', () => {
+    const text = pastedAttachmentsText([{ name: 'pasted-1.png', url: '/api/v1/x', path: '/abs/pasted-1.png' }]);
+    expect(text).toMatch(/Read a path above whenever you need to SEE an attachment/);
+    expect(text).toMatch(/the file always survives/);
   });
 
   it('wraps the same text as a trailing text ContentBlock', () => {
@@ -186,6 +204,45 @@ describe('pasted screenshots materialize to disk and reach the agent as file pat
     const ndjson = readFileSync(join(dataDir, 'runs', `${record.id}.ndjson`), 'utf8');
     expect(ndjson).not.toContain(TINY_PNG_B64);
   }, 30_000);
+
+  /** The base64 blocks are deliberately first-step-only, so on a multi-step workflow the
+   *  path note is all the second step has. Clearing `startAttachments` alongside them left
+   *  step two with no reference to the screenshot at all — the user pasted it, the run said
+   *  "1 screenshot attached", and the step that did the work never heard about it. */
+  it('a second agent step still receives the on-disk path, without the inline image', async () => {
+    writeFileSync(stdinFile, '', 'utf8');
+    const workflow: WorkflowDef = {
+      name: 'pasted-two-step-test',
+      source: 'built-in',
+      steps: [
+        { id: 'work', prompt: '{{task}}' },
+        { id: 'review', prompt: 'second step reviewing: {{task}}' },
+        { id: 'verify', command: 'true' },
+      ],
+    };
+    const image: ContentBlock = {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: TINY_PNG_B64 },
+    };
+    const record = manager.startRun(workflow, {
+      task: 'act on the screenshot in step two',
+      images: [image],
+      worktree: false,
+    });
+    await waitForStatus(record.id, ['done', 'review', 'failed', 'cancelled']);
+    expect(store.getRun(record.id)?.status, store.getRun(record.id)?.error).toMatch(/^(done|review)$/);
+
+    const lines = readStdinLines();
+    const second = lines.find((line) => line.userText.includes('second step reviewing:'));
+    expect(second).toBeDefined();
+    // No inline copy on a later step — re-sending the bytes to every step is pure cost…
+    expect(second?.imageCount).toBe(0);
+    // …but the path must still be there, or the attachment is invisible to this step.
+    expect(second?.userText).toContain('The user attached 1 pasted file, also saved on disk at:');
+    const pathMatch = second?.userText.match(/- (.*pasted-\d+\.png)/);
+    expect(pathMatch).toBeTruthy();
+    expect(existsSync(pathMatch?.[1] as string)).toBe(true);
+  }, 40_000);
 
   it('a follow-up pasted image is saved and its path is appended to the delivered message', async () => {
     writeFileSync(stdinFile, '', 'utf8');

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -423,15 +423,23 @@ export interface PersistedAttachment {
  * the message for the model to *view*; this note is what lets it *use* the
  * files as files — and the only usable reference on backends (codex,
  * opencode) whose `textOf()` drops image blocks before reaching the model.
+ *
+ * It must therefore say that reading the file is how you SEE the attachment,
+ * not only how you move it around: the blocks ride the first agent step only,
+ * two of the three backends drop them outright, and a compacted session loses
+ * them. An agent told merely to "operate on these files" reports that it
+ * cannot see the screenshot while the screenshot sits on disk beside it.
  */
 export function pastedAttachmentsText(attachments: PersistedAttachment[]): string {
   const list = attachments.map((a) => `- ${a.path}`).join('\n');
   return (
     `The user attached ${attachments.length} pasted file${attachments.length > 1 ? 's' : ''}, ` +
     `also saved on disk at:\n${list}\n` +
-    `When the task involves saving, uploading, attaching, or transforming the pasted content ` +
-    `(e.g. attaching to a GitHub issue/PR, copying into the repo), operate on these files — do ` +
-    `not attempt to reconstruct them from the conversation.`
+    `Read a path above whenever you need to SEE an attachment and no image is visible in this ` +
+    `message — the inline copy is dropped by later workflow steps, by some backends and by ` +
+    `context compaction, but the file always survives. Operate on these files for anything that ` +
+    `saves, uploads, attaches or transforms the pasted content (e.g. attaching to a GitHub ` +
+    `issue/PR, copying into the repo), and never reconstruct them from the conversation.`
   );
 }
 
@@ -2607,7 +2615,7 @@ export class RunManager {
     // `startRun` already persisted task images so a queued bubble can render them
     // (#612). Reuse those files for the agent-facing path note instead of minting
     // duplicate pasted files when execution finally begins.
-    let startAttachments: PersistedAttachment[] = (this.store.getRun(runId)?.taskImages ?? [])
+    const startAttachments: PersistedAttachment[] = (this.store.getRun(runId)?.taskImages ?? [])
       .map((url): PersistedAttachment | null => {
         const name = url.split('/').pop();
         if (!name || name.includes('..') || name.includes('/') || name.includes('\\')) return null;
@@ -2615,11 +2623,13 @@ export class RunManager {
         return existsSync(path) ? { name, url, path } : null;
       })
       .filter((saved): saved is PersistedAttachment => saved !== null);
-    // Task screenshots go with the FIRST agent step's opening message only —
-    // later steps and retry loops run in fresh sessions without them. Stacked
-    // attachments (#472) ride along too, but are NOT re-persisted above: they
-    // already live on disk, and adding them to `taskImages` would both duplicate
-    // the files and make the task bubble claim the stack's images as its own.
+    // The base64 blocks go with the FIRST agent step's opening message only —
+    // later steps and retry loops run in fresh sessions, and re-sending them is
+    // pure token cost. `startAttachments` above is the part that must NOT stop
+    // there: every later step still gets the on-disk paths. Stacked attachments
+    // (#472) ride along too, but are NOT re-persisted above: they already live
+    // on disk, and adding them to `taskImages` would both duplicate the files
+    // and make the task bubble claim the stack's images as its own.
     let startImages =
       input.stackedImages?.length ? [...(input.images ?? []), ...input.stackedImages] : input.images;
 
@@ -2661,8 +2671,11 @@ export class RunManager {
           chainStepNote(workflow.steps, i),
           startAttachments,
         );
+        // The base64 blocks are first-step-only: re-sending megabytes of image
+        // to every later step and every retry buys nothing the path note does
+        // not. The PATHS keep riding along, because from here on they are the
+        // only reference the agent has to the user's screenshot.
         startImages = undefined;
-        startAttachments = [];
         checkFailure = null;
         if (state.cancelled) break;
         if (failure) {
@@ -2796,11 +2809,12 @@ export class RunManager {
         stepId: step.id,
         message: `${images.length} screenshot${images.length > 1 ? 's' : ''} attached to the task`,
       });
-      // Point the agent at the on-disk files for the pasted subset (#357) — the
-      // base64 blocks above still let it *view* the images; this is what lets it
-      // *use* them as files (save, attach to an issue/PR, copy into the repo).
-      if (attachments.length) userPrompt += `\n\n${pastedAttachmentsText(attachments)}`;
     }
+    // Point the agent at the on-disk files for the pasted subset (#357). NOT gated
+    // on `images`: the blocks stop after the first agent step, so from step two
+    // onward — and on every retry — this note is the only thing that still tells
+    // the agent the screenshot exists, and where to read it.
+    if (attachments.length) userPrompt += `\n\n${pastedAttachmentsText(attachments)}`;
 
     const sessionId = randomUUID();
     const backend = step.runner ?? taskBackend;

--- a/packages/web/src/components/composer/composer-images.test.ts
+++ b/packages/web/src/components/composer/composer-images.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { fileToPendingImage, MAX_IMAGE_BYTES, screenFiles } from './composer-images'
+import { fileToPendingImage, imageMediaType, MAX_IMAGE_BYTES, screenFiles } from './composer-images'
 
 /** screenFiles reads only `type`, `size`, `name` — a structural stand-in keeps the 5MB cases
  *  from allocating 5MB buffers. */
@@ -53,6 +53,53 @@ describe('screenFiles — the legacy 4×5MB caps, mirrored from the server zod',
     const intake = screenFiles([fakeFile({ name: '', size: MAX_IMAGE_BYTES + 1 })], 0)
     expect(intake.rejected).toEqual(['image is too large (max 5 MB)'])
   })
+
+  /** A file the browser could not type at all is NOT the "dropped text file" case: the
+   *  user deliberately attached it and expects a thumbnail. Silently skipping it is
+   *  indistinguishable from the paste never registering. */
+  it('accepts a typeless file whose extension names a supported image', () => {
+    const intake = screenFiles([fakeFile({ type: '', name: 'Screenshot 2026-08-23.png' })], 0)
+    expect(intake.accepted).toHaveLength(1)
+    expect(intake.rejected).toEqual([])
+  })
+
+  it('names a typeless file it cannot recognize instead of dropping it silently', () => {
+    const intake = screenFiles([fakeFile({ type: '', name: 'archive.tar.gz' })], 0)
+    expect(intake.accepted).toEqual([])
+    expect(intake.rejected).toEqual(['archive.tar.gz skipped — not a recognized image'])
+  })
+
+  it('a typed non-image stays silent — the drop-a-text-file case is unchanged', () => {
+    expect(screenFiles([fakeFile({ type: 'text/plain', name: 'notes.txt' })], 0).rejected).toEqual([])
+  })
+})
+
+describe('imageMediaType', () => {
+  it('trusts the browser when it typed the file', () => {
+    expect(imageMediaType(fakeFile({ type: 'image/webp', name: 'x.png' }))).toBe('image/webp')
+  })
+
+  it('infers from the extension only when there is no type at all', () => {
+    expect(imageMediaType(fakeFile({ type: '', name: 'shot.JPG' }))).toBe('image/jpeg')
+    expect(imageMediaType(fakeFile({ type: '', name: 'anim.gif' }))).toBe('image/gif')
+    expect(imageMediaType(fakeFile({ type: '', name: 'noextension' }))).toBeNull()
+  })
+
+  /** SVG and friends are image types the model cannot decode; a wrong guess would be
+   *  a rejected API request rather than a rendered attachment. */
+  it('does not invent a type for image extensions the backends cannot render', () => {
+    expect(imageMediaType(fakeFile({ type: '', name: 'diagram.svg' }))).toBeNull()
+  })
+
+  it('rejects a typed non-image outright', () => {
+    expect(imageMediaType(fakeFile({ type: 'application/pdf', name: 'doc.pdf' }))).toBeNull()
+  })
+
+  /** The extension is user-supplied, so the lookup must not answer off a prototype. */
+  it('does not resolve an extension that only exists on Object.prototype', () => {
+    expect(imageMediaType(fakeFile({ type: '', name: 'payload.constructor' }))).toBeNull()
+    expect(imageMediaType(fakeFile({ type: '', name: 'payload.toString' }))).toBeNull()
+  })
 })
 
 describe('fileToPendingImage', () => {
@@ -62,6 +109,13 @@ describe('fileToPendingImage', () => {
     expect(image.mediaType).toBe('image/png')
     expect(image.name).toBe('tiny.png')
     expect(image.data).toBe(btoa(String.fromCharCode(137, 80, 78, 71)))
+    expect(image.preview).toBe(`data:image/png;base64,${image.data}`)
+  })
+
+  it('sends the inferred type for a file the browser left untyped', async () => {
+    const file = new File([new Uint8Array([137, 80])], 'shot.png', { type: '' })
+    const image = await fileToPendingImage(file)
+    expect(image.mediaType).toBe('image/png')
     expect(image.preview).toBe(`data:image/png;base64,${image.data}`)
   })
 })

--- a/packages/web/src/components/composer/composer-images.ts
+++ b/packages/web/src/components/composer/composer-images.ts
@@ -10,6 +10,29 @@ import type { ImageInput } from '@open-mercato/cezar-api-client'
 export const MAX_IMAGES = 4
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 
+/** The four formats every backend can actually render — the same set `persistImage`
+ *  maps to a file extension server-side. Consulted ONLY when the browser reports no
+ *  type at all: some Linux file managers and clipboard sources hand over a `File`
+ *  with `type: ''`, and dropping that silently is, from the user's side, identical
+ *  to the paste never happening. */
+const EXTENSION_MEDIA_TYPES = new Map<string, string>([
+  ['png', 'image/png'],
+  ['jpg', 'image/jpeg'],
+  ['jpeg', 'image/jpeg'],
+  ['gif', 'image/gif'],
+  ['webp', 'image/webp'],
+])
+
+/** The media type to send for a file, or null when it is not an image we can send.
+ *  A Map, not an object literal: the key is a user-supplied filename fragment, and
+ *  an object would answer `constructor`/`toString` off the prototype. */
+export function imageMediaType(file: File): string | null {
+  if (file.type.startsWith('image/')) return file.type
+  if (file.type) return null
+  const extension = file.name.split('.').pop()?.toLowerCase() ?? ''
+  return EXTENSION_MEDIA_TYPES.get(extension) ?? null
+}
+
 /** A pending attachment: the wire shape plus the data-URL the thumbnail row renders. */
 export interface PendingImage extends ImageInput {
   preview: string
@@ -24,10 +47,11 @@ export async function fileToPendingImage(file: File): Promise<PendingImage> {
     binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000))
   }
   const data = btoa(binary)
+  const mediaType = imageMediaType(file) ?? file.type
   return {
-    mediaType: file.type,
+    mediaType,
     data,
-    preview: `data:${file.type};base64,${data}`,
+    preview: `data:${mediaType};base64,${data}`,
     name: file.name || 'pasted image',
   }
 }
@@ -40,16 +64,21 @@ export interface ImageIntake {
 }
 
 /**
- * Validate a batch against what is already attached: non-images are ignored outright (a text
- * file dropped on the composer is not an error, it is just not an attachment), oversized files
- * and over-cap files are named in the rejection so the user knows which ones never made it.
+ * Validate a batch against what is already attached: typed non-images are ignored outright (a
+ * text file dropped on the composer is not an error, it is just not an attachment), oversized
+ * files and over-cap files are named in the rejection so the user knows which ones never made
+ * it. A file the browser could not type at ALL is the third case and it is not silent: the
+ * user believes they attached something, so an unrecognized one has to say so.
  */
 export function screenFiles(files: readonly File[], alreadyAttached: number): ImageIntake {
   const accepted: File[] = []
   const rejected: string[] = []
   let count = alreadyAttached
   for (const file of files) {
-    if (!file.type.startsWith('image/')) continue
+    if (!imageMediaType(file)) {
+      if (!file.type) rejected.push(`${file.name || 'file'} skipped — not a recognized image`)
+      continue
+    }
     if (file.size > MAX_IMAGE_BYTES) {
       rejected.push(`${file.name || 'image'} is too large (max 5 MB)`)
       continue

--- a/packages/web/src/components/composer/composer.test.tsx
+++ b/packages/web/src/components/composer/composer.test.tsx
@@ -89,9 +89,19 @@ const type = (textarea: HTMLTextAreaElement, value: string) =>
 const pngFile = (name = 'shot.png', bytes: number[] = [1, 2, 3]) =>
   new File([new Uint8Array(bytes)], name, { type: 'image/png' })
 
+/** A real `DataTransferItem` carries `kind` as well as `type`, and the composer screens on
+ *  `kind` — a clipboard file the OS could not type still has `kind: 'file'`. */
 const paste = (textarea: HTMLTextAreaElement, files: File[]) =>
   fireEvent.paste(textarea, {
-    clipboardData: { items: files.map((file) => ({ type: file.type, getAsFile: () => file })) },
+    clipboardData: {
+      items: files.map((file) => ({ kind: 'file', type: file.type, getAsFile: () => file })),
+    },
+  })
+
+/** A plain text paste: string items, no files — it must fall through to the textarea. */
+const pasteText = (textarea: HTMLTextAreaElement) =>
+  fireEvent.paste(textarea, {
+    clipboardData: { items: [{ kind: 'string', type: 'text/plain', getAsFile: () => null }] },
   })
 
 describe('submit shortcuts', () => {
@@ -231,6 +241,29 @@ describe('images — attach, paste, thumbnails, caps (legacy parity)', () => {
     paste(textarea, [big])
     expect(await screen.findByText('huge.png is too large (max 5 MB)')).toBeTruthy()
     expect(screen.queryByLabelText('Remove huge.png')).toBeNull()
+  })
+
+  /** The paste path used to screen on `item.type` before `screenFiles` ever saw the file,
+   *  so a clipboard screenshot the OS handed over untyped was dropped with no thumbnail
+   *  and no toast — the user's paste simply did nothing. */
+  it('a clipboard screenshot the OS could not type still attaches', async () => {
+    const { textarea } = renderComposer()
+    const untyped = new File([new Uint8Array([7, 7])], 'Screenshot.png', { type: '' })
+    paste(textarea, [untyped])
+    expect(await screen.findByLabelText('Remove Screenshot.png')).toBeTruthy()
+  })
+
+  it('an untyped clipboard file that is not an image says so instead of vanishing', async () => {
+    const { textarea } = renderComposer()
+    paste(textarea, [new File([new Uint8Array([7])], 'notes.tar.gz', { type: '' })])
+    expect(await screen.findByText('notes.tar.gz skipped — not a recognized image')).toBeTruthy()
+  })
+
+  it('a plain text paste attaches nothing and is left to the textarea', () => {
+    const { textarea } = renderComposer()
+    const event = pasteText(textarea)
+    expect(event).toBe(true) // not preventDefault()-ed: the browser still inserts the text
+    expect(screen.queryAllByLabelText(/^Remove /)).toHaveLength(0)
   })
 })
 

--- a/packages/web/src/components/composer/composer.tsx
+++ b/packages/web/src/components/composer/composer.tsx
@@ -288,8 +288,13 @@ export function Composer({
   )
 
   const onPaste = (event: ClipboardEvent) => {
+    // Take every FILE item and let `screenFiles` be the single judge of what is an image.
+    // Filtering on `item.type` here re-screened the dominant paste path against a narrower
+    // rule than the drop path, and a clipboard file the OS could not type vanished with no
+    // thumbnail and no toast. Text items are `kind: 'string'`, so a plain paste still yields
+    // zero files and falls through to the textarea untouched.
     const files = [...(event.clipboardData?.items ?? [])]
-      .filter((item) => item.type.startsWith('image/'))
+      .filter((item) => item.kind === 'file')
       .map((item) => item.getAsFile())
       .filter((file): file is File => file !== null)
     if (files.length === 0) return


### PR DESCRIPTION
## The bug

A user pastes a screenshot into a task; the agent answers *"I can't see your screenshot."* The PNG is on disk, one `Read` away, and the agent was told about it — just not in a way that suggested opening it would show it the picture.

Cezar hands a pasted attachment over twice: as a base64 image block (viewable) and as an absolute path (operable). The block is the fragile half and goes missing on three separate paths; the path is durable and was under-sold.

## What was wrong

**1. Both prompt surfaces described the path as move-only.** `pastedAttachmentsText` said *"When the task involves saving, uploading, attaching, or transforming the pasted content … operate on these files"*, and the `## Pasted attachments` handoff fragment closed with *"the inline image is for viewing only"* — which reads as **no inline image, no attachment**. Neither told an agent that couldn't see the image that reading the file was how to see it.

**2. A later workflow step got nothing at all.** `execute()` cleared `startAttachments` alongside `startImages` after the first agent step, and `runAgentStep` appended the path note only inside `if (images?.length)`. So on a two-agent-step workflow — or any post-check retry — step two received neither the blocks nor the paths. The run said "1 screenshot attached to the task" and the step that did the work never heard about it.

**3. An untyped clipboard file vanished silently.** `onPaste` screened items on `type.startsWith('image/')` before `screenFiles` ever saw them — a narrower rule than the drop path used. A `File` the OS handed over with `type: ''` (some Linux file managers and clipboard sources) produced no thumbnail and no toast: indistinguishable from the paste never registering.

## The fix

- **Prompts** (`pastedAttachmentsText`, `HANDOFF_ONLY_INSTRUCTIONS`) now state that reading a path is how you *see* an attachment, name the three cases where the inline copy is dropped, and say not to report a missing attachment without opening its path first.
- **`run.ts`** keeps `startAttachments` alive across steps and appends the note ungated by `images`. The base64 blocks stay deliberately first-step-only — re-sending megabytes to every retry buys nothing the path note doesn't — but the paths now ride the whole workflow.
- **Composer** filters clipboard items on `kind === 'file'`, making `screenFiles` the single screening authority on both paste and drop, and `screenFiles` infers a media type from the extension when the browser reports none, naming the file in a toast when it can't. Extension inference is restricted to the four formats the backends actually decode (png/jpeg/gif/webp) — guessing `image/svg+xml` would trade a silent drop for a rejected API request — and uses a `Map` rather than an object literal, since the key is a user-supplied filename fragment.

Behavior deliberately unchanged: a *typed* non-image (`text/plain`, `application/pdf`) is still ignored in silence — dropping a text file on the composer is not an error.

## Coverage

Nine new assertions across `pasted-attachments.test.ts`, `composer-images.test.ts` and `composer.test.tsx`, including an end-to-end two-agent-step run through `CEZ_DRY_RUN=1` that asserts step two sees `imageCount: 0` **and** the real on-disk path.

Per `AGENTS.md` § *Prove the regression test fails without the fix*: with the four source files stashed and the tests kept, **13 assertions go red**; restored, all pass.

## Validation

The full ordered gate from `.ai/agentic.config.json`, run locally:

| Command | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm test` | 6172 passed / 326 files |
| `npm run test:unit` | 36 passed |
| `npm run build` | ok — `check:pack` 475 files |
| `npm run test:package` | 15 passed |

No contract surface touched: `BACKWARD_COMPATIBILITY.md` §8 freezes the `CEZ:*` marker vocabulary in `handoff.ts`, not the surrounding prose, and no marker changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)