### PR TITLE
fix(composer): stop the Alt quick replies from eating typed characters

### DIFF
--- a/packages/web/src/components/composer/composer.test.tsx
+++ b/packages/web/src/components/composer/composer.test.tsx
@@ -434,6 +434,21 @@ describe('quick replies (legacy Alt+A / Alt+C)', () => {
     expect(onSubmit).toHaveBeenCalledWith('Continue.', [])
   })
 
+  /** ⌥ is a CHARACTER modifier on macOS: ⌥C types `ć` on a Polish layout (`ç` on a US one) and
+   *  ⌥A types `ą`/`å` — each arriving with the very `event.code` this shortcut matches on. Typed
+   *  into the composer, that fired "Continue." at the agent and `preventDefault` swallowed the
+   *  letter. Someone with a caret in the textarea is writing, not reaching for an accelerator. */
+  it('leaves an Alt-composed character alone while the caret is in an editable', () => {
+    const { textarea, onSubmit } = renderComposer({ quickReplies: true })
+    type(textarea, 'popraw to')
+    const delivered = fireEvent.keyDown(textarea, { code: 'KeyC', key: 'ć', altKey: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+    // Not prevented either — the browser still gets to insert the character.
+    expect(delivered).toBe(true)
+    fireEvent.keyDown(textarea, { code: 'KeyA', key: 'ą', altKey: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
   it('does nothing without the flag, with other modifiers, or while disabled', () => {
     const { onSubmit } = renderComposer({ quickReplies: true, disabled: true })
     fireEvent.keyDown(window, { code: 'KeyA', altKey: true })

--- a/packages/web/src/components/composer/composer.tsx
+++ b/packages/web/src/components/composer/composer.tsx
@@ -23,6 +23,7 @@ import { Command, CommandItem, CommandList } from '@/components/ui/command'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { toast } from '@/components/ui/toaster'
 import { insertTemplate } from '@/lib/prompt-templates'
+import { isEditableTarget } from '@/lib/use-command-shortcut'
 import { bumpSkillUsage, filterSkills, fuzzyMatch, isProjectSkill } from '@/lib/skills'
 import { useNow } from '@/lib/use-now'
 import { isSubmitShortcut } from '@/lib/use-submit-shortcut'
@@ -391,6 +392,14 @@ export function Composer({
     if (!quickReplies || disabled) return
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
       if (!event.altKey || event.metaKey || event.ctrlKey || event.repeat) return
+      // Alt is a TEXT modifier on macOS: ⌥ composes characters, so ⌥C types `ć` on a Polish
+      // layout (`ç` on a US one) and ⌥A types `ą`/`å` — same `event.code`, and this handler
+      // matches the code, not the character. Typed into the composer that fired "Continue." at
+      // the agent and swallowed the letter with `preventDefault`. Same rule the ⌘K family
+      // already follows (`shouldTriggerKeyShortcut`): a focused editable means someone is
+      // typing, and typing always wins. The accelerator still works everywhere else — the
+      // thread composer is not autofocused, which is when these replies are reached for.
+      if (isEditableTarget(event.target)) return
       const reply = QUICK_REPLIES[event.code]
       if (reply === undefined) return
       event.preventDefault()


### PR DESCRIPTION
## What

Typing a Polish letter in the thread composer sent a canned reply to the running agent.

- `ć` (<kbd>⌥C</kbd>) fired **"Continue."** at the agent, mid-sentence.
- `ą` (<kbd>⌥A</kbd>) fired **"Yes, approved."** — an approval nobody gave.
- In both cases `preventDefault` swallowed the letter, so the message went out *and* the character never appeared.

On macOS <kbd>⌥</kbd> is a character modifier, not a chord modifier: every ⌥+letter is text input (`ć`/`ą` on a Polish layout, `ç`/`å` on a US one), and it arrives as a keydown carrying `altKey` with the very `event.code` the quick replies match on. Windows and Linux were never affected — AltGr also sets `ctrlKey`, which the existing modifier guard already rejects.

## How

The window-global listener had no editable-target guard. That is the rule the ⌘K family already follows — `shouldTriggerKeyShortcut` stands down when an input, textarea or contenteditable has focus, because "a bare letter is a keystroke someone is probably typing" — so this reuses the same exported `isEditableTarget` predicate rather than growing a second rule.

The accelerator survives where it is actually reached for: the thread composer is not autofocused, so <kbd>⌥A</kbd> / <kbd>⌥C</kbd> still fire while reading the run. What changes is only the case where a caret is sitting in a text field, which was never a moment for a canned reply.

## Verification

- Regression test in `composer.test.tsx`: ⌥C and ⌥A on the focused textarea submit nothing, and the keydown comes back un-prevented so the browser still inserts the character. Proven red without the fix (`git stash push -- composer.tsx` → the test fails with `"Continue."` actually delivered), green with it.
- The existing quick-reply tests are untouched and still pass — they dispatch on `window`, pinning the accelerator that stays.
- Full gate green: `npm run typecheck`, `npm test` (6196), `npm run test:unit`, `npm run build`, `npm run test:package`.

Reported by Maciej Gren while typing a Polish reply in the cockpit.
