### PR TITLE
fix(composer): let a picked skill be taken back off, and open every task without one

### DIFF
--- a/packages/cezar/src/server/server.ts
+++ b/packages/cezar/src/server/server.ts
@@ -683,11 +683,15 @@ const appearanceSchema = z.object({
 
 const uiStateSchema = z
   .object({
+    // `null` clears the recorded choice — the composer's "no skill, no workflow" state,
+    // which is a plain quick-task run. Written through to the file like any other value, so an
+    // older cockpit reading it falls back to its own default instead of restoring a stale skill.
     lastTask: z
       .object({
         source: z.enum(['workflow', 'skill']),
         ref: z.string().min(1).max(200),
       })
+      .nullable()
       .optional(),
     // Composer picker recency (newest first, capped) + the remembered worktree
     // choice for single-skill runs. Additive prefs, like the rest of ui-state.

--- a/packages/cezar/src/server/ui-state-api.test.ts
+++ b/packages/cezar/src/server/ui-state-api.test.ts
@@ -81,6 +81,35 @@ describe('the ui-state API — skillUsage (#408)', () => {
     expect((await res.json()) as { error: string }).toHaveProperty('error');
   });
 
+  // ---- lastTask: the "no skill" value ---------------------------------------------------------
+  // The composer can run a task with NO skill and no workflow (the plain built-in quick-task).
+  // `null` is how that choice is recorded, and it has to be a real value rather than an omitted
+  // key: omitting it leaves whatever the previous run stored, because the merge is shallow.
+  describe('lastTask records "nothing picked" as null', () => {
+    it('accepts null, writes it, and round-trips it through GET', async () => {
+      const res = await put({ lastTask: null });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ lastTask: null });
+      expect(rawFile()).toHaveProperty('lastTask', null);
+      expect(await (await get()).json()).toMatchObject({ lastTask: null });
+    });
+
+    it('null REPLACES a stored source — an omitted key would have kept it', async () => {
+      await put({ lastTask: { source: 'skill', ref: 'om-fix' } });
+      await put({ lastTask: null });
+      expect(rawFile().lastTask).toBeNull();
+      // The omitted-key case, for contrast: the shallow merge keeps what is already there.
+      await put({ lastTask: { source: 'skill', ref: 'om-fix' } });
+      await put({ lastAutonomous: true });
+      expect(rawFile().lastTask).toEqual({ source: 'skill', ref: 'om-fix' });
+    });
+
+    it('still refuses a malformed source', async () => {
+      expect((await put({ lastTask: { source: 'nonsense', ref: 'x' } })).status).toBe(400);
+      expect((await put({ lastTask: { source: 'skill' } })).status).toBe(400);
+    });
+  });
+
   // ---- bounds ------------------------------------------------------------------------------
   // The body is written straight to ui-state.json, which every cockpit load GETs back and every
   // later PUT re-reads — so an unbounded map is an unbounded file. Every other field in this

--- a/packages/contract/src/workspace.ts
+++ b/packages/contract/src/workspace.ts
@@ -143,8 +143,13 @@ const taskTableUiStateSchema = z.looseObject({
  * listed it, which made it wider than the route.
  */
 export const uiStateSchema = z.looseObject({
+  /** What the last started run used. `null` is a VALUE, not an absence: it records a run that
+   *  chose neither a skill nor a workflow (the plain built-in `quick-task`), which the composer
+   *  can now express since the source picker grew an empty state. Absent still means "no
+   *  run has been recorded here" — a cockpit reading either one selects nothing. */
   lastTask: z
     .object({ source: z.enum(['workflow', 'skill']), ref: z.string() })
+    .nullable()
     .optional(),
   /** Most-recently-run sources, newest first (deduped, capped). Feeds the composer picker's
    *  recency sort. */

--- a/packages/web/e2e/agent-browser.ts
+++ b/packages/web/e2e/agent-browser.ts
@@ -61,7 +61,40 @@ export function fixtureServeEnv(
   dataRoot: string,
   extra: Record<string, string> = {},
 ): NodeJS.ProcessEnv {
-  return { ...process.env, CEZ_DRY_RUN: '1', CEZ_HOME: resolve(dataRoot, '.cez-home'), ...extra }
+  return {
+    ...process.env,
+    // One line on purpose: the `fixture-serve-must-pin-cez-home` design guardian reads these
+    // two together, and a CEZ_DRY_RUN without CEZ_HOME beside it is exactly the mistake it
+    // exists to catch.
+    CEZ_DRY_RUN: '1', CEZ_HOME: resolve(dataRoot, '.cez-home'),
+    // A fixture repo must hold exactly the skills the fixture wrote. Open Mercato skill updates
+    // are default-on (AGENTS.md § Zero config), so a boot inside the six-hour window installs the
+    // whole `om-*` collection INTO the fixture and every "these are the project skills"
+    // assertion starts depending on the machine's cache and network. The shared test env
+    // (`skills-update.e2e.ts` attaches to it) is where that behaviour is exercised on purpose;
+    // `extra` can still turn it back on for a spec that wants it.
+    CEZ_SKILLS_AUTO_UPDATE: '0',
+    ...extra,
+  }
+}
+
+/**
+ * A JSON GET that survives a RESET idle connection.
+ *
+ * Specs boot a server, drive the browser for tens of seconds, then read the API back. Node's
+ * fetch pools the connection opened during the health probe, and reusing a socket the server has
+ * since closed surfaces as `ECONNRESET` — a dead connection, never a dead server (the process is
+ * still answering the browser at that moment). One retry opens a fresh one.
+ */
+export async function getJson<T>(url: string): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return (await (await fetch(url)).json()) as T
+    } catch (error) {
+      if (attempt >= 2) throw error
+      await new Promise((r) => setTimeout(r, 250))
+    }
+  }
 }
 
 /**

--- a/packages/web/e2e/composer-defaults.e2e.ts
+++ b/packages/web/e2e/composer-defaults.e2e.ts
@@ -98,10 +98,15 @@ describe('configurable composer run defaults', () => {
     await putDefaults(null, null)
     try {
       browser.goto(`${baseUrl}/p/${bootProject}/new`)
+      // A cold composer picks nothing: the source pill is the empty invitation, and the run it
+      // would start is the plain built-in quick-task. Wait on the LABEL, not on the kind — an
+      // unpicked pill reports `none` while it is still showing its loading ellipsis.
       browser.waitForFunction(
-        `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('quick-task')`,
+        `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('Skill')`,
       )
-      expect(browser.text('[data-slot="source-pill"]')).toContain('quick-task')
+      expect(browser.evaluate(
+        `document.querySelector('[data-slot="source-pill"]')?.dataset.sourceKind`,
+      )).toBe('none')
       expect(browser.evaluate(
         `document.querySelector('[data-slot="worktree-toggle"]')?.getAttribute('aria-checked')`,
       )).toBe('true')
@@ -115,6 +120,9 @@ describe('configurable composer run defaults', () => {
       browser.waitForFunction(
         `document.querySelector('[data-slot="interactive-skill-hint"]') !== null`,
       )
+      // The popover is dismissed by the pick, but its exit animation still covers the chip row
+      // for a frame or two — and the toggles below are exactly what this spec clicks next.
+      browser.waitForFunction(`document.querySelector('[data-slot="source-menu"]') === null`)
       for (const slot of ['worktree-toggle', 'autonomous-toggle']) {
         expect(browser.evaluate(
           `document.querySelector('[data-slot="${slot}"]')?.getAttribute('aria-checked')`,

--- a/packages/web/e2e/new-task.e2e.ts
+++ b/packages/web/e2e/new-task.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv, getJson } from './agent-browser'
 
 /**
  * The full-screen /new composer (R4 Steps 1.1 + 1.3) end-to-end against a LIVE dry-run server:
@@ -79,6 +79,17 @@ beforeAll(async () => {
     'utf8',
   )
 
+  // One real workflow file, so the picker has a Workflows group to render: the built-in
+  // `quick-task` is not a row of its own any more (it IS the "No skill" row), and a fixture with
+  // only the built-in would leave the group empty for reasons that have nothing to do with the
+  // grouping under test.
+  mkdirSync(join(dataRoot, '.ai/cezar/workflows'), { recursive: true })
+  writeFileSync(
+    join(dataRoot, '.ai/cezar/workflows/fix-and-verify.yaml'),
+    'name: fix-and-verify\ndescription: Fix, then prove it with the tests\nskills:\n  - lint-fix\n',
+    'utf8',
+  )
+
   const port = await freePort()
   baseUrl = `http://localhost:${port}`
   server = spawn(
@@ -118,11 +129,15 @@ describe('the full-screen /new against a live dry-run server', () => {
     expect(browser.count('[data-slot="suggested-chip"]')).toBe(3)
   })
 
-  it('the pill row resolves: project skill preselected, runner pill iff >1 backend, base: main, ×1', async () => {
-    // Sources are ready once the pill shows a real skill (the first project skill, #377 order).
+  it('the pill row resolves: no source picked, runner pill iff >1 backend, base: main, ×1', async () => {
+    // Sources are ready once the pill stops showing its loading ellipsis. A resolved composer
+    // picks NOTHING — the empty state is the default, so there is no name to wait for.
     browser.waitForFunction(
-      `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('lint-fix')`,
+      `!document.querySelector('[data-slot="source-pill"]')?.textContent.includes('…')`,
     )
+    expect(browser.evaluate(
+      `document.querySelector('[data-slot="source-pill"]')?.dataset.sourceKind`,
+    )).toBe('none')
     // Health must have SETTLED before judging the runner pill — the version chip renders from
     // the same response, so it is the "health arrived" signal.
     browser.waitForFunction(`document.querySelector('[data-slot="version-chip"]') !== null`)
@@ -141,7 +156,14 @@ describe('the full-screen /new against a live dry-run server', () => {
     } else {
       expect(browser.count('[data-slot="runner-pill"]')).toBe(0)
     }
-    expect(browser.text('[data-slot="model-pill"]')).toContain('auto')
+    // Same rule as the runner pill above, for the same reason: the model pill shows the HOST's
+    // native default when the installed agent pins one (`readAgentModelDefaults` seeds
+    // `defaultModels` from the agent's own settings), and `auto` only when it does not. Asserting
+    // `auto` unconditionally failed on any machine whose claude settings name a model.
+    const config = await getJson<{ defaultModels?: Record<string, string> }>(
+      `${baseUrl}/api/v1/config`,
+    )
+    expect(browser.text('[data-slot="model-pill"]')).toContain(config.defaultModels?.claude || 'auto')
     expect(browser.text('[data-slot="variants-pill"]')).toContain('×1')
     expect(browser.text('[data-slot="base-pill"]')).toContain('base: main')
     browser.screenshot(`${artifactsDir}/new-task-hero.png`)
@@ -153,10 +175,23 @@ describe('the full-screen /new against a live dry-run server', () => {
     const groups = browser.evaluate(`[...document.querySelectorAll('[cmdk-group-heading]')].map(h => h.textContent)`) as string[]
     expect(groups[0]).toBe('Project skills')
     expect(groups).toContain('Workflows')
-    const projectRefs = browser.evaluate(
-      `[...document.querySelectorAll('[data-slot="source-option"][data-source-kind="skill"]')].slice(0, 2).map(o => o.dataset.sourceRef)`,
+    // The first row is the heading-less way out of any selection, and the built-in it runs has
+    // no second row under Workflows.
+    expect(browser.evaluate(
+      `[...document.querySelectorAll('[data-slot="source-option"]')][0]?.textContent`,
+    )).toContain('No skill')
+    expect(browser.count('[data-slot="source-option"][data-source-ref="quick-task"]')).toBe(0)
+    const skillRefs = browser.evaluate(
+      `[...document.querySelectorAll('[data-slot="source-option"][data-source-kind="skill"]')].map(o => o.dataset.sourceRef)`,
     ) as string[]
-    expect(projectRefs).toEqual(['lint-fix', 'spec-writer'])
+    // The fixture's own two skills, in #377 order. Asserted by their relative order rather than
+    // by being the first two rows: a machine whose shared team-skill cache is populated
+    // (`getTeamSkillsCached`, global and unrelated to this repo) lists those here too, and they
+    // must not decide an assertion about the fixture's grouping.
+    expect(skillRefs.filter((ref) => ref === 'lint-fix' || ref === 'spec-writer')).toEqual([
+      'lint-fix',
+      'spec-writer',
+    ])
     browser.screenshot(`${artifactsDir}/new-task-source-menu.png`)
 
     browser.click('[data-slot="source-option"][data-source-ref="spec-writer"]')
@@ -164,6 +199,38 @@ describe('the full-screen /new against a live dry-run server', () => {
       `document.querySelector('[data-slot="source-pill"]').textContent.includes('spec-writer')`,
     )
     browser.waitForFunction(`document.querySelector('[data-slot="source-menu"]') === null`)
+  })
+
+  it('the ✕ takes the picked skill back off, and the selected row toggles it off too', () => {
+    // One click, no menu — the affordance the report asked for.
+    browser.click('[data-slot="source-pill-clear"]')
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="source-pill"]')?.dataset.sourceKind === 'none'`,
+    )
+    // Nothing picked, nothing to clear: the ✕ is gone with the selection.
+    expect(browser.count('[data-slot="source-pill-clear"]')).toBe(0)
+    browser.screenshot(`${artifactsDir}/new-task-source-empty.png`)
+
+    // The same state from inside the list: pick it, then pick it again.
+    const pickSpecWriter = () => {
+      browser.click('[data-slot="source-pill"]')
+      browser.waitForFunction(`document.querySelector('[data-slot="source-menu"]') !== null`)
+      browser.click('[data-slot="source-option"][data-source-ref="spec-writer"]')
+    }
+    pickSpecWriter()
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('spec-writer')`,
+    )
+    pickSpecWriter()
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="source-pill"]')?.dataset.sourceKind === 'none'`,
+    )
+
+    // Leave it picked: the next spec submits from here.
+    pickSpecWriter()
+    browser.waitForFunction(
+      `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('spec-writer')`,
+    )
   })
 
   it('type + submit → the thread; the run record carries the exact skill chain', async () => {
@@ -175,30 +242,38 @@ describe('the full-screen /new against a live dry-run server', () => {
     const runId = (browser.evaluate(`location.pathname.split('/').pop()`) as string) ?? ''
     expect(runId).not.toBe('')
     // API readback: the run started from the PICKED skill, as the one-step inline chain.
-    const record = (await (await fetch(`${baseUrl}/api/v1/runs/${runId}`)).json()) as {
+    const record = await getJson<{
       task: string
       workflowDef?: { steps?: Array<Record<string, unknown>> }
-    }
+    }>(`${baseUrl}/api/v1/runs/${runId}`)
     expect(record.task).toBe('Draft a spec for the new-task hero e2e.')
     expect(record.workflowDef?.steps).toEqual([
       expect.objectContaining({ id: 'task', name: 'spec-writer', skill: 'spec-writer', prompt: '{{task}}' }),
     ])
 
-    // And the source persisted as lastTask, so the next visit preselects it.
-    const uiState = (await (await fetch(`${baseUrl}/api/v1/ui-state`)).json()) as {
-      lastTask?: { source: string; ref: string }
-    }
+    // The source is recorded as lastTask — a record of what ran, not a preselection for the
+    // next task (see the next spec, and `resolveSource`).
+    const uiState = await getJson<{ lastTask?: { source: string; ref: string } | null }>(
+      `${baseUrl}/api/v1/ui-state`,
+    )
     expect(uiState.lastTask).toEqual({ source: 'skill', ref: 'spec-writer' })
 
     // The thread really rendered (the run parks at waiting under the dry-run mock).
     browser.waitForFunction(`document.querySelector('[data-slot="composer"] textarea') !== null`)
   }, 90_000)
 
-  it('back on /new the picked source stuck and the spent draft is gone; iPhone hero screenshot', () => {
+  it('back on /new the skill is gone with the task it ran; iPhone hero screenshot', () => {
     browser.click(`[data-slot="sidebar"] a[href="${scoped('/new')}"]`)
+    // The started skill does NOT follow the user into the next task — the whole point of the
+    // empty state. A fresh composer picks nothing and shows the invitation. Waiting on the
+    // label rather than the kind: an unpicked pill reports `none` while still loading, and a
+    // "does not contain spec-writer" assertion would pass against the ellipsis for free.
     browser.waitForFunction(
-      `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('spec-writer')`,
+      `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('Skill')`,
     )
+    expect(browser.evaluate(
+      `document.querySelector('[data-slot="source-pill"]')?.dataset.sourceKind`,
+    )).toBe('none')
     expect(
       browser.evaluate(`document.querySelector('[data-slot="composer"] textarea').value`),
     ).toBe('')
@@ -212,7 +287,7 @@ describe('the full-screen /new against a live dry-run server', () => {
 
 describe('the bookmarklet contract on full /new loads (spec 011, Step 1.3)', () => {
   const runCount = async (): Promise<number> =>
-    ((await (await fetch(`${baseUrl}/api/v1/runs`)).json()) as unknown[]).length
+    (await getJson<unknown[]>(`${baseUrl}/api/v1/runs`)).length
 
   it('auto=1 with the REAL launch key starts a run unattended and lands in its thread', async () => {
     // The documented on-disk contract: the server bakes this secret into the bookmarklets it
@@ -228,10 +303,10 @@ describe('the bookmarklet contract on full /new loads (spec 011, Step 1.3)', () 
     browser.waitForFunction(`location.pathname.startsWith('${scoped('/tasks/')}')`)
 
     const runId = (browser.evaluate(`location.pathname.split('/').pop()`) as string) ?? ''
-    const record = (await (await fetch(`${baseUrl}/api/v1/runs/${runId}`)).json()) as {
+    const record = await getJson<{
       task: string
       workflowDef?: { steps?: Array<Record<string, unknown>> }
-    }
+    }>(`${baseUrl}/api/v1/runs/${runId}`)
     expect(record.task).toBe('hello')
     expect(record.workflowDef?.steps).toEqual([
       expect.objectContaining({ id: 'task', name: 'lint-fix', skill: 'lint-fix', prompt: '{{task}}' }),

--- a/packages/web/e2e/plan-mode.e2e.ts
+++ b/packages/web/e2e/plan-mode.e2e.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv } from './agent-browser'
+import { AgentBrowser, bootProjectId, cezarCli, fixtureServeEnv, getJson } from './agent-browser'
 
 /**
  * Plan mode end-to-end (R4 Step 1.2, #383 + spec 008) against a LIVE dry-run server. Under
@@ -124,9 +124,10 @@ describe('plan mode against a live dry-run server', () => {
     browser.waitForFunction(`document.querySelector('[data-slot="mode-plan"]') !== null`)
     // Sources must have LOADED before submitting — a plan submit races the workflows/skills
     // queries otherwise and is (correctly) rejected with the "still loading" toast. The pill
-    // showing the fixture's project skill is the ready signal (same trick as new-task.e2e).
+    // dropping its loading ellipsis is the ready signal (same trick as new-task.e2e): a
+    // resolved composer picks nothing, so there is no name to wait for.
     browser.waitForFunction(
-      `document.querySelector('[data-slot="source-pill"]')?.textContent.includes('lint-fix')`,
+      `!document.querySelector('[data-slot="source-pill"]')?.textContent.includes('…')`,
     )
 
     expect(browser.evaluate(`document.querySelector('[data-slot="mode-plan"]').getAttribute('aria-checked')`)).toBe('false')
@@ -164,9 +165,9 @@ describe('plan mode against a live dry-run server', () => {
     browser.click('[data-slot="plan-save-dialog"] button[type="submit"]')
     browser.waitForFunction(`document.querySelector('[data-slot="plan-save-dialog"]') === null`)
 
-    const readback = (await (await fetch(`${baseUrl}/api/v1/workflows`)).json()) as {
+    const readback = await getJson<{
       workflows: Array<{ name: string; source: string; steps: Array<{ id: string }> }>
-    }
+    }>(`${baseUrl}/api/v1/workflows`)
     const saved = readback.workflows.find((w) => w.name === 'e2e planned chain')
     expect(saved?.source).toBe('file')
     expect(saved?.steps.map((s) => s.id)).toEqual(['implement', 'verify', 'review'])
@@ -182,9 +183,9 @@ describe('plan mode against a live dry-run server', () => {
       `document.querySelector('[data-slot="plan-overwrite-dialog"]') === null &&
        document.querySelector('[data-slot="plan-save-dialog"]') === null`,
     )
-    const again = (await (await fetch(`${baseUrl}/api/v1/workflows`)).json()) as {
-      workflows: Array<{ name: string }>
-    }
+    const again = await getJson<{ workflows: Array<{ name: string }> }>(
+      `${baseUrl}/api/v1/workflows`,
+    )
     expect(again.workflows.filter((w) => w.name === 'e2e planned chain')).toHaveLength(1)
   }, 90_000)
 
@@ -204,6 +205,11 @@ describe('plan mode against a live dry-run server', () => {
     expect(rect.x).toBe(0)
     expect(rect.y).toBe(0)
     expect(rect.w).toBe(390)
+
+    // The previous spec's "saved" toast sits over the step cards at this width — 360px of
+    // pointer-events-auto across a 390px viewport. It expires on its own; the reorder below
+    // clicks exactly where it lands, so wait it out rather than click through it.
+    browser.waitForFunction(`document.querySelector('[data-slot="toast"]') === null`)
 
     // Touch-honest reorder: buttons, not drag.
     await clickStepControl(

--- a/packages/web/src/routes/new-task-draft.test.ts
+++ b/packages/web/src/routes/new-task-draft.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
-  clearDraftText,
+  clearStartedDraft,
   composerRunModeNote,
   readDraft,
   resetDraft,
@@ -96,10 +96,10 @@ describe('the new-task draft store', () => {
     expect(readDraft().text).toBe('fix it')
   })
 
-  it('clearDraftText spends the text but keeps the picker choices (legacy keeps its pills)', () => {
+  it('clearStartedDraft spends the text AND the source, keeping the way-of-working pills', () => {
     writeDraft({
       text: 'shipped',
-      source: { source: 'workflow', ref: 'quick-task' },
+      source: { source: 'skill', ref: 'om-fix' },
       runner: null,
       agentProfile: null,
       model: 'opus',
@@ -109,12 +109,14 @@ describe('the new-task draft store', () => {
       autonomous: null,
       generateFollowups: true,
     })
-    clearDraftText()
+    clearStartedDraft()
     expect(readDraft()).toEqual({
       text: '',
-      source: { source: 'workflow', ref: 'quick-task' },
+      // The skill goes with the task it ran: the next `/new` starts with none.
+      source: null,
       runner: null,
       agentProfile: null,
+      // Runner/model/variants/plan-first are a way of working — they survive, as they always did.
       model: 'opus',
       variants: 3,
       planFirst: true,

--- a/packages/web/src/routes/new-task-draft.ts
+++ b/packages/web/src/routes/new-task-draft.ts
@@ -182,10 +182,15 @@ export function writeDraft(next: NewTaskDraft, projectId: string | null = null):
   }
 }
 
-/** After a successful submit: the text is spent, the picker choices remain — the next task
- *  usually runs the same way (legacy keeps its pills too). */
-export function clearDraftText(projectId: string | null = null): void {
-  writeDraft({ ...readDraft(projectId), text: '' }, projectId)
+/** After a successful submit: the text is spent AND the source resets to nothing.
+ *
+ *  The runner/model/variants/plan-first pills stay — those are a way of working, and the next
+ *  task usually runs the same way (legacy keeps its pills too). A SKILL is not: it is a
+ *  decision about the task that just started, and carrying it into the next one is how a skill
+ *  picked once ended up silently running every task after it. A fresh `/new` starts with no
+ *  skill; picking one again is one click. */
+export function clearStartedDraft(projectId: string | null = null): void {
+  writeDraft({ ...readDraft(projectId), text: '', source: null }, projectId)
 }
 
 /** Test isolation — drop EVERY project's cache and stored draft, so the next read re-consults

--- a/packages/web/src/routes/new-task-form.test.ts
+++ b/packages/web/src/routes/new-task-form.test.ts
@@ -147,25 +147,26 @@ describe('model option resolution', () => {
   })
 })
 
-describe('resolveSource (candidate validation + cold quick-task default)', () => {
+describe('resolveSource (the draft pick, validated — no cold default)', () => {
   const skills = [skill('om-fix'), skill('deploy', 'global')]
   const workflows = [workflow('quick-task'), workflow('fix-and-verify')]
 
-  it('takes the first candidate that still exists', () => {
-    expect(
-      resolveSource(
-        [{ source: 'skill', ref: 'gone' }, { source: 'workflow', ref: 'fix-and-verify' }],
-        skills,
-        workflows,
-      ),
-    ).toEqual({ source: 'workflow', ref: 'fix-and-verify' })
+  it('keeps a pick the catalog still has', () => {
+    expect(resolveSource({ source: 'workflow', ref: 'fix-and-verify' }, skills, workflows))
+      .toEqual({ source: 'workflow', ref: 'fix-and-verify' })
+    expect(resolveSource({ source: 'skill', ref: 'om-fix' }, skills, workflows))
+      .toEqual({ source: 'skill', ref: 'om-fix' })
   })
 
-  it('defaults cold to quick-task, then first skill when quick-task is unavailable', () => {
-    expect(resolveSource([], skills, workflows)).toEqual({ source: 'workflow', ref: 'quick-task' })
-    expect(resolveSource([], skills, [workflow('fix-and-verify')])).toEqual({ source: 'skill', ref: 'om-fix' })
-    expect(resolveSource([], [], workflows)).toEqual({ source: 'workflow', ref: 'quick-task' })
-    expect(resolveSource([], [], [])).toEqual({ source: 'workflow', ref: 'quick-task' })
+  it('resolves to NOTHING when there is no pick, or the pick is gone', () => {
+    // The empty composer state: `/new` opens here, and nothing preselects it away.
+    expect(resolveSource(null, skills, workflows)).toBeNull()
+    expect(resolveSource(undefined, skills, workflows)).toBeNull()
+    // A skill deleted since it was drafted must not stay in the pill.
+    expect(resolveSource({ source: 'skill', ref: 'gone' }, skills, workflows)).toBeNull()
+    expect(resolveSource({ source: 'workflow', ref: 'gone' }, skills, workflows)).toBeNull()
+    // An empty catalog is the same answer, with no quick-task/first-skill fallback left.
+    expect(resolveSource({ source: 'skill', ref: 'om-fix' }, [], [])).toBeNull()
   })
 
   it('sourceExists checks the matching catalog only', () => {
@@ -196,6 +197,21 @@ describe('buildCreateRunBody — the exact POST /api/v1/runs payloads legacy sen
     })
     // What actually goes over the wire: the undefineds vanish.
     expect(JSON.parse(JSON.stringify(body))).toEqual({ task: 'do the thing', workflow: 'quick-task' })
+  })
+
+  it('NO source → the built-in quick-task, because the route demands workflow XOR steps', () => {
+    const body = buildCreateRunBody({
+      task: 'just do it',
+      source: null,
+      model: '',
+      runner: 'claude',
+      defaultRunner: 'claude',
+      variants: 1,
+      images: [],
+    })
+    // Byte-identical to picking quick-task by hand — which is why the picker stopped offering
+    // both. `POST /runs` 400s on a body carrying neither key, so "nothing" cannot go out bare.
+    expect(JSON.parse(JSON.stringify(body))).toEqual({ task: 'just do it', workflow: 'quick-task' })
   })
 
   it('skill source → the one-step inline chain (spec 008: same shape as inbox/bookmarklet)', () => {

--- a/packages/web/src/routes/new-task-form.ts
+++ b/packages/web/src/routes/new-task-form.ts
@@ -23,6 +23,11 @@ import type {
  *  `ui-state.json` stores as `lastTask`, so persistence needs no mapping. */
 export type TaskSource = NonNullable<UiState['lastTask']>
 
+/** The zero-config built-in: one agent step that runs the prompt. It is what a task with NO
+ *  source picked runs as, which is why the composer's picker does not also offer it as a
+ *  workflow row — "No skill" and "quick-task" would be two names for one run. */
+export const QUICK_TASK = 'quick-task'
+
 /** Prepend `source` to the recency list (newest first), dropping any earlier occurrence of the
  *  same source+ref, and cap the length. Pure so the picker's recency sort is table-testable. */
 export function pushRecentSource(
@@ -215,23 +220,29 @@ export function sourceExists(
 }
 
 /**
- * The effective source: the first candidate that still exists (the draft pick, then the
- * persisted `lastTask`), else the zero-config cold default: built-in quick-task.
+ * The effective source: the draft's own pick when the catalog still has it, else NOTHING.
+ *
+ * `null` is the composer's empty state — no skill and no workflow — and it is what `/new` now
+ * opens on. Two mechanisms were removed here, both deliberately:
+ *
+ *  - the persisted `lastTask` no longer preselects. It was load-bearing for one thing: the
+ *    picker remembering a way of working across visits. It also meant a skill picked once sat
+ *    in the pill for every task afterwards, with no way out that reads as one (the composer
+ *    offered no deselect at all — the only exit was picking the `quick-task` WORKFLOW, which
+ *    is what this change is a fix for). `lastTask` is still WRITTEN, so an older cockpit reading
+ *    the same `ui-state.json` behaves exactly as it always did.
+ *  - the cold quick-task/first-skill fallback chain is gone with it: `null` says "nothing is
+ *    selected" honestly, and `buildCreateRunBody` is the one place that turns that into the
+ *    plain built-in run the server performs.
+ *
+ * The existence check stays: a skill deleted since it was drafted must not stay in the pill.
  */
 export function resolveSource(
-  candidates: ReadonlyArray<TaskSource | null | undefined>,
+  candidate: TaskSource | null | undefined,
   skills: readonly Skill[],
   workflows: readonly WorkflowDef[],
-): TaskSource {
-  for (const candidate of candidates) {
-    if (candidate && sourceExists(candidate, skills, workflows)) return candidate
-  }
-  if (workflows.some((workflow) => workflow.name === 'quick-task')) {
-    return { source: 'workflow', ref: 'quick-task' }
-  }
-  const firstSkill = skills[0]
-  if (firstSkill) return { source: 'skill', ref: firstSkill.name }
-  return { source: 'workflow', ref: workflows[0]?.name ?? 'quick-task' }
+): TaskSource | null {
+  return candidate && sourceExists(candidate, skills, workflows) ? candidate : null
 }
 
 /**
@@ -239,6 +250,10 @@ export function resolveSource(
  *  - a skill runs as a one-step inline chain (spec 008's API — the same shape the inbox and
  *    the bookmarklet auto-start use): `steps: [{ id: 'task', name, skill, prompt: '{{task}}' }]`;
  *  - a workflow goes by name;
+ *  - NO source (`null` — the composer's empty state) goes by the built-in `quick-task` name,
+ *    because `POST /runs` requires exactly one of `workflow`/`steps`. That name is also what
+ *    the server resolves an inbox/bookmarklet run to, so "nothing selected" and "quick-task
+ *    selected" are the same run, which is exactly why the picker offers only one of them;
  *  - an explicit/sticky `runner` always rides the request; an untouched runner is omitted only
  *    when it equals the active project's known default (unknown defaults and connected fallbacks
  *    stay explicit);
@@ -246,7 +261,8 @@ export function resolveSource(
  */
 export function buildCreateRunBody(opts: {
   task: string
-  source: TaskSource
+  /** `null` — nothing picked — runs the built-in `quick-task`. */
+  source: TaskSource | null
   model: string
   /** Native coding-agent settings stay visible, but a locked model is never a request override. */
   modelsLocked?: boolean
@@ -290,9 +306,9 @@ export function buildCreateRunBody(opts: {
   } = opts
   return {
     task,
-    ...(source.source === 'skill'
+    ...(source?.source === 'skill'
       ? { steps: [{ id: 'task', name: source.ref, skill: source.ref, prompt: '{{task}}' }] }
-      : { workflow: source.ref }),
+      : { workflow: source?.ref ?? QUICK_TASK }),
     model: modelsLocked ? undefined : model || undefined,
     runner: runnerOverride(runner, defaultRunner, runnerExplicit),
     // Sent only when the user picked one — an absent key is "follow the project", which is what

--- a/packages/web/src/routes/new-task-project.test.tsx
+++ b/packages/web/src/routes/new-task-project.test.tsx
@@ -223,7 +223,7 @@ const sourcePill = () => screen.getByRole('button', { name: 'Choose a skill or w
 const pathname = () => screen.getByTestId('location').textContent
 
 /** The composer is only settled once the pickers resolved against the mounted scope. */
-async function composerReady(sourceLabel: string) {
+async function composerReady(sourceLabel = 'Skill') {
   await waitFor(() => {
     expect(sourcePill().textContent).toContain(sourceLabel)
     expect(textarea().disabled).toBe(false)
@@ -248,7 +248,7 @@ describe('the new-task project pill', () => {
   it('is preselected from the URL scope and lists the registry with branches', async () => {
     serve()
     renderAt(`/p/${OTHER}/new`)
-    await composerReady('ship-storefront')
+    await composerReady()
 
     expect(projectPill().textContent).toContain('shop-frontend')
     fireEvent.click(projectPill())
@@ -269,7 +269,7 @@ describe('the new-task project pill', () => {
       registry: { ...REGISTRY, projects: [REGISTRY.projects[0]!] },
     })
     renderAt(`/p/${BOOT}/new`)
-    await composerReady('quick-task')
+    await composerReady()
     expect(screen.queryByRole('button', { name: 'Project' })).toBeNull()
     expect(document.querySelector('[data-slot="source-pill"]')).not.toBeNull()
   })
@@ -281,17 +281,18 @@ describe('switching project', () => {
   it('re-resolves the skills, workflows and config pickers against the new project', async () => {
     serve()
     renderAt(`/p/${BOOT}/new`)
-    await composerReady('quick-task')
+    await composerReady()
 
     // The boot project reads the unscoped legacy surface (step 3.1) …
     fireEvent.click(sourcePill())
     await screen.findByPlaceholderText('search skills & workflows…')
-    expect(sourceRefs()).toEqual(['om-fix', 'quick-task'])
+    // A leading `null` is the "No skill" row; the built-in `quick-task` has no row of its own.
+    expect(sourceRefs()).toEqual([null, 'om-fix'])
     fireEvent.keyDown(document.body, { key: 'Escape' })
 
     await switchProject(OTHER)
     await waitFor(() => expect(pathname()).toBe(`/p/${OTHER}/new`))
-    await composerReady('ship-storefront')
+    await composerReady()
 
     // … and the second project reads its own, through the `/api/v1/p/<id>` prefix.
     for (const path of ['/skills', '/workflows', '/config', '/repo']) {
@@ -299,7 +300,9 @@ describe('switching project', () => {
     }
     fireEvent.click(sourcePill())
     await screen.findByPlaceholderText('search skills & workflows…')
-    expect(sourceRefs()).toEqual(['ship-storefront', 'release-train'])
+    // Both pills read "Skill" until something is picked, so the catalog — not the label — is
+    // what proves the swap re-resolved.
+    await waitFor(() => expect(sourceRefs()).toEqual([null, 'ship-storefront', 'release-train']))
 
     // Config too: the Model pill's preset comes from the project's `defaultModels`.
     await waitFor(() =>
@@ -310,11 +313,11 @@ describe('switching project', () => {
   it('keeps drafts isolated per project — one composer never leaks into the other', async () => {
     serve()
     renderAt(`/p/${BOOT}/new`)
-    await composerReady('quick-task')
+    await composerReady()
     fireEvent.change(textarea(), { target: { value: 'fix the cezar flake' } })
 
     await switchProject(OTHER)
-    await composerReady('ship-storefront')
+    await composerReady()
     // The arriving project starts from ITS draft, which is empty — not the departing text.
     expect(textarea().value).toBe('')
     fireEvent.change(textarea(), { target: { value: 'ship the storefront' } })
@@ -331,18 +334,18 @@ describe('switching project', () => {
     // Switching back restores what was typed there, untouched by the detour.
     await switchProject(BOOT)
     await waitFor(() => expect(pathname()).toBe(`/p/${BOOT}/new`))
-    await composerReady('quick-task')
+    await composerReady()
     expect(textarea().value).toBe('fix the cezar flake')
   })
 
   it('submits to the SELECTED project and clears only that project’s draft text', async () => {
     serve()
     renderAt(`/p/${BOOT}/new`)
-    await composerReady('quick-task')
+    await composerReady()
     fireEvent.change(textarea(), { target: { value: 'left behind in cezar' } })
 
     await switchProject(OTHER)
-    await composerReady('ship-storefront')
+    await composerReady()
     fireEvent.change(textarea(), { target: { value: 'Ship the storefront' } })
     fireEvent.click(screen.getByRole('button', { name: 'Start task' }))
 

--- a/packages/web/src/routes/new-task.test.tsx
+++ b/packages/web/src/routes/new-task.test.tsx
@@ -332,8 +332,15 @@ const textarea = () => screen.getByLabelText('Describe a task for the agent') as
 const sourcePill = () => screen.getByRole('button', { name: 'Choose a skill or workflow' })
 const location = () => screen.getByTestId('location').textContent
 
-/** The pickers resolve once workflows+skills+ui-state answered — wait for the real label. */
-async function pillReady(label = 'quick-task') {
+/** Seed the composer draft with a picked source — the ONLY thing that preselects one now.
+ *  The persisted `lastTask` deliberately no longer does (see `resolveSource`), which is what
+ *  keeps a skill from following the user into every task after the one they picked it for. */
+const draftSource = (source: { source: 'skill' | 'workflow'; ref: string }) =>
+  writeDraft({ ...readDraft(), source })
+
+/** The pickers resolve once workflows+skills+ui-state answered — wait for the real label.
+ *  The default is the EMPTY source pill: `/new` opens with no skill and no workflow picked. */
+async function pillReady(label = 'Skill') {
   await waitFor(() => {
     expect(sourcePill().textContent).toContain(label)
     expect(textarea().disabled).toBe(false)
@@ -567,16 +574,30 @@ describe('picker data flows', () => {
     })
   })
 
-  it('preselects the persisted lastTask when it still exists', async () => {
-    serve({ uiState: { lastTask: { source: 'workflow', ref: 'fix-and-verify' } } })
+  it('opens with NOTHING picked, whatever the last run used', async () => {
+    // The report this fixes: a skill picked once sat in the pill for every task afterwards,
+    // and the composer offered no way to take it out. `lastTask` is still recorded — it just
+    // no longer decides what the next task runs.
+    serve({ uiState: { lastTask: { source: 'skill', ref: 'om-fix' } } })
     renderNewTask()
-    await pillReady('fix-and-verify')
+    await pillReady()
+    expect(sourcePill().getAttribute('data-source-kind')).toBe('none')
+    expect(sourcePill().textContent).not.toContain('om-fix')
   })
 
-  it('falls back to quick-task when lastTask names something gone', async () => {
-    serve({ uiState: { lastTask: { source: 'skill', ref: 'deleted-skill' } } })
+  it('preselects the draft pick, and drops it when the catalog no longer has it', async () => {
+    draftSource({ source: 'workflow', ref: 'fix-and-verify' })
+    serve()
     renderNewTask()
-    await pillReady('quick-task')
+    await pillReady('fix-and-verify')
+
+    cleanup()
+    resetDraft()
+    draftSource({ source: 'skill', ref: 'deleted-skill' })
+    serve()
+    renderNewTask()
+    await pillReady()
+    expect(sourcePill().getAttribute('data-source-kind')).toBe('none')
   })
 
   it('the source menu groups: Project skills (bold), Workflows, Global last', async () => {
@@ -587,9 +608,14 @@ describe('picker data flows', () => {
     await screen.findByPlaceholderText('search skills & workflows…')
 
     const options = [...document.querySelectorAll('[data-slot="source-option"]')]
-    expect(options.map((o) => o.getAttribute('data-source-ref'))).toEqual([
-      'om-fix', 'quick-task', 'fix-and-verify', 'deploy',
+    // "No skill" leads, heading-less; `quick-task` is NOT a row of its own — that row is it.
+    expect(options.map((o) => o.getAttribute('data-source-kind'))).toEqual([
+      'none', 'skill', 'workflow', 'skill',
     ])
+    expect(options.map((o) => o.getAttribute('data-source-ref'))).toEqual([
+      null, 'om-fix', 'fix-and-verify', 'deploy',
+    ])
+    expect(options[0]!.textContent).toContain('No skill')
     const headings = [...document.querySelectorAll('[cmdk-group-heading]')].map((h) => h.textContent)
     expect(headings).toEqual(['Project skills', 'Workflows', 'Global'])
   })
@@ -626,6 +652,121 @@ describe('picker data flows', () => {
   })
 })
 
+// ---- clearing the source (the reported bug: no way to deselect a skill) -----------------------
+
+describe('clearing the picked skill or workflow', () => {
+  const clearButton = () => document.querySelector<HTMLButtonElement>('[data-slot="source-pill-clear"]')
+  const openMenu = async () => {
+    fireEvent.click(sourcePill())
+    await screen.findByPlaceholderText('search skills & workflows…')
+  }
+  const option = (kind: string, ref?: string) =>
+    document.querySelector<HTMLElement>(
+      ref === undefined
+        ? `[data-slot="source-option"][data-source-kind="${kind}"]`
+        : `[data-slot="source-option"][data-source-kind="${kind}"][data-source-ref="${ref}"]`,
+    )
+
+  it('the ✕ clears in one click, without opening the menu', async () => {
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve()
+    renderNewTask()
+    await pillReady('om-fix')
+
+    expect(clearButton()?.getAttribute('aria-label')).toBe('Clear the skill om-fix')
+    fireEvent.click(clearButton()!)
+
+    await waitFor(() => expect(sourcePill().getAttribute('data-source-kind')).toBe('none'))
+    // No menu was ever opened — the whole point of the affordance.
+    expect(screen.queryByPlaceholderText('search skills & workflows…')).toBeNull()
+    // And the run really does go out as the plain built-in.
+    fireEvent.change(textarea(), { target: { value: 'Ship it plain' } })
+    await startTask()
+    expect(postedBody()).toEqual({ task: 'Ship it plain', workflow: 'quick-task' })
+  })
+
+  it('offers no ✕ while nothing is picked — there is nothing to clear', async () => {
+    serve()
+    renderNewTask()
+    await pillReady()
+    expect(clearButton()).toBeNull()
+  })
+
+  it('Backspace on the focused pill clears it, like a token in a tag field', async () => {
+    draftSource({ source: 'workflow', ref: 'fix-and-verify' })
+    serve()
+    renderNewTask()
+    await pillReady('fix-and-verify')
+
+    fireEvent.keyDown(sourcePill(), { key: 'Backspace' })
+    await waitFor(() => expect(sourcePill().getAttribute('data-source-kind')).toBe('none'))
+  })
+
+  it('leaves the pill alone on ⌘/Ctrl+Backspace — that is a text gesture, not a picker one', async () => {
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve()
+    renderNewTask()
+    await pillReady('om-fix')
+
+    fireEvent.keyDown(sourcePill(), { key: 'Backspace', metaKey: true })
+    expect(sourcePill().getAttribute('data-source-kind')).toBe('skill')
+  })
+
+  it('picking the SELECTED row again clears it — for a skill and for a workflow', async () => {
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve()
+    renderNewTask()
+    await pillReady('om-fix')
+
+    await openMenu()
+    fireEvent.click(option('skill', 'om-fix')!)
+    await waitFor(() => expect(sourcePill().getAttribute('data-source-kind')).toBe('none'))
+
+    await openMenu()
+    fireEvent.click(option('workflow', 'fix-and-verify')!)
+    await waitFor(() => expect(sourcePill().textContent).toContain('fix-and-verify'))
+    await openMenu()
+    fireEvent.click(option('workflow', 'fix-and-verify')!)
+    await waitFor(() => expect(sourcePill().getAttribute('data-source-kind')).toBe('none'))
+  })
+
+  it('the "No skill" row clears the picker, and answers to a search for quick-task', async () => {
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve()
+    renderNewTask()
+    await pillReady('om-fix')
+
+    await openMenu()
+    const input = screen.getByPlaceholderText('search skills & workflows…')
+    // The built-in has no row of its own any more — typing its name finds the row that runs it.
+    fireEvent.change(input, { target: { value: 'quick' } })
+    await waitFor(() => {
+      const visible = [...document.querySelectorAll('[data-slot="source-option"]')]
+      expect(visible.map((o) => o.getAttribute('data-source-kind'))).toEqual(['none'])
+    })
+
+    fireEvent.click(option('none')!)
+    await waitFor(() => expect(sourcePill().getAttribute('data-source-kind')).toBe('none'))
+  })
+
+  it('a cleared pill stays cleared for the NEXT task, and the started one is not remembered', async () => {
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve({ createRun: { id: 'run-2' } })
+    renderNewTask()
+    await pillReady('om-fix')
+    fireEvent.change(textarea(), { target: { value: 'Fix it with the skill' } })
+    await startTask()
+    await waitFor(() => expect(location()).toBe('/tasks/run-2'))
+
+    // Same browser, same project, next visit: the skill went with the task it ran.
+    cleanup()
+    serve()
+    renderNewTask()
+    await pillReady()
+    expect(sourcePill().getAttribute('data-source-kind')).toBe('none')
+  })
+})
+
 // ---- provider authentication gate -------------------------------------------------------------
 
 describe('provider authentication gate', () => {
@@ -639,7 +780,7 @@ describe('provider authentication gate', () => {
     })
     renderNewTask()
 
-    await waitFor(() => expect(sourcePill().textContent).toContain('quick-task'))
+    await waitFor(() => expect(sourcePill().textContent).toContain('Skill'))
     expect(textarea().disabled).toBe(true)
     expect(textarea().placeholder).toBe('Checking agent providers…')
     expect(screen.queryByRole('link', { name: 'Configure providers' })).toBeNull()
@@ -775,10 +916,8 @@ describe('provider authentication gate', () => {
 
 describe('submit', () => {
   it('a SKILL source posts the one-step inline chain and persists lastTask, then navigates', async () => {
-    serve({
-      createRun: { id: 'run-9' },
-      uiState: { lastTask: { source: 'skill', ref: 'om-fix' } },
-    })
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve({ createRun: { id: 'run-9' } })
     renderNewTask()
     await pillReady('om-fix')
     fireEvent.change(textarea(), { target: { value: 'Fix the flaky worktree test' } })
@@ -827,33 +966,56 @@ describe('submit', () => {
   })
 
   it('a WORKFLOW source posts { workflow, task }', async () => {
-    serve({ uiState: { lastTask: { source: 'workflow', ref: 'quick-task' } } })
+    draftSource({ source: 'workflow', ref: 'fix-and-verify' })
+    serve()
     renderNewTask()
-    await pillReady('quick-task')
+    await pillReady('fix-and-verify')
+    fireEvent.change(textarea(), { target: { value: 'Ship it' } })
+    await startTask()
+
+    expect(postedBody()).toEqual({ task: 'Ship it', workflow: 'fix-and-verify' })
+  })
+
+  it('NO source posts the plain quick-task, records lastTask:null and no recency entry', async () => {
+    serve({ createRun: { id: 'run-plain' } })
+    renderNewTask()
+    await pillReady()
     fireEvent.change(textarea(), { target: { value: 'Ship it' } })
     await startTask()
 
     expect(postedBody()).toEqual({ task: 'Ship it', workflow: 'quick-task' })
+    await waitFor(() =>
+      expect(requests.find((r) => r.method === 'PUT' && r.url === '/api/v1/ui-state')?.body).toEqual({
+        // An honest record of a run that picked nothing — and the value that stops an older
+        // cockpit restoring a stale skill from this same file.
+        lastTask: null,
+        // Nothing was picked, so nothing joins the recency list or the frequency map.
+        lastGenerateFollowups: true,
+      }),
+    )
   })
 
   it('posts worktree:false after opt-out for every single-step source shape', async () => {
     const cases: Array<{
       label: string
+      source?: { source: 'skill' | 'workflow'; ref: string }
       overrides: NonNullable<Parameters<typeof serve>[0]>
       expected: Record<string, unknown>
     }> = [
       {
-        label: 'quick-task',
+        label: 'Skill',
         overrides: {},
         expected: { workflow: 'quick-task' },
       },
       {
         label: 'om-fix',
-        overrides: { uiState: { lastTask: { source: 'skill', ref: 'om-fix' } } },
+        source: { source: 'skill', ref: 'om-fix' },
+        overrides: {},
         expected: { steps: [{ id: 'task', name: 'om-fix', skill: 'om-fix', prompt: '{{task}}' }] },
       },
       {
         label: 'one-step',
+        source: { source: 'workflow', ref: 'one-step' },
         overrides: {
           workflows: {
             workflows: [
@@ -862,7 +1024,6 @@ describe('submit', () => {
             ],
             issues: [],
           },
-          uiState: { lastTask: { source: 'workflow', ref: 'one-step' } },
         },
         expected: { workflow: 'one-step' },
       },
@@ -871,6 +1032,7 @@ describe('submit', () => {
     for (const testCase of cases) {
       cleanup()
       resetDraft()
+      if (testCase.source) draftSource(testCase.source)
       serve(testCase.overrides)
       renderNewTask()
       await pillReady(testCase.label)
@@ -1032,12 +1194,10 @@ describe('submit', () => {
   })
 
   it('applies an interactive skill hint to untouched controls while keeping both overridable', async () => {
-    // The cold default is now quick-task, so an interactive skill only drives the recommendation
-    // once it is the selected source — here via the persisted lastTask.
-    serve({
-      skills: [{ ...SKILLS[0]!, interactive: true }, SKILLS[1]!],
-      uiState: { lastTask: { source: 'skill', ref: 'om-fix' } },
-    })
+    // The composer opens on no source, so an interactive skill only drives the recommendation
+    // once it is the selected one — here from the draft.
+    draftSource({ source: 'skill', ref: 'om-fix' })
+    serve({ skills: [{ ...SKILLS[0]!, interactive: true }, SKILLS[1]!] })
     renderNewTask()
     await pillReady('om-fix')
 
@@ -1056,6 +1216,7 @@ describe('submit', () => {
   })
 
   it('lets a multi-step workflow opt out and submits worktree:false', async () => {
+    draftSource({ source: 'workflow', ref: 'fix-and-verify' })
     serve({
       workflows: {
         workflows: [
@@ -1071,7 +1232,6 @@ describe('submit', () => {
         ],
         issues: [],
       },
-      uiState: { lastTask: { source: 'workflow', ref: 'fix-and-verify' } },
     })
     renderNewTask()
     await pillReady('fix-and-verify')
@@ -1444,7 +1604,9 @@ describe('bookmarklet auto-start', () => {
     await screen.findByText('Unknown skill "ghost" — prefilled for quick-task; review and press Start')
     // Legacy initFromQuery verbatim: the intent goes into the text, quick-task resolves it.
     expect(textarea().value).toBe('Use the "ghost" skill on: hello')
-    await pillReady('quick-task')
+    // "quick-task" IS the empty picker now — the prefill lands on it by picking nothing.
+    await pillReady()
+    expect(sourcePill().getAttribute('data-source-kind')).toBe('none')
     expect(runsPosted()).toHaveLength(0)
   })
 
@@ -1882,8 +2044,8 @@ describe('prompt templates on the new-task composer', () => {
     renderNewTask()
     await pillReady()
 
-    await pickSource('quick-task')
-    await waitFor(() => expect(sourcePill().textContent).toContain('quick-task'))
+    await pickSource('fix-and-verify')
+    await waitFor(() => expect(sourcePill().textContent).toContain('fix-and-verify'))
     expect(textarea().value).toBe('')
   })
 

--- a/packages/web/src/routes/new-task.tsx
+++ b/packages/web/src/routes/new-task.tsx
@@ -2,11 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   CheckIcon,
   ChevronDownIcon,
+  CircleSlashIcon,
   EyeIcon,
   FolderOpenIcon,
+  PlusIcon,
   SparklesIcon,
   SquareIcon,
   WorkflowIcon,
+  XIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useParams, useSearchParams } from 'react-router'
@@ -63,6 +66,7 @@ import {
   isProjectSkill,
   orderSkillsByUsage,
   partitionSkillsForDisplay,
+  queryScore,
   searchSkills,
   searchWorkflows,
   skillKeywords,
@@ -78,7 +82,7 @@ import {
   type DeepLinkNotice,
 } from './new-task-autostart'
 import {
-  clearDraftText,
+  clearStartedDraft,
   composerRunModeNote,
   readDraft,
   resolveComposerRunMode,
@@ -90,6 +94,7 @@ import {
   modelsForRunner,
   modelCatalogStatus,
   pushRecentSource,
+  QUICK_TASK,
   resolveModel,
   resolveRunner,
   resolveSource,
@@ -179,8 +184,10 @@ export function NewTaskRoute() {
   const projectList = projects.data?.projects ?? []
   const sourcesReady =
     skills.data !== undefined && workflows.data !== undefined && !uiState.isPending
-  const source = resolveSource([draft.source, uiState.data?.lastTask], skillList, workflowList)
-  const selectedSkill = source.source === 'skill'
+  // The draft's pick alone — a fresh `/new` selects nothing (see `resolveSource` for what the
+  // persisted `lastTask` preselection was load-bearing for, and why it is gone).
+  const source = resolveSource(draft.source, skillList, workflowList)
+  const selectedSkill = source?.source === 'skill'
     ? skillList.find((skill) => skill.name === source.ref)
     : undefined
 
@@ -193,7 +200,7 @@ export function NewTaskRoute() {
     () => normalizePromptTemplates(uiState.data?.promptTemplates),
     [uiState.data?.promptTemplates],
   )
-  const autoText = autoApplyText(templates, source.source === 'skill' ? [source.ref] : [])
+  const autoText = autoApplyText(templates, source?.source === 'skill' ? [source.ref] : [])
   const draftTextRef = useRef(draft.text)
   draftTextRef.current = draft.text
   const autoAppliedRef = useRef('')
@@ -298,7 +305,9 @@ export function NewTaskRoute() {
       workspaceConfig.data?.composerDefaults?.worktree
       ?? workspaceConfig.data?.composerDefaults?.inheritedWorktree
       ?? true,
-    source: source.source,
+    // Nothing picked runs the plain built-in workflow, and the 'source-dependent' autonomy
+    // default keys off exactly that: skills default autonomous, everything else does not.
+    source: source?.source ?? 'workflow',
   })
   const worktreeOn = runMode.worktree
   const autonomousOn = runMode.autonomous
@@ -371,7 +380,7 @@ export function NewTaskRoute() {
       if (launchKey !== '' && deepLink.key === launchKey) {
         try {
           const created = await createRun(bookmarkletRunBody(deepLink, runner, defaultRunner))
-          clearDraftText(draftProjectId)
+          clearStartedDraft(draftProjectId)
           void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
           void navigate(startedRunPath(created))
           return
@@ -399,12 +408,9 @@ export function NewTaskRoute() {
         ? deepLink.skill
         : ''
     if (unknownSkill !== '') {
-      update({
-        text: unknownSkillPrefillText(deepLink.skill, deepLink.ref),
-        ...(workflowList.some((w) => w.name === 'quick-task')
-          ? { source: { source: 'workflow', ref: 'quick-task' } as TaskSource }
-          : {}),
-      })
+      // Legacy put the intent into the text and ran quick-task; `null` IS that run now, and
+      // needs no catalog lookup to say so.
+      update({ text: unknownSkillPrefillText(deepLink.skill, deepLink.ref), source: null })
     }
     const { message, tone } = deepLinkToast(notice, unknownSkill)
     toast(message, { tone })
@@ -471,21 +477,25 @@ export function NewTaskRoute() {
     // `saveLastTaskSource`) and float it to the top of the picker next time
     // (recency sort) — fire-and-forget: a failed write only costs the convenience.
     void putUiState({
+      // `null` when nothing was picked — an honest record of a plain run, and the value that
+      // stops an older cockpit (which still preselects `lastTask`) restoring a stale skill.
       lastTask: source,
-      recentSources: pushRecentSource(recentSources, source),
+      // Recency is a list of PICKS: a task that chose nothing did not pick quick-task, and
+      // filling the list with the default would push real choices out of it.
+      ...(source ? { recentSources: pushRecentSource(recentSources, source) } : {}),
       ...(followupsToggleShown ? { lastGenerateFollowups: generateFollowupsOn } : {}),
       // Frequency sort (#408): only a SKILL pick counts — the map is keyed by skill name, and a
       // workflow choice here doesn't select one directly. Gated on the CURRENT map being known:
       // the PUT merge is shallow, so bumping off an errored ui-state query (`sourcesReady` only
       // rules out `isPending`, not a failed fetch) would send a one-entry map and wipe every
       // accumulated count.
-      ...(source.source === 'skill' && uiState.data !== undefined
+      ...(source?.source === 'skill' && uiState.data !== undefined
         ? { skillUsage: bumpSkillUsage(uiState.data.skillUsage, source.ref) }
         : {}),
     })
       .then(() => queryClient.invalidateQueries({ queryKey: queryKeys.uiState }))
       .catch(() => {})
-    clearDraftText(draftProjectId)
+    clearStartedDraft(draftProjectId)
     void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
     navigate(startedRunPath(created))
   }
@@ -519,7 +529,7 @@ export function NewTaskRoute() {
           .then(() => queryClient.invalidateQueries({ queryKey: queryKeys.uiState }))
           .catch(() => {})
       }
-      clearDraftText(draftProjectId)
+      clearStartedDraft(draftProjectId)
       setPlan(null)
       void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
       navigate(startedRunPath(created))
@@ -1002,8 +1012,23 @@ function ProjectPill({
 
 /**
  * The workflow/skill picker (#385's searchable cmdk dropdown, #519's tier ordering): ONE pill
- * for both kinds of source. Groups render Most used (skills picked before, frequency
- * descending), Project skills (bold), Workflows, then Global.
+ * for both kinds of source — and one that can be EMPTY.
+ *
+ * `null` — no skill, no workflow — is a first-class state rather than a hidden default. It is
+ * what a fresh `/new` opens on, and there are three ways back to it: the ✕ on the pill (one
+ * click, no menu), picking the selected row again (the toggle the GitHub hand-off's workflow
+ * row already had — this picker was the one that swallowed the second click), and the "No
+ * skill" row at the head of the list. Before that the only exit was picking the `quick-task`
+ * WORKFLOW, which reads as a third mode to learn rather than as "none of the above" — the
+ * report this fixes was a user hunting for it.
+ *
+ * `quick-task` is therefore not a row of its own: it IS the run an empty picker performs, and
+ * one run behind two names is what made the exit invisible. The "No skill" row carries the
+ * catalog's own description for it, so a workspace whose file shadows the built-in still
+ * describes what it will actually run.
+ *
+ * Groups render No skill, Most used (skills picked before, frequency descending), Project
+ * skills (bold), Workflows, then Global.
  */
 function SourcePill({
   source,
@@ -1013,12 +1038,12 @@ function SourcePill({
   workflows,
   onPick,
 }: {
-  source: TaskSource
+  source: TaskSource | null
   ready: boolean
   skills: readonly Skill[]
   skillUsage: Readonly<Record<string, number>> | undefined
   workflows: readonly WorkflowDef[]
-  onPick: (source: TaskSource) => void
+  onPick: (source: TaskSource | null) => void
 }) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -1028,16 +1053,30 @@ function SourcePill({
   // ranked matches into the #519 display tiers so each group stays match-ordered.
   const matched = searchSkills(skills, search, skillUsage)
   const { mostUsed, project, global } = partitionSkillsForDisplay(matched, skillUsage)
-  const matchedWorkflows = searchWorkflows(workflows, search)
+  const quickTask = workflows.find((workflow) => workflow.name === QUICK_TASK)
+  const matchedWorkflows = searchWorkflows(workflows, search).filter((w) => w.name !== QUICK_TASK)
+  // The empty row answers to what people type when they mean "none of these" — including the
+  // built-in's own name, which is no longer a row of its own. Same match signal as every other
+  // row, so one query ranks the whole list.
+  const noneMatches =
+    queryScore('no skill', `none plain ${QUICK_TASK} ${quickTask?.description ?? ''}`, search) > 0
   const nothingMatches =
-    mostUsed.length === 0 && project.length === 0 && global.length === 0 && matchedWorkflows.length === 0
-  const pick = (next: TaskSource) => {
+    !noneMatches
+    && mostUsed.length === 0
+    && project.length === 0
+    && global.length === 0
+    && matchedWorkflows.length === 0
+  const pick = (next: TaskSource | null) => {
     onPick(next)
     setOpen(false)
   }
+  /** Picking what is already picked CLEARS it — the gesture every other toggle in the cockpit
+   *  answers to, and the one the report asked for by name. */
+  const toggle = (next: TaskSource) =>
+    pick(source?.source === next.source && source.ref === next.ref ? null : next)
 
   const skillItem = (skill: Skill, emphasized: boolean) => {
-    const selected = source.source === 'skill' && source.ref === skill.name
+    const selected = source?.source === 'skill' && source.ref === skill.name
     return (
       <CommandItem
         key={skill.path}
@@ -1047,7 +1086,7 @@ function SourcePill({
         data-slot="source-option"
         data-source-kind="skill"
         data-source-ref={skill.name}
-        onSelect={() => pick({ source: 'skill', ref: skill.name })}
+        onSelect={() => toggle({ source: 'skill', ref: skill.name })}
       >
         <span className={cn('shrink-0 font-mono text-xs', emphasized && 'font-semibold')}>
           {skill.name}
@@ -1078,6 +1117,47 @@ function SourcePill({
     )
   }
 
+  const SourceIcon = source === null ? PlusIcon : source.source === 'skill' ? SparklesIcon : WorkflowIcon
+  // An empty picker looks empty: dashed, quiet, an invitation rather than a value. Every other
+  // pill in this row shows a resolved choice, so a filled-looking pill that nobody chose was
+  // read as one that could not be changed.
+  const trigger = (
+    <button
+      type="button"
+      data-slot="source-pill"
+      data-source-kind={source?.source ?? 'none'}
+      aria-label="Choose a skill or workflow"
+      title={
+        source === null
+          ? 'No skill — the task runs as one plain agent step. Pick a skill or workflow to change that.'
+          : `Runs the ${source.source} "${source.ref}" — pick it again, or press ✕, to run without it`
+      }
+      disabled={!ready}
+      onKeyDown={(event) => {
+        // A filled pill clears like a token in a tag field. Modifiers stay out of it: ⌘⌫ is a
+        // text gesture in the composer this row belongs to, not a picker one.
+        if (source === null || event.metaKey || event.ctrlKey || event.altKey) return
+        if (event.key !== 'Backspace' && event.key !== 'Delete') return
+        event.preventDefault()
+        onPick(null)
+      }}
+      className={cn(
+        chipClass,
+        'font-mono text-[11.5px]',
+        source === null
+          ? 'border-dashed text-soft-foreground'
+          : 'rounded-r-none border-r-0 border-foreground/60 pr-1.5 font-semibold text-foreground',
+      )}
+    >
+      <SourceIcon
+        aria-hidden="true"
+        className={cn('size-3 shrink-0', source === null ? 'text-soft-foreground' : 'text-violet')}
+      />
+      <span className="max-w-44 truncate">{!ready ? '…' : (source?.ref ?? 'Skill')}</span>
+      {chevron}
+    </button>
+  )
+
   return (
     <>
       <SkillPreviewDialog skill={preview} onClose={() => setPreview(null)} />
@@ -1088,23 +1168,26 @@ function SourcePill({
           if (!next) setSearch('')
         }}
       >
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            data-slot="source-pill"
-            aria-label="Choose a skill or workflow"
-            disabled={!ready}
-            className={cn(chipClass, 'border-foreground/60 font-mono text-[11.5px] font-semibold text-foreground')}
-          >
-            {source.source === 'skill' ? (
-              <SparklesIcon aria-hidden="true" className="size-3 shrink-0 text-violet" />
-            ) : (
-              <WorkflowIcon aria-hidden="true" className="size-3 shrink-0 text-violet" />
-            )}
-            <span className="max-w-44 truncate">{ready ? source.ref : '…'}</span>
-            {chevron}
-          </button>
-        </PopoverTrigger>
+        {/* Split control, not a button inside a button: the trigger owns the menu, the ✕ owns
+            the clear, and the seam between them is the ✕'s left border. */}
+        <span className="inline-flex items-center">
+          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+          {source !== null && ready ? (
+            <button
+              type="button"
+              data-slot="source-pill-clear"
+              aria-label={`Clear the ${source.source} ${source.ref}`}
+              title="Run without it"
+              onClick={() => onPick(null)}
+              className={cn(
+                chipClass,
+                'rounded-l-none border-foreground/60 pl-1.5 pr-2 text-soft-foreground hover:text-foreground',
+              )}
+            >
+              <XIcon aria-hidden="true" className="size-3" />
+            </button>
+          ) : null}
+        </span>
         <PopoverContent
           align="start"
           sideOffset={8}
@@ -1125,6 +1208,28 @@ function SourcePill({
               className="max-h-[min(18rem,calc(var(--radix-popover-content-available-height)-3rem))]"
             >
               {nothingMatches ? <CommandEmpty>Nothing matches.</CommandEmpty> : null}
+              {/* Heading-less and first: "run it plain" is not a kind of skill, and the way out
+                  of a selection has to be the thing you see when the list opens. */}
+              {noneMatches ? (
+                <CommandGroup>
+                  <CommandItem
+                    value="none no-skill"
+                    keywords={['none', 'plain', ...skillKeywords(QUICK_TASK)]}
+                    data-slot="source-option"
+                    data-source-kind="none"
+                    onSelect={() => pick(null)}
+                  >
+                    <CircleSlashIcon aria-hidden="true" className="size-3.5 shrink-0 text-soft-foreground" />
+                    <span className="shrink-0 text-xs font-medium">No skill</span>
+                    <span className="min-w-0 flex-1 truncate text-xs text-soft-foreground">
+                      {quickTask?.description ?? 'One agent run on your task — no ceremony.'}
+                    </span>
+                    {source === null ? (
+                      <CheckIcon aria-hidden="true" className="ml-auto size-3.5 shrink-0 text-primary" />
+                    ) : null}
+                  </CommandItem>
+                </CommandGroup>
+              ) : null}
               {/* Most used leads (#519), then Project skills before Global — the closer a
                   skill lives to the repo, the more likely it's the one being picked. */}
               {mostUsed.length > 0 ? (
@@ -1140,7 +1245,7 @@ function SourcePill({
               {matchedWorkflows.length > 0 ? (
                 <CommandGroup heading="Workflows">
                   {matchedWorkflows.map((workflow) => {
-                    const selected = source.source === 'workflow' && source.ref === workflow.name
+                    const selected = source?.source === 'workflow' && source.ref === workflow.name
                     return (
                       <CommandItem
                         key={workflow.name}
@@ -1149,7 +1254,7 @@ function SourcePill({
                         data-slot="source-option"
                         data-source-kind="workflow"
                         data-source-ref={workflow.name}
-                        onSelect={() => pick({ source: 'workflow', ref: workflow.name })}
+                        onSelect={() => toggle({ source: 'workflow', ref: workflow.name })}
                       >
                         <span className="shrink-0 font-mono text-xs">{workflow.name}</span>
                         {workflow.description ? (


### PR DESCRIPTION
## What

The composer's source pill always showed a value and offered no way out of it.

- Clicking the **already selected** skill in the dropdown re-picked it — the menu closed and nothing changed.
- The only exit was the `quick-task` row under **Workflows**, which reads as a third mode to learn rather than as "none of the above". The reporter found it only after hunting: *"trzeba wybrać workflow → quick task, ale to kompletnie nieintuicyjne"*.
- A skill picked once was persisted as `lastTask` and preselected for **every task after it**, so it silently ran tasks it was never chosen for — and (via the `source-dependent` autonomy default) turned those runs autonomous too.

Reported by Piotr Chabros on Discord.

## How

**"Nothing picked" becomes a real state (`source: null`), not a hidden default.** Three ways back to it, because the report is really about discoverability:

| Affordance | Where |
| --- | --- |
| **✕ on the pill** | One click, no menu. Same grammar as the GitHub hand-off's skill chips, which have always been removable. |
| **Pick the selected row again** | The toggle the hand-off's *workflow* picker already had (`onChange(selected ? null : name)`); the composer was the one picker that swallowed the second click. |
| **"No skill" row, first in the list** | Heading-less, above *Most used*. It answers to a search for `quick-task` too. |

<kbd>Backspace</kbd>/<kbd>Delete</kbd> on the focused pill clears it as well (modifiers excluded — ⌘⌫ is a text gesture in the composer this row lives in).

**An empty picker now looks empty**: a dashed, quiet `+ Skill` instead of a resolved-looking value nobody chose. That is what made the old pill read as "a choice you cannot change".

**`quick-task` is no longer a row of its own.** It is exactly the run an empty picker performs, and one run behind two names is what made the exit invisible. The "No skill" row carries the catalog's own description for it, so a workspace whose file shadows the built-in still describes what it will actually run.

**A new task starts with no skill.** `resolveSource` now validates the draft's own pick and nothing else; `lastTask` no longer preselects, and the source is cleared with the spent text after a run starts (`clearDraftText` → `clearStartedDraft` — the runner/model/variants pills still survive, those are a way of working). Full reasoning is in the `resolveSource` doc comment, including what the removed mechanism was load-bearing for.

## API

`ui-state.lastTask` accepts **`null`** (contract + the route's write schema), so "this run picked nothing" is a value rather than an omitted key — the merge is shallow, so omitting it would leave the previous run's skill in the file. It is still written on every start, which is what keeps an older cockpit reading the same `ui-state.json` from restoring a stale skill: it sees no source and falls back to its own default. `POST /runs` is untouched — the route requires exactly one of `workflow`/`steps`, and a source-less task goes out as `workflow: "quick-task"`, byte-identical to picking it by hand.

## Verification

- `npm run typecheck`, `npm test` (6170), `npm run test:unit`, `npm run build`, `npm run test:package` — all green.
- New unit coverage in `new-task.test.tsx`: the ✕ clears without opening the menu and the run really goes out as quick-task; no ✕ when nothing is picked; Backspace clears and ⌘+Backspace does not; the selected row toggles off for a skill and for a workflow; the "No skill" row answers to a `quick` search; a cleared pill stays cleared for the next task; a stale `lastTask` no longer preselects.
- Manually driven in a real Chrome against `CEZ_DRY_RUN=1 npm run dev`, both themes.

### e2e

The three files that drive this composer (`new-task`, `plan-mode`, `composer-defaults`) were waiting on a pill label the cold composer has not shown for a long time (`lint-fix`), so **10 of their 14 specs were already failing on `main`** — all on that one timeout, which hid everything behind it. They now wait for the pill to drop its loading ellipsis, and **all 15 specs pass** (14 + the new ✕/toggle one). Five repairs were needed, each an environment dependency rather than a product bug:

- `fixtureServeEnv` sets `CEZ_SKILLS_AUTO_UPDATE=0`, so a fixture repo holds exactly the skills the fixture wrote instead of whatever the six-hour update window installed **into it**. The shared test env, where `skills-update.e2e.ts` attaches, still exercises that behaviour on purpose.
- The fixture's own skills are asserted by their relative order rather than by being the first two rows — a machine with a populated team-skill cache (`getTeamSkillsCached`, global and unrelated to the fixture) lists those here too.
- The model pill reads the live `/api/v1/config` default instead of assuming `auto`: `defaultModels` is seeded from the installed agent's own settings, so the old assertion failed on any machine whose claude pins a model. Same rule the runner pill beside it already followed.
- A shared `getJson` retries a readback once. Node's fetch pools the connection opened during the health probe, and reusing a socket the server has since closed surfaces as `ECONNRESET` against a perfectly healthy server.
- Two waits for something to get out of the way before a click: the source popover's exit animation over the chip row, and (on the iPhone viewport) the previous spec's toast over the plan-step controls.

The wider suite has substantial pre-existing failures on this machine in files this PR does not touch (`agents-dock`, `thread-scroll`, `task-thread`, `quick-list`, several `settings-*`); the shared test env accumulates state across runs, and which of them fail shifts between runs. Every one of them fails the same way with this branch stashed.
