### PR TITLE
fix(cockpit): scroll the Changes file tree independently of the diff

### DIFF
--- a/packages/web/e2e/diff-scroll.e2e.ts
+++ b/packages/web/e2e/diff-scroll.e2e.ts
@@ -258,22 +258,36 @@ describe(`diff virtualization on a generated ${FIXTURE_FILES}-file changeset`, (
       return {
         rows: pane.querySelectorAll('[data-slot="tree-file"]').length,
         overflow: Math.round(pane.scrollHeight - pane.clientHeight),
-        height: Math.round(pane.clientHeight),
-        room: Math.round(scroller.clientHeight),
+        paneBottom: Math.round(pane.getBoundingClientRect().bottom),
+        scrollerBottom: Math.round(scroller.getBoundingClientRect().bottom),
         mainTop: Math.round(scroller.scrollTop),
       }
-    })()`) as { rows: number; overflow: number; height: number; room: number; mainTop: number } | null
+    })()`) as {
+      rows: number
+      overflow: number
+      paneBottom: number
+      scrollerBottom: number
+      mainTop: number
+    } | null
 
     expect(pane, 'the tree pane did not render — is the viewport below md?').not.toBeNull()
     // The premise: more files than fit. Without it the rest proves nothing.
     expect(pane!.rows).toBeGreaterThan(FIXTURE_FILES / 2)
     expect(pane!.overflow, 'the tree pane is unbounded — it grows the page instead of scrolling').toBeGreaterThan(0)
-    // Capped by the room under the sticky chrome, never taller than the scrollport itself.
-    expect(pane!.height).toBeLessThanOrEqual(pane!.room)
+    // Capped by the room under the sticky chrome: the pane's bottom edge sits inside the
+    // scrollport. Edges, not heights — a height comparison passes with the cap's whole slack to
+    // spare and so would stay green even with the pane hanging below the fold, which is the one
+    // failure mode this cap exists to prevent.
+    expect(pane!.paneBottom, 'the tree pane hangs below the fold').toBeLessThanOrEqual(pane!.scrollerBottom)
 
     // The claim itself: the tree runs to its end while the diff stays exactly where it was.
     // Compared against the offset measured a moment ago, not against 0 — the specs above share
     // this page load and leave `main` scrolled, and where it sits is not this test's business.
