### PR TITLE
fix(workflows): expand /skill in a fresh run's opening prompt (#278)

### DIFF
--- a/packages/cezar/src/workflows/run.test.ts
+++ b/packages/cezar/src/workflows/run.test.ts
@@ -2007,3 +2007,110 @@ describe('registry /skill expansion survives a continuation (#811)', () => {
     expect(echoed?.text).toContain('/compact please');
   }, 40_000);
 });
+
+/**
+ * #278 — registry `/skill` expansion on a FRESH run's OPENING prompt.
+ *
+ * A task STARTED with `/om-...` as its first message is delivered straight to
+ * `startSession` inside `execute`, never through `deliverMessage`, and #811 only
+ * patched the continuation seam. So the opening prompt leaked the raw slash to the
+ * backend, which answered "Unknown command" even though Cezar lists the skill.
+ *
+ * The mock CLI echoes the prompt it received (`Okay — looking into: …`), so the
+ * transcript is a faithful witness of what actually reached the backend.
+ */
+describe("registry /skill expansion on a fresh run's opening prompt (#278)", () => {
+  let repoRoot: string;
+  let store: RunStore;
+  let manager: RunManager;
+  let runId: string | undefined;
+  let savedDryRun: string | undefined;
+  const SINGLE_STEP: WorkflowDef = {
+    name: 'quick-task',
+    source: 'built-in',
+    steps: [{ id: 'task', name: 'Task', prompt: '{{task}}' }],
+  };
+
+  beforeEach(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-278-'));
+    savedDryRun = process.env.CEZ_DRY_RUN;
+    process.env.CEZ_DRY_RUN = '1';
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    mkdirSync(join(repoRoot, '.ai/cezar/skills'), { recursive: true });
+    writeFileSync(
+      join(repoRoot, '.ai/cezar/skills/demo-review.md'),
+      '---\nname: demo-review\ndescription: Review a diff.\n---\n\nRun the demo review playbook.\n',
+    );
+    store = RunStore.open(join(repoRoot, '.ai/cezar'));
+    manager = new RunManager(store, repoRoot);
+    runId = undefined;
+  });
+
+  afterEach(() => {
+    if (runId) manager.cancel(runId);
+    if (savedDryRun === undefined) delete process.env.CEZ_DRY_RUN;
+    else process.env.CEZ_DRY_RUN = savedDryRun;
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  // Tolerant of the pre-first-event window: the run's ndjson does not exist until
+  // the engine writes its first event, and this describe polls events directly
+  // (no store-status gate first), so a missing file is simply "no events yet".
+  const eventsOf = (id: string) => {
+    let raw: string;
+    try {
+      raw = readFileSync(join(repoRoot, '.ai/cezar/runs', `${id}.ndjson`), 'utf8').trim();
+    } catch {
+      return [] as { type: string; text?: string; stepId?: string }[];
+    }
+    if (!raw) return [] as { type: string; text?: string; stepId?: string }[];
+    return raw.split('\n').map((line) => JSON.parse(line) as { type: string; text?: string; stepId?: string });
+  };
+
+  const waitFor = async (predicate: () => boolean, ms = 20_000) => {
+    const deadline = Date.now() + ms;
+    while (!predicate()) {
+      if (Date.now() > deadline) throw new Error('condition not met in time');
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  };
+
+  it('expands the opening prompt before it reaches the backend', async () => {
+    const record = manager.startRun(SINGLE_STEP, {
+      task: '/demo-review look at the diff',
+      worktree: false,
+    });
+    runId = record.id;
+    await waitFor(() =>
+      eventsOf(record.id).some(
+        (e) => e.stepId === 'task' && e.type === 'text' && e.text?.includes('looking into'),
+      ),
+    );
+
+    const echoed = eventsOf(record.id).find(
+      (e) => e.stepId === 'task' && e.type === 'text' && e.text?.includes('looking into'),
+    );
+    // The backend saw the expanded skill prompt, NOT the bare slash command it would
+    // reject as an unknown command.
+    expect(echoed?.text).toContain('Selected skill: /demo-review');
+    expect(echoed?.text).not.toContain('/demo-review look at the diff');
+  }, 40_000);
+
+  it('leaves an unknown slash command untouched so backend-native commands still work', async () => {
+    const record = manager.startRun(SINGLE_STEP, { task: '/compact please', worktree: false });
+    runId = record.id;
+    await waitFor(() =>
+      eventsOf(record.id).some(
+        (e) => e.stepId === 'task' && e.type === 'text' && e.text?.includes('looking into'),
+      ),
+    );
+    const echoed = eventsOf(record.id).find(
+      (e) => e.stepId === 'task' && e.type === 'text' && e.text?.includes('looking into'),
+    );
+    expect(echoed?.text).toContain('/compact please');
+  }, 40_000);
+});

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -2836,6 +2836,14 @@ export class RunManager {
     }
 
     let userPrompt = applyTemplate(step.prompt ?? '{{task}}', input.task);
+    // A fresh run's OPENING prompt is delivered straight to `startSession`, never through
+    // `deliverMessage`, so — like the continuation seam above (#811) — it needs the same
+    // delivery-only `/skill` rewrite. Without it a task STARTED with `/om-...` as its first
+    // message leaks the raw slash to the backend, which answers "Unknown command" even though
+    // Cezar lists the skill (#278). `state.skills` was populated by `discoverSkills` earlier in
+    // `execute`. Expand before the chain/check/attachment prefixes so the leading slash still
+    // matches; a leading `/name` that is not a known skill passes through byte-for-byte.
+    userPrompt = expandRegistrySlashSkillText(userPrompt, state.skills ?? []);
     if (chainNote) userPrompt = `${chainNote}\n\n---\n\n${userPrompt}`;
     if (checkFailure) {
       userPrompt += `\n\nA verification command failed after the previous attempt. Fix the cause. Failing output:\n\n${checkFailure}`;


### PR DESCRIPTION
## Problem
Starting a **new** Cezar task whose first message is a `/skill` slash command that Cezar lists (e.g. `/om-auto-implement-spec …`) fails: the backend answers `Unknown command: /om-auto-implement-spec`. The skill is visible in the Skills list, so it looks like "the skill exists but can't be run".

Reported in a live CRM sandbox running `@open-mercato/cezar@0.9.2-nightly.20260814.2`; reproduced against `main` / `0.10.0` too.

## Root cause
Cezar expands a leading `/skill` into the skill's full prompt **before** it reaches the backend (`expandRegistrySlashSkillText`). Three delivery seams exist; only two applied the rewrite:

| Seam | Location | Expanded? |
|---|---|---|
| Live reply in an open session | `deliverMessage` (run.ts:1929) | yes |
| Continuation / resume opening prompt | run.ts:2422 (added by #811) | yes |
| **Fresh-run opening prompt** | `execute()` — `userPrompt = applyTemplate('{{task}}', input.task)` → `startSession` | **no** |

A brand-new task's opening message goes through `execute`, so the raw `/om-...` was handed to the backend verbatim. `#811` fixed the continuation seam but not this one.

The skill still appears in the Skills list because the catalog uses `discoverSkills()` (`server.ts`), a separate seam — so Cezar advertised a skill the fresh-run path couldn't run.

## Fix
Expand the opening prompt in `execute()` before the chain/check/attachment prefixes are prepended (so the leading slash still matches), mirroring the #811 continuation seam. `state.skills` is already populated by `discoverSkills` earlier in `execute`, and a leading `/name` that is not a known skill passes through byte-for-byte, so a backend's own slash commands keep working.

## Tests
Adds a `#278` describe to `run.test.ts` covering the fresh-run seam:
- a task started with `/demo-review …` reaches the backend as the **expanded** skill prompt (`Selected skill: /demo-review`), not the raw slash;
- an unknown slash (`/compact please`) passes through untouched.

Verified the first test **fails** without the one-line fix (backend echoes the raw `/demo-review …`) and passes with it. Full `run.test.ts` (90 tests) and `tsc --noEmit` are green.

Fixes open-mercato/mercato-sandboxes#278
