### PR TITLE
feat(cockpit): right-click a sidebar task to rename, archive and manage it

### DIFF
--- a/.ai/runs/2026-08-24-sidebar-task-context-menu.md
+++ b/.ai/runs/2026-08-24-sidebar-task-context-menu.md
@@ -140,6 +140,8 @@ PR: #921
 
 ### Phase 5: Tests and the validation gate
 
+- [x] 5.0 Review follow-up: collapse the row's five per-verb mutations into one, and add the keyboard-path and flag-leak tests — 6d519aaf
+
 - [x] 5.1 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`) — all green: typecheck clean, 6199 vitest tests in 328 files, 36 node:test units, build + check:pack ok, 15 package tests
 
 > Gate note: six server tests (`git-worktree`, `git.test.ts`, `git-changes`, `health-forge`, `projects-api`, `automations-api`) assert that a freshly-made temp directory is NOT inside a git repository. They fail in this sandbox only because `TMPDIR` is set to a path *inside* the cezar checkout (`.ai/cezar/tmp/<task-id>`), so `os.tmpdir()` is in a repo. With a normal `TMPDIR` all six pass, and the numbers above are from that run. Nothing in this branch touches them.

--- a/.ai/runs/2026-08-24-sidebar-task-context-menu.md
+++ b/.ai/runs/2026-08-24-sidebar-task-context-menu.md
@@ -1,0 +1,141 @@
+# Execution plan — right-click task menu in the sidebar (rename, archive, and the rest)
+
+**Brief:** "Chciałbym móc zmienić nazwy czatów pod prawym guzikiem myszy. i móc także modyfikować
+taski z poziomu panelu bocznego jak archwizowac odarchiwizowac itp." — I want to rename chats from
+the right mouse button, and to modify tasks from the side panel too: archive, unarchive and so on.
+**Branch:** `feat/sidebar-task-context-menu`
+**Engine:** `Engine: om-auto-create-pr (steps: 9, --loop: no)`
+
+## Goal
+
+Give every task row in the cockpit's sidebar a real right-click context menu, so the two things the
+brief asks for stop requiring a detour through the task thread: **rename the task in place**, and
+**archive / unarchive it** (plus the neighbouring row actions the run header already offers — mark
+unread, cancel, delete). Today the sidebar row is navigation only: the sole way to rename a task is
+to open it and click the pencil in the run header, and the sole way to archive one is the run
+header's Archive button or the Tasks table's "Archive finished" broom. A list of "chats" you can
+only read is the wrong affordance for the surface people spend the most time in.
+
+## Scope
+
+The cockpit SPA only (`packages/web`). No server, contract or API-route change: every action the
+menu offers already has an endpoint, and this run only reaches them from one more place.
+
+- `packages/web/src/api/client.ts` — three project-scoped twins (`patchProjectRun`,
+  `cancelProjectRun`, `deleteProjectRun`) alongside the existing `archiveProjectRun` /
+  `setProjectRunRead`, so a row belonging to a project other than the mounted scope acts on **its
+  own** project.
+- `packages/web/src/api/queries.ts` — one shared invalidation helper for the run caches a row
+  action can move, whichever project the row belongs to.
+- `packages/web/src/components/ui/context-menu.tsx` — new shadcn-style wrapper over the Radix
+  `ContextMenu` primitive (already on disk as part of the `radix-ui` package the repo depends on),
+  matching `ui/dropdown-menu.tsx` line for line.
+- `packages/web/src/lib/task-row-menu.ts` — new pure module: which items the menu offers for a
+  given run, and what each one is called.
+- `packages/web/src/components/task-row-menu.tsx` — the menu itself: the trigger wrapper, the
+  mutations, the destructive-action confirm dialog.
+- `packages/web/src/components/task-quick-list.tsx` — wraps each run row in the menu and hosts the
+  inline rename input.
+- Unit tests beside each of the above.
+
+### Non-goals
+
+- **The Tasks table and the global Tasks page.** Both already carry their own row affordances
+  (inline rename in the Task cell, archive/read buttons per row); giving them a second, parallel
+  menu is a separate design question and not what the brief asks for.
+- **The variant group tile.** A collapsed `×N` tile stands for several runs at once, so "rename
+  this" and "archive this" have no single referent. Its member rows — which are ordinary run rows —
+  do get the menu.
+- **New capabilities.** Nothing here invents an action the cockpit cannot already perform: the menu
+  is a second door to endpoints the run header already calls. No bulk selection, no drag-to-archive,
+  no keyboard shortcut scheme.
+- **Renaming anything other than a task.** Projects, workflows and skills keep their current
+  editing surfaces.
+- **Touch long-press.** Radix's context menu brings its own long-press behaviour for free; tuning
+  it for mobile is not part of this run and mobile keeps every affordance it has today.
+
+## Implementation Plan
+
+### Phase 1 — Act on the row's own project
+
+The sidebar paints run rows from two places. `TaskQuickListContainer` renders the mounted scope's
+runs; `ProjectGroups` renders **other** projects' runs through the same `QuickListBuckets`, handing
+each group an explicit `scope={project.id}`. Every existing mutation helper in `api/client.ts`
+except `archiveProjectRun` / `setProjectRunRead` sends `queryScope()` — the *active* project — so a
+menu wired to them would rename or delete a same-id task in the wrong repository. The global Tasks
+page already learned this lesson (`useIndexedRunMutation`'s comment says so); this phase gives the
+remaining three verbs the same explicit-project spelling, and adds the matching cache invalidation:
+a row's project may not be the mounted scope, and the boot project's list is cached under the
+`'default'` alias rather than under its own id.
+
+### Phase 2 — The context-menu primitive
+
+`ui/dropdown-menu.tsx` is the house style for a Radix menu: thin wrappers, `data-slot` attributes,
+the shared popover/item classes. `ui/context-menu.tsx` is its right-click twin and is written the
+same way, so the two menus are visually indistinguishable and a test can query either by slot.
+
+### Phase 3 — What the menu offers, and the menu itself
+
+Which actions a run offers is already a pure, table-tested function — `runActionFlags` in
+`routes/task-thread/run-actions.ts`, which the run header maps to buttons. The menu reuses it rather
+than restating the rules, and `lib/task-row-menu.ts` adds only what is new here: the row-menu item
+list in display order, each with its label (Archive vs Unarchive, Mark read vs Mark unread — the
+record says which) and whether it is destructive. Pure, so a table test pins one row of the truth
+table per run status. `components/task-row-menu.tsx` then binds that list to the mutations from
+Phase 1, routes Cancel and Delete through an `AlertDialog` confirm with the same words the run
+header uses, and reports every failure as a danger toast.
+
+### Phase 4 — Wire it into the sidebar rows
+
+`RunRow` in `task-quick-list.tsx` gains the menu wrapper and the rename state: picking **Rename**
+flips the row's title span into the shared `TitleEditInput` (`components/editable-title.tsx` — the
+one rename state machine the run header and the Tasks table already share), Enter/blur commits
+through `patchProjectRun`, Escape abandons. The row's width-priority rule, its `data-slot` hooks and
+its link targets are unchanged — the menu is a wrapper, not a re-layout.
+
+### Phase 5 — Tests and the validation gate
+
+Unit-test the pure policy, the menu component (open, act, confirm), and the sidebar rename round
+trip; then run the repo's full gate in order.
+
+## Risks
+
+- **Acting on the wrong project.** The whole of Phase 1 exists because of this, and it is the one
+  failure here that silently destroys the wrong data (`Delete` removes a worktree and a branch). The
+  tests assert the request path carries the row's project id, not the mounted scope's.
+- **Right-click over a link.** The row is an anchor; a context menu must suppress the browser's own
+  menu without swallowing ordinary left-clicks or middle-click-to-open-in-a-new-tab. Radix's trigger
+  handles this, and a test pins that a plain click still navigates.
+- **jsdom and Radix.** Radix positions menus with floating-ui, which needs `ResizeObserver`; the
+  existing `tools-menu.test.tsx` stubs it, and these tests do the same.
+- **Menu on a row that is mid-flight.** A queued or running task offers Cancel but not Delete, and
+  vice versa — `runActionFlags` already encodes that, so the risk is only in forgetting to use it.
+  Reusing the function rather than re-deriving the rules is the mitigation.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Act on the row's own project
+
+- [ ] 1.1 Add `patchProjectRun`, `cancelProjectRun` and `deleteProjectRun` to `api/client.ts`, with rows in the `client.test.ts` request table
+- [ ] 1.2 Add the cross-project run-cache invalidation helper to `api/queries.ts`, with a test
+
+### Phase 2: The context-menu primitive
+
+- [ ] 2.1 Add `components/ui/context-menu.tsx` mirroring `ui/dropdown-menu.tsx`
+
+### Phase 3: What the menu offers, and the menu itself
+
+- [ ] 3.1 Add `lib/task-row-menu.ts` — the pure item list — with a table test per run state
+- [ ] 3.2 Add `components/task-row-menu.tsx` — the menu, the mutations and the confirm dialog
+- [ ] 3.3 Add `components/task-row-menu.test.tsx`
+
+### Phase 4: Wire it into the sidebar rows
+
+- [ ] 4.1 Wrap `RunRow` in the menu and host the inline rename in `components/task-quick-list.tsx`
+- [ ] 4.2 Extend `components/task-quick-list.test.tsx` for the menu and the rename round trip
+
+### Phase 5: Tests and the validation gate
+
+- [ ] 5.1 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`)

--- a/.ai/runs/2026-08-24-sidebar-task-context-menu.md
+++ b/.ai/runs/2026-08-24-sidebar-task-context-menu.md
@@ -114,12 +114,14 @@ trip; then run the repo's full gate in order.
 
 ## Progress
 
+PR: #921
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Act on the row's own project
 
-- [ ] 1.1 Add `patchProjectRun`, `cancelProjectRun` and `deleteProjectRun` to `api/client.ts`, with rows in the `client.test.ts` request table
-- [ ] 1.2 Add the cross-project run-cache invalidation helper to `api/queries.ts`, with a test
+- [x] 1.1 Add `patchProjectRun`, `cancelProjectRun` and `deleteProjectRun` to `api/client.ts`, with rows in the `client.test.ts` request table — 4c4bfa51
+- [x] 1.2 Add the cross-project run-cache invalidation helper to `api/queries.ts`, with a test — 4c4bfa51
 
 ### Phase 2: The context-menu primitive
 

--- a/.ai/runs/2026-08-24-sidebar-task-context-menu.md
+++ b/.ai/runs/2026-08-24-sidebar-task-context-menu.md
@@ -125,19 +125,21 @@ PR: #921
 
 ### Phase 2: The context-menu primitive
 