+    //
+    // This is a scripted scroll, so it proves the pane is its OWN scroller and that reaching the
+    // last file no longer moves `main`. It says nothing about `overscroll-contain`: a scripted
+    // scroll never chains to an ancestor whatever the overscroll-behavior is, and the driver's
+    // input ops are pointer-based, with no wheel to send. Wheel chaining stays manual-QA territory.
     const moved = browser.evaluate(`(() => {
       const pane = document.querySelector('[data-slot="changes-tree-pane"]')
       pane.scrollTop = pane.scrollHeight

--- a/packages/web/e2e/diff-scroll.e2e.ts
+++ b/packages/web/e2e/diff-scroll.e2e.ts
@@ -241,4 +241,46 @@ describe(`diff virtualization on a generated ${FIXTURE_FILES}-file changeset`, (
     // The topmost mounted card starts at or above the fold — no uncovered band.
     expect(gap!).toBeLessThanOrEqual(0)
   }, 120_000)
+
+  /**
+   * The file tree is its OWN scroller, not a passenger on the page's. This fixture is the only
+   * place with a tree taller than the viewport (120+ files), which is exactly the shape that was
+   * broken: the pane was `sticky` but unbounded, so it grew the page instead of scrolling, and
+   * the last file could only be reached by dragging `main` — the diff — to the bottom.
+   */
+  it('scrolls the file tree independently of the diff', () => {
+    openChanges('virtual')
+
+    const pane = browser.evaluate(`(() => {
+      const pane = document.querySelector('[data-slot="changes-tree-pane"]')
+      if (!pane) return null
+      const scroller = ${MAIN}
+      return {
+        rows: pane.querySelectorAll('[data-slot="tree-file"]').length,
+        overflow: Math.round(pane.scrollHeight - pane.clientHeight),
+        height: Math.round(pane.clientHeight),
+        room: Math.round(scroller.clientHeight),
+        mainTop: Math.round(scroller.scrollTop),
+      }
+    })()`) as { rows: number; overflow: number; height: number; room: number; mainTop: number } | null
+
+    expect(pane, 'the tree pane did not render — is the viewport below md?').not.toBeNull()
+    // The premise: more files than fit. Without it the rest proves nothing.
+    expect(pane!.rows).toBeGreaterThan(FIXTURE_FILES / 2)
+    expect(pane!.overflow, 'the tree pane is unbounded — it grows the page instead of scrolling').toBeGreaterThan(0)
+    // Capped by the room under the sticky chrome, never taller than the scrollport itself.
+    expect(pane!.height).toBeLessThanOrEqual(pane!.room)
+
+    // The claim itself: the tree runs to its end while the diff stays exactly where it was.
+    // Compared against the offset measured a moment ago, not against 0 — the specs above share
+    // this page load and leave `main` scrolled, and where it sits is not this test's business.
+    const moved = browser.evaluate(`(() => {
+      const pane = document.querySelector('[data-slot="changes-tree-pane"]')
+      pane.scrollTop = pane.scrollHeight
+      return { paneTop: Math.round(pane.scrollTop), mainTop: Math.round(${MAIN}.scrollTop) }
+    })()`) as { paneTop: number; mainTop: number }
+
+    expect(moved.paneTop).toBeGreaterThan(0)
+    expect(moved.mainTop, 'scrolling the tree dragged the diff along').toBe(pane!.mainTop)
+  }, 120_000)
 })

--- a/packages/web/src/routes/repo-git/repo-changes.tsx
+++ b/packages/web/src/routes/repo-git/repo-changes.tsx
@@ -82,7 +82,12 @@ export function RepoChangesSection() {
         />
       ) : (
         <div className="flex min-h-0 flex-1 items-start gap-5 px-4 py-4 [--diff-sticky-top:7rem] md:px-6">
-          <aside className="sticky top-28 hidden w-60 shrink-0 md:block lg:w-72">
+          {/* Same deal as the task Changes tab: sticky AND its own scroller, so a long file list
+              never has to drag the diff to the bottom to show its last row. */}
+          <aside
+            data-slot="changes-tree-pane"
+            className="sticky top-28 hidden max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)] w-60 shrink-0 overflow-y-auto overscroll-contain md:block lg:w-72"
+          >
             <ChangesTree root={tree} selected={selected} onSelect={selectFile} />
           </aside>
           <Diff files={files} viewRef={diffRef} mode={effectiveMode} wrap={effectiveWrap} className="min-w-0 flex-1" />

--- a/packages/web/src/routes/repo-git/repo-git.test.tsx
+++ b/packages/web/src/routes/repo-git/repo-git.test.tsx
@@ -169,6 +169,11 @@ describe('the repo view Changes segment', () => {
     // The SAME tree + facade the task Changes tab uses: compacted folder, per-file ±.
     await waitFor(() => expect(document.querySelector('[data-slot="changes-tree"]')).not.toBeNull())
     expect(document.querySelector('[data-slot="tree-dir"]')?.textContent).toContain('src/util')
+    // …including its own bounded scroller, so a long list never drags the diff down with it.
+    const pane = document.querySelector('[data-slot="changes-tree-pane"]') as HTMLElement
+    expect(pane.className).toContain('max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)]')
+    expect(pane.className).toContain('overflow-y-auto')
+    expect(pane.className).toContain('overscroll-contain')
     await waitFor(() => expect(document.querySelectorAll('[data-slot="diff-file"]')).toHaveLength(2))
     expect(document.querySelector('[data-slot="changes-stat"]')?.textContent).toContain('+5')
     // The view toggles are the shared control, wired to the facade's mode.

--- a/packages/web/src/routes/repo-git/repo-git.test.tsx
+++ b/packages/web/src/routes/repo-git/repo-git.test.tsx
@@ -170,6 +170,7 @@ describe('the repo view Changes segment', () => {
     await waitFor(() => expect(document.querySelector('[data-slot="changes-tree"]')).not.toBeNull())
     expect(document.querySelector('[data-slot="tree-dir"]')?.textContent).toContain('src/util')
     // …including its own bounded scroller, so a long list never drags the diff down with it.
+    await waitFor(() => expect(document.querySelector('[data-slot="changes-tree-pane"]')).not.toBeNull())
     const pane = document.querySelector('[data-slot="changes-tree-pane"]') as HTMLElement
     expect(pane.className).toContain('max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)]')
     expect(pane.className).toContain('overflow-y-auto')

--- a/packages/web/src/routes/task-git/task-changes.test.tsx
+++ b/packages/web/src/routes/task-git/task-changes.test.tsx
@@ -175,6 +175,27 @@ describe('the Changes tab route', () => {
     expect(document.querySelectorAll('[data-slot="tree-file"]')).toHaveLength(1)
   })
 
+  // The tree column is its OWN scroller. Sticky alone left a tree taller than the viewport
+  // growing the PAGE, so reaching its last file meant dragging the shared `main` scroller — and
+  // the diff with it — all the way down. jsdom lays nothing out, so the classes are all this can
+  // check; the real-layout proof (the pane overflows, and scrolling it leaves `main` where it
+  // was) lives in `e2e/diff-scroll.e2e.ts`.
+  it('gives the tree column its own bounded scroller, not the page’s', async () => {
+    stubFetch()
+    renderChangesRoute()
+
+    await waitFor(() => expect(document.querySelector('[data-slot="changes-tree-pane"]')).not.toBeNull())
+    const pane = document.querySelector('[data-slot="changes-tree-pane"]') as HTMLElement
+    // Bounded by the room left under the sticky chrome — an unbounded pane cannot scroll at all.
+    expect(pane.className).toContain('max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)]')
+    expect(pane.className).toContain('overflow-y-auto')
+    // …and a wheel that bottoms out inside the tree must not chain into the diff.
+    expect(pane.className).toContain('overscroll-contain')
+    // The cap is measured from the offset the pane is actually pinned at (`top-40` = 10rem).
+    expect(pane.className).toContain('sticky top-40')
+    expect(pane.parentElement?.className).toContain('[--diff-sticky-top:10rem]')
+  })
+
   it('shows the empty state when the worktree is clean', async () => {
     stubFetch({
       'GET /api/v1/runs/r1/changes': () => jsonResponse({ files: [], stat: { adds: 0, dels: 0, files: 0 } }),

--- a/packages/web/src/routes/task-git/task-changes.tsx
+++ b/packages/web/src/routes/task-git/task-changes.tsx
@@ -191,8 +191,16 @@ function ChangesView({ run }: { run: ApiRun }) {
         />
       ) : (
         <div className="flex min-h-0 flex-1 items-start gap-5 px-4 py-4 [--diff-sticky-top:10rem] md:px-6">
-          {/* The tree column: sticky under the header so long diffs scroll beside it. */}
-          <aside className="sticky top-40 hidden w-60 shrink-0 md:block lg:w-72">
+          {/* The tree column: sticky under the header so long diffs scroll beside it, and its OWN
+              scroller. Sticky alone is not enough — a tree taller than the viewport grows the page
+              instead, so the only way to reach its last file was to drag the shared `main` scroller
+              (and the diff with it) to the bottom. Capping the pane at the space left under the
+              sticky chrome gives the list its own scrollbar; `overscroll-contain` keeps a wheel
+              inside it from chaining into the diff once it bottoms out. */}
+          <aside
+            data-slot="changes-tree-pane"
+            className="sticky top-40 hidden max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)] w-60 shrink-0 overflow-y-auto overscroll-contain md:block lg:w-72"
+          >
             <ChangesTree root={tree} selected={selected} onSelect={selectFile} />
           </aside>
           <Diff

--- a/packages/web/src/routes/task-git/task-files.test.tsx
+++ b/packages/web/src/routes/task-git/task-files.test.tsx
@@ -131,6 +131,13 @@ describe('the Files tab route', () => {
     expect(rows).toEqual(['src', 'big.txt', 'blob.dat', 'hello.ts', 'logo.png'])
     // Nothing selected yet — the pane says so instead of pretending.
     expect(screen.getByRole('heading', { level: 2, name: 'Select a file' })).toBeTruthy()
+    // Desktop only: the tree owns its scroller so a deep tree never drags the preview along.
+    // Below md the columns stack and the page IS the pane, so none of it applies there.
+    const pane = document.querySelector('[data-slot="files-tree-pane"]') as HTMLElement
+    expect(pane.className).toContain('md:max-h-[calc(100dvh_-_8rem)]')
+    expect(pane.className).toContain('md:overflow-y-auto')
+    expect(pane.className).toContain('md:overscroll-contain')
+    expect(pane.className.split(' ')).not.toContain('overflow-y-auto')
   })
 
   it('directories are lazy: closed by default, fetched only on first expand', async () => {

--- a/packages/web/src/routes/task-git/task-files.test.tsx
+++ b/packages/web/src/routes/task-git/task-files.test.tsx
@@ -133,8 +133,12 @@ describe('the Files tab route', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Select a file' })).toBeTruthy()
     // Desktop only: the tree owns its scroller so a deep tree never drags the preview along.
     // Below md the columns stack and the page IS the pane, so none of it applies there.
+    await waitFor(() => expect(document.querySelector('[data-slot="files-tree-pane"]')).not.toBeNull())
     const pane = document.querySelector('[data-slot="files-tree-pane"]') as HTMLElement
-    expect(pane.className).toContain('md:max-h-[calc(100dvh_-_8rem)]')
+    // Pin and cap both read the one var the parent declares, so they cannot drift apart.
+    expect(pane.parentElement?.className).toContain('[--diff-sticky-top:7rem]')
+    expect(pane.className).toContain('md:top-[var(--diff-sticky-top)]')
+    expect(pane.className).toContain('md:max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)]')
     expect(pane.className).toContain('md:overflow-y-auto')
     expect(pane.className).toContain('md:overscroll-contain')
     expect(pane.className.split(' ')).not.toContain('overflow-y-auto')

--- a/packages/web/src/routes/task-git/task-files.tsx
+++ b/packages/web/src/routes/task-git/task-files.tsx
@@ -57,8 +57,13 @@ function FilesView({ run }: { run: ApiRun }) {
         />
       ) : (
         <div className="flex min-h-0 flex-1 flex-col items-stretch gap-5 px-4 py-4 md:flex-row md:items-start md:px-6">
-          {/* Sticky beside a long preview on desktop; first in the stack on phones. */}
-          <aside className="w-full shrink-0 md:sticky md:top-28 md:w-60 lg:w-72">
+          {/* Sticky beside a long preview on desktop, with its own scroller so a deep tree scrolls
+              without dragging the preview along; first in the stack (and no scroller of its own) on
+              phones, where the page IS the pane. */}
+          <aside
+            data-slot="files-tree-pane"
+            className="w-full shrink-0 md:sticky md:top-28 md:max-h-[calc(100dvh_-_8rem)] md:w-60 md:overflow-y-auto md:overscroll-contain lg:w-72"
+          >
             <FilesTree runId={run.id} selected={selected} onSelect={setSelected} />
           </aside>
           <FilePreview runId={run.id} path={selected} className="min-w-0 flex-1" />

--- a/packages/web/src/routes/task-git/task-files.tsx
+++ b/packages/web/src/routes/task-git/task-files.tsx
@@ -56,13 +56,14 @@ function FilesView({ run }: { run: ApiRun }) {
           subtitle={root.error.message}
         />
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col items-stretch gap-5 px-4 py-4 md:flex-row md:items-start md:px-6">
+        <div className="flex min-h-0 flex-1 flex-col items-stretch gap-5 px-4 py-4 [--diff-sticky-top:7rem] md:flex-row md:items-start md:px-6">
           {/* Sticky beside a long preview on desktop, with its own scroller so a deep tree scrolls
               without dragging the preview along; first in the stack (and no scroller of its own) on
-              phones, where the page IS the pane. */}
+              phones, where the page IS the pane. The cap reads the same var the pin is set from, so
+              the two cannot drift when this tab's chrome height changes. */}
           <aside
             data-slot="files-tree-pane"
-            className="w-full shrink-0 md:sticky md:top-28 md:max-h-[calc(100dvh_-_8rem)] md:w-60 md:overflow-y-auto md:overscroll-contain lg:w-72"
+            className="w-full shrink-0 md:sticky md:top-[var(--diff-sticky-top)] md:max-h-[calc(100dvh_-_var(--diff-sticky-top)_-_1rem)] md:w-60 md:overflow-y-auto md:overscroll-contain lg:w-72"
           >
             <FilesTree runId={run.id} selected={selected} onSelect={setSelected} />
           </aside>


### PR DESCRIPTION
## The bug

In the Changes tab, the left file tree could not be scrolled on its own. With a lot of changed files, reaching the bottom of the tree meant dragging the diff all the way to the bottom with it.

The tree column is `position: sticky` but **unbounded** — no height cap and no scroller of its own (`task-changes.tsx`). The only scroll container on the page is the app shell's `<main>`, which the diff also lives in, so a tree taller than the viewport grows the *page* instead of scrolling.

## The fix

Cap the pane at the room left under the sticky chrome and give it its own `overflow-y-auto` + `overscroll-contain`, so a wheel that bottoms out inside the tree does not chain into the diff.

The cap reuses the `--diff-sticky-top` var already set on the row, so it cannot drift from the offset the pane is pinned at.

- `routes/task-git/task-changes.tsx` — the Changes tab
- `routes/repo-git/repo-changes.tsx` — the `/git` Changes segment, same layout, same defect
- `routes/task-git/task-files.tsx` — the Files tab, `md:`-gated (below `md` the columns stack and the page *is* the pane)

Known limitation: the cap is `100dvh`-based, so while a shell banner is showing, the pane can extend past the fold by the banner's height. It degrades to "slightly taller than fits", never back to the old behaviour. Same tradeoff the Skills list pane already makes.

## Tests

- Class assertions in the three unit suites — jsdom lays nothing out, so that is the honest limit there.
- A real-layout regression in `e2e/diff-scroll.e2e.ts`, reusing that spec's existing 120-file fixture: the pane overflows, is never taller than the scrollport, and scrolling it to the end leaves `main.scrollTop` where it was.

Verified red-without-fix: reverting only the three source files turns exactly the three new assertions red and leaves everything else green.

## Validation

- `NODE_ENV=test npm test -- packages/web/src/routes/task-git packages/web/src/routes/repo-git` → 62/62 pass, run on this branch.
- `npm run typecheck` (contract + client + server + web, `e2e/**` included) → clean.
- Built the web bundle and grepped the emitted CSS to confirm Tailwind v4 generates the arbitrary calc utilities: `max-height:calc(100dvh - var(--diff-sticky-top) - 1rem)` and `.md\:max-h-\[calc\(100dvh_-_8rem\)\]` are both present.
- The new e2e was **not executed** — this environment has no `agent-browser` provider installed and no `packages/cezar/dist` build. It needs a run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)