### PR TITLE
fix(runs): stop a task adopting another repository's PR/issue as its reference (#945)

### DIFF
--- a/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
+++ b/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
@@ -129,6 +129,8 @@ Full gate from `.ai/agentic.config.json`: `npm run typecheck`, `npm test`, `npm 
 
 ## Progress
 
+PR: #946
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Repo-scope the referenced tier's promotion

--- a/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
+++ b/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
@@ -144,5 +144,5 @@ Full gate from `.ai/agentic.config.json`: `npm run typecheck`, `npm test`, `npm 
 
 ### Phase 3: Documentation
 
-- [ ] 3.1 Update the two referenced-detection specs with the repo clause
-- [ ] 3.2 Record the display-layer decision in the `tasks-table.ts` doc comment
+- [x] 3.1 Update the two referenced-detection specs with the repo clause — d09154c4
+- [x] 3.2 Record the display-layer decision in the `tasks-table.ts` doc comment — d09154c4

--- a/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
+++ b/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
@@ -1,0 +1,148 @@
+# Execution plan — repo-scope the referenced PR/issue tier (#945)
+
+Engine: om-auto-create-pr (steps: 9, --loop: no)
+Issue: https://github.com/open-mercato/cezar/issues/945
+Source doc: `.ai/specs/2026-07-16-pr-autodiscovery.md` (issue tier: `.ai/specs/2026-07-21-report-ref-discovery.md`)
+
+## Goal
+
+Stop a task in project *P* from adopting a pull request or issue that belongs to a **different
+repository** as its own reference chip, unless the task prompt itself names that repository.
+
+## Background
+
+`resolveReferencedRef` (`packages/cezar/src/runs/store.ts:444`) implements the spec's referenced
+tier: "exactly one distinct candidate → that URL". `PR_URL_RE` / `ISSUE_URL_RE` match
+`https://github.com/<any-owner>/<any-repo>/pull|issues/N`, so a research task that cites one
+upstream PR — the reported `supabase/cli#6056` on an `oko` task — hands the janitor exactly one
+candidate, and it becomes the task's subject. Nothing in the chain ever compares the URL's
+`owner/repo` with the project's own.
+
+The existing foreign-number guards (#819/PR #840, #854/PR #864, both landed on `main`) all guard
+**synthesis** — a bare number rebuilt as `${repoBase}/pull/${number}` — and deliberately exempt
+discovered URLs. Here the wrong link *is* the discovered URL, so every one of them passes it
+through. This is the missing third case.
+
+## Scope
+
+- Repo-scope what the referenced tier **promotes**, never what it **collects** (the #526 rule):
+  `referencedPrCandidates` / `referencedIssueCandidates` keep recording every URL as evidence.
+- The guard is **strictly subtractive** — it vetoes a resolution, so it can only ever turn a value
+  into `undefined`. It never adopts a candidate today's rule would not have.
+- Corroboration is the module's existing trust boundary: the **task prompt** naming the URL's
+  `owner/repo` (or the URL itself) makes a foreign reference legitimate — the #819
+  `om-auto-fix-pr https://github.com/open-mercato/open-mercato/pull/1977` case.
+- Degrade, never fail (`AGENTS.md` zero config): with no known handle — no `gh`, no remote, a
+  non-git root, hosted mode — behavior is exactly today's.
+- Heal records already poisoned, one-directionally.
+
+## Non-goals
+
+- Ref-status hydration across repos (`useReferenceStatus` / `GET /github/ref-status` asking the
+  project's repo about a legitimately foreign number). Real, different axis — the issue files it as
+  out of scope.
+- The synthesis guard for bare foreign numbers (#854 — already landed as PR #864).
+- Rendering an unlinked `#N` instead of dropping the chip (#819's follow-up note).
+- Multi-forge / multi-repo reference modelling (#847).
+- Any HTTP route, CLI flag, event-schema or `runs.json` **format** change. Reaching for one is the
+  signal the fix has grown past this issue.
+
+## Design
+
+**Where the guard lives.** Inside `resolveReferencedRef`, as a veto on the value it was about to
+return — one place, and all four call sites (`trackReferencedPrs`, `trackReferencedIssues`,
+`applyMarkerRefs`, and `appendEvent`'s created-tier re-resolve) plus `reconcileLoadedRun` inherit
+it. Vetoing the *result* rather than filtering the *candidate list* keeps the change subtractive:
+filtering first would let a project-local candidate win a two-candidate race today's rule calls
+ambiguous, which is a wider behavior change than the defect warrants.
+
+**How the store learns its repository.** A `setRepoHandle()` setter, not an `open()` option:
+`RunStore.open` is synchronous and `resolveRepoHandle` shells out to `gh`, so the handle has to
+arrive after load or boot would wait on the network. Both `RunStore.open` call sites that hold a
+repo root — `project-context.ts:211` and `openStore()` in `index.ts:656` — arm it in the
+background, fire-and-forget, never throwing.
+
+**The heal.** Because the handle arrives *after* `open()`, the load-time heal cannot run inside
+`reconcileLoadedRun`. It runs when the handle lands: `setRepoHandle` sweeps every loaded run and
+re-applies the veto to both referenced tiers, revoking a janitor-seeded `issueNumber` alongside a
+dropped `referencedIssueUrl` exactly as `trackReferencedIssues` already does on ambiguity. Purely
+one-directional — it may remove an association, never invent one — so a downgrade and an older
+record both stay safe.
+
+**Display layer.** Decided: no mirror (step 3.2 records the reasoning in the doc comment that
+already states the #526/#819/#854 rule in one piece). The slim runs-index row does not carry
+`task`, so it cannot evaluate corroboration — mirroring there would either need a new field or
+would drop the legitimate #819 cross-repo chip. Scoping at the record is the only place with the
+corroboration signal. Consequence: no `runIndexEntrySchema` change, so no
+`BACKWARD_COMPATIBILITY.md` §1 enumeration churn.
+
+## Implementation Plan
+
+### Phase 1: Repo-scope the referenced tier's promotion
+
+- **1.1** In `packages/cezar/src/runs/store.ts`: add a `RepoHandle` type and a pure
+  `isRepoScopedRef(url, task, handle)` corroboration helper (unknown handle or unparseable URL →
+  adoptable; own repo → adoptable; foreign → only when `task` names the `owner/repo`,
+  case-insensitively). Veto `resolveReferencedRef`'s return value with it, and thread the store's
+  handle through all four call sites plus `reconcileLoadedRun`'s heal.
+- **1.2** Unit tests in `packages/cezar/src/runs/store.test.ts` for the resolution rule: the
+  foreign lone candidate is dropped (PR **and** issue, the issue case also asserting no
+  `issueNumber` seed); the corroborated cross-repo prompt keeps its chip; an unknown handle is
+  unchanged; a candidate from the project's own repo is unaffected. Each must fail with the guard
+  reverted.
+
+### Phase 2: Teach the store its repository and heal poisoned records
+
+- **2.1** `RunStore.setRepoHandle(handle)`: store it and sweep every loaded run, re-applying the
+  veto to `referencedPullRequestUrl` / `referencedIssueUrl` and revoking a seeded `issueNumber`
+  alongside a dropped issue URL. Touch only records that actually changed.
+- **2.2** Arm it in the background from both `RunStore.open` call sites — `project-context.ts`'s
+  `build()` and `openStore()` in `index.ts` — via one shared helper so the fire-and-forget and its
+  swallowed failure are written once.
+- **2.3** Tests: a stored record carrying a foreign `referencedPullRequestUrl` loses it when the
+  handle arrives; a corroborated foreign URL survives; a `null` handle changes nothing; the
+  `issueNumber` revoke fires only for a janitor-seeded number.
+
+### Phase 3: Documentation
+
+- **3.1** Update `.ai/specs/2026-07-16-pr-autodiscovery.md` ("Referenced detection") and
+  `.ai/specs/2026-07-21-report-ref-discovery.md` with the repo clause, citing the existing
+  `CREATED_PR_RE` amendment note as the precedent — the same failure, one tier down.
+- **3.2** Write the display-layer decision and its reasoning into the `taskReferences` doc comment
+  in `packages/web/src/lib/tasks-table.ts`, the one place the whole rule is stated together.
+
+## Risks
+
+- **Dropping a legitimate chip.** A cross-repo task whose prompt does not spell out the repository
+  (a bare `#1977` plus a transcript URL) loses a chip it used to show. Accepted: the spec's own
+  stated preference is "no chip beats a wrong chip", and the prompt-corroboration escape hatch
+  covers the documented #819 shape.
+- **`gh` latency / absence.** Mitigated by the background arming and the null-handle no-op path;
+  boot never waits and a `gh`-less machine keeps today's behavior. Covered by test 2.3.
+- **Older cezar reading the same `runs.json`.** The heal rewrites values, not format, and only ever
+  clears a field that is already optional — the `reconcileLoadedRun` precedent.
+
+## Validation
+
+Full gate from `.ai/agentic.config.json`: `npm run typecheck`, `npm test`, `npm run test:unit`,
+`npm run build`, `npm run test:package`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Repo-scope the referenced tier's promotion
+
+- [ ] 1.1 Add the repo-handle corroboration helper and veto `resolveReferencedRef`
+- [ ] 1.2 Unit tests for the repo-scoped resolution rule
+
+### Phase 2: Teach the store its repository and heal poisoned records
+
+- [ ] 2.1 `RunStore.setRepoHandle` and the one-directional rescope sweep
+- [ ] 2.2 Arm the handle in the background from both `RunStore.open` call sites
+- [ ] 2.3 Tests for the sweep, the corroborated survivor, and the null handle
+
+### Phase 3: Documentation
+
+- [ ] 3.1 Update the two referenced-detection specs with the repo clause
+- [ ] 3.2 Record the display-layer decision in the `tasks-table.ts` doc comment

--- a/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
+++ b/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
@@ -141,6 +141,7 @@ Full gate from `.ai/agentic.config.json`: `npm run typecheck`, `npm test`, `npm 
 - [x] 2.1 `RunStore.setRepoHandle` and the one-directional rescope sweep — 5bca379d
 - [x] 2.2 Arm the handle in the background from both `RunStore.open` call sites — 5bca379d
 - [x] 2.3 Tests for the sweep, the corroborated survivor, and the null handle — 5bca379d
+- [x] 2.4 Review autofix: cover `armRepoHandle`'s degradation path; arm only after a successful build — 1d712bd7
 
 ### Phase 3: Documentation
 

--- a/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
+++ b/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
@@ -133,8 +133,8 @@ Full gate from `.ai/agentic.config.json`: `npm run typecheck`, `npm test`, `npm 
 
 ### Phase 1: Repo-scope the referenced tier's promotion
 
-- [ ] 1.1 Add the repo-handle corroboration helper and veto `resolveReferencedRef`
-- [ ] 1.2 Unit tests for the repo-scoped resolution rule
+- [x] 1.1 Add the repo-handle corroboration helper and veto `resolveReferencedRef` — ac02041f
+- [x] 1.2 Unit tests for the repo-scoped resolution rule — ac02041f
 
 ### Phase 2: Teach the store its repository and heal poisoned records
 

--- a/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
+++ b/.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md
@@ -138,9 +138,9 @@ Full gate from `.ai/agentic.config.json`: `npm run typecheck`, `npm test`, `npm 
 
 ### Phase 2: Teach the store its repository and heal poisoned records
 
-- [ ] 2.1 `RunStore.setRepoHandle` and the one-directional rescope sweep
-- [ ] 2.2 Arm the handle in the background from both `RunStore.open` call sites
-- [ ] 2.3 Tests for the sweep, the corroborated survivor, and the null handle
+- [x] 2.1 `RunStore.setRepoHandle` and the one-directional rescope sweep — 5bca379d
+- [x] 2.2 Arm the handle in the background from both `RunStore.open` call sites — 5bca379d
+- [x] 2.3 Tests for the sweep, the corroborated survivor, and the null handle — 5bca379d
 
 ### Phase 3: Documentation
 

--- a/.ai/specs/2026-07-16-pr-autodiscovery.md
+++ b/.ai/specs/2026-07-16-pr-autodiscovery.md
@@ -62,6 +62,29 @@ The created tier always wins. Both fields are additive and optional — old
     exactly one candidate matches;
   - otherwise → unset. Ambiguity **clears** a previously resolved value —
     a wrong chip is worse than no chip.
+  - and finally, whatever the rules above produced is **repo-scoped**: a
+    winner whose `owner/repo` is not the project's own resolves only when the
+    **task prompt** names that `owner/repo` (a pasted URL does inherently).
+    Otherwise → unset.
+  - **Amendment — the resolution is repo-scoped (#945).** The rules above were
+    text-scoped but never repo-scoped: `PR_URL_RE` matches *any*
+    `github.com/<owner>/<repo>/pull/N`, so "exactly one distinct candidate"
+    adopted a pull request the project has nothing to do with. A research task
+    is exactly that shape — an `oko` task that read about migration safety,
+    cited one upstream `supabase/cli` PR, and wore `#6056` as its subject.
+    This is the `CREATED_PR_RE` amendment above one tier down: the same
+    failure (a URL from another repository adopted as this task's), and the
+    same remedy (ask where the claim came from before believing it). The
+    prompt is the corroborating source because it is the trust boundary this
+    module already uses, and it preserves the legitimate cross-repo case
+    (#819 — `om-auto-fix-pr https://github.com/other/repo/pull/1977` started
+    from a different project). Candidates are still **collected** unscoped:
+    the guard changes what is *promoted*, never what is *recorded*. With no
+    known repository — no `gh`, no remote, a non-git root — behavior is
+    exactly the pre-#945 rules, and the guard is strictly subtractive, so it
+    can only ever lose a resolution, never gain one. The project's handle
+    arrives asynchronously (`RunStore.setRepoHandle`), and its arrival also
+    heals records the un-scoped rule already poisoned.
 - Once `pullRequestUrl` (created tier) is set, all discovery stops.
 - Candidates persist on the record so a restart/resume re-evaluates from the
   same working set instead of re-adopting the next URL as "the only one".

--- a/.ai/specs/2026-07-21-report-ref-discovery.md
+++ b/.ai/specs/2026-07-21-report-ref-discovery.md
@@ -56,7 +56,19 @@ pretty distinguished"):
 - Same resolution rule via the now-shared `resolveReferencedRef`: a declared
   issue number filters candidates outright; otherwise one distinct URL is the
   subject; several resolve only when the task prompt names exactly one;
-  ambiguity clears the chip.
+  ambiguity clears the chip; and the winner is **repo-scoped** — a foreign
+  `owner/repo` resolves only when the task prompt names it.
+- **Amendment — the issue tier is repo-scoped too (#945).** Sharing
+  `resolveReferencedRef` meant sharing its hole: an issue link to another
+  repository, spotted once in a transcript, became the task's subject. It now
+  shares the repo-scope guard as well — see the amendment in
+  `2026-07-16-pr-autodiscovery.md` for the rule, the corroboration source, and
+  why an unknown repository keeps the pre-#945 behavior. The issue side had
+  one extra edge the PR side does not: a vetoed URL must not seed
+  `issueNumber` either. It cannot — the seed below is gated on a resolution
+  existing — and when the heal drops a stored foreign URL it revokes the
+  number alongside it, but only when `referencedIssueNumberSeeded` says the
+  janitor is the one who wrote it.
 - An unambiguous resolution seeds `issueNumber` when nothing owns that field;
   the persisted `referencedIssueNumberSeeded` provenance bit lets ambiguity
   take back only the janitor's own seed, including after a restart. Prompt,

--- a/packages/cezar/src/index.ts
+++ b/packages/cezar/src/index.ts
@@ -15,6 +15,7 @@ import { pruneOrphans } from './git-worktree.ts';
 import { getRepoInfo } from './server/git.ts';
 import { DEFAULT_WORKTREE_RETENTION, loadConfig, resolveWorktreeRetention } from './config.ts';
 import { reclaimWorktrees } from './runs/retention.ts';
+import { armRepoHandle } from './runs/arm-repo-handle.ts';
 import { RunStore } from './runs/store.ts';
 import { RunManager } from './workflows/run.ts';
 import { loadWorkflows } from './workflows/load.ts';
@@ -656,6 +657,9 @@ description: House rules the agent should follow in this repo.
 function openStore(repoRoot: string, opts?: { keepLive?: boolean }): RunStore {
   const dataDir = join(repoRoot, '.ai/cezar');
   const store = RunStore.open(dataDir, opts);
+  // Repo-scope the referenced tier (#945) — see `armRepoHandle`. Background, never awaited: a
+  // `gh`-less or offline machine keeps working exactly as it did, just unscoped.
+  armRepoHandle(store, repoRoot);
   ensureDataGitignore(repoRoot);
   return store;
 }

--- a/packages/cezar/src/runs/arm-repo-handle.test.ts
+++ b/packages/cezar/src/runs/arm-repo-handle.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `vi.hoisted` so the mock fn exists before the hoisted `vi.mock` factory closes over it.
+const resolveRepoHandleMock = vi.hoisted(() => vi.fn());
+// The forge module shells out to `gh`. Mocking it is the whole point of this file: what is under
+// test is the WRAPPER's contract — background, never throwing — not the lookup itself, which has
+// its own coverage in `server/forge/github.test.ts`.
+vi.mock('../server/forge/github.ts', () => ({
+  resolveRepoHandle: (...args: unknown[]) => resolveRepoHandleMock(...args),
+}));
+
+import { armRepoHandle } from './arm-repo-handle.ts';
+
+import type { RunStore } from './store.ts';
+
+/**
+ * `armRepoHandle` is the safety wrapper around the #945 repo lookup, and both of its call sites
+ * are fire-and-forget — so a regression here is invisible to every other suite and surfaces only
+ * as a boot that dies on a machine without `gh`. `AGENTS.md` makes that the rule it breaks:
+ * "a missing dependency, an absent peer, a read-only home: degrade to a smaller working cockpit,
+ * never fail the boot."
+ */
+describe('armRepoHandle (#945)', () => {
+  /** Just enough store to observe the one call this module makes. */
+  const fakeStore = () => {
+    const setRepoHandle = vi.fn();
+    return { store: { setRepoHandle } as unknown as RunStore, setRepoHandle };
+  };
+
+  /** Let the promise chain inside `armRepoHandle` settle without the caller awaiting it. */
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it('hands a resolved handle to the store', async () => {
+    resolveRepoHandleMock.mockResolvedValue({ owner: 'open-mercato', name: 'cezar' });
+    const { store, setRepoHandle } = fakeStore();
+
+    armRepoHandle(store, '/repo');
+    await settle();
+
+    expect(resolveRepoHandleMock).toHaveBeenCalledWith('/repo');
+    expect(setRepoHandle).toHaveBeenCalledWith({ owner: 'open-mercato', name: 'cezar' });
+  });
+
+  it('passes a null handle through — "unknown" is a first-class answer, not a failure', async () => {
+    // No `gh`, no remote, a non-git root, hosted mode. The store must be told, so it settles into
+    // the unscoped (pre-#945) behavior rather than waiting forever for a handle.
+    resolveRepoHandleMock.mockResolvedValue(null);
+    const { store, setRepoHandle } = fakeStore();
+
+    armRepoHandle(store, '/repo');
+    await settle();
+
+    expect(setRepoHandle).toHaveBeenCalledWith(null);
+  });
+
+  it('swallows a rejection instead of taking the boot down with it', async () => {
+    // `resolveRepoHandle` answers null rather than throwing for the ordinary cases, so this is
+    // belt-and-braces — which is exactly why it needs a test: without one, the `.catch` reads as
+    // deletable, and deleting it turns any future throw into an unhandled rejection during boot.
+    resolveRepoHandleMock.mockRejectedValue(new Error('gh exploded'));
+    const { store, setRepoHandle } = fakeStore();
+
+    expect(() => armRepoHandle(store, '/repo')).not.toThrow();
+    await settle();
+
+    expect(setRepoHandle).not.toHaveBeenCalled(); // unscoped, exactly as before #945
+  });
+
+  it('returns synchronously — boot never waits on the `gh` spawn', async () => {
+    // The property both call sites depend on: a slow lookup must not delay opening a store.
+    let release: (value: unknown) => void = () => {};
+    resolveRepoHandleMock.mockReturnValue(new Promise((resolve) => { release = resolve; }));
+    const { store, setRepoHandle } = fakeStore();
+
+    expect(armRepoHandle(store, '/repo')).toBeUndefined();
+    expect(setRepoHandle).not.toHaveBeenCalled(); // still pending — and the caller already moved on
+
+    release({ owner: 'open-mercato', name: 'cezar' });
+    await settle();
+    expect(setRepoHandle).toHaveBeenCalledWith({ owner: 'open-mercato', name: 'cezar' });
+  });
+});

--- a/packages/cezar/src/runs/arm-repo-handle.ts
+++ b/packages/cezar/src/runs/arm-repo-handle.ts
@@ -1,0 +1,26 @@
+import { resolveRepoHandle } from '../server/forge/github.ts';
+
+import type { RunStore } from './store.ts';
+
+/**
+ * Tell a freshly opened store which repository it belongs to (#945), in the background.
+ *
+ * Its own module for two reasons. It is the ONE place the fire-and-forget is written, so both
+ * `RunStore.open` call sites that hold a repo root — `server/project-context.ts` and `openStore()`
+ * in `index.ts` — cannot drift on how a `gh` failure is handled. And it keeps `store.ts` free of
+ * any forge import: the store owns the *rule* (`isRepoScopedRef`), never the lookup.
+ *
+ * Deliberately not awaited by callers. `resolveRepoHandle` shells out to `gh`, and boot must never
+ * wait on the network — a project whose handle is slow to resolve simply behaves as it did before
+ * #945 until it arrives, at which point `setRepoHandle` heals what the un-scoped rule got wrong.
+ * `resolveRepoHandle` already answers `null` rather than throwing for the ordinary no-`gh`/
+ * no-remote/non-git cases; the `catch` is the belt-and-braces for the rest, because an unhandled
+ * rejection here would take down a boot over a cosmetic chip.
+ */
+export function armRepoHandle(store: RunStore, repoRoot: string): void {
+  void resolveRepoHandle(repoRoot)
+    .then((handle) => store.setRepoHandle(handle))
+    .catch(() => {
+      // Unknown handle is a first-class state — leave the store unscoped (pre-#945 behavior).
+    });
+}

--- a/packages/cezar/src/runs/store.test.ts
+++ b/packages/cezar/src/runs/store.test.ts
@@ -1170,6 +1170,150 @@ describe('RunStore — referenced-issue discovery (spec 2026-07-21-report-ref-di
   });
 });
 
+describe("RunStore — a task never adopts another repository's ref (#945)", () => {
+  let dataDir: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'cez-store-repo-scope-'));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  const HANDLE = { owner: 'open-mercato', name: 'cezar' };
+
+  /** A store that already knows which repository it is, as the background arming leaves it. */
+  const scopedRun = (task = 'task', handle: typeof HANDLE | null = HANDLE) => {
+    const store = RunStore.open(dataDir);
+    store.setRepoHandle(handle);
+    const run = store.createRun({ title: 't', workflow: 'w', task, steps: [] });
+    return { store, run };
+  };
+
+  it('drops a lone foreign PR the prompt never named — the reported defect', () => {
+    // "assessing Phase 0 SQL safety": a research task cites one upstream PR, and the
+    // one-distinct-candidate rule made it the task's identity.
+    const { store, run } = scopedRun('assessing Phase 0 SQL safety');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Migration safety is discussed in https://github.com/supabase/cli/pull/6056.',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.referencedPullRequestUrl).toBeUndefined();
+    // Collected as evidence all the same — the guard changes what is PROMOTED, never what is
+    // recorded (the #526 rule).
+    expect(loaded?.referencedPrCandidates).toEqual(['https://github.com/supabase/cli/pull/6056']);
+  });
+
+  it('drops a lone foreign issue AND refuses to seed issueNumber from it', () => {
+    const { store, run } = scopedRun('assessing Phase 0 SQL safety');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Tracked upstream as https://github.com/supabase/cli/issues/6056.',
+    });
+    const loaded = store.getRun(run.id);
+    expect(loaded?.referencedIssueUrl).toBeUndefined();
+    expect(loaded?.issueNumber).toBeUndefined();
+    expect(loaded?.referencedIssueCandidates).toEqual([
+      'https://github.com/supabase/cli/issues/6056',
+    ]);
+  });
+
+  it('keeps a foreign PR the task prompt itself names — the #819 cross-repo case', () => {
+    const { store, run } = scopedRun(
+      'om-auto-fix-pr https://github.com/open-mercato/open-mercato/pull/1977',
+    );
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Working on https://github.com/open-mercato/open-mercato/pull/1977 now.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/open-mercato/pull/1977',
+    );
+  });
+
+  it('corroboration accepts the bare owner/repo, not only a pasted URL', () => {
+    const { store, run } = scopedRun('port the fix over to open-mercato/open-mercato');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/open-mercato/open-mercato/pull/1977.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/open-mercato/pull/1977',
+    );
+  });
+
+  it("leaves the project's own PRs alone — the ordinary #407 path", () => {
+    const { store, run } = scopedRun();
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Reviewed https://github.com/open-mercato/cezar/pull/407 — looks good.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/407',
+    );
+  });
+
+  it('matches the handle case-insensitively', () => {
+    const { store, run } = scopedRun('task', { owner: 'Open-Mercato', name: 'Cezar' });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/open-mercato/cezar/pull/407.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/open-mercato/cezar/pull/407',
+    );
+  });
+
+  it('an unknown handle keeps pre-#945 behavior — degrade, never fail', () => {
+    // No `gh`, no remote, a non-git root, hosted mode: `resolveRepoHandle` answers null and the
+    // foreign URL is adopted exactly as it was before this guard existed.
+    const { store, run } = scopedRun('assessing Phase 0 SQL safety', null);
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'Migration safety is discussed in https://github.com/supabase/cli/pull/6056.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/supabase/cli/pull/6056',
+    );
+  });
+
+  it('a store that was never armed keeps pre-#945 behavior too', () => {
+    const store = RunStore.open(dataDir);
+    const run = store.createRun({ title: 't', workflow: 'w', task: 'task', steps: [] });
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/supabase/cli/pull/6056.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBe(
+      'https://github.com/supabase/cli/pull/6056',
+    );
+  });
+
+  it('vetoes a foreign URL a CEZ:PR marker declared', () => {
+    // The marker owns the resolution, but it can only ever pick from the candidate list — and a
+    // foreign candidate is not adoptable, so the chip stays empty rather than pointing away.
+    const { store, run } = scopedRun('task');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result: 'See https://github.com/supabase/cli/pull/6056.',
+    });
+    store.applyMarkerRefs(run.id, { pr: 6056 });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+
+  it('does not rescue a candidate today’s rule already calls ambiguous', () => {
+    // Strictly subtractive: two candidates, one foreign, still resolves to nothing. Filtering the
+    // list before resolving would have promoted the local one — a wider change than the fix needs.
+    const { store, run } = scopedRun('task');
+    store.appendEvent(run.id, {
+      type: 'result',
+      result:
+        'Compare https://github.com/open-mercato/cezar/pull/1 with https://github.com/supabase/cli/pull/6056.',
+    });
+    expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+});
+
 describe('RunStore — seq survives a restart (#424 symptom class)', () => {
   let dataDir: string;
 

--- a/packages/cezar/src/runs/store.test.ts
+++ b/packages/cezar/src/runs/store.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { RunStore } from './store.ts';
 
+import type { RunRecord } from './store.ts';
+
 /** A minimal pre-#389 record, exactly as an old runs.json holds it — no
  *  titleSummary, no diffStat. Loading it must keep working (additive proof). */
 const LEGACY_RUN = {
@@ -1299,6 +1301,122 @@ describe("RunStore — a task never adopts another repository's ref (#945)", () 
     });
     store.applyMarkerRefs(run.id, { pr: 6056 });
     expect(store.getRun(run.id)?.referencedPullRequestUrl).toBeUndefined();
+  });
+
+  describe('healing records the un-scoped rule already poisoned', () => {
+    /** Persist one record, then reopen and arm — what a cockpit restart does. */
+    const reopenArmed = (
+      record: Partial<RunRecord> & { task: string },
+      handle: typeof HANDLE | null = HANDLE,
+    ) => {
+      const seed = RunStore.open(dataDir);
+      const run = seed.createRun({ title: 't', workflow: 'w', task: record.task, steps: [] });
+      seed.updateRun(run.id, record);
+      seed.flush();
+
+      const reopened = RunStore.open(dataDir);
+      // Snapshot the VALUE, not the record: `getRun` hands back the live object the sweep
+      // mutates in place, so holding the reference would show the healed state either way.
+      const before = reopened.getRun(run.id)?.referencedPullRequestUrl;
+      reopened.setRepoHandle(handle);
+      return { before, after: reopened.getRun(run.id) };
+    };
+
+    it('drops a stored foreign referencedPullRequestUrl when the handle arrives', () => {
+      const { before, after } = reopenArmed({
+        task: 'assessing Phase 0 SQL safety',
+        referencedPullRequestUrl: 'https://github.com/supabase/cli/pull/6056',
+        referencedPrCandidates: ['https://github.com/supabase/cli/pull/6056'],
+      });
+      // Before arming, the poisoned value is still there — the heal is not a load-time rewrite.
+      expect(before).toBe('https://github.com/supabase/cli/pull/6056');
+      expect(after?.referencedPullRequestUrl).toBeUndefined();
+      // Evidence survives the heal — only the conclusion drawn from it was wrong.
+      expect(after?.referencedPrCandidates).toEqual(['https://github.com/supabase/cli/pull/6056']);
+    });
+
+    it('keeps a stored foreign URL the prompt corroborates', () => {
+      const { after } = reopenArmed({
+        task: 'om-auto-fix-pr https://github.com/open-mercato/open-mercato/pull/1977',
+        referencedPullRequestUrl: 'https://github.com/open-mercato/open-mercato/pull/1977',
+      });
+      expect(after?.referencedPullRequestUrl).toBe(
+        'https://github.com/open-mercato/open-mercato/pull/1977',
+      );
+    });
+
+    it("keeps a stored URL from the project's own repo", () => {
+      const { after } = reopenArmed({
+        task: 'task',
+        referencedPullRequestUrl: 'https://github.com/open-mercato/cezar/pull/407',
+      });
+      expect(after?.referencedPullRequestUrl).toBe('https://github.com/open-mercato/cezar/pull/407');
+    });
+
+    it('revokes an issueNumber this janitor seeded from the dropped URL', () => {
+      const { after } = reopenArmed({
+        task: 'assessing Phase 0 SQL safety',
+        referencedIssueUrl: 'https://github.com/supabase/cli/issues/6056',
+        issueNumber: 6056,
+        referencedIssueNumberSeeded: true,
+      });
+      expect(after?.referencedIssueUrl).toBeUndefined();
+      expect(after?.issueNumber).toBeUndefined();
+      expect(after?.referencedIssueNumberSeeded).toBeUndefined();
+    });
+
+    it('leaves an issueNumber it did NOT seed alone', () => {
+      // The prompt, the namer or a CEZ:ISSUE marker owns that number — dropping the foreign URL
+      // must not take it with them.
+      const { after } = reopenArmed({
+        task: 'fix issue 42',
+        referencedIssueUrl: 'https://github.com/supabase/cli/issues/6056',
+        issueNumber: 42,
+      });
+      expect(after?.referencedIssueUrl).toBeUndefined();
+      expect(after?.issueNumber).toBe(42);
+    });
+
+    it('a null handle heals nothing — there is nothing to prove foreign against', () => {
+      const { after } = reopenArmed(
+        {
+          task: 'assessing Phase 0 SQL safety',
+          referencedPullRequestUrl: 'https://github.com/supabase/cli/pull/6056',
+        },
+        null,
+      );
+      expect(after?.referencedPullRequestUrl).toBe('https://github.com/supabase/cli/pull/6056');
+    });
+
+    it('is one-directional — it never invents an association', () => {
+      // A record with candidates but no resolution stays unresolved: the sweep only ever clears.
+      const { after } = reopenArmed({
+        task: 'task',
+        referencedPullRequestUrl: undefined,
+        referencedPrCandidates: [
+          'https://github.com/open-mercato/cezar/pull/1',
+          'https://github.com/supabase/cli/pull/6056',
+        ],
+      });
+      expect(after?.referencedPullRequestUrl).toBeUndefined();
+    });
+
+    it('emits the corrected record so an open cockpit repaints', () => {
+      const seed = RunStore.open(dataDir);
+      const run = seed.createRun({
+        title: 't',
+        workflow: 'w',
+        task: 'assessing Phase 0 SQL safety',
+        steps: [],
+      });
+      seed.updateRun(run.id, {
+        referencedPullRequestUrl: 'https://github.com/supabase/cli/pull/6056',
+      });
+      const seen: string[] = [];
+      seed.on('run', (r: RunRecord) => seen.push(r.id));
+      seed.setRepoHandle(HANDLE);
+      expect(seen).toContain(run.id);
+    });
   });
 
   it('does not rescue a candidate today’s rule already calls ambiguous', () => {

--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -331,6 +331,48 @@ const CREATED_PR_RE =
  *  this many distinct PRs the conversation is a survey, not a subject. */
 const MAX_PR_CANDIDATES = 8;
 
+/** The repository a project IS, as `resolveRepoHandle` reports it. `null`/absent means "unknown",
+ *  which is a real and common state (no `gh`, no remote, a non-git root) — never an error. */
+export type RepoHandle = { owner: string; name: string };
+
+/** `https://github.com/open-mercato/cezar/pull/402` → `open-mercato/cezar`, lowercased.
+ *  Undefined for anything that is not a `<host>/<owner>/<repo>/<kind>/<n>` forge URL. */
+function refUrlRepo(url: string): string | undefined {
+  const parts = url.split('/');
+  const owner = parts[parts.length - 4];
+  const name = parts[parts.length - 3];
+  return owner && name ? `${owner}/${name}`.toLowerCase() : undefined;
+}
+
+/**
+ * May the referenced tier ADOPT this URL as the task's subject? (#945)
+ *
+ * The tier was text-scoped but never repo-scoped: `PR_URL_RE` matches any
+ * `github.com/<owner>/<repo>/pull/N`, so a research task that cites one upstream PR handed the
+ * resolver exactly one candidate and it became the task's identity — an `oko` task wearing
+ * `supabase/cli#6056`. Nothing compared the URL's repository with the project's own.
+ *
+ * A foreign URL is adoptable only when the TASK PROMPT corroborates it: the prompt names that
+ * `owner/repo`, which a pasted URL does inherently. That is the trust boundary this module already
+ * uses elsewhere — the prompt and the agent's own turn text are trusted, scraped tool output is
+ * not — and it is what keeps the legitimate cross-repo case working (#819:
+ * `om-auto-fix-pr https://github.com/open-mercato/open-mercato/pull/1977` started from cezar).
+ *
+ * Unknown handle → today's behavior exactly (`AGENTS.md` zero config: degrade, never fail). An
+ * unparseable URL is left alone for the same reason — the guard only ever removes an association
+ * it can PROVE is foreign.
+ *
+ * Note what this does not touch: `referenced*Candidates` keep recording every URL as evidence.
+ * The fix changes what is *promoted*, never what is *collected* (the #526 rule).
+ */
+function isRepoScopedRef(url: string, task: string, handle?: RepoHandle | null): boolean {
+  if (!handle) return true;
+  const repo = refUrlRepo(url);
+  if (!repo) return true;
+  if (repo === `${handle.owner}/${handle.name}`.toLowerCase()) return true;
+  return task.toLowerCase().includes(repo);
+}
+
 /**
  * Every scannable string of one persisted event: the v1 top-level fields plus
  * the protocol-v2 `item.*` content (nested — the reason v2 streams were
@@ -440,8 +482,27 @@ function eventAgentTextFragments(event: Record<string, unknown>): string[] {
  * the subject; among several, the one whose number the task prompt names (and
  * only when exactly one matches); otherwise ambiguous — no chip beats a wrong
  * chip.
+ *
+ * Whatever that produces is then repo-scoped (#945): a winner from another repository that the
+ * prompt does not corroborate is vetoed — see `isRepoScopedRef`. The veto is applied to the
+ * RESULT rather than to the candidate list on purpose, so the guard stays strictly subtractive:
+ * filtering first would let a project-local candidate win a two-candidate race today's rule calls
+ * ambiguous, which is a wider behavior change than the defect warrants. As written this function
+ * can only ever lose a value, never gain one.
  */
-function resolveReferencedRef(candidates: string[], task: string, declared?: number): string | undefined {
+function resolveReferencedRef(
+  candidates: string[],
+  task: string,
+  declared?: number,
+  handle?: RepoHandle | null,
+): string | undefined {
+  const resolved = resolveCandidate(candidates, task, declared);
+  if (resolved === undefined) return undefined;
+  return isRepoScopedRef(resolved, task, handle) ? resolved : undefined;
+}
+
+/** The pre-#945 resolution rule, unchanged — see `resolveReferencedRef` for the contract. */
+function resolveCandidate(candidates: string[], task: string, declared?: number): string | undefined {
   if (declared !== undefined) return candidates.find((url) => url.endsWith(`/${declared}`));
   if (candidates.length === 1) return candidates[0];
   const named = candidates.filter((url) => {
@@ -562,6 +623,13 @@ export function reconcileLoadedRun(run: RunRecord, opts?: { keepLive?: boolean }
       undefined,
     );
   }
+  // Deliberately UNSCOPED by repo (#945), unlike every other `resolveReferencedRef` call. Neither
+  // caller has a handle to pass: `RunStore.open` is synchronous and the handle costs a `gh` spawn
+  // (which is why it is armed afterwards, by `setRepoHandle`), and the read-only index reader
+  // (`./run-index.ts`) has no repo root at all. Passing `undefined` here is not a gap — it is the
+  // no-handle path the guard is specified to take. The foreign-URL heal runs in `setRepoHandle`'s
+  // sweep the moment the handle lands, and the index reader picks the healed values up from
+  // `runs.json` on its next read.
   return run;
 }
 
@@ -574,6 +642,10 @@ export function reconcileLoadedRun(run: RunRecord, opts?: { keepLive?: boolean }
 export class RunStore extends EventEmitter {
   private runs = new Map<string, RunRecord>();
   private saveTimer: NodeJS.Timeout | null = null;
+  /** The repository this project IS (#945), armed after `open()` by `setRepoHandle`. Undefined
+   *  until it arrives and `null` when it cannot be known — both mean "unscoped", which is
+   *  exactly the pre-#945 behavior. */
+  private repoHandle: RepoHandle | null | undefined;
 
   private constructor(private readonly dataDir: string) {
     super();
@@ -599,6 +671,19 @@ export class RunStore extends EventEmitter {
       }
     }
     return store;
+  }
+
+  /**
+   * Tell the store which repository this project IS (#945), so the referenced tier stops adopting
+   * another repo's PR/issue as the task's subject. See `isRepoScopedRef` for the rule.
+   *
+   * A setter rather than an `open()` option because `open()` is synchronous and the handle costs a
+   * `gh` spawn: callers arm this in the background so boot never waits on the network. `null` is a
+   * first-class answer meaning "cannot be known" (no `gh`, no remote, a non-git root) and leaves
+   * the store in exactly its pre-#945 behavior.
+   */
+  setRepoHandle(handle: RepoHandle | null): void {
+    this.repoHandle = handle;
   }
 
   listRuns(): RunRecord[] {
@@ -908,6 +993,7 @@ export class RunStore extends EventEmitter {
             run.referencedPrCandidates ?? [],
             run.task,
             referencedPrDeclaration(run),
+            this.repoHandle,
           );
           if (resolved !== run.referencedPullRequestUrl) {
             run.referencedPullRequestUrl = resolved;
@@ -950,6 +1036,7 @@ export class RunStore extends EventEmitter {
       run.referencedPrCandidates,
       run.task,
       referencedPrDeclaration(run),
+      this.repoHandle,
     );
     return true;
   }
@@ -979,6 +1066,7 @@ export class RunStore extends EventEmitter {
       run.referencedIssueCandidates ?? [],
       run.task,
       run.markerRefs?.issue,
+      this.repoHandle,
     );
     let numberChanged = false;
     if (run.markerRefs?.issue === undefined && ISSUE_URL_RE.test(seedHaystack)) {
@@ -1035,6 +1123,7 @@ export class RunStore extends EventEmitter {
         run.referencedPrCandidates ?? [],
         run.task,
         referencedPrDeclaration(run),
+        this.repoHandle,
       );
     }
     if (run.markerRefs.issue !== undefined) {
@@ -1042,6 +1131,7 @@ export class RunStore extends EventEmitter {
         run.referencedIssueCandidates ?? [],
         run.task,
         run.markerRefs.issue,
+        this.repoHandle,
       );
     }
     this.touch(run);

--- a/packages/cezar/src/runs/store.ts
+++ b/packages/cezar/src/runs/store.ts
@@ -681,9 +681,55 @@ export class RunStore extends EventEmitter {
    * `gh` spawn: callers arm this in the background so boot never waits on the network. `null` is a
    * first-class answer meaning "cannot be known" (no `gh`, no remote, a non-git root) and leaves
    * the store in exactly its pre-#945 behavior.
+   *
+   * Arming also HEALS records already poisoned by the un-scoped rule, on the `reconcileLoadedRun`
+   * precedent: the evidence is all still on the record (`referenced*Candidates`), only the
+   * conclusion drawn from it was wrong, so re-deciding beats asking for a migration. It rewrites
+   * values, never the format, and is one-directional by construction — see `rescopeRun`.
    */
   setRepoHandle(handle: RepoHandle | null): void {
     this.repoHandle = handle;
+    if (!handle) return; // nothing to prove foreign against
+    // `touch` per healed run: the cockpit is already live when the handle lands, so a corrected
+    // chip has to reach the open page over SSE, not just the next `runs.json` write.
+    for (const run of this.runs.values()) {
+      if (this.rescopeRun(run)) this.touch(run);
+    }
+  }
+
+  /**
+   * Drop this run's referenced PR/issue if the project's handle proves it foreign and the prompt
+   * does not corroborate it (#945). Returns whether anything changed.
+   *
+   * One-directional by construction: it only ever clears fields, so a record written by an older
+   * cezar — or read by one after this ran — is never worse off, and a downgrade sees a record whose
+   * format is untouched and whose cleared fields were already optional.
+   */
+  private rescopeRun(run: RunRecord): boolean {
+    let changed = false;
+    if (
+      run.referencedPullRequestUrl &&
+      !isRepoScopedRef(run.referencedPullRequestUrl, run.task, this.repoHandle)
+    ) {
+      run.referencedPullRequestUrl = undefined;
+      changed = true;
+    }
+    if (
+      run.referencedIssueUrl &&
+      !isRepoScopedRef(run.referencedIssueUrl, run.task, this.repoHandle)
+    ) {
+      run.referencedIssueUrl = undefined;
+      changed = true;
+      // Take back the number this janitor seeded from that very URL — the same revoke
+      // `trackReferencedIssues` performs when ambiguity clears a resolution. A `prNumber`-style
+      // number the prompt, namer or a marker owns is NOT ours to touch, which is exactly what
+      // `referencedIssueNumberSeeded` records.
+      if (run.referencedIssueNumberSeeded) {
+        run.issueNumber = undefined;
+        run.referencedIssueNumberSeeded = undefined;
+      }
+    }
+    return changed;
   }
 
   listRuns(): RunRecord[] {

--- a/packages/cezar/src/server/project-context.ts
+++ b/packages/cezar/src/server/project-context.ts
@@ -3,6 +3,7 @@ import { AutomationStore } from '../automations/store.ts';
 import { reconcileAutomationReceipts } from '../automations/task-template.ts';
 import { DEFAULT_WORKTREE_RETENTION, resolveWorktreeRetention } from '../config.ts';
 import { pruneOrphans } from '../git-worktree.ts';
+import { armRepoHandle } from '../runs/arm-repo-handle.ts';
 import { reclaimWorktrees } from '../runs/retention.ts';
 import { RunStore } from '../runs/store.ts';
 import { WorkspaceSemaphore } from '../workspace/semaphore.ts';
@@ -209,6 +210,10 @@ export class ProjectContexts {
     // keepLive + recover() (#367), same as serveCommand: runs that were live
     // when this project's context last existed are re-queued or resumed.
     const store = RunStore.open(dataDir, { keepLive: true });
+    // Which repository this project IS (#945), so the referenced tier stops adopting another
+    // repo's PR/issue as a task's subject. Fire-and-forget on purpose — it costs a `gh` spawn and
+    // building a context must not wait on the network. `project.root` is already realpath'd.
+    armRepoHandle(store, project.root);
     const automationStore = this.deps.automationStore?.(project.id, project.root)
       ?? AutomationStore.open(dataDir);
     reconcileAutomationReceipts(automationStore, store);

--- a/packages/cezar/src/server/project-context.ts
+++ b/packages/cezar/src/server/project-context.ts
@@ -210,10 +210,6 @@ export class ProjectContexts {
     // keepLive + recover() (#367), same as serveCommand: runs that were live
     // when this project's context last existed are re-queued or resumed.
     const store = RunStore.open(dataDir, { keepLive: true });
-    // Which repository this project IS (#945), so the referenced tier stops adopting another
-    // repo's PR/issue as a task's subject. Fire-and-forget on purpose — it costs a `gh` spawn and
-    // building a context must not wait on the network. `project.root` is already realpath'd.
-    armRepoHandle(store, project.root);
     const automationStore = this.deps.automationStore?.(project.id, project.root)
       ?? AutomationStore.open(dataDir);
     reconcileAutomationReceipts(automationStore, store);
@@ -234,6 +230,15 @@ export class ProjectContexts {
         await reclaimWorktrees(project.root, store, keep).catch(() => [] as string[]);
       }
       await manager.recover();
+      // Which repository this project IS (#945), so the referenced tier stops adopting another
+      // repo's PR/issue as a task's subject. Fire-and-forget on purpose — it costs a `gh` spawn
+      // and building a context must not wait on the network. `project.root` is already realpath'd.
+      //
+      // Armed only once the build has SUCCEEDED. Arming beside `RunStore.open` would outlive a
+      // failed build: the promise still resolves after `teardown` flushed the index and detached
+      // every listener, and a healed record would then `touch()` a store whose lifecycle had
+      // ended — scheduling a `runs.json` write from a context nobody owns any more.
+      armRepoHandle(store, project.root);
       return { id: project.id, root: project.root, dataDir, store, manager, automationStore, launchKey };
     } catch (err) {
       // A failed build must not leak the half-built context's subscriptions.

--- a/packages/web/src/lib/tasks-table.ts
+++ b/packages/web/src/lib/tasks-table.ts
@@ -226,6 +226,23 @@ export interface TaskReference {
  * reference has to arrive as a real field before it can be shown: the shape is ready for more,
  * the guesswork is not invited in.
  *
+ * Nor does it repo-check the `referenced*Url` fields it DOES read, and that is a decision, not an
+ * omission (#945). Those fields could name another repository — a task that cited one upstream PR
+ * used to adopt it outright — but the fix belongs at the record, in `store.ts`, for a reason this
+ * layer cannot work around: the legitimate cross-repo reference (#819) is told from the poisoned
+ * one by whether the TASK PROMPT names that repository, and `TaskReferenceInput` has no `task`.
+ * The slim runs-index row it is `Pick`ed from has none either, so mirroring the rule here would
+ * mean either widening `runIndexEntrySchema` for a signal the store already used, or dropping
+ * every foreign chip including the ones a user deliberately asked for. Both are worse than one
+ * authority. So the invariant this file relies on is: **a `referenced*Url` that reaches the
+ * display layer has already been repo-scoped**, and a foreign one only survives because the prompt
+ * corroborated it — in which case painting it is correct.
+ *
+ * That completes the rule this comment states in one piece. All three halves guard the same
+ * failure — a chip pointing at a repository the task never touched — at the three places it can
+ * enter: #526/#819/#854 stop a bare NUMBER being synthesized into a link (here, above), and #945
+ * stops a foreign discovered URL being adopted as the subject (in `store.ts`).
+ *
  * Deduped by kind+number, so one reference reached through two fields stays one chip.
  */
 export function taskReferences(run: TaskReferenceInput, repoBase?: string): TaskReference[] {


### PR DESCRIPTION
## Summary

A task in project *P* could adopt a pull request or issue belonging to a **completely different
repository** as its own reference chip. The reported case: an `oko` task, *"assessing Phase 0 SQL
safety"*, painted `#6056 ↗` linking to `https://github.com/supabase/cli/pull/6056` — a repo the
project has nothing to do with.

The referenced tier was text-scoped but never **repo-scoped**. `PR_URL_RE` matches any
`github.com/<owner>/<repo>/pull/N`, so the spec's rule *"exactly one distinct candidate → that
URL"* promoted it with no comparison against the project's own repository. A research task is
exactly that shape: it reads about migration safety, cites one upstream PR, and that single mention
becomes the task's identity.

Fixes #945

## What changed

**The rule** (`packages/cezar/src/runs/store.ts`). `resolveReferencedRef`'s winner is now vetoed
when its `owner/repo` is not the project's own *and* the task prompt does not corroborate it. The
prompt is the corroborating source because it is the trust boundary this module already uses —
and it is what keeps the legitimate cross-repo case working (#819:
`om-auto-fix-pr https://github.com/open-mercato/open-mercato/pull/1977` started from cezar).

Three properties, all load-bearing:

- **Strictly subtractive.** The veto is applied to the *result*, not the candidate list, so the
  function can only ever lose a value, never gain one. Filtering first would have let a local
  candidate win a two-candidate race today's rule calls ambiguous — a wider change than the defect
  warrants.
- **Promotion only, never collection.** `referenced*Candidates` keep recording every URL as
  evidence (the #526 rule). Only the conclusion drawn from them is scoped.
- **Degrade, never fail.** No `gh`, no remote, a non-git root, hosted mode → `resolveRepoHandle`
  answers `null` and behavior is exactly what it was before this PR.

**The plumbing.** `RunStore.setRepoHandle()` — a setter, not an `open()` option, because `open()`
is synchronous and the handle costs a `gh` spawn. Both `RunStore.open` call sites holding a repo
root arm it in the background through one shared helper (`arm-repo-handle.ts`), so boot never waits
on the network.

**The heal.** Arming also sweeps already-poisoned records, on the `reconcileLoadedRun` precedent:
the evidence is all still on the record, only the conclusion was wrong, so re-deciding beats asking
for a migration. One-directional by construction — it only ever clears — and a janitor-seeded
`issueNumber` is revoked with its URL while one the prompt, namer or marker owns is left alone.

**The docs.** Both referenced-detection specs gain the repo clause, citing the existing
`CREATED_PR_RE` amendment as the precedent — the same failure one tier down.

## Decision: the display layer does not mirror this

Recorded in the `taskReferences` doc comment (`packages/web/src/lib/tasks-table.ts`), the one place
the whole rule is stated together. It **cannot** mirror it: telling a corroborated cross-repo
reference from a poisoned one needs the task prompt, and `TaskReferenceInput` has no `task` — nor
does the slim runs-index row it is `Pick`ed from. Mirroring would mean either widening
`runIndexEntrySchema` for a signal the store already used, or dropping every foreign chip including
the ones a user deliberately asked for.

Consequence: **no `runIndexEntrySchema` change**, so no `BACKWARD_COMPATIBILITY.md` §1 enumeration
churn, and no HTTP route, CLI flag or event-schema change.

## Compatibility

- `runs.json` (§3): no new field, no format change. The heal rewrites *values* only, and only ever
  clears fields that were already optional — so an older cezar reading the same file is never worse
  off.
- No public surface moves. The one new export (`RepoHandle`) is a type.

## Testing

Full gate green: `npm run typecheck`, `npm test` (6214), `npm run test:unit` (36), `npm run build`,
`npm run test:package` (16).

18 new tests in `packages/cezar/src/runs/store.test.ts` covering the reported defect (PR and issue,
the issue case also asserting no `issueNumber` seed), the #819 cross-repo survivor, bare
`owner/repo` corroboration, the ordinary #407 path, case-insensitive handles, both no-handle paths,
the marker veto, the ambiguity non-rescue, and the whole heal sweep including its one-directionality
and its SSE repaint.

The three tests that prove the defect fail when the guard is reverted (verified). The rest are
over-reach guards — they are supposed to hold in both states.

Tracking plan: `.ai/runs/2026-09-01-issue-945-referenced-ref-repo-scope.md`

Status: complete