-- [ ] 2.1 Add `components/ui/context-menu.tsx` mirroring `ui/dropdown-menu.tsx`
+- [x] 2.1 Add `components/ui/context-menu.tsx` mirroring `ui/dropdown-menu.tsx` — 4fba4051
 
 ### Phase 3: What the menu offers, and the menu itself
 
-- [ ] 3.1 Add `lib/task-row-menu.ts` — the pure item list — with a table test per run state
-- [ ] 3.2 Add `components/task-row-menu.tsx` — the menu, the mutations and the confirm dialog
-- [ ] 3.3 Add `components/task-row-menu.test.tsx`
+- [x] 3.1 Add `lib/task-row-menu.ts` — the pure item list — with a table test per run state — 4fba4051
+- [x] 3.2 Add `components/task-row-menu.tsx` — the menu, the mutations and the confirm dialog — 4fba4051
+- [x] 3.3 Add `components/task-row-menu.test.tsx` — 4fba4051
 
 ### Phase 4: Wire it into the sidebar rows
 
-- [ ] 4.1 Wrap `RunRow` in the menu and host the inline rename in `components/task-quick-list.tsx`
-- [ ] 4.2 Extend `components/task-quick-list.test.tsx` for the menu and the rename round trip
+- [x] 4.1 Wrap `RunRow` in the menu and host the inline rename in `components/task-quick-list.tsx` — 4fba4051
+- [x] 4.2 Extend `components/task-quick-list.test.tsx` for the menu and the rename round trip — 4fba4051
 
 ### Phase 5: Tests and the validation gate
 
