### PR TITLE
fix(automations): filter the timeline before validating it (#914)

### DIFF
--- a/packages/cezar/src/automations/github-poller.test.ts
+++ b/packages/cezar/src/automations/github-poller.test.ts
@@ -87,6 +87,61 @@ describe('GithubPoller', () => {
     ]));
   });
 
+  it('keeps polling when the timeline carries entries other than labeled/unlabeled', async () => {
+    // Every issue anyone has commented on has such an entry, so validating the
+    // whole `/timeline` array against `timelineEventSchema` made label triggers
+    // unusable: the throw escaped `poll()` and no candidate on the page was
+    // evaluated — not even from issues whose own history is all labels (#914).
+    const run = vi.fn(async (_executable: string, args: readonly string[]) => {
+      if (args.some((arg) => arg.includes('/timeline'))) {
+        return JSON.stringify([
+          { id: 1, event: 'labeled', created_at: '2026-07-26T02:00:00.000Z', label: { name: 'other' } },
+          { id: 2, event: 'commented', created_at: '2026-07-26T02:01:00.000Z' },
+          { id: 3, event: 'cross-referenced', created_at: '2026-07-26T02:02:00.000Z' },
+          { id: 4, event: 'labeled', created_at: '2026-07-26T02:03:00.000Z', label: { name: 'triage' } },
+        ]);
+      }
+      return JSON.stringify({ items: [item] });
+    });
+
+    const result = await new GithubPoller({ run }).poll('acme', 'demo', {
+      ...definition,
+      events: ['issue.labeled'],
+      filters: { ...definition.filters, changedLabels: ['triage'] },
+    }, { since: '2026-07-26T01:00:00.000Z' });
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      event: 'issue.labeled',
+      number: 7,
+      changedLabel: 'triage',
+      timestamp: '2026-07-26T02:03:00.000Z',
+    });
+  });
+
+  it('drops a labeled entry whose label is malformed instead of failing the poll', async () => {
+    // The filter is `safeParse`, not a widened schema: `timelineEventSchema`
+    // still defines what an entry must look like to be reconstructed from.
+    const run = vi.fn(async (_executable: string, args: readonly string[]) => {
+      if (args.some((arg) => arg.includes('/timeline'))) {
+        return JSON.stringify([
+          { id: 1, event: 'labeled', created_at: '2026-07-26T02:00:00.000Z' },
+          { id: 2, event: 'labeled', created_at: '2026-07-26T02:01:00.000Z', label: { name: 'triage' } },
+        ]);
+      }
+      return JSON.stringify({ items: [item] });
+    });
+
+    const result = await new GithubPoller({ run }).poll('acme', 'demo', {
+      ...definition,
+      events: ['issue.labeled'],
+      filters: { ...definition.filters, changedLabels: ['triage'] },
+    }, { since: '2026-07-26T01:00:00.000Z' });
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({ changedLabel: 'triage' });
+  });
+
   it('builds activity-specific queries for opened and label-event drains', () => {
     expect(buildSearchQuery('acme', 'demo', definition, 'issues', 'created', '2026-07-25T00:00:00.000Z'))
       .toContain('created:>=2026-07-25T00:00:00.000Z');

--- a/packages/cezar/src/automations/github-poller.ts
+++ b/packages/cezar/src/automations/github-poller.ts
@@ -202,7 +202,18 @@ export class GithubPoller {
       'api', '--method', 'GET', `repos/${owner}/${repo}/issues/${number}/timeline`,
       '-H', 'Accept: application/vnd.github+json', '-f', 'per_page=100',
     ]);
-    return z.array(timelineEventSchema).parse(JSON.parse(raw));
+    // Filter BEFORE validating. `/timeline` is a heterogeneous, additive GitHub
+    // surface — `commented`, `cross-referenced`, `assigned`, `renamed`, … all
+    // share the array with the two entries this poller reconstructs from. Passing
+    // the whole array through `timelineEventSchema` made the first such entry
+    // reject the parse, and the throw propagated out of `poll()`, so no candidate
+    // on the page was ever evaluated (#914). `timelineEventSchema` stays strict
+    // for the entries that matter: a `labeled` entry with a malformed `label` is
+    // still dropped rather than crashing the poll.
+    return z.array(z.unknown()).parse(JSON.parse(raw)).flatMap((entry) => {
+      const parsed = timelineEventSchema.safeParse(entry);
+      return parsed.success ? [parsed.data] : [];
+    });
   }
 }
 


### PR DESCRIPTION
Fixes #914 — automations on `issue.labeled` / `issue.unlabeled` failed on every poll against a real repository.

## The bug

`GithubPoller.timeline()` validated the **whole** `/timeline` response with `timelineEventSchema`, which admits only `labeled` and `unlabeled` entries. The timeline is a heterogeneous, additive GitHub surface, so the first `commented` (or `cross-referenced`, `assigned`, `renamed`, …) entry rejected the array parse — and the throw propagated out of `poll()`, so **no candidate on the page was evaluated**, not even from issues whose own history is nothing but label events.

Since any issue anyone has commented on carries such an entry, the two label events were unusable in practice. `pull_request.opened` and `issue.opened` never reach `timeline()` and were unaffected.

## The fix

Exactly what the issue suggests — filter before validating, via `safeParse` per entry:

```ts
return z.array(z.unknown()).parse(JSON.parse(raw)).flatMap((entry) => {
  const parsed = timelineEventSchema.safeParse(entry);
  return parsed.success ? [parsed.data] : [];
});
```

`timelineEventSchema` stays strict for the entries that matter — a `labeled` entry with a malformed `label` is still dropped rather than crashing the poll — and `reconstructLabelEvents` is untouched. Widening the `z.enum` to `z.string()` and filtering afterwards would also work, but it would cost the schema its role as the definition of "an entry we can reconstruct from".

Silently discarding unparseable entries is the right default here: the timeline is open-ended, and a new GitHub event type must never be able to stop an automation.

## Tests

Two regression tests in `github-poller.test.ts`, **both of which fail on the parent commit**:

- `keeps polling when the timeline carries entries other than labeled/unlabeled` — mixes `commented` and `cross-referenced` entries between two `labeled` ones, asserts the poll still yields the label candidate.
- `drops a labeled entry whose label is malformed instead of failing the poll` — guards the half that a widened schema would have lost.

```
without the fix:  Tests  2 failed | 6 passed (8)
with the fix:     Tests  8 passed (8)
```

Also verified end to end against a live repository: the poll raised a `ZodError` before the change and returned candidates after it.

The full validation gate is clean on this branch: `npm run typecheck`, `npm run test:unit`, `npm run build` (including `check:pack`), and `npm run test:package` all pass.

`npm test` reports **6154 passed, 6 failed (6160)**, none of them in this code path: four (`git-changes.test.ts` ×2, `directional-usage.test.tsx`, `agents-section.test.tsx`) fail identically on the parent commit, and the other two (`automations-gate.test.ts`, `run-isolation.test.ts`) are load-sensitive — they pass on parent and on this branch alike when run on their own.

<details>
<summary>One note on running the suite outside a scratch directory</summary>

Several server tests fail when `TMPDIR` points inside a git work tree — `mkdtempSync(join(tmpdir(), …))` then lands in a repository, so assertions like `expect(await getRepoInfo(bare)).toBeNull()` see the enclosing repo. `TMPDIR=/tmp` clears most of them. Not part of this PR, just what tripped me up first.

</details>
