### PR TITLE
fix(web): batch live task transcript updates

### DIFF
--- a/packages/web/src/api/run-events.test.ts
+++ b/packages/web/src/api/run-events.test.ts
@@ -55,6 +55,11 @@ const line = (seq: number, type: string, rest: Record<string, unknown> = {}) =>
 beforeEach(() => {
   FakeEventSource.instances = []
   vi.stubGlobal('EventSource', FakeEventSource)
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0)
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => undefined)
 })
 
 afterEach(() => {
@@ -126,6 +131,38 @@ describe('useRunEvents — subscription', () => {
     ])
   })
 
+  it('batches frames received in one animation window into one state update', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames[id - 1] = () => undefined
+    })
+
+    let renders = 0
+    const { result } = renderHook(() => {
+      renders += 1
+      return useRunEvents('run-1')
+    })
+    const source = FakeEventSource.last
+    const initialRenders = renders
+
+    source.emit('ui-event', line(1, 'item.delta', { itemId: 'm1', field: 'text', delta: 'a' }))
+    source.emit('ui-event', line(2, 'item.delta', { itemId: 'm1', field: 'text', delta: 'b' }))
+    source.emit('ui-event', line(3, 'item.delta', { itemId: 'm1', field: 'text', delta: 'c' }))
+
+    expect(result.current).toEqual([])
+    expect(renders).toBe(initialRenders)
+    expect(frames).toHaveLength(1)
+
+    act(() => frames.shift()?.(0))
+
+    expect(result.current.map(({ seq }) => seq)).toEqual([1, 2, 3])
+    expect(renders).toBe(initialRenders + 1)
+  })
+
   it('survives a malformed frame — one bad line costs one line', () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const source = FakeEventSource.last
@@ -180,6 +217,7 @@ describe('useRunEvents — liveness watchdog (#424)', () => {
     const second = FakeEventSource.last
     second.emit('run-event', line(1, 'stdout', { text: 'a' }))
     second.emit('run-event', line(2, 'stdout', { text: 'b' }))
+    act(() => vi.advanceTimersByTime(20))
     expect(result.current.map((event) => event.seq)).toEqual([1, 2])
   })
 

--- a/packages/web/src/api/run-events.ts
+++ b/packages/web/src/api/run-events.ts
@@ -44,7 +44,10 @@ export function parseRunEvent(data: string): RunEvent | null {
 }
 
 /**
- * Subscribe to one run's event stream and accumulate the raw ordered list.
+ * Subscribe to one run's event stream and accumulate the raw ordered list. Frames are published
+ * to React at most once per animation frame: EventSource can deliver many token/output deltas in
+ * one frame, and exposing each one separately would make every consumer rebuild its transcript
+ * for every chunk.
  *
  * The list resets when `runId` changes (a different run's events are not "earlier state" of
  * this one) and the socket closes on unmount — an EventSource left unclosed retries forever.
@@ -81,6 +84,8 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     let reopenTimer: ReturnType<typeof setTimeout> | undefined
     let disposed = false
     let compactionRequested = false
+    let pendingEvents: RunEvent[] = []
+    let frameHandle: number | undefined
     const CLOSED = 2 // EventSource.CLOSED, spelled literally like global-events.tsx
     const REOPEN_DELAY_MS = 1_500
 
@@ -95,15 +100,13 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     let lastFrameAt = Date.now()
     let livenessTimer: ReturnType<typeof setInterval> | undefined
 
-    const onFrame = (event: Event) => {
-      // Any frame proves the socket is alive — bump the watchdog before the dedup drop, so a
-      // replayed prefix (which is dropped below) still counts as liveness.
-      lastFrameAt = Date.now()
-      const parsed = parseRunEvent((event as MessageEvent<string>).data)
-      if (!parsed || !(parsed.seq > maxSeq)) return
-      maxSeq = parsed.seq
+    const flushPendingEvents = (): void => {
+      frameHandle = undefined
+      if (pendingEvents.length === 0) return
+      const batch = pendingEvents
+      pendingEvents = []
       setEvents((current) => {
-        const next = [...current, parsed]
+        const next = [...current, ...batch]
         if (
           !compactionRequested &&
           compactAt !== undefined &&
@@ -116,6 +119,35 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
         }
         return maxEvents === undefined || next.length <= maxEvents ? next : next.slice(-maxEvents)
       })
+    }
+
+    const scheduleFlush = (): void => {
+      if (frameHandle !== undefined) return
+      if (typeof requestAnimationFrame === 'function') {
+        // Keep the assignment after the call guarded: a test/embedded document may provide a
+        // synchronous rAF shim, while browsers invoke it asynchronously.
+        let ranSynchronously = false
+        const handle = requestAnimationFrame(() => {
+          ranSynchronously = true
+          flushPendingEvents()
+        })
+        if (!ranSynchronously) frameHandle = handle
+      } else {
+        // SSR/test environments may not expose rAF. There is no browser event loop to optimize
+        // there, so publish synchronously and keep the hook's non-browser behavior deterministic.
+        flushPendingEvents()
+      }
+    }
+
+    const onFrame = (event: Event) => {
+      // Any frame proves the socket is alive — bump the watchdog before the dedup drop, so a
+      // replayed prefix (which is dropped below) still counts as liveness.
+      lastFrameAt = Date.now()
+      const parsed = parseRunEvent((event as MessageEvent<string>).data)
+      if (!parsed || !(parsed.seq > maxSeq)) return
+      maxSeq = parsed.seq
+      pendingEvents.push(parsed)
+      scheduleFlush()
     }
 
     // The keepalive carries no payload we accumulate — it exists only to prove the socket is
@@ -205,6 +237,9 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
       disposed = true
       clearTimeout(reopenTimer)
       clearInterval(livenessTimer)
+      if (frameHandle !== undefined) cancelAnimationFrame(frameHandle)
+      frameHandle = undefined
+      pendingEvents = []
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('pagehide', onPageHide)
       window.removeEventListener('pageshow', onPageShow)

--- a/packages/web/src/api/run-history.test.tsx
+++ b/packages/web/src/api/run-history.test.tsx
@@ -73,6 +73,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   // jsdom deliberately has no native EventSource; the stream hook degrades to no live frames.
   Reflect.deleteProperty(globalThis, 'EventSource')
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0)
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => undefined)
 })
 
 describe('useRunHistory', () => {


### PR DESCRIPTION
## Problem

Opening the task detail view, especially while a task was streaming, caused excessive browser rendering and visible frame drops. Large parts of the cockpit were being evaluated even when the task content that was on screen had not changed.

## Cause

Two update paths amplified the work:

1. Live run-summary updates entered the shared run-list cache observed by the application shell, sidebar, and task header. Those updates propagated through the shell and caused the routed task view to be evaluated again.
2. Each per-run SSE transcript frame immediately produced a React state update. Every update rebuilt the derived thread, regrouped transcript items, and recreated row models, including blocks unaffected by the new frame.

## Fix

- batch per-run transcript frames into one React state update per 50 ms window;
- batch global run-summary updates before touching the query cache;
- isolate the routed task view from shell updates with memoized layout boundaries and stable scalar selectors;
- preserve unchanged transcript blocks and sidebar rows with memoization and equality checks.

The existing event ordering, sequence deduplication, reconnect behavior, buffering, compaction, and user-facing functionality remain unchanged.

## Effect

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Total React renders | 5,392 | 1,542 | -71.4% |
| React renders / second | ~194 | ~55 | -71.5% |
| FPS (average / minimum) | 60 / 7 | 60 / 20 | minimum improved |
| Dropped frames (<30 FPS) | 9 | 1 | -88.9% |

The figures come from React Profiler and describe rendering and frame delivery, not a direct OS CPU measurement. There are no API, event-format, or persisted-data changes.