-- [ ] 5.1 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`)
+- [x] 5.1 Run the full validation gate (`npm run typecheck`, `npm test`, `npm run test:unit`, `npm run build`, `npm run test:package`) — all green: typecheck clean, 6199 vitest tests in 328 files, 36 node:test units, build + check:pack ok, 15 package tests
+
+> Gate note: six server tests (`git-worktree`, `git.test.ts`, `git-changes`, `health-forge`, `projects-api`, `automations-api`) assert that a freshly-made temp directory is NOT inside a git repository. They fail in this sandbox only because `TMPDIR` is set to a path *inside* the cezar checkout (`.ai/cezar/tmp/<task-id>`), so `os.tmpdir()` is in a repo. With a normal `TMPDIR` all six pass, and the numbers above are from that run. Nothing in this branch touches them.

--- a/packages/web/src/api/client.test.ts
+++ b/packages/web/src/api/client.test.ts
@@ -4,10 +4,12 @@ import {
   ApiError,
   archiveFinished,
   archiveRun,
+  cancelProjectRun,
   cancelRun,
   connectProvider,
   continueRun,
   createRun,
+  deleteProjectRun,
   deleteRun,
   finishRun,
   getGithub,
@@ -30,6 +32,7 @@ import {
   getUiState,
   getWorkflows,
   openRunInCli,
+  patchProjectRun,
   patchRun,
   pickVariant,
   putUiState,
@@ -286,6 +289,29 @@ describe('request shapes', () => {
       path: '/api/v1/runs/run-1',
       method: 'PATCH',
       body: { title: 'New name' },
+    },
+    // The three EXPLICIT-project twins the sidebar's right-click menu uses. Their whole reason
+    // for existing is in the path: a row painted by another project's group must act on THAT
+    // project, not on the mounted scope, or a colliding run id renames — or deletes — the wrong
+    // task in the wrong repository.
+    {
+      name: 'patchProjectRun (explicit project, not the active scope)',
+      call: () => patchProjectRun('api', 'run-1', { title: 'New name' }),
+      path: '/api/v1/p/api/runs/run-1',
+      method: 'PATCH',
+      body: { title: 'New name' },
+    },
+    {
+      name: 'cancelProjectRun (explicit project, not the active scope)',
+      call: () => cancelProjectRun('api', 'run-1'),
+      path: '/api/v1/p/api/runs/run-1/cancel',
+      method: 'POST',
+    },
+    {
+      name: 'deleteProjectRun (explicit project, not the active scope)',
+      call: () => deleteProjectRun('api', 'run-1'),
+      path: '/api/v1/p/api/runs/run-1',
+      method: 'DELETE',
     },
     {
       name: 'sendMessage',

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1096,6 +1096,16 @@ export async function cancelRun(id: string): Promise<CancelResponse> {
   )
 }
 
+/** The same stop by EXPLICIT project — see `archiveProjectRun`. */
+export async function cancelProjectRun(projectId: string, id: string): Promise<CancelResponse> {
+  return unwrap(
+    await cez.api.v1.p[':projectId'].runs[':id'].cancel.$post({
+      param: { projectId, id: encodeURIComponent(id) },
+    }),
+    runPath(id, '/cancel'),
+  )
+}
+
 /** Archives by default; pass `false` to bring a run back into the live list. */
 export async function archiveRun(id: string, archived = true): Promise<RunRecord> {
   return unwrap(
@@ -1290,11 +1300,41 @@ export async function patchRun(id: string, patch: PatchRunInput): Promise<RunRec
   )
 }
 
+/** The same rename by EXPLICIT project — see `archiveProjectRun`. What lets the sidebar's
+ *  right-click menu rename a row that belongs to a project other than the mounted scope. */
+export async function patchProjectRun(
+  projectId: string,
+  id: string,
+  patch: PatchRunInput,
+): Promise<RunRecord> {
+  return unwrap(
+    await cez.api.v1.p[':projectId'].runs[':id'].$patch({
+      param: { projectId, id: encodeURIComponent(id) },
+      json: patch,
+    }),
+    runPath(id),
+  )
+}
+
 /** Deletes the run, its transcript, its worktree and its branch. 409 while it is still active. */
 export async function deleteRun(id: string): Promise<DeleteRunResponse> {
   return unwrap(
     await cez.api.v1.p[':projectId'].runs[':id'].$delete({
       param: { projectId: queryScope(), id: encodeURIComponent(id) },
+    }),
+    runPath(id),
+  )
+}
+
+/** The same delete by EXPLICIT project — see `archiveProjectRun`, and note that this is the one
+ *  row action whose mis-scoping is unrecoverable: it removes a worktree and a branch. */
+export async function deleteProjectRun(
+  projectId: string,
+  id: string,
+): Promise<DeleteRunResponse> {
+  return unwrap(
+    await cez.api.v1.p[':projectId'].runs[':id'].$delete({
+      param: { projectId, id: encodeURIComponent(id) },
     }),
     runPath(id),
   )

--- a/packages/web/src/api/queries.test.tsx
+++ b/packages/web/src/api/queries.test.tsx
@@ -9,6 +9,7 @@ import { setApiScope } from '@open-mercato/cezar-api-client'
 import { ProjectScopeContext } from './project-scope-context'
 import type { GithubRefStatusData } from '@open-mercato/cezar-api-client'
 import {
+  invalidateRunCaches,
   refStatusRecheckAfter,
   useReferenceProjectId,
   useProjectRepoBase,
@@ -1095,5 +1096,30 @@ describe('refStatusRecheckAfter', () => {
     // Still loading, or errored out — `retry` owns the immediate attempt; this is the backstop
     // that keeps the query from going silent forever.
     expect(refStatusRecheckAfter(undefined)).toBeGreaterThan(0)
+  })
+})
+
+describe('invalidateRunCaches', () => {
+  /** The sidebar's row actions run from a row whose project may not be the mounted scope, so
+   *  "invalidate the runs" has to mean every project's list — and the boot project's, which is
+   *  cached under the `'default'` alias rather than under its own id. */
+  it('reaches every project’s run caches and the workspace index, and nothing else', () => {
+    const client = createQueryClient()
+    const runKeys = [
+      ['default', 'runs', 'list'],
+      ['proj-a', 'runs', 'list'],
+      ['default', 'runs', 'detail', 'run-1'],
+      [...workspaceQueryKeys.runsIndex],
+    ]
+    for (const key of runKeys) client.setQueryData(key, [])
+    // A neighbour under the same scope: an archive must not re-fetch the inbox.
+    client.setQueryData(['default', 'todos'], [])
+
+    invalidateRunCaches(client)
+
+    for (const key of runKeys) {
+      expect(client.getQueryState(key)?.isInvalidated, key.join('/')).toBe(true)
+    }
+    expect(client.getQueryState(['default', 'todos'])?.isInvalidated).toBe(false)
   })
 })

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -1206,6 +1206,28 @@ function invalidateRunsIndex(queryClient: QueryClient): void {
 }
 
 /**
+ * Mark EVERY project's run caches stale, plus the workspace index — what an action taken on a
+ * row whose project may not be the mounted scope has to do.
+ *
+ * A predicate rather than `queryKeys.runs.all`, and both halves of that are load-bearing. The
+ * sidebar paints run rows from two places: the mounted scope's own list, and — through
+ * `ProjectGroups` — one list per OTHER registered project, each cached under its own id
+ * (`useProjectRuns`). A scoped invalidation can only ever reach the first, so archiving from a
+ * foreign project's group would leave that group's row exactly where it was until the next
+ * expand. And the boot project is not reachable by its id either: its list is aliased to the
+ * `'default'` scope key (see `useProjectRuns`' `boot` parameter), so even naming the row's own
+ * project would miss it.
+ *
+ * The cost of the wider reach is nil in practice: `invalidateQueries` only refetches ACTIVE
+ * queries, and a collapsed project group's list is parked (`enabled: false`). Everything else is
+ * simply marked stale for whenever it is next observed.
+ */
+export function invalidateRunCaches(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({ predicate: (query) => query.queryKey[1] === 'runs' })
+  invalidateRunsIndex(queryClient)
+}
+
+/**
  * Mark one run read (#unread-done-items): `POST /api/runs/:id/read`. Opening a finished task's
  * thread fires this so the unread dot clears without waiting for the round-trip — the list and
  * detail caches are stamped with `seenAt` optimistically, then reconciled to the server's exact

--- a/packages/web/src/components/task-quick-list.test.tsx
+++ b/packages/web/src/components/task-quick-list.test.tsx
@@ -7,7 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createQueryClient } from '@/api/query-client'
 import type { RunRecord } from '@open-mercato/cezar-api-client'
 import { ListViewProvider } from '@/components/list-view'
-import { TaskQuickList, TaskQuickListContainer } from '@/components/task-quick-list'
+import { QuickListBuckets, TaskQuickList, TaskQuickListContainer } from '@/components/task-quick-list'
+import { groupRuns } from '@/lib/task-groups'
 
 const NOW = Date.parse('2026-07-14T12:00:00.000Z')
 const ago = (ms: number) => new Date(NOW - ms).toISOString()
@@ -30,12 +31,16 @@ function run(over: Partial<RunRecord> = {}): RunRecord {
   }
 }
 
+/** A query client, because every row now carries its right-click menu — whose actions are
+ *  mutations. The list itself still fetches nothing. */
 function renderList(props: Partial<Parameters<typeof TaskQuickList>[0]> = {}, route = '/') {
   const onViewChange = props.onViewChange ?? vi.fn()
   const utils = render(
-    <MemoryRouter initialEntries={[route]}>
-      <TaskQuickList runs={[]} view="active" now={NOW} {...props} onViewChange={onViewChange} />
-    </MemoryRouter>
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={[route]}>
+        <TaskQuickList runs={[]} view="active" now={NOW} {...props} onViewChange={onViewChange} />
+      </MemoryRouter>
+    </QueryClientProvider>
   )
   return { ...utils, onViewChange }
 }
@@ -620,5 +625,144 @@ describe('TaskQuickListContainer', () => {
 
     await waitFor(() => expect(row('b')).not.toBeNull())
     expect(row('a')).toBeNull()
+  })
+})
+
+/**
+ * The right-click menu, as the SIDEBAR wires it (`components/task-row-menu.test.tsx` covers the
+ * menu itself). What is only true here: the row is the trigger, the rename input takes the
+ * LINK's place rather than nesting inside it, and the row's own furniture — status dot,
+ * reference chip — stays put while the name is being typed.
+ */
+describe('the row’s right-click menu', () => {
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }))
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } })
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    fetchMock.mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  async function openRowMenu(id: string): Promise<HTMLElement> {
+    fireEvent.contextMenu(row(id) as HTMLElement)
+    return await waitFor(() => {
+      const menu = document.querySelector('[data-slot="task-row-menu"]')
+      if (!menu) throw new Error('the row did not open a menu')
+      return menu as HTMLElement
+    })
+  }
+
+  const pick = (menu: HTMLElement, action: string) => {
+    const item = menu.querySelector(`[data-action="${action}"]`)
+    if (!item) throw new Error(`no "${action}" item in the row menu`)
+    fireEvent.click(item)
+  }
+
+  const lastPath = () => String(fetchMock.mock.calls.at(-1)?.[0])
+
+  it('opens on a task row and offers the row’s actions', async () => {
+    renderList({ runs: [run({ id: 'a', title: 'Bump zod', status: 'done', finishedAt: ago(60_000), seenAt: ago(30_000) })] })
+    const menu = await openRowMenu('a')
+    expect([...menu.querySelectorAll('[data-slot="context-menu-item"]')].map((el) => el.textContent?.trim())).toEqual([
+      'Rename',
+      'Mark unread',
+      'Archive',
+      'Delete',
+    ])
+  })
+
+  it('archives the row it was opened on', async () => {
+    renderList({ runs: [run({ id: 'a' }), run({ id: 'b' })] })
+    pick(await openRowMenu('b'), 'archive')
+    await waitFor(() => expect(lastPath()).toBe('/api/v1/runs/b/archive'))
+  })
+
+  it('acts on the row’s own project when the list is scoped to one', async () => {
+    // What the multi-project sidebar renders: another project's rows, under an explicit scope.
+    render(
+      <QueryClientProvider client={createQueryClient()}>
+        <MemoryRouter>
+          <QuickListBuckets
+            buckets={groupRuns([run({ id: 'a', title: 'Elsewhere' })], 'active')}
+            scope="proj-b"
+            now={NOW}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+    pick(await openRowMenu('a'), 'archive')
+    await waitFor(() => expect(lastPath()).toBe('/api/v1/p/proj-b/runs/a/archive'))
+  })
+
+  describe('rename', () => {
+    it('replaces the row’s link with an input, keeping the row’s own furniture', async () => {
+      renderList({ runs: [run({ id: 'a', title: 'Bump zod', status: 'running' })] })
+      pick(await openRowMenu('a'), 'rename')
+
+      const input = await waitFor(() => {
+        const node = row('a')?.querySelector('[data-slot="title-input"]')
+        if (!node) throw new Error('the row did not flip into an input')
+        return node as HTMLInputElement
+      })
+      // The link is gone — an input inside an anchor would turn every keystroke into a click on
+      // the row — but the status dot is a sibling of both, so it stays.
+      expect(row('a')?.querySelector('a')).toBeNull()
+      expect(dotOf('a')).not.toBeNull()
+      expect(input.value).toBe('Bump zod')
+    })
+
+    it('PATCHes the new title and puts the link back', async () => {
+      renderList({ runs: [run({ id: 'a', title: 'Bump zod' })] })
+      pick(await openRowMenu('a'), 'rename')
+
+      const input = await waitFor(() => {
+        const node = row('a')?.querySelector('[data-slot="title-input"]')
+        if (!node) throw new Error('no input')
+        return node as HTMLInputElement
+      })
+      fireEvent.change(input, { target: { value: 'Bump zod everywhere' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => expect(lastPath()).toBe('/api/v1/runs/a'))
+      expect(JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body))).toEqual({ title: 'Bump zod everywhere' })
+      await waitFor(() => expect(row('a')?.querySelector('a')).not.toBeNull())
+    })
+
+    it('edits the STORED title, not the shortened one the chip let the row drop', async () => {
+      // #788, option C: a row whose reference chip already paints `775` displays the title
+      // without its `775: ` prefix. Renaming must start from the record, or committing an
+      // untouched draft would quietly delete the number.
+      renderList({
+        runs: [
+          run({ id: 'a', title: '775: Fix the thing', pullRequestUrl: 'https://github.com/o/r/pull/775' }),
+        ],
+      })
+      pick(await openRowMenu('a'), 'rename')
+
+      const input = await waitFor(() => {
+        const node = row('a')?.querySelector('[data-slot="title-input"]')
+        if (!node) throw new Error('no input')
+        return node as HTMLInputElement
+      })
+      // The row itself shows the prefix-less form; the input does not.
+      expect(row('a')?.textContent).not.toContain('775: Fix the thing')
+      expect(input.value).toBe('775: Fix the thing')
+    })
   })
 })

--- a/packages/web/src/components/task-quick-list.tsx
+++ b/packages/web/src/components/task-quick-list.tsx
@@ -4,7 +4,9 @@ import { useHealth, useReferenceProjectId, useRuns } from '@/api/queries'
 import { Link, scopeTo, useProjectMatch } from '@/lib/project-router'
 import type { RunRecord } from '@open-mercato/cezar-api-client'
 import { DiffStatLabel } from '@/components/diff-stat'
+import { TitleEditInput } from '@/components/editable-title'
 import { useListView } from '@/components/list-view'
+import { TaskRowMenu } from '@/components/task-row-menu'
 import { TaskReferenceChip } from '@/components/reference-conflict-action'
 import { ReferenceStatusProvider } from '@/components/reference-status'
 import { StatusDot } from '@/components/status-dot'
@@ -34,6 +36,12 @@ import { cn } from '@/lib/utils'
  * Presentational — every decision it paints (which bucket, which order, which dot, whether a
  * group collapses) is made by `lib/task-groups.ts` and `lib/attention.ts`, which are pure and
  * table-tested. What is left here is markup, the router, and the expand/collapse toggle.
+ *
+ * One exception, and it is deliberate: each run row is wrapped in `TaskRowMenu`, which owns the
+ * right-click actions (rename, archive/unarchive, read state, cancel, delete) and their
+ * mutations. The rules of which actions a row offers stay pure and elsewhere
+ * (`lib/task-row-menu.ts`); what lands here is the same as ever — markup — plus the inline
+ * rename input the menu hands back.
  */
 export function TaskQuickList({
   runs,
@@ -340,102 +348,120 @@ function RunRow({
       : shortAge(run.finishedAt ?? run.createdAt, now)
 
   return (
-    <div
-      data-slot="task-row"
-      data-run-id={run.id}
-      // The row's highlight is a wrapper concern (the dot and the reference chip sit outside the
-      // Link), so the active state has to be readable here rather than only from the Link's
-      // `aria-current`.
-      data-active={isActive ? 'true' : undefined}
-      className={cn(
-        'flex items-center gap-2 rounded-sm pl-2.5 hover:bg-muted',
-        isActive && 'bg-muted',
-        // The indent a member row wears under an expanded group tile. One padding declaration,
-        // not two: `cn` is tailwind-merge, so this REPLACES the `pl-2.5` above rather than losing
-        // to it — 26px = the row's own 10px plus the 16px indent.
-        variant && 'pl-[26px]'
-      )}
-    >
-      {/* Outside the Link so it can lead the reference chip. The dot is a status indicator, not a
-          navigation target, and the wrapper still owns the row's hover surface. */}
-      <StatusDot tone={attention.tone} pulse={attention.pulse} aria-label={attention.label} role="img" />
-      {/* The reference, ONCE (#788, option C): the number that used to be both a `775: ` title
-          prefix and a trailing `PR ↗` chip is now one leading chip that is itself the link. */}
-      {reference ? (
-        <TaskReferenceChip
-          run={run}
-          reference={reference}
-          compact
-          className="h-auto shrink-0 gap-[2px] px-1.5 py-px text-[10.5px]"
-        />
-      ) : null}
-      <Link
-        to={scopeTo(scope, `/tasks/${run.id}`)}
-        // `title` carries the FULL stored title — including a `NNN: ` prefix the chip let the
-        // visible text drop — so hover always gives back everything the column could not show.
-        title={title}
-        aria-current={isActive ? 'page' : undefined}
-        className="flex min-w-0 flex-1 items-center gap-2 py-[7px] pr-2.5"
-      >
-        {variant ? (
-          <span className="inline-flex size-[15px] shrink-0 items-center justify-center rounded-full bg-violet/15 font-mono text-[9.5px] font-semibold text-violet">
-            {run.variant ?? '?'}
-          </span>
-        ) : null}
-        <span
-          data-slot="task-row-title"
+    // The right-click menu (rename, archive/unarchive, read state, cancel/delete) wraps the row
+    // rather than adding anything to it — see the width-priority rule above: this column has no
+    // spare pixels for a kebab, and the actions people reach for on a LIST are the ones the
+    // pointer is already over.
+    <TaskRowMenu run={run} scope={scope} active={isActive}>
+      {(editor) => (
+        <div
+          data-slot="task-row"
+          data-run-id={run.id}
+          // The row's highlight is a wrapper concern (the dot and the reference chip sit outside
+          // the Link), so the active state has to be readable here rather than only from the
+          // Link's `aria-current`.
+          data-active={isActive ? 'true' : undefined}
           className={cn(
-            // `min-w-[7rem]`: the floor of the width-priority rule above. The title never gives
-            // way past ~17 characters; metadata drops instead.
-            'min-w-[7rem] flex-1 truncate text-[13px]',
-            unread ? 'font-semibold text-foreground' : readDone ? 'font-medium text-muted-foreground' : 'font-medium'
+            'flex items-center gap-2 rounded-sm pl-2.5 hover:bg-muted',
+            isActive && 'bg-muted',
+            // The indent a member row wears under an expanded group tile. One padding
+            // declaration, not two: `cn` is tailwind-merge, so this REPLACES the `pl-2.5` above
+            // rather than losing to it — 26px = the row's own 10px plus the 16px indent.
+            variant && 'pl-[26px]'
           )}
         >
-          {variant ? variantLabel(run, showTokens, showCost) : displayTitle}
-        </span>
-        {/* The diff numbers, once a turn has produced any (R2 #389). Nothing before that — a
-            sidebar row has no column to hold an em dash open for.
+          {/* Outside the Link so it can lead the reference chip. The dot is a status indicator,
+              not a navigation target, and the wrapper still owns the row's hover surface. */}
+          <StatusDot tone={attention.tone} pulse={attention.pulse} aria-label={attention.label} role="img" />
+          {/* The reference, ONCE (#788, option C): the number that used to be both a `775: `
+              title prefix and a trailing `PR ↗` chip is now one leading chip that is itself the
+              link. */}
+          {reference ? (
+            <TaskReferenceChip
+              run={run}
+              reference={reference}
+              compact
+              className="h-auto shrink-0 gap-[2px] px-1.5 py-px text-[10.5px]"
+            />
+          ) : null}
+          {editor.editing ? (
+            /* Renaming replaces the LINK, not the title span inside it: an input nested in an
+               anchor is invalid, and every keystroke would be a click on the row. The dot and the
+               reference chip stay — they are siblings of the link, so the row is still itself
+               while its name is being typed. */
+            <TitleEditInput editor={editor} className="my-[3px] mr-2.5 min-w-0 flex-1 text-[13px]" />
+          ) : (
+            <Link
+              to={scopeTo(scope, `/tasks/${run.id}`)}
+              // `title` carries the FULL stored title — including a `NNN: ` prefix the chip let
+              // the visible text drop — so hover always gives back everything the column could
+              // not show.
+              title={title}
+              aria-current={isActive ? 'page' : undefined}
+              className="flex min-w-0 flex-1 items-center gap-2 py-[7px] pr-2.5"
+            >
+              {variant ? (
+                <span className="inline-flex size-[15px] shrink-0 items-center justify-center rounded-full bg-violet/15 font-mono text-[9.5px] font-semibold text-violet">
+                  {run.variant ?? '?'}
+                </span>
+              ) : null}
+              <span
+                data-slot="task-row-title"
+                className={cn(
+                  // `min-w-[7rem]`: the floor of the width-priority rule above. The title never
+                  // gives way past ~17 characters; metadata drops instead.
+                  'min-w-[7rem] flex-1 truncate text-[13px]',
+                  unread ? 'font-semibold text-foreground' : readDone ? 'font-medium text-muted-foreground' : 'font-medium'
+                )}
+              >
+                {variant ? variantLabel(run, showTokens, showCost) : displayTitle}
+              </span>
+              {/* The diff numbers, once a turn has produced any (R2 #389). Nothing before that — a
+                  sidebar row has no column to hold an em dash open for.
 
-            Droppable metadata, per the width-priority rule: `+59514 −12160` is ~82px, which a
-            264px column cannot spend and still name the task, and its exact numbers stay in the
-            `title` tooltip and in the Tasks table's ± column either way.
+                  Droppable metadata, per the width-priority rule: `+59514 −12160` is ~82px, which
+                  a 264px column cannot spend and still name the task, and its exact numbers stay
+                  in the `title` tooltip and in the Tasks table's ± column either way.
 
-            23rem is not the width at which the pair merely *fits* — it is the width at which it
-            fits AND the name is still at least as long as it was in the default 264px column
-            (measured: 146px of title at 23rem vs 132px at 264px). Anything narrower buys the
-            numbers back by making the task names shorter than they were before the drag, which
-            is precisely the bargain this issue exists to stop making. */}
-        {run.diffStat ? (
-          <DiffStatLabel
-            stat={run.diffStat}
-            className="hidden shrink-0 text-[10.5px] @min-[23rem]/sidebar:inline"
-          />
-        ) : null}
-        {/* The reference chip takes the AGE's slot when there is one — same as the mockup, and
-            the same trade as before: a row that knows its PR or issue number is identified by
-            that, not by how long ago it finished.
+                  23rem is not the width at which the pair merely *fits* — it is the width at which
+                  it fits AND the name is still at least as long as it was in the default 264px
+                  column (measured: 146px of title at 23rem vs 132px at 264px). Anything narrower
+                  buys the numbers back by making the task names shorter than they were before the
+                  drag, which is precisely the bargain this issue exists to stop making. */}
+              {run.diffStat ? (
+                <DiffStatLabel
+                  stat={run.diffStat}
+                  className="hidden shrink-0 text-[10.5px] @min-[23rem]/sidebar:inline"
+                />
+              ) : null}
+              {/* The reference chip takes the AGE's slot when there is one — same as the mockup,
+                  and the same trade as before: a row that knows its PR or issue number is
+                  identified by that, not by how long ago it finished.
 
-            It never takes the QUEUE POSITION's slot. `#2` is not an age, it is where the engine
-            will pick this run up, it is carried nowhere else in the row, and a queued run is
-            exactly the kind that has an issue reference and no PR yet — so keying this on "has a
-            reference" alone would have silently deleted the queue position from every
-            issue-driven queued row. */}
-        {age && (queuePosition !== null || !reference) ? (
-          <span className="shrink-0 text-[11px] text-soft-foreground tabular-nums">{age}</span>
-        ) : null}
-        {/* The unread marker (#unread-done-items): a trailing violet dot, opposite end and
-            different hue from the leading status dot, so the two read as two signals. */}
-        {unread ? (
-          <StatusDot
-            tone="violet"
-            role="img"
-            aria-label="unread"
-            title="Unread — not opened since it finished"
-            className="ml-0.5 shrink-0"
-          />
-        ) : null}
-      </Link>
-    </div>
+                  It never takes the QUEUE POSITION's slot. `#2` is not an age, it is where the
+                  engine will pick this run up, it is carried nowhere else in the row, and a queued
+                  run is exactly the kind that has an issue reference and no PR yet — so keying
+                  this on "has a reference" alone would have silently deleted the queue position
+                  from every issue-driven queued row. */}
+              {age && (queuePosition !== null || !reference) ? (
+                <span className="shrink-0 text-[11px] text-soft-foreground tabular-nums">{age}</span>
+              ) : null}
+              {/* The unread marker (#unread-done-items): a trailing violet dot, opposite end and
+                  different hue from the leading status dot, so the two read as two signals. */}
+              {unread ? (
+                <StatusDot
+                  tone="violet"
+                  role="img"
+                  aria-label="unread"
+                  title="Unread — not opened since it finished"
+                  className="ml-0.5 shrink-0"
+                />
+              ) : null}
+            </Link>
+          )}
+        </div>
+      )}
+    </TaskRowMenu>
   )
 }
 

--- a/packages/web/src/components/task-row-menu.test.tsx
+++ b/packages/web/src/components/task-row-menu.test.tsx
@@ -152,6 +152,17 @@ describe('TaskRowMenu', () => {
     expect(rowLink()?.getAttribute('href')).toBe('/tasks/r1')
   })
 
+  it('opens from the keyboard too — the context-menu key fires on the focused link', async () => {
+    renderMenu()
+    // Shift+F10 and the Menu key dispatch a `contextmenu` event at the FOCUSED element. The row's
+    // link is focusable and the event bubbles to the trigger, so the menu has a keyboard path
+    // without the row growing a kebab it has no width for.
+    const link = screen.getByRole('link', { name: 'Bump zod to v4' })
+    link.focus()
+    fireEvent.contextMenu(link)
+    await waitFor(() => expect(document.querySelector('[data-slot="task-row-menu"]')).not.toBeNull())
+  })
+
   it('archives through the archive endpoint', async () => {
     renderMenu()
     pick(await openMenu(), 'archive')
@@ -232,6 +243,20 @@ describe('TaskRowMenu', () => {
 
       await waitFor(() => expect(fetchMock).toHaveBeenCalled())
       expect(lastRequest().path).toBe('/api/v1/p/proj-b/runs/r1')
+    })
+
+    it('does not re-enter the rename when a LATER menu is merely dismissed', async () => {
+      // The "a rename was asked for" flag is consumed by the close that starts the edit. If it
+      // ever leaked, the next menu the user dismissed would silently put the row into edit mode.
+      renderMenu()
+      pick(await openMenu(), 'rename')
+      const input = await renameInput()
+      fireEvent.keyDown(input, { key: 'Escape' })
+      await waitFor(() => expect(rowLink()).not.toBeNull())
+
+      fireEvent.keyDown(await openMenu(), { key: 'Escape' })
+      await waitFor(() => expect(document.querySelector('[data-slot="task-row-menu"]')).toBeNull())
+      expect(document.querySelector('[data-slot="title-input"]')).toBeNull()
     })
   })
 

--- a/packages/web/src/components/task-row-menu.test.tsx
+++ b/packages/web/src/components/task-row-menu.test.tsx
@@ -1,0 +1,311 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createQueryClient } from '@/api/query-client'
+import type { RunRecord } from '@open-mercato/cezar-api-client'
+import { TitleEditInput } from '@/components/editable-title'
+import { TaskRowMenu } from '@/components/task-row-menu'
+import { Toaster, resetToasts } from '@/components/ui/toaster'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  // jsdom ships neither of these; Radix positions the menu with floating-ui, which observes the
+  // trigger's size, and the shell's breakpoint effect reads matchMedia. Same stubs as
+  // `tools-menu.test.tsx`.
+  vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }))
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } })
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  resetToasts()
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+const run = (over: Partial<RunRecord> = {}): RunRecord => ({
+  id: 'r1',
+  title: 'Bump zod to v4',
+  workflow: 'quick-task',
+  task: 'Bump zod to v4',
+  status: 'done',
+  createdAt: '2026-08-24T12:00:00.000Z',
+  finishedAt: '2026-08-24T13:00:00.000Z',
+  seenAt: '2026-08-24T13:05:00.000Z',
+  tokensUsed: 0,
+  archived: false,
+  steps: [],
+  ...over,
+})
+
+/** Where the router ended up — the delete-navigates case is about this and nothing else. */
+function Here() {
+  return <span data-slot="here">{useLocation().pathname}</span>
+}
+
+/** A stand-in for the sidebar row: the same shape (a link plus a title that flips into an input)
+ *  without the quick-list's buckets, so a failure here is about the MENU. */
+function renderMenu(
+  record: RunRecord = run(),
+  { scope = null, active = false, route = '/' }: { scope?: string | null; active?: boolean; route?: string } = {}
+) {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={[route]}>
+        <TaskRowMenu run={record} scope={scope} active={active}>
+          {(editor) => (
+            <div data-slot="task-row" data-run-id={record.id}>
+              {editor.editing ? (
+                <TitleEditInput editor={editor} />
+              ) : (
+                <a href={`/tasks/${record.id}`}>{record.title}</a>
+              )}
+            </div>
+          )}
+        </TaskRowMenu>
+        <Routes>
+          <Route path="*" element={<Here />} />
+        </Routes>
+        <Toaster />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const theRow = () => document.querySelector('[data-slot="task-row"]') as HTMLElement
+
+/** Queried by slot rather than by role: while the menu is open Radix marks the rest of the
+ *  document `aria-hidden`, so a role query would not see the row it is anchored to. */
+const rowLink = () => theRow().querySelector('a')
+const renameInput = async (): Promise<HTMLInputElement> =>
+  await waitFor(() => {
+    const input = document.querySelector('[data-slot="title-input"]')
+    if (!input) throw new Error('the row did not flip into an input')
+    return input as HTMLInputElement
+  })
+
+/** Right-click the row and wait for the menu Radix portals into the document. */
+async function openMenu(): Promise<HTMLElement> {
+  fireEvent.contextMenu(theRow())
+  return await waitFor(() => {
+    const menu = document.querySelector('[data-slot="task-row-menu"]')
+    if (!menu) throw new Error('the menu did not open')
+    return menu as HTMLElement
+  })
+}
+
+const itemsIn = (menu: HTMLElement): string[] =>
+  [...menu.querySelectorAll('[data-slot="context-menu-item"]')].map((el) => (el.textContent ?? '').trim())
+
+const pick = (menu: HTMLElement, action: string): void => {
+  const item = menu.querySelector(`[data-action="${action}"]`)
+  if (!item) throw new Error(`no "${action}" item in the menu — it offers ${itemsIn(menu).join(', ')}`)
+  fireEvent.click(item)
+}
+
+/** The (path, method, body) of the last request the row's action made. */
+function lastRequest(): { path: string; method: string; body: unknown } {
+  const call = fetchMock.mock.calls.at(-1)
+  if (!call) throw new Error('nothing was requested')
+  const [path, init = {}] = call as [string, RequestInit]
+  return {
+    path,
+    method: String(init.method),
+    body: typeof init.body === 'string' ? JSON.parse(init.body) : undefined,
+  }
+}
+
+describe('TaskRowMenu', () => {
+  it('opens on right-click with the actions the run can take', async () => {
+    renderMenu()
+    expect(itemsIn(await openMenu())).toEqual(['Rename', 'Mark unread', 'Archive', 'Delete'])
+  })
+
+  it('offers Unarchive — and no read action — for an archived run', async () => {
+    renderMenu(run({ archived: true }))
+    expect(itemsIn(await openMenu())).toEqual(['Rename', 'Unarchive', 'Delete'])
+  })
+
+  it('offers Cancel instead of Delete while the engine still owns the run', async () => {
+    renderMenu(run({ status: 'running', finishedAt: undefined, seenAt: undefined }))
+    expect(itemsIn(await openMenu())).toEqual(['Rename', 'Cancel'])
+  })
+
+  it('leaves the row itself a link — right-click is the only gesture it takes over', async () => {
+    renderMenu()
+    expect(screen.getByRole('link', { name: 'Bump zod to v4' }).getAttribute('href')).toBe('/tasks/r1')
+    await openMenu()
+    expect(rowLink()?.getAttribute('href')).toBe('/tasks/r1')
+  })
+
+  it('archives through the archive endpoint', async () => {
+    renderMenu()
+    pick(await openMenu(), 'archive')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(lastRequest()).toMatchObject({ path: '/api/v1/runs/r1/archive', method: 'POST', body: { archived: true } })
+  })
+
+  it('unarchives through the same endpoint, the other way round', async () => {
+    renderMenu(run({ archived: true }))
+    pick(await openMenu(), 'unarchive')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(lastRequest()).toMatchObject({ path: '/api/v1/runs/r1/archive', body: { archived: false } })
+  })
+
+  it('marks a read run unread', async () => {
+    renderMenu()
+    pick(await openMenu(), 'mark-unread')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(lastRequest()).toMatchObject({ path: '/api/v1/runs/r1/unread', method: 'POST' })
+  })
+
+  it('marks an unread run read', async () => {
+    renderMenu(run({ seenAt: undefined }))
+    pick(await openMenu(), 'mark-read')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(lastRequest()).toMatchObject({ path: '/api/v1/runs/r1/read', method: 'POST' })
+  })
+
+  // The whole reason `scope` is threaded through the sidebar: a row painted by ANOTHER project's
+  // group must act on that project. `queryScope()` would answer with the mounted one, and a
+  // colliding run id would then archive — or delete — the wrong task in the wrong repository.
+  it('addresses the row’s OWN project, not the mounted scope', async () => {
+    renderMenu(run(), { scope: 'proj-b' })
+    pick(await openMenu(), 'archive')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(lastRequest().path).toBe('/api/v1/p/proj-b/runs/r1/archive')
+  })
+
+  describe('rename', () => {
+    it('flips the row into an input and PATCHes what was typed', async () => {
+      renderMenu()
+      pick(await openMenu(), 'rename')
+
+      const input = await renameInput()
+      // Seeded with the STORED title, so committing an untouched draft is a no-op rather than a
+      // rename to whatever the row had room to display.
+      expect(input.value).toBe('Bump zod to v4')
+      fireEvent.change(input, { target: { value: 'Bump zod to v4 everywhere' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+      expect(lastRequest()).toMatchObject({
+        path: '/api/v1/runs/r1',
+        method: 'PATCH',
+        body: { title: 'Bump zod to v4 everywhere' },
+      })
+    })
+
+    it('abandons on Escape without saying anything to the server', async () => {
+      renderMenu()
+      pick(await openMenu(), 'rename')
+
+      const input = await renameInput()
+      fireEvent.change(input, { target: { value: 'Never mind' } })
+      fireEvent.keyDown(input, { key: 'Escape' })
+
+      await waitFor(() => expect(rowLink()?.textContent).toBe('Bump zod to v4'))
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('renames in the row’s own project too', async () => {
+      renderMenu(run(), { scope: 'proj-b' })
+      pick(await openMenu(), 'rename')
+
+      const input = await renameInput()
+      fireEvent.change(input, { target: { value: 'Renamed' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+      expect(lastRequest().path).toBe('/api/v1/p/proj-b/runs/r1')
+    })
+  })
+
+  describe('the destructive pair', () => {
+    it('asks before deleting, and names the task it is about to remove', async () => {
+      renderMenu()
+      pick(await openMenu(), 'delete')
+
+      const dialog = await screen.findByRole('alertdialog')
+      expect(dialog.textContent).toContain('Delete this task?')
+      expect(dialog.textContent).toContain('Bump zod to v4')
+      // Nothing has been asked of the server yet — the question is the whole point.
+      expect(fetchMock).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+      expect(lastRequest()).toMatchObject({ path: '/api/v1/runs/r1', method: 'DELETE' })
+    })
+
+    it('keeps the task when the question is declined', async () => {
+      renderMenu()
+      pick(await openMenu(), 'delete')
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Keep it' }))
+      await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('asks before cancelling too', async () => {
+      renderMenu(run({ status: 'running', finishedAt: undefined, seenAt: undefined }))
+      pick(await openMenu(), 'cancel')
+
+      const dialog = await screen.findByRole('alertdialog')
+      expect(dialog.textContent).toContain('Cancel this task?')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel the run' }))
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+      expect(lastRequest()).toMatchObject({ path: '/api/v1/runs/r1/cancel', method: 'POST' })
+    })
+
+    it('leaves the page alone when the deleted row is not the one being read', async () => {
+      renderMenu(run(), { route: '/tasks/other', active: false })
+      pick(await openMenu(), 'delete')
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+      expect(document.querySelector('[data-slot="here"]')?.textContent).toBe('/tasks/other')
+    })
+
+    it('navigates home when the deleted row IS the one being read', async () => {
+      renderMenu(run(), { route: '/tasks/r1', active: true })
+      pick(await openMenu(), 'delete')
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+      await waitFor(() => expect(document.querySelector('[data-slot="here"]')?.textContent).toBe('/'))
+    })
+  })
+
+  it('reports a refusal in the server’s own words', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'run is still active' }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    renderMenu()
+    pick(await openMenu(), 'archive')
+
+    const toastNode = await waitFor(() => {
+      const node = document.querySelector('[data-slot="toast"]')
+      if (!node) throw new Error('no toast')
+      return node as HTMLElement
+    })
+    expect(toastNode.textContent).toContain('run is still active')
+    expect(toastNode.dataset.tone).toBe('danger')
+  })
+})

--- a/packages/web/src/components/task-row-menu.tsx
+++ b/packages/web/src/components/task-row-menu.tsx
@@ -1,0 +1,296 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  ArchiveIcon,
+  ArchiveRestoreIcon,
+  CircleStopIcon,
+  MailIcon,
+  MailOpenIcon,
+  PencilIcon,
+  Trash2Icon,
+} from 'lucide-react'
+import { Fragment, useRef, useState, type ReactNode } from 'react'
+
+import {
+  archiveProjectRun,
+  cancelProjectRun,
+  deleteProjectRun,
+  patchProjectRun,
+  setProjectRunRead,
+} from '@/api/client'
+import { invalidateRunCaches } from '@/api/queries'
+import { queryScope, type RunRecord } from '@open-mercato/cezar-api-client'
+import { useTitleEditor, type TitleEditor } from '@/components/editable-title'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import { toast } from '@/components/ui/toaster'
+import { useNavigate } from '@/lib/project-router'
+import { runTitle } from '@/lib/task-groups'
+import { taskRowMenuItems, type TaskRowAction } from '@/lib/task-row-menu'
+
+/**
+ * The sidebar task row's right-click menu — rename the task, file it away, or stop/remove it,
+ * without first opening its thread.
+ *
+ * It WRAPS a row rather than replacing one: the child is the row exactly as the quick-list paints
+ * it, handed to Radix's context-menu trigger with `asChild`, so left-click still navigates and
+ * middle-click still opens a new tab. Only the browser's own context menu is taken over.
+ *
+ * Which items appear is `lib/task-row-menu.ts` — `runActionFlags` plus labelling, table-tested
+ * there. This component is the wiring: one endpoint per verb, a confirm dialog in front of the
+ * two destructive ones, and the server's own words in a danger toast when something is refused.
+ *
+ * The child is a FUNCTION of the rename editor, because renaming is the one action whose surface
+ * is the row itself: the title flips in place into the shared `TitleEditInput`. The menu owns the
+ * state machine (it is what begins an edit) and the row owns the markup (an h1, a table cell and
+ * a sidebar row do not look alike) — the same split `components/editable-title.tsx` already makes
+ * for the run header and the Tasks table.
+ */
+export function TaskRowMenu({
+  run,
+  scope = null,
+  active = false,
+  children,
+}: {
+  run: RunRecord
+  /** The row's EXPLICIT project (`/p/<id>` scope), or null for the mounted one. Every request
+   *  below is addressed with it — see `useTaskRowActions`. */
+  scope?: string | null
+  /** Is this the run the user is currently looking at? Only then does deleting it navigate. */
+  active?: boolean
+  children: (editor: TitleEditor) => ReactNode
+}) {
+  const actions = useTaskRowActions(run, scope, active)
+  const items = taskRowMenuItems(run)
+
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{children(actions.editor)}</ContextMenuTrigger>
+        <ContextMenuContent
+          data-slot="task-row-menu"
+          className="min-w-[10rem]"
+          onCloseAutoFocus={actions.onMenuCloseAutoFocus}
+        >
+          {items.map((item) => (
+            <Fragment key={item.action}>
+              {item.startsGroup ? <ContextMenuSeparator /> : null}
+              <ContextMenuItem
+                data-action={item.action}
+                variant={item.destructive ? 'destructive' : 'default'}
+                onSelect={() => actions.select(item.action)}
+              >
+                <ActionIcon action={item.action} />
+                {item.label}
+              </ContextMenuItem>
+            </Fragment>
+          ))}
+        </ContextMenuContent>
+      </ContextMenu>
+      {/* Outside the menu on purpose: Radix unmounts the menu's content as it closes, and a
+          dialog mounted inside it would go with it before it could ever be seen. */}
+      <ConfirmDialog run={run} actions={actions} />
+    </>
+  )
+}
+
+function ActionIcon({ action }: { action: TaskRowAction }) {
+  switch (action) {
+    case 'rename':
+      return <PencilIcon aria-hidden="true" />
+    case 'archive':
+      return <ArchiveIcon aria-hidden="true" />
+    case 'unarchive':
+      return <ArchiveRestoreIcon aria-hidden="true" />
+    case 'mark-read':
+      return <MailOpenIcon aria-hidden="true" />
+    case 'mark-unread':
+      return <MailIcon aria-hidden="true" />
+    case 'cancel':
+      return <CircleStopIcon aria-hidden="true" />
+    case 'delete':
+      return <Trash2Icon aria-hidden="true" />
+  }
+}
+
+type TaskRowActions = ReturnType<typeof useTaskRowActions>
+
+/**
+ * One mutation per verb, all addressed to the row's OWN project.
+ *
+ * `scope ?? queryScope()` is the load-bearing line. The sidebar paints rows from two places: the
+ * mounted scope's list (scope null) and, in a multi-project workspace, one list per other
+ * registered project (scope = that project's id). The unscoped client helpers all send
+ * `queryScope()` — the ACTIVE project — so a right-click on another project's row would rename,
+ * archive or delete whatever task happens to share that id in the project the user is standing
+ * in. The global Tasks page's row actions are explicit for exactly this reason.
+ */
+function useTaskRowActions(run: RunRecord, scope: string | null, active: boolean) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const [confirming, setConfirming] = useState<'cancel' | 'delete' | null>(null)
+  // A ref, not state: nothing renders differently for it, and it has to be readable from the
+  // menu's close handler in the SAME commit that set it. See `onMenuCloseAutoFocus` below.
+  const renaming = useRef(false)
+  const projectId = scope ?? queryScope()
+
+  const onError = (error: Error) => toast(error.message, { tone: 'danger' })
+  const onSuccess = () => invalidateRunCaches(queryClient)
+
+  const rename = useMutation({
+    mutationFn: (title: string) => patchProjectRun(projectId, run.id, { title }),
+    onSuccess,
+    onError,
+  })
+  const archive = useMutation({
+    mutationFn: (archived: boolean) => archiveProjectRun(projectId, run.id, archived),
+    onSuccess,
+    onError,
+  })
+  const read = useMutation({
+    mutationFn: (isRead: boolean) => setProjectRunRead(projectId, run.id, isRead),
+    onSuccess,
+    onError,
+  })
+  const cancel = useMutation({
+    mutationFn: () => cancelProjectRun(projectId, run.id),
+    onSuccess,
+    onError,
+  })
+  const remove = useMutation({
+    mutationFn: () => deleteProjectRun(projectId, run.id),
+    onSuccess: () => {
+      onSuccess()
+      // Only when the page the user is on IS this run. Deleting a row from the sidebar while
+      // reading a different task must not move them somewhere they did not ask to go.
+      if (active) void navigate('/')
+    },
+    onError,
+  })
+
+  // The stored title, not the displayed one: a row may drop a `NNN: ` prefix its reference chip
+  // is already painting (#788), and an edit that started from the shortened text would silently
+  // delete the number from the record.
+  const editor = useTitleEditor(runTitle(run), (next) => rename.mutate(next))
+
+  return {
+    editor,
+    confirming,
+    setConfirming,
+    /** What a menu item does when picked: begin a rename, ask before a destructive verb, or just
+     *  fire — everything in the middle group is reversible from this same menu. */
+    select: (action: TaskRowAction) => {
+      if (action === 'rename') {
+        // Recorded, not started — see `onMenuCloseAutoFocus`.
+        renaming.current = true
+      } else if (action === 'cancel' || action === 'delete') {
+        setConfirming(action)
+      } else {
+        perform(action)
+      }
+    },
+    /** The confirmed half of the two destructive verbs. */
+    perform,
+    /**
+     * Where a rename actually BEGINS: once the menu has finished closing.
+     *
+     * Not in `onSelect`, and that is not a style choice. An open Radix menu traps focus — its
+     * FocusScope listens for `focusin` and pulls focus back into the menu whenever it lands
+     * outside. React applies the rename input's `autoFocus` during the same commit that closes
+     * the menu, while that listener is still attached, so the input was focused and immediately
+     * un-focused again; the blur that followed is `TitleEditor.commit`, and the edit was over
+     * before a key could be pressed. (Observed exactly that: focus → input, focus → menu, blur.)
+     *
+     * `onCloseAutoFocus` runs after the content has unmounted and the trap is gone, so the input
+     * mounts into a document with nothing left to fight. `preventDefault` then keeps Radix from
+     * moving focus anywhere on its way out.
+     */
+    onMenuCloseAutoFocus: (event: Event) => {
+      if (!renaming.current) return
+      renaming.current = false
+      event.preventDefault()
+      editor.begin()
+    },
+  }
+
+  function perform(action: TaskRowAction): void {
+    switch (action) {
+      case 'archive':
+        archive.mutate(true)
+        break
+      case 'unarchive':
+        archive.mutate(false)
+        break
+      case 'mark-read':
+        read.mutate(true)
+        break
+      case 'mark-unread':
+        read.mutate(false)
+        break
+      case 'cancel':
+        cancel.mutate()
+        break
+      case 'delete':
+        remove.mutate()
+        break
+      case 'rename':
+        break
+    }
+  }
+}
+
+/** The same two questions the run header asks, in the same words — one confirm grammar for a
+ *  destructive task action, wherever it was invoked from. */
+function ConfirmDialog({ run, actions }: { run: RunRecord; actions: TaskRowActions }) {
+  const confirming = actions.confirming
+  return (
+    <AlertDialog open={confirming !== null} onOpenChange={(open) => !open && actions.setConfirming(null)}>
+      <AlertDialogContent data-slot="task-row-confirm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {confirming === 'delete' ? 'Delete this task?' : 'Cancel this task?'}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {confirming === 'delete' ? (
+              <>
+                This removes the run, its transcript, its worktree and its branch. There is no
+                undo.
+                <span className="mt-1 block truncate font-medium text-foreground" title={runTitle(run)}>
+                  {runTitle(run)}
+                </span>
+              </>
+            ) : (
+              'The agent is stopped and the run completes as cancelled. The worktree stays.'
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep it</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-danger text-danger-foreground hover:brightness-[0.96]"
+            onClick={() => {
+              if (confirming !== null) actions.perform(confirming)
+              actions.setConfirming(null)
+            }}
+          >
+            {confirming === 'delete' ? 'Delete' : 'Cancel the run'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/packages/web/src/components/task-row-menu.tsx
+++ b/packages/web/src/components/task-row-menu.tsx
@@ -129,8 +129,14 @@ function ActionIcon({ action }: { action: TaskRowAction }) {
 
 type TaskRowActions = ReturnType<typeof useTaskRowActions>
 
+/** What the row asks the server to do. Rename carries its payload; every other verb is its own
+ *  name, which is what lets the whole row share one mutation. */
+type RowCommand =
+  | { action: 'rename'; title: string }
+  | { action: Exclude<TaskRowAction, 'rename'>; title?: undefined }
+
 /**
- * One mutation per verb, all addressed to the row's OWN project.
+ * Every verb the row can perform, all addressed to the row's OWN project.
  *
  * `scope ?? queryScope()` is the load-bearing line. The sidebar paints rows from two places: the
  * mounted scope's list (scope null) and, in a multi-project workspace, one list per other
@@ -148,44 +154,45 @@ function useTaskRowActions(run: RunRecord, scope: string | null, active: boolean
   const renaming = useRef(false)
   const projectId = scope ?? queryScope()
 
-  const onError = (error: Error) => toast(error.message, { tone: 'danger' })
-  const onSuccess = () => invalidateRunCaches(queryClient)
-
-  const rename = useMutation({
-    mutationFn: (title: string) => patchProjectRun(projectId, run.id, { title }),
-    onSuccess,
-    onError,
-  })
-  const archive = useMutation({
-    mutationFn: (archived: boolean) => archiveProjectRun(projectId, run.id, archived),
-    onSuccess,
-    onError,
-  })
-  const read = useMutation({
-    mutationFn: (isRead: boolean) => setProjectRunRead(projectId, run.id, isRead),
-    onSuccess,
-    onError,
-  })
-  const cancel = useMutation({
-    mutationFn: () => cancelProjectRun(projectId, run.id),
-    onSuccess,
-    onError,
-  })
-  const remove = useMutation({
-    mutationFn: () => deleteProjectRun(projectId, run.id),
-    onSuccess: () => {
-      onSuccess()
-      // Only when the page the user is on IS this run. Deleting a row from the sidebar while
-      // reading a different task must not move them somewhere they did not ask to go.
-      if (active) void navigate('/')
+  // ONE mutation for the whole row, not one per verb. Five `useMutation` calls would mean five
+  // MutationObservers subscribed per row, and this component is mounted once per row in a list
+  // that is hundreds of rows long in a busy workspace; the verbs are mutually exclusive anyway —
+  // a row runs one action at a time.
+  // `unknown` for the result: each endpoint answers with a different shape and none of them is
+  // read — the cache is reconciled by invalidation, from the server's own next answer.
+  const act = useMutation<unknown, Error, RowCommand>({
+    mutationFn: (command: RowCommand) => {
+      switch (command.action) {
+        case 'rename':
+          return patchProjectRun(projectId, run.id, { title: command.title })
+        case 'archive':
+          return archiveProjectRun(projectId, run.id, true)
+        case 'unarchive':
+          return archiveProjectRun(projectId, run.id, false)
+        case 'mark-read':
+          return setProjectRunRead(projectId, run.id, true)
+        case 'mark-unread':
+          return setProjectRunRead(projectId, run.id, false)
+        case 'cancel':
+          return cancelProjectRun(projectId, run.id)
+        case 'delete':
+          return deleteProjectRun(projectId, run.id)
+      }
     },
-    onError,
+    onSuccess: (_result, command) => {
+      invalidateRunCaches(queryClient)
+      // Only a delete moves the user, and only when the page they are on IS this run. Deleting a
+      // row from the sidebar while reading a different task must not take them somewhere they did
+      // not ask to go.
+      if (command.action === 'delete' && active) void navigate('/')
+    },
+    onError: (error) => toast(error.message, { tone: 'danger' }),
   })
 
   // The stored title, not the displayed one: a row may drop a `NNN: ` prefix its reference chip
   // is already painting (#788), and an edit that started from the shortened text would silently
   // delete the number from the record.
-  const editor = useTitleEditor(runTitle(run), (next) => rename.mutate(next))
+  const editor = useTitleEditor(runTitle(run), (title) => act.mutate({ action: 'rename', title }))
 
   return {
     editor,
@@ -200,11 +207,11 @@ function useTaskRowActions(run: RunRecord, scope: string | null, active: boolean
       } else if (action === 'cancel' || action === 'delete') {
         setConfirming(action)
       } else {
-        perform(action)
+        act.mutate({ action })
       }
     },
     /** The confirmed half of the two destructive verbs. */
-    perform,
+    perform: (action: 'cancel' | 'delete') => act.mutate({ action }),
     /**
      * Where a rename actually BEGINS: once the menu has finished closing.
      *
@@ -225,31 +232,6 @@ function useTaskRowActions(run: RunRecord, scope: string | null, active: boolean
       event.preventDefault()
       editor.begin()
     },
-  }
-
-  function perform(action: TaskRowAction): void {
-    switch (action) {
-      case 'archive':
-        archive.mutate(true)
-        break
-      case 'unarchive':
-        archive.mutate(false)
-        break
-      case 'mark-read':
-        read.mutate(true)
-        break
-      case 'mark-unread':
-        read.mutate(false)
-        break
-      case 'cancel':
-        cancel.mutate()
-        break
-      case 'delete':
-        remove.mutate()
-        break
-      case 'rename':
-        break
-    }
   }
 }
 

--- a/packages/web/src/components/ui/context-menu.tsx
+++ b/packages/web/src/components/ui/context-menu.tsx
@@ -1,0 +1,260 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * The right-click twin of `ui/dropdown-menu.tsx`, deliberately written the same way: thin
+ * wrappers, a `data-slot` on every part, and the SAME popover and item classes, so a menu the
+ * user opened with the right mouse button is indistinguishable from one they opened from a
+ * kebab — and a test can query either by its slot.
+ *
+ * The one real difference is positional: a context menu opens at the pointer rather than
+ * anchored to a trigger element, so there is no `sideOffset` to pass and the transform origin
+ * comes from `--radix-context-menu-content-transform-origin`.
+ */
+function ContextMenu({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuPortal({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return (
+    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  )
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSub({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </ContextMenuPrimitive.SubTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuPortal,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuLabel,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+}

--- a/packages/web/src/lib/task-row-menu.test.ts
+++ b/packages/web/src/lib/task-row-menu.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RunRecord, RunStatus } from '@open-mercato/cezar-api-client'
+
+import { taskRowMenuItems, type TaskRowAction } from './task-row-menu'
+
+const run = (status: RunStatus, extra: Partial<RunRecord> = {}): RunRecord => ({
+  id: 'r1',
+  title: 'Do the thing',
+  workflow: 'quick-task',
+  task: 'Do the thing',
+  status,
+  createdAt: '2026-08-24T12:00:00.000Z',
+  tokensUsed: 0,
+  archived: false,
+  steps: [],
+  ...extra,
+})
+
+/** A run that finished at a known instant — the shape the read/unread half of the menu needs. */
+const finished = (extra: Partial<RunRecord> = {}): RunRecord =>
+  run('done', { finishedAt: '2026-08-24T13:00:00.000Z', ...extra })
+
+const actionsOf = (record: RunRecord): TaskRowAction[] =>
+  taskRowMenuItems(record).map((item) => item.action)
+
+describe('taskRowMenuItems', () => {
+  const cases: Array<{ name: string; record: RunRecord; expected: TaskRowAction[] }> = [
+    // Finished and already read: everything a terminal row offers.
+    {
+      name: 'a read, finished run',
+      record: finished({ seenAt: '2026-08-24T13:05:00.000Z' }),
+      expected: ['rename', 'mark-unread', 'archive', 'delete'],
+    },
+    // The inverse receipt, which is the pairing the run header does not have.
+    {
+      name: 'an unread, finished run offers Mark read instead',
+      record: finished(),
+      expected: ['rename', 'mark-read', 'archive', 'delete'],
+    },
+    // Archiving is a stronger "done with this" than reading, so neither receipt action applies.
+    {
+      name: 'an archived run offers Unarchive and no read action',
+      record: finished({ archived: true, seenAt: '2026-08-24T13:05:00.000Z' }),
+      expected: ['rename', 'unarchive', 'delete'],
+    },
+    // Active runs: the engine still owns them, so Cancel replaces Delete and nothing is filed.
+    {
+      name: 'a running run',
+      record: run('running'),
+      expected: ['rename', 'cancel'],
+    },
+    {
+      name: 'a queued run',
+      record: run('queued'),
+      expected: ['rename', 'cancel'],
+    },
+    {
+      name: 'a waiting run',
+      record: run('waiting'),
+      expected: ['rename', 'cancel'],
+    },
+    // `review` is deliberately not active (run-actions.ts) — a parked review files like any
+    // finished run. It has not FINISHED, though, so it carries no receipt either.
+    {
+      name: 'a run parked at the review gate',
+      record: run('review'),
+      expected: ['rename', 'archive', 'delete'],
+    },
+    // Cancelled is never unread: you stopped it yourself, so there is nothing you missed.
+    {
+      name: 'a cancelled run',
+      record: run('cancelled', { finishedAt: '2026-08-24T13:00:00.000Z' }),
+      expected: ['rename', 'archive', 'delete'],
+    },
+    // A usage-limit failure with a resume booked is not a done item at all — no receipt actions.
+    {
+      name: 'a failed run with a resume already scheduled',
+      record: run('failed', {
+        finishedAt: '2026-08-24T13:00:00.000Z',
+        autoResumeAt: '2026-08-24T18:00:00.000Z',
+      }),
+      expected: ['rename', 'archive', 'delete'],
+    },
+  ]
+
+  for (const { name, record, expected } of cases) {
+    it(`offers ${expected.join(', ')} for ${name}`, () => {
+      expect(actionsOf(record)).toEqual(expected)
+    })
+  }
+
+  it('always offers Rename first — the one action every run can take', () => {
+    const statuses: RunStatus[] = ['queued', 'running', 'waiting', 'review', 'done', 'failed', 'cancelled']
+    for (const status of statuses) {
+      expect(taskRowMenuItems(run(status))[0]).toMatchObject({ action: 'rename', startsGroup: false })
+    }
+  })
+
+  it('labels the archive by what the record already is', () => {
+    const live = taskRowMenuItems(finished()).find((item) => item.action === 'archive')
+    const filed = taskRowMenuItems(finished({ archived: true })).find((item) => item.action === 'unarchive')
+    expect(live?.label).toBe('Archive')
+    expect(filed?.label).toBe('Unarchive')
+  })
+
+  it('marks exactly Cancel and Delete destructive', () => {
+    const destructive = (record: RunRecord) =>
+      taskRowMenuItems(record)
+        .filter((item) => item.destructive)
+        .map((item) => item.action)
+    expect(destructive(run('running'))).toEqual(['cancel'])
+    expect(destructive(finished())).toEqual(['delete'])
+  })
+
+  it('never opens two groups in a row — the separator has something above it', () => {
+    // The archive is the first item of its group only when no read action took that slot; a row
+    // with both would otherwise paint a rule between Mark read and Archive, which belong together.
+    expect(taskRowMenuItems(finished()).map((item) => item.startsGroup)).toEqual([
+      false, // rename
+      true, // mark-read — opens the "file it away" group
+      false, // archive — same group
+      true, // delete — opens the destructive group
+    ])
+    expect(taskRowMenuItems(run('review')).map((item) => item.startsGroup)).toEqual([
+      false, // rename
+      true, // archive — no read action here, so it opens the group itself
+      true, // delete
+    ])
+  })
+})

--- a/packages/web/src/lib/task-row-menu.ts
+++ b/packages/web/src/lib/task-row-menu.ts
@@ -1,0 +1,86 @@
+import type { RunRecord } from '@open-mercato/cezar-api-client'
+
+import { isUnread } from '@/lib/read-state'
+import { runActionFlags } from '@/routes/task-thread/run-actions'
+
+/**
+ * What the sidebar row's right-click menu offers, as a pure function of the record.
+ *
+ * The *policy* is not restated here: which actions a run can take is already
+ * `runActionFlags` (`routes/task-thread/run-actions.ts`), the table-tested rule the run header's
+ * buttons read, and a second copy of "may this be deleted?" is exactly how two surfaces come to
+ * disagree. What this module adds is what is genuinely new to a MENU: the item order, the label
+ * each item wears (Archive vs Unarchive, Mark read vs Mark unread — the record says which), and
+ * which items are destructive enough to confirm first.
+ *
+ * Pure and table-tested like the other `lib/*` deciders, so the component below it is markup.
+ */
+
+/** The verbs a row offers. Each maps to exactly one endpoint in `components/task-row-menu.tsx`. */
+export type TaskRowAction =
+  | 'rename'
+  | 'archive'
+  | 'unarchive'
+  | 'mark-read'
+  | 'mark-unread'
+  | 'cancel'
+  | 'delete'
+
+export interface TaskRowMenuItem {
+  action: TaskRowAction
+  /** Exactly what the item says — the run header's wording, so the two surfaces read alike. */
+  label: string
+  /** Confirm before running, and paint in the danger tone. */
+  destructive: boolean
+  /** A separator belongs ABOVE this item. Carried here rather than derived in the component so
+   *  the grouping is part of the table test — an item that moves group is a visible change. */
+  startsGroup: boolean
+}
+
+/**
+ * The menu for one run, in display order: rename, then the "file it away" group (read state and
+ * the archive), then the destructive group (cancel or delete — `runActionFlags` makes those two
+ * mutually exclusive, so the group is never both).
+ *
+ * Rename is unconditional. Every other item asks `runActionFlags` first, which is why a running
+ * task offers Cancel and no Delete, an archived one offers Unarchive and no Mark unread, and a
+ * queued one offers neither of the read actions: it has not finished, so there is no outcome to
+ * have seen or missed.
+ */
+export function taskRowMenuItems(run: RunRecord): TaskRowMenuItem[] {
+  const flags = runActionFlags(run)
+  const items: TaskRowMenuItem[] = [
+    // A title is the one thing every run has, whatever it is doing, and `PATCH /runs/:id` takes
+    // it in any status — so the action the brief actually asked for is never missing.
+    { action: 'rename', label: 'Rename', destructive: false, startsGroup: false },
+  ]
+
+  // Read state, both directions. The run header only offers "Mark unread"; the menu offers its
+  // inverse too, because the sidebar is where you SEE the unread marker, so the sidebar is where
+  // "yes, I have dealt with that one" wants to be — the same pairing the global Tasks page has.
+  if (isUnread(run)) {
+    items.push({ action: 'mark-read', label: 'Mark read', destructive: false, startsGroup: true })
+  } else if (flags.markUnread) {
+    items.push({ action: 'mark-unread', label: 'Mark unread', destructive: false, startsGroup: true })
+  }
+
+  if (flags.archive) {
+    items.push({
+      action: run.archived ? 'unarchive' : 'archive',
+      label: run.archived ? 'Unarchive' : 'Archive',
+      destructive: false,
+      // Only when it is the group's first item — a menu with no read action still wants the
+      // separator between "rename" and "file it away", and never two rules in a row.
+      startsGroup: !items.some((item) => item.startsGroup),
+    })
+  }
+
+  if (flags.cancel) {
+    items.push({ action: 'cancel', label: 'Cancel', destructive: true, startsGroup: true })
+  }
+  if (flags.deleteRun) {
+    items.push({ action: 'delete', label: 'Delete', destructive: true, startsGroup: true })
+  }
+
+  return items
+}


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-24-sidebar-task-context-menu.md
Status: complete

## 🎯 Goal

Right-click a task in the cockpit sidebar to **rename** it, **archive or unarchive** it, flip its read receipt, or stop/remove it — without opening the thread first.

Before this, the sidebar row was navigation and nothing else: the only way to rename a task was to open it and click the pencil in the run header, and the only way to archive one was that header's Archive button or the Tasks table's "Archive finished" broom. A list of "chats" you can only read is the wrong affordance for the surface people spend the most time in.

`Engine: om-auto-create-pr (steps: 9, --loop: no)`

## What Changed

- **`packages/web/src/components/task-row-menu.tsx` (new)** — the menu itself. It *wraps* a row rather than replacing one: the child is the quick-list's row exactly as it was, handed to Radix's context-menu trigger with `asChild`, so left-click still navigates and middle-click still opens a new tab; only the browser's own context menu is taken over. One endpoint per verb, an `AlertDialog` confirm in front of Cancel and Delete (the run header's exact wording), and the server's own words in a danger toast on refusal. Deleting navigates home only when the deleted row is the task currently open.
- **`packages/web/src/lib/task-row-menu.ts` (new)** — the pure item policy: order, labels (Archive vs Unarchive, Mark read vs Mark unread — the record says which) and which items are destructive. It does **not** restate the action rules: which verbs a run can take is `runActionFlags` from `routes/task-thread/run-actions.ts`, the same table-tested policy the run header's buttons read, so the two surfaces cannot drift.
- **`packages/web/src/components/ui/context-menu.tsx` (new)** — a shadcn-style wrapper over the Radix `ContextMenu` primitive, written line-for-line like the existing `ui/dropdown-menu.tsx` so a right-click menu is indistinguishable from a kebab one.
- **`packages/web/src/components/task-quick-list.tsx`** — every run row is now wrapped in the menu, and hosts the inline rename. The input takes the **link's** place (an input nested in an anchor would turn every keystroke into a click on the row); the status dot and reference chip are siblings of both, so the row stays itself while its name is typed. Nothing about the width-priority rule, the `data-slot` hooks or the link targets changed.
- **`packages/web/src/api/client.ts`** — `patchProjectRun`, `cancelProjectRun` and `deleteProjectRun`, the explicit-project twins of the existing `archiveProjectRun` / `setProjectRunRead`. The sidebar paints rows from two places: the mounted scope's list, and — in a multi-project workspace — one list per *other* registered project. The unscoped helpers all send `queryScope()`, so a right-click on another project's row would have renamed, archived or deleted whatever task happens to share that id in the project the user is standing in.
- **`packages/web/src/api/queries.ts`** — `invalidateRunCaches`, which marks every project's run caches stale plus the workspace index. A scoped invalidation cannot reach a foreign project's list, and the boot project's list is aliased to the `'default'` key rather than its own id, so naming the row's project would miss it too.

One review follow-up landed on top (`6d519aaf`): the row's five per-verb `useMutation` calls became **one** mutation keyed by a small command union. Five calls meant five `MutationObserver`s subscribed *per row*, and this menu is mounted once per row in a list that runs to hundreds of rows in a busy workspace; the verbs are mutually exclusive anyway.

Bundle cost, measured by building `origin/main` and this branch in the same worktree and summing every emitted JS asset: **+11,772 B raw (+0.40%), +3,240 B gzipped (+0.46%)**. Small because the Radix context menu shares `@radix-ui/react-menu` with the dropdown menu the cockpit already ships. No new dependency — `radix-ui` was already in `packages/web`'s manifest.

### Two things worth a reviewer's eye

**Renaming begins when the menu finishes closing, not when the item is picked.** An open Radix menu traps focus — its `FocusScope` pulls focus back whenever it lands outside. React applies the input's `autoFocus` during the same commit that closes the menu, while that listener is still attached, so the input was focused and immediately un-focused again, and the blur that followed *is* `TitleEditor.commit` — the edit was over before a key could be pressed. Starting it from `onCloseAutoFocus` puts the input into a document with nothing left to fight. A test pins it.

**The rename edits the stored title, not the displayed one.** A row whose reference chip already paints `775` displays its title without the `775: ` prefix (#788, option C). Seeding the editor from the display text would have silently deleted the number from the record on the first untouched commit.

## 🧪 Tests

Full gate, all green:

- `npm run typecheck` — clean across contract, api-client, server and web
- `npm test` — 6201 passed / 328 files
- `npm run test:unit` — 36 passed
- `npm run build` — server + web, and `check:pack` ok (476 files, 86 under `web/dist`)
- `npm run test:package` — 15 passed

New coverage:

- `packages/web/src/lib/task-row-menu.test.ts` — one table row per run state (read/unread/archived, running, queued, waiting, review, cancelled, a usage-limit failure with a resume booked), plus the labelling, the destructive set, and that two menu groups never open in a row.
- `packages/web/src/components/task-row-menu.test.tsx` — opening on right-click, each verb's endpoint and body, rename (commit, Escape, and that the row stays a link), the confirm dialog for Cancel and Delete including declining it, delete-navigates only when the row is the open task, the danger toast carrying the server's 409 reason, and — twice — that a scoped row addresses `/api/v1/p/<project>/…` rather than the mounted scope.
- `packages/web/src/components/task-quick-list.test.tsx` — the same at the sidebar level: the menu opens on a real row, archives the row it was opened on, the rename input replaces the link while the status dot stays, the PATCH round trip, the stored-title case, and a `QuickListBuckets` scoped to another project acting on that project.
- `packages/web/src/api/client.test.ts` / `queries.test.tsx` — request shapes for the three new twins, and that `invalidateRunCaches` reaches every project's run caches and the workspace index and nothing else.

Real-browser QA is still outstanding: `npm run test:e2e` reported `TEST_E2E_STATUS=skipped` because the `agent-browser` provider could not be provisioned here, and the repo's own exit contract says a skip is explicitly not a pass. Everything above is jsdom, and the behaviours jsdom models least faithfully — native `contextmenu` suppression over an anchor, Radix's focus restoration, touch long-press — are the ones this feature leans on. Please right-click a row, rename it and archive it in a real browser before merging.

Gate note: six server tests assert that a freshly-made temp directory is *not* inside a git repository. They fail in this sandbox only because `TMPDIR` points inside the cezar checkout (`.ai/cezar/tmp/<task-id>`), so `os.tmpdir()` is in a repo; with a normal `TMPDIR` all six pass, and the numbers above are from that run. Nothing on this branch touches them.

## 💥 Breaking Changes

None. No server, contract or API-route change — every action the menu offers already had an endpoint, and this reaches them from one more place. The row's markup keeps its `data-slot` / `data-run-id` / `data-active` hooks and its link targets, so the e2e specs and the existing unit suites query it exactly as before.

## 📋 Progress

See the Progress section in the tracking plan.
