### PR TITLE
fix(web): improve task detail rendering performance

### DIFF
--- a/packages/web/src/api/global-events.test.tsx
+++ b/packages/web/src/api/global-events.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createUsageStore, type UsageStore } from './events'
-import { GlobalEventsProvider, useGlobalEvents, useRunUsage, useUsage } from './global-events'
+import { GlobalEventsProvider, RUN_EVENT_BATCH_MS, useGlobalEvents, useRunUsage, useUsage } from './global-events'
 import { setApiScope } from '@open-mercato/cezar-api-client'
 import { createQueryClient } from './query-client'
 import { queryKeys, useProviderStatus, workspaceQueryKeys } from './queries'
@@ -116,6 +116,12 @@ const CONNECTED_PROVIDERS: ProviderStatusResponse = {
  *  stamp riding along, which the parser strips back off before the reducers see it. */
 function stampedRun(record: RunRecord, project = BOOT): string {
   return JSON.stringify({ ...record, project })
+}
+
+async function flushRunEvents(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, RUN_EVENT_BATCH_MS + 5))
+  })
 }
 
 let client: QueryClient
@@ -249,11 +255,12 @@ describe('useGlobalEvents — back/forward cache', () => {
 })
 
 describe('useGlobalEvents — run events', () => {
-  it('upserts a run into the list cache without refetching', () => {
+  it('upserts a run into the list cache without refetching', async () => {
     client.setQueryData<ApiRun[]>(queryKeys.runs.list(), [])
     const { source } = mount()
 
     source.emit('run', stampedRun(runRecord('r1', { status: 'queued' })))
+    await flushRunEvents()
 
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())).toEqual([
       runRecord('r1', { status: 'queued' }),
@@ -262,13 +269,14 @@ describe('useGlobalEvents — run events', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('updates in place on a second event for the same run — no duplicate row', () => {
+  it('updates in place on a second event for the same run — no duplicate row', async () => {
     client.setQueryData<ApiRun[]>(queryKeys.runs.list(), [])
     const { source } = mount()
 
     source.emit('run', stampedRun(runRecord('r1', { status: 'queued' })))
     source.emit('run', stampedRun(runRecord('r1', { status: 'running', tokensUsed: 42 })))
     source.emit('run', stampedRun(runRecord('r1', { status: 'done', tokensUsed: 99 })))
+    await flushRunEvents()
 
     const list = client.getQueryData<ApiRun[]>(queryKeys.runs.list())
     expect(list).toHaveLength(1)
@@ -276,12 +284,13 @@ describe('useGlobalEvents — run events', () => {
     expect(list?.[0]?.tokensUsed).toBe(99)
   })
 
-  it('patches a run detail cache that exists, and creates none that does not', () => {
+  it('patches a run detail cache that exists, and creates none that does not', async () => {
     client.setQueryData<ApiRun>(queryKeys.runs.detail('r1'), { ...runRecord('r1'), usage: SAMPLE })
     const { source } = mount()
 
     source.emit('run', stampedRun(runRecord('r1', { status: 'done' })))
     source.emit('run', stampedRun(runRecord('r2', { status: 'done' })))
+    await flushRunEvents()
 
     const detail = client.getQueryData<ApiRun>(queryKeys.runs.detail('r1'))
     expect(detail?.status).toBe('done')
@@ -291,7 +300,7 @@ describe('useGlobalEvents — run events', () => {
     expect(client.getQueryData(queryKeys.runs.detail('r2'))).toBeUndefined()
   })
 
-  it('invalidates the changes cache on a run event so an ended run’s final writes appear (#488)', () => {
+  it('invalidates the changes cache on a run event so an ended run’s final writes appear (#488)', async () => {
     // The Changes tab stops polling the moment a run leaves the active set, so without this the
     // last diff would wait for the next SSE reconnect. A cache the user opened must refresh.
     client.setQueryData(queryKeys.runs.changes('r1'), { files: [], stat: { adds: 0, dels: 0, files: 0 } })
@@ -299,6 +308,7 @@ describe('useGlobalEvents — run events', () => {
     const { source } = mount()
 
     source.emit('run', stampedRun(runRecord('r1', { status: 'done' })))
+    await flushRunEvents()
 
     expect(invalidate).toHaveBeenCalledWith({ queryKey: queryKeys.runs.changes('r1') })
   })
@@ -358,7 +368,7 @@ describe('useGlobalEvents — run events', () => {
     expect(indexRefreshes).toHaveLength(1)
   })
 
-  it('ignores a malformed frame and keeps serving the next one', () => {
+  it('ignores a malformed frame and keeps serving the next one', async () => {
     client.setQueryData<ApiRun[]>(queryKeys.runs.list(), [])
     const { source } = mount()
 
@@ -367,16 +377,18 @@ describe('useGlobalEvents — run events', () => {
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())).toEqual([])
 
     source.emit('run', stampedRun(runRecord('r1')))
+    await flushRunEvents()
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())).toHaveLength(1)
   })
 
-  it('drops a deleted run from the list and throws away its detail and diff caches', () => {
+  it('drops a deleted run from the list and throws away its detail and diff caches', async () => {
     client.setQueryData<ApiRun[]>(queryKeys.runs.list(), [runRecord('r1'), runRecord('r2')])
     client.setQueryData(queryKeys.runs.detail('r1'), runRecord('r1'))
     client.setQueryData(queryKeys.runs.diff('r1'), { files: [] })
     const { source } = mount()
 
     source.emit('run-deleted', JSON.stringify({ id: 'r1', project: BOOT }))
+    await flushRunEvents()
 
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.map((r) => r.id)).toEqual(['r2'])
     // Removed, not emptied: anything still mounted on them must go ask the server and get its 404.
@@ -674,7 +686,7 @@ describe('useGlobalEvents — project scoping (multi-project spec, step 3.1)', (
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())).toEqual([])
   })
 
-  it('drops stamped events until health has named the boot project, without crashing', () => {
+  it('drops stamped events until health has named the boot project, without crashing', async () => {
     client.removeQueries({ queryKey: queryKeys.health })
     client.setQueryData<ApiRun[]>(queryKeys.runs.list(), [])
     const { source } = mount()
@@ -686,10 +698,11 @@ describe('useGlobalEvents — project scoping (multi-project spec, step 3.1)', (
     // Health answered — from here on the boot project's events flow.
     client.setQueryData(queryKeys.health, { bootProject: BOOT })
     source.emit('run', stampedRun(runRecord('r1')))
+    await flushRunEvents()
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())).toHaveLength(1)
   })
 
-  it('applies the scoped project\'s events — and only those — once a scope is mounted', () => {
+  it('applies the scoped project\'s events — and only those — once a scope is mounted', async () => {
     setApiScope('other-project')
     // Scoped keys: this cache belongs to other-project (queries.ts leads every key with the scope).
     client.setQueryData<ApiRun[]>(queryKeys.runs.list(), [])
@@ -700,6 +713,7 @@ describe('useGlobalEvents — project scoping (multi-project spec, step 3.1)', (
 
     source.emit('run', stampedRun(runRecord('theirs'), 'other-project'))
     source.emit('usage', JSON.stringify({ project: 'other-project', usage: { theirs: SAMPLE } }))
+    await flushRunEvents()
 
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.map((r) => r.id)).toEqual(['theirs'])
     expect(usage.get()).toEqual({ theirs: SAMPLE })

--- a/packages/web/src/api/global-events.test.tsx
+++ b/packages/web/src/api/global-events.test.tsx
@@ -4,10 +4,11 @@ import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createUsageStore, type UsageStore } from './events'
-import { GlobalEventsProvider, RUN_EVENT_BATCH_MS, useGlobalEvents, useRunUsage, useUsage } from './global-events'
+import { GlobalEventsProvider, useGlobalEvents, useRunUsage, useUsage } from './global-events'
 import { setApiScope } from '@open-mercato/cezar-api-client'
 import { createQueryClient } from './query-client'
-import { queryKeys, useProviderStatus, workspaceQueryKeys } from './queries'
+import { queryKeys, useProviderStatus, useRuns, useTodos, workspaceQueryKeys } from './queries'
+import { RUN_EVENT_BATCH_MS } from './run-events'
 import type { ApiRun, ProviderStatusResponse, RunRecord } from '@open-mercato/cezar-api-client'
 
 /**
@@ -718,6 +719,75 @@ describe('useGlobalEvents — project scoping (multi-project spec, step 3.1)', (
     expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.map((r) => r.id)).toEqual(['theirs'])
     expect(usage.get()).toEqual({ theirs: SAMPLE })
   })
+
+  it('drops a queued event when the active project changes before the batch flushes', async () => {
+    vi.useFakeTimers()
+    setApiScope('project-a')
+    const projectAKey = queryKeys.runs.list()
+    client.setQueryData<ApiRun[]>(projectAKey, [])
+    const { source } = mount()
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+
+    source.emit('run', stampedRun(runRecord('r1'), 'project-a'))
+    setApiScope('project-b')
+    const projectBKey = queryKeys.runs.list()
+    client.setQueryData<ApiRun[]>(projectBKey, [])
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_EVENT_BATCH_MS)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(450)
+    })
+
+    expect(client.getQueryData<ApiRun[]>(projectAKey)).toEqual([])
+    expect(client.getQueryData<ApiRun[]>(projectBKey)).toEqual([])
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ['project-a', 'runs'],
+      refetchType: 'none',
+    })
+  })
+
+  it('marks an inactive project cache stale without applying its event to the active scope', async () => {
+    setApiScope('project-b')
+    const projectAKey = ['project-a', 'runs', 'list'] as const
+    client.setQueryData<ApiRun[]>(projectAKey, [runRecord('r1')])
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    const { source } = mount()
+
+    source.emit('run', stampedRun(runRecord('r1', { status: 'done' }), 'project-a'))
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 450))
+    })
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['project-a', 'runs'], refetchType: 'none' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['project-a', 'todos'], refetchType: 'none' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['project-a', 'worktrees'], refetchType: 'none' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['run-history', 'project-a'], refetchType: 'none' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['run-history-context', 'project-a'], refetchType: 'none' })
+    expect(client.getQueryData<ApiRun[]>(projectAKey)?.[0]?.status).toBe('running')
+    expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())).toBeUndefined()
+  })
+
+  it('refetches an inactive cache if that project becomes active before the debounce flushes', async () => {
+    vi.useFakeTimers()
+    setApiScope('project-b')
+    client.setQueryData<ApiRun[]>(['project-a', 'runs', 'list'], [runRecord('r1')])
+    const invalidate = vi.spyOn(client, 'invalidateQueries')
+    const { source } = mount()
+
+    source.emit('run', stampedRun(runRecord('r1', { status: 'done' }), 'project-a'))
+    setApiScope('project-a')
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(450)
+    })
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ['project-a', 'runs'],
+      refetchType: 'active',
+    })
+  })
 })
 
 describe('useGlobalEvents — reconcile doctrine', () => {
@@ -745,7 +815,7 @@ describe('useGlobalEvents — reconcile doctrine', () => {
     source.drop()
     source.open()
 
-    expect(invalidatedKeys(invalidate)).toEqual([
+    expect(invalidatedKeys(invalidate)).toEqual(expect.arrayContaining([
       queryKeys.runs.all, // covers the list and every detail under it
       // The cross-project index behind the global Tasks page. Nothing else here covers it: the
       // scoped caches hold one project, and this spans the workspace.
@@ -754,7 +824,111 @@ describe('useGlobalEvents — reconcile doctrine', () => {
       queryKeys.health, // the repo/branch chip — health is not on the stream (#369)
       queryKeys.worktrees, // the Resources panel's list/total (#483)
       workspaceQueryKeys.providerStatus,
-    ])
+      ['run-history', 'default'],
+      ['run-history-context', 'default'],
+    ]))
+  })
+
+  it('marks cached inactive project and transcript queries stale on reconnect', async () => {
+    setApiScope('project-b')
+    const projectAListKey = ['project-a', 'runs', 'list'] as const
+    const projectAHistoryKey = ['run-history', 'project-a', 'run-1'] as const
+    client.setQueryData(projectAListKey, [])
+    client.setQueryData(projectAHistoryKey, { pages: [], pageParams: [] })
+    const { source } = mount()
+    source.open()
+    source.drop()
+    source.open()
+
+    await waitFor(() => {
+      expect(client.getQueryState(projectAListKey)?.isInvalidated).toBe(true)
+      expect(client.getQueryState(projectAHistoryKey)?.isInvalidated).toBe(true)
+    })
+  })
+
+  it('flushes the queued run batch before reconnect reconciliation', async () => {
+    const initial = deferredResponse()
+    const reconciled = deferredResponse()
+    vi.mocked(fetch).mockReturnValueOnce(initial.promise).mockReturnValueOnce(reconciled.promise)
+
+    function RunsProbe() {
+      useRuns()
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <GlobalEventsProvider>
+          <RunsProbe />
+        </GlobalEventsProvider>
+      </QueryClientProvider>,
+    )
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+    const source = FakeEventSource.last
+    source.open()
+    await act(async () => initial.resolve(json([runRecord('r1', { status: 'queued' })])))
+    await waitFor(() => expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.[0]?.status).toBe('queued'))
+
+    source.emit('run', stampedRun(runRecord('r1', { status: 'running' })))
+    source.drop()
+    source.open()
+    expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.[0]?.status).toBe('running')
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+
+    // This event arrives after the authoritative request starts but before its older response
+    // resolves. The batcher must hold it until the response has been applied.
+    source.emit('run', stampedRun(runRecord('r1', { status: 'done' })))
+    await act(async () => reconciled.resolve(json([runRecord('r1', { status: 'running' })])))
+    await waitFor(() => expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.[0]?.status).toBe('done'))
+    await new Promise((resolve) => setTimeout(resolve, RUN_EVENT_BATCH_MS + 10))
+    expect(client.getQueryData<ApiRun[]>(queryKeys.runs.list())?.[0]?.status).toBe('done')
+  })
+
+  it('does not apply a queued todo snapshot over the authoritative reconcile response', async () => {
+    const initial = deferredResponse()
+    const reconciled = deferredResponse()
+    const afterEvent = deferredResponse()
+    vi.mocked(fetch)
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reconciled.promise)
+      .mockReturnValueOnce(afterEvent.promise)
+
+    function TodosProbe() {
+      useTodos()
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <GlobalEventsProvider>
+          <TodosProbe />
+        </GlobalEventsProvider>
+      </QueryClientProvider>,
+    )
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+    const source = FakeEventSource.last
+    source.open()
+    await act(async () => initial.resolve(json([{ id: 'todo-b', summary: 'authoritative' }])) )
+    await waitFor(() => expect(client.getQueryData(queryKeys.todos)).toEqual([
+      { id: 'todo-b', summary: 'authoritative' },
+    ]))
+
+    source.drop()
+    source.open()
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+    source.emit('todos', JSON.stringify({
+      project: BOOT,
+      items: [{ id: 'todo-a', summary: 'stale stream snapshot' }],
+    }))
+    await act(async () => reconciled.resolve(json([{ id: 'todo-b', summary: 'authoritative' }])) )
+    await waitFor(() => expect(client.getQueryData(queryKeys.todos)).toEqual([
+      { id: 'todo-b', summary: 'authoritative' },
+    ]))
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3))
+    await act(async () => afterEvent.resolve(json([{ id: 'todo-b', summary: 'authoritative' }])) )
+    await waitFor(() => expect(client.getQueryData(queryKeys.todos)).toEqual([
+      { id: 'todo-b', summary: 'authoritative' },
+    ]))
   })
 
   it('refetches when a hidden tab comes back', () => {
@@ -768,7 +942,7 @@ describe('useGlobalEvents — reconcile doctrine', () => {
     // A phone that slept: the tab was frozen, no error handler ever ran, and the stream may have
     // been dead for an hour. What is on screen is about to be read as true.
     setVisibility('visible')
-    expect(invalidatedKeys(invalidate)).toEqual([
+    expect(invalidatedKeys(invalidate)).toEqual(expect.arrayContaining([
       queryKeys.runs.all,
       // The cross-project index behind the global Tasks page — nothing else here covers it.
       workspaceQueryKeys.runsIndex,
@@ -776,7 +950,9 @@ describe('useGlobalEvents — reconcile doctrine', () => {
       queryKeys.health,
       queryKeys.worktrees,
       workspaceQueryKeys.providerStatus,
-    ])
+      ['run-history', 'default'],
+      ['run-history-context', 'default'],
+    ]))
   })
 
   it('stops listening for visibility once unmounted', () => {

--- a/packages/web/src/api/global-events.tsx
+++ b/packages/web/src/api/global-events.tsx
@@ -108,6 +108,9 @@ export function onWorkspaceEvent(
  */
 const RUNS_INDEX_REFRESH_DEBOUNCE_MS = 400
 
+/** A live run can touch its summary several times while one transcript batch is arriving. */
+export const RUN_EVENT_BATCH_MS = 50
+
 /** Built per mount, not module-level: a pending timer holds the `queryClient` it will write to,
  *  and one that outlives its provider would invalidate a cache nobody is reading. `cancel` runs
  *  in the effect cleanup. */
@@ -128,6 +131,41 @@ function createRunsIndexRefresher(queryClient: QueryClient): {
     cancel() {
       clearTimeout(pending)
       pending = undefined
+    },
+  }
+}
+
+/**
+ * Coalesce global run summaries before touching the query cache. The sidebar needs live status,
+ * but it does not need one React notification per token/usage update.
+ */
+function createRunEventBatcher(queryClient: QueryClient, usage: UsageStore): {
+  onEvent: (event: Extract<GlobalEvent, { type: 'run' | 'run-deleted' }>) => void
+  cancel: () => void
+} {
+  let pending = new Map<string, Extract<GlobalEvent, { type: 'run' | 'run-deleted' }>>()
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const flush = (): void => {
+    timer = undefined
+    const events = [...pending.values()]
+    pending = new Map()
+    for (const event of events) applyGlobalEvent(queryClient, usage, event)
+  }
+
+  const schedule = (): void => {
+    if (timer === undefined) timer = setTimeout(flush, RUN_EVENT_BATCH_MS)
+  }
+
+  return {
+    onEvent(event) {
+      pending.set(event.type === 'run' ? event.run.id : event.id, event)
+      schedule()
+    },
+    cancel() {
+      clearTimeout(timer)
+      timer = undefined
+      pending.clear()
     },
   }
 }
@@ -245,6 +283,7 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
 
     let source: EventSource | null = null
     const runsIndexRefresher = createRunsIndexRefresher(queryClient)
+    const runEventBatcher = createRunEventBatcher(queryClient, usage)
     let reopenTimer: ReturnType<typeof setTimeout> | undefined
     let everOpened = false
     let disposed = false
@@ -304,7 +343,11 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
           // project's data only, and the reconcile-on-switch (3.2's provider swap) refetches
           // the rest. `ping` (project null) always passes — liveness is not project-owned.
           if (parsed.project !== null && parsed.project !== activeProject(queryClient)) return
-          applyGlobalEvent(queryClient, usage, parsed.event)
+          if (parsed.event.type === 'run' || parsed.event.type === 'run-deleted') {
+            runEventBatcher.onEvent(parsed.event)
+          } else {
+            applyGlobalEvent(queryClient, usage, parsed.event)
+          }
         })
       }
 
@@ -404,6 +447,7 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
       disposed = true
       clearTimeout(reopenTimer)
       runsIndexRefresher.cancel()
+      runEventBatcher.cancel()
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('pagehide', onPageHide)
       window.removeEventListener('pageshow', onPageShow)

--- a/packages/web/src/api/global-events.tsx
+++ b/packages/web/src/api/global-events.tsx
@@ -199,6 +199,7 @@ function createInactiveProjectRefresher(queryClient: QueryClient): {
   let scopes = new Set<string>()
   return {
     onEvent(project) {
+      if (pending !== undefined && scopes.has(project)) return
       for (const scope of projectCacheScopes(queryClient, project)) scopes.add(scope)
       if (pending !== undefined) return
       pending = setTimeout(() => {

--- a/packages/web/src/api/global-events.tsx
+++ b/packages/web/src/api/global-events.tsx
@@ -1,7 +1,11 @@
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { createContext, useContext, useEffect, useState, useSyncExternalStore, type ReactNode } from 'react'
 
-import { applyProviderStatusRow, parseProviderStatusEventRow } from '@/lib/provider-status'
+import {
+  applyProviderStatusRow,
+  parseProviderStatusEventRow,
+  type ProviderStatusEventRow,
+} from '@/lib/provider-status'
 import {
   applyRunDeleted,
   applyRunEvent,
@@ -12,8 +16,9 @@ import {
   type GlobalEvent,
   type UsageStore,
 } from './events'
-import { apiPath, getApiScope } from '@open-mercato/cezar-api-client'
+import { apiPath, getApiScope, queryScope } from '@open-mercato/cezar-api-client'
 import { queryKeys, useHealthSubscription, workspaceQueryKeys } from './queries'
+import { RUN_EVENT_BATCH_MS } from './run-events'
 import type {
   ApiRun,
   HealthResponse,
@@ -107,9 +112,7 @@ export function onWorkspaceEvent(
  * busy minute would be a refetch per event. One request per quiet moment is the whole point.
  */
 const RUNS_INDEX_REFRESH_DEBOUNCE_MS = 400
-
-/** A live run can touch its summary several times while one transcript batch is arriving. */
-export const RUN_EVENT_BATCH_MS = 50
+const RECONCILE_TIMEOUT_MS = 15_000
 
 /** Built per mount, not module-level: a pending timer holds the `queryClient` it will write to,
  *  and one that outlives its provider would invalidate a cache nobody is reading. `cancel` runs
@@ -135,22 +138,126 @@ function createRunsIndexRefresher(queryClient: QueryClient): {
   }
 }
 
+function projectCacheScopes(queryClient: QueryClient, project: string): string[] {
+  let bootProject: string | undefined
+  for (const query of queryClient.getQueryCache().getAll()) {
+    if (query.queryKey[1] !== 'health') continue
+    const candidate = (query.state.data as HealthResponse | undefined)?.bootProject
+    if (typeof candidate === 'string') {
+      bootProject = candidate
+      break
+    }
+  }
+  const scopes = new Set([project])
+  if (bootProject === project) scopes.add('default')
+  return [...scopes]
+}
+
+function historyQueryKeys(scope: string): readonly (readonly unknown[])[] {
+  return [
+    ['run-history', scope],
+    ['run-history-context', scope],
+    ['run-history-tail', scope],
+  ]
+}
+
+function eventQueryKeys(scope: string): readonly (readonly unknown[])[] {
+  return [
+    [scope, 'runs'],
+    [scope, 'todos'],
+    [scope, 'worktrees'],
+    ...historyQueryKeys(scope),
+  ]
+}
+
+/** Extract the scope from a cached project key, including the two transcript keys that have a
+ *  semantic prefix before their scope. Workspace keys are deliberately excluded. */
+function projectQueryScope(queryKey: readonly unknown[]): string | undefined {
+  if (queryKey[0] === 'workspace') return undefined
+  if (
+    queryKey[0] === 'run-history'
+    || queryKey[0] === 'run-history-context'
+    || queryKey[0] === 'run-history-tail'
+  ) {
+    return typeof queryKey[1] === 'string' ? queryKey[1] : undefined
+  }
+  return typeof queryKey[0] === 'string' ? queryKey[0] : undefined
+}
+
+function cachedProjectScopes(queryClient: QueryClient): string[] {
+  return [...new Set(queryClient.getQueryCache().getAll()
+    .map(({ queryKey }) => projectQueryScope(queryKey))
+    .filter((scope): scope is string => scope !== undefined))]
+}
+
+/** Mark inactive project caches stale in one quiet batch; never patch them with another scope's data. */
+function createInactiveProjectRefresher(queryClient: QueryClient): {
+  onEvent: (project: string) => void
+  cancel: () => void
+} {
+  let pending: ReturnType<typeof setTimeout> | undefined
+  let scopes = new Set<string>()
+  return {
+    onEvent(project) {
+      for (const scope of projectCacheScopes(queryClient, project)) scopes.add(scope)
+      if (pending !== undefined) return
+      pending = setTimeout(() => {
+        pending = undefined
+        const queued = scopes
+        scopes = new Set()
+        const activeScope = queryScope()
+        for (const scope of queued) {
+          for (const queryKey of eventQueryKeys(scope)) {
+            void queryClient.invalidateQueries({
+              queryKey,
+              refetchType: scope === activeScope ? 'active' : 'none',
+            })
+          }
+        }
+      }, RUNS_INDEX_REFRESH_DEBOUNCE_MS)
+    },
+    cancel() {
+      clearTimeout(pending)
+      pending = undefined
+      scopes.clear()
+    },
+  }
+}
+
 /**
  * Coalesce global run summaries before touching the query cache. The sidebar needs live status,
  * but it does not need one React notification per token/usage update.
  */
-function createRunEventBatcher(queryClient: QueryClient, usage: UsageStore): {
-  onEvent: (event: Extract<GlobalEvent, { type: 'run' | 'run-deleted' }>) => void
+function createRunEventBatcher(
+  queryClient: QueryClient,
+  usage: UsageStore,
+  onDroppedProject: (project: string) => void,
+): {
+  onEvent: (event: Extract<GlobalEvent, { type: 'run' | 'run-deleted' }>, project: string) => void
+  beginReconcile: () => void
+  endReconcile: () => void
   cancel: () => void
 } {
-  let pending = new Map<string, Extract<GlobalEvent, { type: 'run' | 'run-deleted' }>>()
+  let pending = new Map<string, {
+    event: Extract<GlobalEvent, { type: 'run' | 'run-deleted' }>
+    project: string
+  }>()
   let timer: ReturnType<typeof setTimeout> | undefined
+  let reconciliationDepth = 0
 
   const flush = (): void => {
+    clearTimeout(timer)
     timer = undefined
-    const events = [...pending.values()]
+    if (reconciliationDepth > 0) return
+    const project = activeProject(queryClient)
+    const events = pending
     pending = new Map()
-    for (const event of events) applyGlobalEvent(queryClient, usage, event)
+    for (const queued of events.values()) {
+      // The route can change while the 50 ms window is open. Never resolve the cache keys from
+      // the new scope for an event that arrived under the old one.
+      if (queued.project === project) applyGlobalEvent(queryClient, usage, queued.event)
+      else onDroppedProject(queued.project)
+    }
   }
 
   const schedule = (): void => {
@@ -158,14 +265,27 @@ function createRunEventBatcher(queryClient: QueryClient, usage: UsageStore): {
   }
 
   return {
-    onEvent(event) {
-      pending.set(event.type === 'run' ? event.run.id : event.id, event)
+    onEvent(event, project) {
+      const id = event.type === 'run' ? event.run.id : event.id
+      pending.set(`${project}:${id}`, { event, project })
       schedule()
+    },
+    beginReconcile() {
+      // Flush the pre-reconcile snapshot, then hold later live events until the authoritative
+      // invalidations finish. Otherwise an older response can overwrite a newer queued event.
+      flush()
+      reconciliationDepth += 1
+    },
+    endReconcile() {
+      if (reconciliationDepth === 0) return
+      reconciliationDepth -= 1
+      if (reconciliationDepth === 0) flush()
     },
     cancel() {
       clearTimeout(timer)
       timer = undefined
       pending.clear()
+      reconciliationDepth = 0
     },
   }
 }
@@ -189,16 +309,46 @@ function createRunEventBatcher(queryClient: QueryClient, usage: UsageStore): {
  * the rest stale for whenever it next mounts. A background tab with fifty cached runs should not
  * fetch fifty runs to come back.
  */
-function reconcile(queryClient: QueryClient): void {
-  void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
-  // Events happened while we were disconnected, and the index is cross-project — nothing else
-  // here covers it.
-  void queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.runsIndex })
-  void queryClient.invalidateQueries({ queryKey: queryKeys.todos })
-  void queryClient.invalidateQueries({ queryKey: queryKeys.health })
-  // The worktree panel's list/total (#483) — a run finishing or a reclaim changes it.
-  void queryClient.invalidateQueries({ queryKey: queryKeys.worktrees })
-  void queryClient.invalidateQueries({ queryKey: workspaceQueryKeys.providerStatus })
+async function reconcile(queryClient: QueryClient): Promise<void> {
+  const activeScope = queryScope()
+  const keys = [
+    queryKeys.runs.all,
+    // Events happened while we were disconnected, and the index is cross-project — nothing else
+    // here covers it.
+    workspaceQueryKeys.runsIndex,
+    queryKeys.todos,
+    queryKeys.health,
+    // The worktree panel's list/total (#483) — a run finishing or a reclaim changes it.
+    queryKeys.worktrees,
+    workspaceQueryKeys.providerStatus,
+    ['run-history', activeScope] as const,
+    ['run-history-context', activeScope] as const,
+  ] as const
+  const invalidations = Promise.allSettled(
+    [
+      ...cachedProjectScopes(queryClient)
+        .filter((scope) => scope !== activeScope)
+        .flatMap((scope) => eventQueryKeys(scope).map((queryKey) =>
+          queryClient.invalidateQueries({ queryKey, refetchType: 'none' }))),
+      ...keys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+    ],
+  )
+  let completed = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      invalidations.then(() => { completed = true }),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, RECONCILE_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
+  if (completed) return
+  // A broken request must not hold the live-event queue forever. Cancelling marks the queries
+  // stale without allowing a late fetch result to win over the events released below.
+  await Promise.allSettled(keys.map((queryKey) => queryClient.cancelQueries({ queryKey })))
 }
 
 /**
@@ -283,12 +433,20 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
 
     let source: EventSource | null = null
     const runsIndexRefresher = createRunsIndexRefresher(queryClient)
-    const runEventBatcher = createRunEventBatcher(queryClient, usage)
+    const inactiveProjectRefresher = createInactiveProjectRefresher(queryClient)
+    const runEventBatcher = createRunEventBatcher(
+      queryClient,
+      usage,
+      inactiveProjectRefresher.onEvent,
+    )
     let reopenTimer: ReturnType<typeof setTimeout> | undefined
     let everOpened = false
     let disposed = false
     let providerStatusRefetching = false
     let providerStatusDirty = false
+    let reconciliationDepth = 0
+    let pendingTodos = new Set<string>()
+    let pendingProviderRows: ProviderStatusEventRow[] = []
 
     const refetchUncachedProviderStatus = (): void => {
       providerStatusRefetching = true
@@ -307,6 +465,59 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
         })
     }
 
+    const applyProviderStatusEvent = (row: ProviderStatusEventRow): void => {
+      const key = workspaceQueryKeys.providerStatus
+      const response = queryClient.getQueryData<ProviderStatusResponse>(key)
+      const updated = applyProviderStatusRow(response, row)
+      if (updated !== undefined) {
+        queryClient.setQueryData(key, updated)
+        return
+      }
+      // An additive row cannot safely seed the complete provider cache. Discard an old
+      // initial fetch and replace it after the server emitted this latch. Further valid rows
+      // while that replacement is in flight coalesce into one trailing fetch.
+      if (providerStatusRefetching) {
+        providerStatusDirty = true
+        return
+      }
+      refetchUncachedProviderStatus()
+    }
+
+    const reconcileNow = (): void => {
+      reconciliationDepth += 1
+      runEventBatcher.beginReconcile()
+      void reconcile(queryClient).finally(() => {
+        reconciliationDepth -= 1
+        if (reconciliationDepth === 0) {
+          if (disposed) {
+            pendingTodos.clear()
+            pendingProviderRows = []
+          } else {
+            flushDeferredEvents()
+          }
+        }
+        runEventBatcher.endReconcile()
+      })
+    }
+
+    const flushDeferredEvents = (): void => {
+      const todosQueued = pendingTodos
+      const providerRows = pendingProviderRows
+      pendingTodos = new Set()
+      pendingProviderRows = []
+      // The payload has no version. The reconnect's REST response is authoritative; refetch once
+      // more instead of allowing an older queued snapshot to overwrite it.
+      const active = activeProject(queryClient)
+      for (const project of todosQueued) {
+        if (project === active) {
+          void queryClient.invalidateQueries({ queryKey: queryKeys.todos })
+        } else {
+          inactiveProjectRefresher.onEvent(project)
+        }
+      }
+      for (const row of providerRows) applyProviderStatusEvent(row)
+    }
+
     const reopenLater = (): void => {
       if (disposed || reopenTimer !== undefined) return
       reopenTimer = setTimeout(() => {
@@ -319,18 +530,21 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
       source?.close()
       // Remote cockpits commonly sit behind HTTP Basic Auth. EventSource supports an explicit
       // credentials mode (unlike WebSocket), so keep every automatic reconnect authenticated.
-      source = new Source(url, { withCredentials: true })
+      const current = new Source(url, { withCredentials: true })
+      source = current
 
-      source.addEventListener('open', () => {
+      current.addEventListener('open', () => {
+        if (disposed || source !== current) return
         // Not the first one: at boot the queries are fetching anyway, and invalidating them here
         // would only ask the same questions twice. Every later open is a *re*connect — we were
         // disconnected, events happened without us, and the cache is now a guess.
-        if (everOpened) reconcile(queryClient)
+        if (everOpened) reconcileNow()
         everOpened = true
       })
 
       for (const name of EVENT_NAMES) {
-        source.addEventListener(name, (event) => {
+        current.addEventListener(name, (event) => {
+          if (disposed || source !== current) return
           const parsed = parseWorkspaceEvent(name, (event as MessageEvent<string>).data)
           if (!parsed) return
           // The cross-project index first, and BEFORE the scope filter below — it is the one
@@ -339,12 +553,17 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
           // the namer had rewritten stayed stale until the next tick, and the tick does not run
           // in a background tab, so coming back to one showed yesterday's rows until a reload.
           runsIndexRefresher.onEvent(parsed.event)
-          // Another project's news patches nothing SCOPED: this scope's caches hold this
-          // project's data only, and the reconcile-on-switch (3.2's provider swap) refetches
-          // the rest. `ping` (project null) always passes — liveness is not project-owned.
-          if (parsed.project !== null && parsed.project !== activeProject(queryClient)) return
+          // Another project's news never patches the active scope. Its own cache is marked stale
+          // in a debounced batch so a later project switch refetches truth without cross-project
+          // bleed. `ping` (project null) always passes — liveness is not project-owned.
+          if (parsed.project !== null && parsed.project !== activeProject(queryClient)) {
+            inactiveProjectRefresher.onEvent(parsed.project)
+            return
+          }
           if (parsed.event.type === 'run' || parsed.event.type === 'run-deleted') {
-            runEventBatcher.onEvent(parsed.event)
+            if (parsed.project !== null) runEventBatcher.onEvent(parsed.event, parsed.project)
+          } else if (parsed.event.type === 'todos' && reconciliationDepth > 0) {
+            if (parsed.project !== null) pendingTodos.add(parsed.project)
           } else {
             applyGlobalEvent(queryClient, usage, parsed.event)
           }
@@ -352,7 +571,8 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
       }
 
       for (const name of WORKSPACE_EVENT_NAMES) {
-        source.addEventListener(name, (event) => {
+        current.addEventListener(name, (event) => {
+          if (disposed || source !== current) return
           let payload: unknown
           try {
             payload = JSON.parse((event as MessageEvent<string>).data)
@@ -370,7 +590,8 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
         })
       }
 
-      source.addEventListener('provider-status', (event) => {
+      current.addEventListener('provider-status', (event) => {
+        if (disposed || source !== current) return
         let payload: unknown
         try {
           payload = JSON.parse((event as MessageEvent<string>).data)
@@ -379,30 +600,21 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
         }
         const row = parseProviderStatusEventRow(payload)
         if (!row) return
-        const key = workspaceQueryKeys.providerStatus
-        const response = queryClient.getQueryData<ProviderStatusResponse>(key)
-        const updated = applyProviderStatusRow(response, row)
-        if (updated !== undefined) {
-          queryClient.setQueryData(key, updated)
+        if (reconciliationDepth > 0) {
+          pendingProviderRows.push(row)
           return
         }
-        // An additive row cannot safely seed the complete provider cache. Discard an old
-        // initial fetch and replace it after the server emitted this latch. Further valid rows
-        // while that replacement is in flight coalesce into one trailing fetch.
-        if (providerStatusRefetching) {
-          providerStatusDirty = true
-          return
-        }
-        refetchUncachedProviderStatus()
+        applyProviderStatusEvent(row)
       })
 
-      source.addEventListener('error', () => {
+      current.addEventListener('error', () => {
+        if (disposed || source !== current) return
         // An ordinary drop leaves the stream CONNECTING and the browser retries it on its own —
         // touching that would just race its backoff. CLOSED means it gave up for good, which is
         // what a restarting server produces (the request is answered with a non-2xx while it
         // boots). Nothing would ever reopen it, so the cockpit would sit there looking live and
         // showing yesterday's state.
-        if (source?.readyState === CLOSED) reopenLater()
+        if (current.readyState === CLOSED) reopenLater()
       })
     }
 
@@ -411,7 +623,7 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
       // The phone-in-a-pocket case: mobile browsers freeze background tabs, so the stream may have
       // been dead for an hour with no error handler ever running. Whatever is on screen right now
       // is what the reader is about to trust, so ask the server before they read it.
-      reconcile(queryClient)
+      reconcileNow()
       if (!source || source.readyState === CLOSED) {
         // Don't make them wait out a backoff that started while they were away.
         clearTimeout(reopenTimer)
@@ -427,14 +639,16 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
       // free socket. Close eagerly; pageshow reopens if the document ever comes back.
       clearTimeout(reopenTimer)
       reopenTimer = undefined
-      source?.close()
+      const current = source
+      source = null
+      current?.close()
     }
 
     const onPageShow = (event: PageTransitionEvent): void => {
       // Only a bfcache restore (`persisted`) finds this document alive with its stream closed
       // by onPageHide; on a normal load this effect just ran and the stream is fresh.
       if (!event.persisted) return
-      reconcile(queryClient)
+      reconcileNow()
       connect()
     }
 
@@ -447,14 +661,18 @@ export function useGlobalEvents(usage: UsageStore, url: string = SSE_URL): void 
       disposed = true
       clearTimeout(reopenTimer)
       runsIndexRefresher.cancel()
+      inactiveProjectRefresher.cancel()
       runEventBatcher.cancel()
+      pendingTodos.clear()
+      pendingProviderRows = []
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('pagehide', onPageHide)
       window.removeEventListener('pageshow', onPageShow)
       // Explicit: an EventSource keeps its socket (and its retry loop) alive on its own, so a
       // dropped reference leaks a connection per remount, and StrictMode remounts every effect.
-      source?.close()
+      const current = source
       source = null
+      current?.close()
     }
   }, [queryClient, usage, url])
 }

--- a/packages/web/src/api/queries.ts
+++ b/packages/web/src/api/queries.ts
@@ -85,6 +85,7 @@ import type { ContinueOptions } from './client'
 import type {
   CheckoutProjectInput,
   CreateAgentProfileInput,
+  ApiRun,
   HealthResponse,
   MessageInput,
   Runner,
@@ -764,10 +765,11 @@ export function useOpenTargets() {
 }
 
 /** The authoritative run list. */
-export function useRuns() {
+export function useRuns<TData = ApiRun[]>(select?: (runs: ApiRun[]) => TData) {
   return useQuery({
     queryKey: queryKeys.runs.list(),
     queryFn: ({ signal }) => getRuns({ signal }),
+    select,
   })
 }
 
@@ -823,11 +825,17 @@ export function useRunsIndex(enabled = true, refetchIntervalMs?: number) {
  * still goes to `/api/p/<bootId>/runs`, which the server answers byte-identically (the
  * route-parity contract).
  */
-export function useProjectRuns(projectId: string, enabled = true, boot = false) {
+export function useProjectRuns<TData = ApiRun[]>(
+  projectId: string,
+  enabled = true,
+  boot = false,
+  select?: (runs: ApiRun[]) => TData,
+) {
   return useQuery({
     queryKey: [boot ? 'default' : projectId, 'runs', 'list'] as const,
     queryFn: ({ signal }) => getProjectRuns(projectId, { signal }),
     enabled,
+    select,
   })
 }
 

--- a/packages/web/src/api/run-events.test.ts
+++ b/packages/web/src/api/run-events.test.ts
@@ -376,10 +376,17 @@ describe('useRunEvents — compaction handoff', () => {
     await flushEvents()
     await vi.waitFor(() => expect(onCompact).toHaveBeenCalled())
 
-    // A numeric high-water cap would silently delete live-only deltas. An empty coverage result
-    // is a successful snapshot with nothing safe to evict, so the chunks collapse losslessly.
+    // A numeric high-water cap would silently delete live-only deltas. Empty coverage keeps the
+    // chunks lossless and backs off instead of retrying on every 50 ms batch.
     expect(result.current).toHaveLength(1)
     expect(result.current[0]?.delta).toHaveLength(5_001)
+    source.emit('ui-event', line(5_002, 'item.delta', {
+      itemId: 'message-1',
+      field: 'text',
+      delta: 'y',
+    }))
+    await flushEvents()
+    expect(onCompact).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/web/src/api/run-events.test.ts
+++ b/packages/web/src/api/run-events.test.ts
@@ -298,7 +298,7 @@ describe('useRunEvents — seq dedup uses `>`', () => {
 describe('useRunEvents — compaction handoff', () => {
   it('labels a coalesced delta with its newest sequence', async () => {
     const { result } = renderHook(() => useRunEvents('run-1', {
-      maxEvents: 10,
+      compactWhenOver: 10,
       compactAt: 100,
     }))
     const source = FakeEventSource.last
@@ -338,7 +338,7 @@ describe('useRunEvents — compaction handoff', () => {
       resolveCompaction = resolve
     })
     const { result } = renderHook(() => useRunEvents('run-1', {
-      maxEvents: 2,
+      compactWhenOver: 2,
       compactAt: 1,
       onCompact: () => compaction,
     }))
@@ -355,10 +355,10 @@ describe('useRunEvents — compaction handoff', () => {
     await vi.waitFor(() => expect(result.current.map(({ seq }) => seq)).toEqual([2, 3]))
   })
 
-  it('keeps more than the target when compaction has no durable coverage', async () => {
+  it('does not truncate live events when compaction has no durable coverage', async () => {
     const onCompact = vi.fn(async () => [])
     const { result } = renderHook(() => useRunEvents('run-1', {
-      maxEvents: 2,
+      compactWhenOver: 2,
       compactAt: 1,
       onCompact,
     }))

--- a/packages/web/src/api/run-events.test.ts
+++ b/packages/web/src/api/run-events.test.ts
@@ -2,7 +2,7 @@ import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { setApiScope } from '@open-mercato/cezar-api-client'
-import { parseRunEvent, useRunEvents } from './run-events'
+import { parseRunEvent, RUN_EVENT_BATCH_MS, useRunEvents } from './run-events'
 
 /**
  * Same doctrine as the global-stream suite: jsdom ships no EventSource, so the stub IS the test
@@ -54,13 +54,21 @@ const line = (seq: number, type: string, rest: Record<string, unknown> = {}) =>
 
 beforeEach(() => {
   FakeEventSource.instances = []
+  vi.useFakeTimers()
   vi.stubGlobal('EventSource', FakeEventSource)
 })
 
 afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
+  vi.useRealTimers()
 })
+
+async function flushEvents(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(RUN_EVENT_BATCH_MS)
+  })
+}
 
 describe('parseRunEvent', () => {
   it.each([
@@ -109,7 +117,7 @@ describe('useRunEvents — subscription', () => {
     }
   })
 
-  it('collects BOTH wire vocabularies into one ordered list — v1 `run-event` and v2 `ui-event`', () => {
+  it('collects BOTH wire vocabularies into one ordered list — v1 `run-event` and v2 `ui-event`', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const source = FakeEventSource.last
 
@@ -117,6 +125,7 @@ describe('useRunEvents — subscription', () => {
     source.emit('ui-event', line(2, 'item.started', { item: { kind: 'message', id: 'm1', role: 'assistant', text: '' } }))
     source.emit('ui-event', line(3, 'item.delta', { itemId: 'm1', field: 'text', delta: 'Hello' }))
     source.emit('run-event', line(4, 'token-usage', { tokensUsed: 42 }))
+    await flushEvents()
 
     expect(result.current.map((event) => [event.seq, event.type])).toEqual([
       [1, 'stdout'],
@@ -126,21 +135,23 @@ describe('useRunEvents — subscription', () => {
     ])
   })
 
-  it('survives a malformed frame — one bad line costs one line', () => {
+  it('survives a malformed frame — one bad line costs one line', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const source = FakeEventSource.last
 
     source.emit('ui-event', 'not json{')
     source.emit('ui-event', '{"type":"item.started"}') // no seq — unorderable
     source.emit('ui-event', line(1, 'plan.updated', { entries: [] }))
+    await flushEvents()
 
     expect(result.current.map((event) => event.type)).toEqual(['plan.updated'])
   })
 
-  it('reopens a CLOSED stream on return-to-visible; the replay dedups (#minor-run-sse-recovery)', () => {
+  it('reopens a CLOSED stream on return-to-visible; the replay dedups (#minor-run-sse-recovery)', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const first = FakeEventSource.last
     first.emit('run-event', line(1, 'stdout', { text: 'a' }))
+    await flushEvents()
 
     // A frozen tab (or a server restart) left the socket dead with no error handler firing.
     first.close() // readyState → CLOSED
@@ -151,19 +162,13 @@ describe('useRunEvents — subscription', () => {
     // The server replays the whole file on reconnect: seq 1 (already seen) is swallowed, seq 2 lands.
     second.emit('run-event', line(1, 'stdout', { text: 'a' }))
     second.emit('run-event', line(2, 'stdout', { text: 'b' }))
+    await flushEvents()
     expect(result.current.map((event) => event.seq)).toEqual([1, 2])
   })
 })
 
 describe('useRunEvents — liveness watchdog (#424)', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('reopens a silently-dead socket that never reached CLOSED, then dedups the replay', () => {
+  it('reopens a silently-dead socket that never reached CLOSED, then dedups the replay', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const first = FakeEventSource.last
     first.emit('run-event', line(1, 'stdout', { text: 'a' }))
@@ -180,6 +185,7 @@ describe('useRunEvents — liveness watchdog (#424)', () => {
     const second = FakeEventSource.last
     second.emit('run-event', line(1, 'stdout', { text: 'a' }))
     second.emit('run-event', line(2, 'stdout', { text: 'b' }))
+    await flushEvents()
     expect(result.current.map((event) => event.seq)).toEqual([1, 2])
   })
 
@@ -225,7 +231,7 @@ describe('useRunEvents — liveness watchdog (#424)', () => {
 })
 
 describe('useRunEvents — seq dedup uses `>`', () => {
-  it('drops the replayed prefix after a reconnect instead of duplicating it', () => {
+  it('drops the replayed prefix after a reconnect instead of duplicating it', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const source = FakeEventSource.last
 
@@ -237,28 +243,31 @@ describe('useRunEvents — seq dedup uses `>`', () => {
     source.emit('run-event', line(1, 'stdout', { text: 'a' }))
     source.emit('ui-event', line(2, 'turn.started', { turnId: 't1' }))
     source.emit('ui-event', line(3, 'turn.completed', { turnId: 't1', stopReason: 'end_turn' }))
+    await flushEvents()
 
     expect(result.current.map((event) => event.seq)).toEqual([1, 2, 3])
   })
 
-  it('accepts seq gaps — ephemeral deltas burn numbers that never replay', () => {
+  it('accepts seq gaps — ephemeral deltas burn numbers that never replay', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const source = FakeEventSource.last
 
     source.emit('ui-event', line(2, 'item.started', { item: { kind: 'reasoning', id: 'r1', text: '' } }))
     // seq 3–6 were coalesced deltas this client never saw; the next persisted line jumps.
     source.emit('ui-event', line(7, 'item.completed', { item: { kind: 'reasoning', id: 'r1', text: 'done' } }))
+    await flushEvents()
 
     expect(result.current.map((event) => event.seq)).toEqual([2, 7])
   })
 
-  it('drops a stale line at the high-water mark, not merely duplicates', () => {
+  it('drops a stale line at the high-water mark, not merely duplicates', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const source = FakeEventSource.last
 
     source.emit('ui-event', line(5, 'turn.started', { turnId: 't1' }))
     source.emit('ui-event', line(5, 'turn.started', { turnId: 't1' })) // equal — not `>`
     source.emit('ui-event', line(4, 'stdout', { text: 'late' })) // below — replayed history
+    await flushEvents()
 
     expect(result.current).toHaveLength(1)
   })
@@ -275,12 +284,13 @@ describe('useRunEvents — lifecycle', () => {
     expect(source.readyState).toBe(2)
   })
 
-  it('resets the list and resubscribes when the run id changes', () => {
+  it('resets the list and resubscribes when the run id changes', async () => {
     const { result, rerender } = renderHook(({ id }: { id: string }) => useRunEvents(id), {
       initialProps: { id: 'run-1' },
     })
     const first = FakeEventSource.last
     first.emit('ui-event', line(9, 'session.ended', { reason: 'end_turn' }))
+    await flushEvents()
     expect(result.current).toHaveLength(1)
 
     rerender({ id: 'run-2' })
@@ -292,6 +302,7 @@ describe('useRunEvents — lifecycle', () => {
 
     // The high-water mark reset with the list: run-2's own seq 1 must not be "stale".
     FakeEventSource.last.emit('run-event', line(1, 'stdout', { text: 'fresh' }))
+    await flushEvents()
     expect(result.current.map((event) => event.seq)).toEqual([1])
   })
 
@@ -302,10 +313,11 @@ describe('useRunEvents — lifecycle', () => {
     expect(FakeEventSource.instances).toHaveLength(0)
   })
 
-  it('closes on pagehide and reopens on a bfcache restore, deduping the replay', () => {
+  it('closes on pagehide and reopens on a bfcache restore, deduping the replay', async () => {
     const { result } = renderHook(() => useRunEvents('run-1'))
     const first = FakeEventSource.last
     first.emit('run-event', line(1, 'stdout', { text: 'before' }))
+    await flushEvents()
 
     // Navigate away: the parked document must not hold a per-origin socket.
     act(() => {
@@ -326,6 +338,7 @@ describe('useRunEvents — lifecycle', () => {
     expect(second.url).toBe('/api/v1/runs/run-1/events')
     second.emit('run-event', line(1, 'stdout', { text: 'before' })) // replayed prefix
     second.emit('run-event', line(2, 'stdout', { text: 'after' }))
+    await flushEvents()
     expect(result.current.map((event) => event.seq)).toEqual([1, 2])
   })
 })

--- a/packages/web/src/api/run-events.test.ts
+++ b/packages/web/src/api/run-events.test.ts
@@ -271,6 +271,116 @@ describe('useRunEvents — seq dedup uses `>`', () => {
 
     expect(result.current).toHaveLength(1)
   })
+
+  it('accepts an unseen late frame after history advances its file high-water mark', async () => {
+    const { result, rerender } = renderHook(
+      ({ afterSeq }: { afterSeq: number }) => useRunEvents('run-1', { afterSeq }),
+      { initialProps: { afterSeq: 100 } },
+    )
+    const source = FakeEventSource.last
+
+    source.emit('run-event', line(101, 'stdout', { text: 'first' }))
+    source.emit('run-event', line(200, 'stdout', { text: 'second' }))
+    await flushEvents()
+
+    // A compaction page may now say 300 even though an ephemeral frame from the old socket is
+    // still in flight. It is newer than the original page and must not be dropped as replay.
+    rerender({ afterSeq: 300 })
+    source.emit('ui-event', line(150, 'item.delta', {
+      itemId: 'm1', field: 'text', delta: 'late-live',
+    }))
+    await flushEvents()
+
+    expect(result.current.map(({ seq }) => seq)).toEqual([101, 200, 150])
+  })
+})
+
+describe('useRunEvents — compaction handoff', () => {
+  it('labels a coalesced delta with its newest sequence', async () => {
+    const { result } = renderHook(() => useRunEvents('run-1', {
+      maxEvents: 10,
+      compactAt: 100,
+    }))
+    const source = FakeEventSource.last
+
+    source.emit('ui-event', line(1, 'item.delta', {
+      itemId: 'm1', field: 'text', delta: 'a',
+    }))
+    source.emit('ui-event', line(3, 'item.delta', {
+      itemId: 'm1', field: 'text', delta: 'b',
+    }))
+    await flushEvents()
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0]).toMatchObject({ seq: 3, delta: 'ab' })
+  })
+
+  it('keeps coalesced deltas ordered around unrelated events', async () => {
+    const { result } = renderHook(() => useRunEvents('run-1', { compactAt: 100 }))
+    const source = FakeEventSource.last
+
+    source.emit('ui-event', line(1, 'item.delta', {
+      itemId: 'm1', field: 'text', delta: 'a',
+    }))
+    source.emit('run-event', line(2, 'stdout', { text: 'tool output' }))
+    source.emit('ui-event', line(3, 'item.delta', {
+      itemId: 'm1', field: 'text', delta: 'b',
+    }))
+    await flushEvents()
+
+    expect(result.current.map(({ seq }) => seq)).toEqual([2, 3])
+    expect(result.current[1]).toMatchObject({ type: 'item.delta', delta: 'ab' })
+  })
+
+  it('does not evict live events while compaction is still pending', async () => {
+    let resolveCompaction!: (coveredSeqs: readonly number[] | false) => void
+    const compaction = new Promise<readonly number[] | false>((resolve) => {
+      resolveCompaction = resolve
+    })
+    const { result } = renderHook(() => useRunEvents('run-1', {
+      maxEvents: 2,
+      compactAt: 1,
+      onCompact: () => compaction,
+    }))
+    const source = FakeEventSource.last
+
+    source.emit('run-event', line(1, 'stdout', { text: 'a' }))
+    source.emit('run-event', line(2, 'stdout', { text: 'b' }))
+    source.emit('run-event', line(3, 'stdout', { text: 'c' }))
+    await flushEvents()
+
+    // A snapshot that has not answered cannot repair any ephemeral prefix it would evict.
+    expect(result.current.map(({ seq }) => seq)).toEqual([1, 2, 3])
+    resolveCompaction([1])
+    await vi.waitFor(() => expect(result.current.map(({ seq }) => seq)).toEqual([2, 3]))
+  })
+
+  it('keeps more than the target when compaction has no durable coverage', async () => {
+    const onCompact = vi.fn(async () => [])
+    const { result } = renderHook(() => useRunEvents('run-1', {
+      maxEvents: 2,
+      compactAt: 1,
+      onCompact,
+    }))
+    const source = FakeEventSource.last
+
+    act(() => {
+      for (let seq = 1; seq <= 5_001; seq += 1) {
+        source.emit('ui-event', line(seq, 'item.delta', {
+          itemId: 'message-1',
+          field: 'text',
+          delta: 'x',
+        }))
+      }
+    })
+    await flushEvents()
+    await vi.waitFor(() => expect(onCompact).toHaveBeenCalled())
+
+    // A numeric high-water cap would silently delete live-only deltas. An empty coverage result
+    // is a successful snapshot with nothing safe to evict, so the chunks collapse losslessly.
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0]?.delta).toHaveLength(5_001)
+  })
 })
 
 describe('useRunEvents — lifecycle', () => {

--- a/packages/web/src/api/run-events.ts
+++ b/packages/web/src/api/run-events.ts
@@ -32,6 +32,14 @@ export const RUN_EVENT_NAMES = ['run-event', 'ui-event'] as const
 export const RUN_EVENT_BATCH_MS = 50
 const COMPACTION_RETRY_BASE_MS = 1_000
 const COMPACTION_RETRY_MAX_MS = 60_000
+const MAX_SEEN_SEQS = 10_000
+
+function rememberSeq(seqs: Set<number>, seq: number): void {
+  seqs.add(seq)
+  if (seqs.size <= MAX_SEEN_SEQS) return
+  const oldest = seqs.values().next().value
+  if (typeof oldest === 'number') seqs.delete(oldest)
+}
 
 export type RunEventCompaction = readonly number[]
 
@@ -208,9 +216,9 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
         .then(
           (coveredSeqs) => {
             if (disposed) return
-            // A failed optimization must be retryable; an empty successful coverage is valid
-            // when the current live window still contains an active item with no durable snapshot.
-            if (!Array.isArray(coveredSeqs)) {
+            // Empty coverage made no progress: keep the live buffer, but back off before asking
+            // for the same snapshot on every 50 ms batch.
+            if (!Array.isArray(coveredSeqs) || coveredSeqs.length === 0) {
               markCompactionFailed()
               return
             }
@@ -227,10 +235,9 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
               // The server will resume after the compacted page's durable high-water mark.
               // Drop dedup state for the same compacted prefix so it cannot grow with a long
               // run; keep the still-live tail (and queued frames not flushed yet).
-              seenSeqsRef.current = new Set([
-                ...next.map(({ seq }) => seq),
-                ...pending.map(({ seq }) => seq),
-              ])
+              const nextSeen = new Set<number>()
+              for (const { seq } of [...next, ...pending]) rememberSeq(nextSeen, seq)
+              seenSeqsRef.current = nextSeen
               return next
             })
           },
@@ -293,7 +300,7 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
         parsed.seq <= maxSeqRef.current
         && (!allowLateFramesRef.current || parsed.seq <= initialPageHighWaterRef.current)
       ) return
-      seenSeqsRef.current.add(parsed.seq)
+      rememberSeq(seenSeqsRef.current, parsed.seq)
       maxSeqRef.current = Math.max(maxSeqRef.current, parsed.seq)
       eventsSinceCompaction += 1
       pending.push(parsed)

--- a/packages/web/src/api/run-events.ts
+++ b/packages/web/src/api/run-events.ts
@@ -152,6 +152,7 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
   const initialPageHighWaterRef = useRef(0)
   const allowLateFramesRef = useRef(false)
   const seenSeqsRef = useRef(new Set<number>())
+  const compactCommittedRef = useRef<((events: readonly RunEvent[]) => void) | undefined>(undefined)
 
   useEffect(() => {
     const { afterSeq = 0 } = optionsRef.current
@@ -203,7 +204,12 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     }
 
     const requestCompaction = (snapshot: readonly RunEvent[]): void => {
-      if (optionsRef.current.onCompact === undefined) return
+      const options = optionsRef.current
+      if (options.onCompact === undefined) return
+      if (
+        (options.compactAt === undefined || eventsSinceCompaction < options.compactAt)
+        && (options.maxEvents === undefined || snapshot.length <= options.maxEvents)
+      ) return
       if (Date.now() < nextCompactionAt) return
       compactionRequested = true
       const requestedAt = eventsSinceCompaction
@@ -230,16 +236,7 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
             // numeric high-water mark is not enough: ephemeral deltas burn sequence numbers.
             const covered = new Set(coveredSeqs)
             if (covered.size === 0) return
-            setEvents((current) => {
-              const next = current.filter(({ seq }) => !covered.has(seq))
-              // The server will resume after the compacted page's durable high-water mark.
-              // Drop dedup state for the same compacted prefix so it cannot grow with a long
-              // run; keep the still-live tail (and queued frames not flushed yet).
-              const nextSeen = new Set<number>()
-              for (const { seq } of [...next, ...pending]) rememberSeq(nextSeen, seq)
-              seenSeqsRef.current = nextSeen
-              return next
-            })
+            setEvents((current) => current.filter(({ seq }) => !covered.has(seq)))
           },
           () => {
             if (!disposed) markCompactionFailed()
@@ -254,26 +251,9 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
       pending = []
       setEvents((current) => {
         const options = optionsRef.current
-        const next = options.compactAt !== undefined || options.onCompact !== undefined
+        return options.compactAt !== undefined || options.onCompact !== undefined
           ? coalesceLiveDeltas([...current, ...batch])
           : [...current, ...batch]
-        if (
-          !compactionRequested &&
-          options.compactAt !== undefined &&
-          eventsSinceCompaction >= options.compactAt
-        ) {
-          requestCompaction(next)
-        }
-        // `maxEvents` is a compaction target, never a lossy cap. A hung or failed snapshot cannot
-        // repair an evicted prefix because ephemeral frames are not replayed.
-        if (
-          !compactionRequested &&
-          options.maxEvents !== undefined &&
-          next.length > options.maxEvents
-        ) {
-          requestCompaction(next)
-        }
-        return next
       })
     }
 
@@ -401,6 +381,7 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     document.addEventListener('visibilitychange', onVisibilityChange)
     window.addEventListener('pagehide', onPageHide)
     window.addEventListener('pageshow', onPageShow)
+    compactCommittedRef.current = requestCompaction
     open()
 
     return () => {
@@ -413,9 +394,15 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('pagehide', onPageHide)
       window.removeEventListener('pageshow', onPageShow)
+      if (compactCommittedRef.current === requestCompaction) compactCommittedRef.current = undefined
       closeSource()
     }
   }, [runId, scope])
+
+  useEffect(() => {
+    if (events.length === 0) return
+    compactCommittedRef.current?.(events)
+  }, [events])
 
   // History compaction advances the persisted high-water mark without changing the run owner.
   // Keep the live buffer intact: persisted `asOfSeq` can move past ephemeral frames that are not

--- a/packages/web/src/api/run-events.ts
+++ b/packages/web/src/api/run-events.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-import { apiPath } from '@open-mercato/cezar-api-client'
+import { apiPath, getApiScope } from '@open-mercato/cezar-api-client'
 import type { RunEvent } from '@open-mercato/cezar-api-client'
 
 /**
@@ -16,10 +16,9 @@ import type { RunEvent } from '@open-mercato/cezar-api-client'
  * Both land in the one list, in arrival (= `seq`) order, because v2 is *additive*: a consumer
  * migrating one panel at a time needs both vocabularies over one clock.
  *
- * Dedup MUST be `seq > maxSeq`, never equality or gap detection: the server replays the whole
- * NDJSON file on every (re)connect — dropping everything at or below the high-water mark is
- * what makes an EventSource auto-reconnect invisible — and ephemeral deltas consume seq numbers
- * that never reappear in a replay, so gaps are normal, not loss.
+ * Dedup is sequence-based, but the page's `asOfSeq` is not a received-event watermark: ephemeral
+ * deltas consume sequence numbers that never reappear in a replay. A page refresh can therefore
+ * move that file high-water mark past a live frame still waiting in this socket.
  */
 
 /** Both wire names. Exported so tests and future consumers subscribe to exactly this set. */
@@ -31,6 +30,71 @@ export const RUN_EVENT_NAMES = ['run-event', 'ui-event'] as const
  * every 50 ms. This is below a normal typing frame while bounding React work during fast streams.
  */
 export const RUN_EVENT_BATCH_MS = 50
+const COMPACTION_RETRY_BASE_MS = 1_000
+const COMPACTION_RETRY_MAX_MS = 60_000
+
+export type RunEventCompaction = readonly number[]
+
+export function runItemKey(stepId: unknown, itemId: string): string {
+  return typeof stepId === 'string' ? `${stepId}:${itemId}` : itemId
+}
+
+export function liveItemKey(event: RunEvent): string | undefined {
+  const itemId = event.type === 'item.delta'
+    ? event.itemId
+    : typeof event.item === 'object' && event.item !== null && !Array.isArray(event.item)
+      ? (event.item as { id?: unknown }).id
+      : undefined
+  return typeof itemId === 'string' && itemId !== ''
+    ? runItemKey(event.stepId, itemId)
+    : undefined
+}
+
+/** Keep optimized transcript state lossless without retaining one row per streamed chunk. */
+function coalesceLiveDeltas(events: readonly RunEvent[]): RunEvent[] {
+  const output: RunEvent[] = []
+  const deltaIndexes = new Map<string, number>()
+  for (const event of events) {
+    const itemKey = liveItemKey(event)
+    if (itemKey !== undefined && event.type !== 'item.delta') {
+      for (const field of ['text', 'reasoning', 'output']) deltaIndexes.delete(`${itemKey}:${field}`)
+    }
+    if (
+      event.type === 'item.delta' &&
+      itemKey !== undefined &&
+      (event.field === 'text' || event.field === 'reasoning' || event.field === 'output') &&
+      typeof event.delta === 'string'
+    ) {
+      const key = `${itemKey}:${event.field}`
+      const previousIndex = deltaIndexes.get(key)
+      if (previousIndex !== undefined) {
+        const previous = output[previousIndex]!
+        // Keep the newest constituent seq. If a durable snapshot covers only the first chunk,
+        // filtering by that old seq must not evict the merged event and lose the later text.
+        const merged = {
+          ...previous,
+          seq: event.seq,
+          ts: event.ts,
+          delta: `${previous.delta as string}${event.delta}`,
+        }
+        if (previousIndex === output.length - 1) {
+          output[previousIndex] = merged
+        } else {
+          output.splice(previousIndex, 1)
+          for (const [trackedKey, index] of deltaIndexes) {
+            if (index > previousIndex) deltaIndexes.set(trackedKey, index - 1)
+          }
+          deltaIndexes.set(key, output.length)
+          output.push(merged)
+        }
+        continue
+      }
+      deltaIndexes.set(key, output.length)
+    }
+    output.push(event)
+  }
+  return output
+}
 
 /**
  * Parse one SSE frame into a `RunEvent`, or null for anything malformed. Null rather than a
@@ -51,7 +115,8 @@ export function parseRunEvent(data: string): RunEvent | null {
 }
 
 /**
- * Subscribe to one run's event stream and accumulate the raw ordered list.
+ * Subscribe to one run's event stream and accumulate the ordered list. The optimized history
+ * caller losslessly coalesces same-item delta chunks; the fallback keeps raw frames.
  *
  * The list resets when `runId` changes (a different run's events are not "earlier state" of
  * this one) and the socket closes on unmount — an EventSource left unclosed retries forever.
@@ -65,15 +130,30 @@ export interface RunEventStreamOptions {
   maxEvents?: number
   /** Ask the history owner to fold the live prefix into a fresh persisted tail page. */
   compactAt?: number
-  onCompact?: () => void
+  /** Return exactly the live sequence numbers now covered by durable history. */
+  onCompact?: (events: readonly RunEvent[]) => RunEventCompaction | false | Promise<RunEventCompaction | false>
 }
 
 export function useRunEvents(runId: string | undefined, options: RunEventStreamOptions = {}): RunEvent[] {
   const [events, setEvents] = useState<RunEvent[]>([])
-  const { cursor, afterSeq = 0, maxEvents, compactAt, onCompact } = options
+  const scope = getApiScope()
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+  const maxSeqRef = useRef(0)
+  const pageHighWaterRef = useRef(0)
+  const initialPageHighWaterRef = useRef(0)
+  const allowLateFramesRef = useRef(false)
+  const seenSeqsRef = useRef(new Set<number>())
 
   useEffect(() => {
-    // The reset also covers the runId-changed case: whatever accumulated belongs to the old id.
+    const { afterSeq = 0 } = optionsRef.current
+    // A runId change is the only time this hook changes owners. Cursor/compaction updates keep the
+    // same socket and live buffer, so ephemeral frames cannot fall into a REST-to-SSE handoff gap.
+    maxSeqRef.current = 0
+    pageHighWaterRef.current = afterSeq
+    initialPageHighWaterRef.current = afterSeq
+    allowLateFramesRef.current = false
+    seenSeqsRef.current.clear()
     setEvents([])
     if (!runId) return
 
@@ -81,13 +161,14 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     const Source = globalThis.EventSource
     if (typeof Source !== 'function') return
 
-    // The high-water mark lives with the socket's effect, not in state: a reconnect replay
-    // arrives between renders, and dedup must not race React's batching.
-    let maxSeq = afterSeq
     let source: EventSource | null = null
+    let streamToken = 0
     let reopenTimer: ReturnType<typeof setTimeout> | undefined
     let disposed = false
     let compactionRequested = false
+    let compactionFailures = 0
+    let nextCompactionAt = 0
+    let eventsSinceCompaction = 0
     let pending: RunEvent[] = []
     let flushTimer: ReturnType<typeof setTimeout> | undefined
     const CLOSED = 2 // EventSource.CLOSED, spelled literally like global-events.tsx
@@ -104,24 +185,88 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     let lastFrameAt = Date.now()
     let livenessTimer: ReturnType<typeof setInterval> | undefined
 
+    const markCompactionFailed = (): void => {
+      compactionRequested = false
+      compactionFailures = Math.min(compactionFailures + 1, 6)
+      nextCompactionAt = Date.now() + Math.min(
+        COMPACTION_RETRY_MAX_MS,
+        COMPACTION_RETRY_BASE_MS * 2 ** (compactionFailures - 1),
+      )
+    }
+
+    const requestCompaction = (snapshot: readonly RunEvent[]): void => {
+      if (optionsRef.current.onCompact === undefined) return
+      if (Date.now() < nextCompactionAt) return
+      compactionRequested = true
+      const requestedAt = eventsSinceCompaction
+      // Read the current callback: the history query can replace it while this request waits.
+      void Promise.resolve()
+        .then(() => {
+          if (disposed) return undefined
+          return optionsRef.current.onCompact?.(snapshot)
+        })
+        .then(
+          (coveredSeqs) => {
+            if (disposed) return
+            // A failed optimization must be retryable; an empty successful coverage is valid
+            // when the current live window still contains an active item with no durable snapshot.
+            if (!Array.isArray(coveredSeqs)) {
+              markCompactionFailed()
+              return
+            }
+            compactionFailures = 0
+            nextCompactionAt = 0
+            eventsSinceCompaction = Math.max(0, eventsSinceCompaction - requestedAt)
+            compactionRequested = false
+            // The history owner knows which persisted snapshots cover live-only frames. A
+            // numeric high-water mark is not enough: ephemeral deltas burn sequence numbers.
+            const covered = new Set(coveredSeqs)
+            if (covered.size === 0) return
+            setEvents((current) => {
+              const next = current.filter(({ seq }) => !covered.has(seq))
+              // The server will resume after the compacted page's durable high-water mark.
+              // Drop dedup state for the same compacted prefix so it cannot grow with a long
+              // run; keep the still-live tail (and queued frames not flushed yet).
+              seenSeqsRef.current = new Set([
+                ...next.map(({ seq }) => seq),
+                ...pending.map(({ seq }) => seq),
+              ])
+              return next
+            })
+          },
+          () => {
+            if (!disposed) markCompactionFailed()
+          },
+        )
+    }
+
     const flush = (): void => {
       flushTimer = undefined
       if (pending.length === 0) return
       const batch = pending
       pending = []
       setEvents((current) => {
-        const next = [...current, ...batch]
+        const options = optionsRef.current
+        const next = options.compactAt !== undefined || options.onCompact !== undefined
+          ? coalesceLiveDeltas([...current, ...batch])
+          : [...current, ...batch]
         if (
           !compactionRequested &&
-          compactAt !== undefined &&
-          next.length >= compactAt
+          options.compactAt !== undefined &&
+          eventsSinceCompaction >= options.compactAt
         ) {
-          compactionRequested = true
-          queueMicrotask(() => {
-            if (!disposed) onCompact?.()
-          })
+          requestCompaction(next)
         }
-        return maxEvents === undefined || next.length <= maxEvents ? next : next.slice(-maxEvents)
+        // `maxEvents` is a compaction target, never a lossy cap. A hung or failed snapshot cannot
+        // repair an evicted prefix because ephemeral frames are not replayed.
+        if (
+          !compactionRequested &&
+          options.maxEvents !== undefined &&
+          next.length > options.maxEvents
+        ) {
+          requestCompaction(next)
+        }
+        return next
       })
     }
 
@@ -129,13 +274,28 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
       if (flushTimer === undefined) flushTimer = setTimeout(flush, RUN_EVENT_BATCH_MS)
     }
 
-    const onFrame = (event: Event) => {
+    const closeSource = (): void => {
+      streamToken += 1
+      const current = source
+      if (!current) return
+      current.close()
+      source = null
+    }
+
+    const onFrame = (event: Event, token: number) => {
+      if (disposed || token !== streamToken) return
       // Any frame proves the socket is alive — bump the watchdog before the dedup drop, so a
       // replayed prefix (which is dropped below) still counts as liveness.
       lastFrameAt = Date.now()
       const parsed = parseRunEvent((event as MessageEvent<string>).data)
-      if (!parsed || !(parsed.seq > maxSeq)) return
-      maxSeq = parsed.seq
+      if (!parsed || seenSeqsRef.current.has(parsed.seq)) return
+      if (
+        parsed.seq <= maxSeqRef.current
+        && (!allowLateFramesRef.current || parsed.seq <= initialPageHighWaterRef.current)
+      ) return
+      seenSeqsRef.current.add(parsed.seq)
+      maxSeqRef.current = Math.max(maxSeqRef.current, parsed.seq)
+      eventsSinceCompaction += 1
       pending.push(parsed)
       scheduleFlush()
     }
@@ -143,7 +303,8 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     // The keepalive carries no payload we accumulate — it exists only to prove the socket is
     // alive during quiet stretches (a run that is thinking emits nothing for seconds), so it
     // feeds the watchdog and nothing else.
-    const onPing = (): void => {
+    const onPing = (token: number): void => {
+      if (disposed || token !== streamToken) return
       lastFrameAt = Date.now()
     }
 
@@ -156,29 +317,41 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     }
 
     const open = (): void => {
-      source?.close()
+      closeSource()
+      const token = streamToken
+      const { cursor, afterSeq = 0 } = optionsRef.current
       // A fresh socket resets the clock: replay is about to arrive, so it must not be judged
       // stale before its first frame lands.
       lastFrameAt = Date.now()
+      pageHighWaterRef.current = Math.max(pageHighWaterRef.current, afterSeq)
       // Scoped per project like every client.ts path (spec 3.1) — unscoped this is the
       // byte-identical legacy URL. Read per (re)open, but the scope only changes with the
       // route, which unmounts this hook first.
       const params = new URLSearchParams()
       if (cursor !== undefined) params.set('cursor', cursor)
-      if (cursor !== undefined || afterSeq > 0) params.set('afterSeq', String(maxSeq))
+      if (cursor !== undefined || afterSeq > 0) {
+        params.set('afterSeq', String(Math.max(pageHighWaterRef.current, maxSeqRef.current)))
+      }
       const query = params.size > 0 ? `?${params.toString()}` : ''
-      source = new Source(apiPath(`/runs/${encodeURIComponent(runId)}/events${query}`), {
+      const current = new Source(apiPath(`/runs/${encodeURIComponent(runId)}/events${query}`), {
         withCredentials: true,
       })
-      for (const name of RUN_EVENT_NAMES) source.addEventListener(name, onFrame)
-      source.addEventListener('ping', onPing)
-      source.addEventListener('error', () => {
+      source = current
+      const frameListener = (event: Event): void => onFrame(event, token)
+      for (const name of RUN_EVENT_NAMES) {
+        current.addEventListener(name, frameListener)
+      }
+      const pingListener = (): void => onPing(token)
+      current.addEventListener('ping', pingListener)
+      const errorListener = (): void => {
+        if (disposed || token !== streamToken) return
         // Ordinary drops leave the socket CONNECTING and the browser retries on its own; CLOSED
         // means it gave up for good (what a restarting server produces), so nothing would reopen
         // it — the transcript would silently freeze while the header (global stream) keeps
         // updating, looking live over stale content. Reopen; `maxSeq` swallows the replay.
-        if (source?.readyState === CLOSED) reopenLater()
-      })
+        if (current.readyState === CLOSED) reopenLater()
+      }
+      current.addEventListener('error', errorListener)
     }
 
     // The phone-in-a-pocket case: a frozen background tab can leave the stream dead for an hour
@@ -200,7 +373,7 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     const onPageHide = (): void => {
       clearTimeout(reopenTimer)
       reopenTimer = undefined
-      source?.close()
+      closeSource()
     }
     const onPageShow = (event: PageTransitionEvent): void => {
       if (event.persisted) open()
@@ -233,9 +406,19 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('pagehide', onPageHide)
       window.removeEventListener('pageshow', onPageShow)
-      source?.close()
+      closeSource()
     }
-  }, [runId, cursor, afterSeq, maxEvents, compactAt, onCompact])
+  }, [runId, scope])
+
+  // History compaction advances the persisted high-water mark without changing the run owner.
+  // Keep the live buffer intact: persisted `asOfSeq` can move past ephemeral frames that are not
+  // in the page, so trimming by sequence here would lose live-only transcript content.
+  const afterSeq = options.afterSeq ?? 0
+  useEffect(() => {
+    if (!runId) return
+    if (afterSeq > pageHighWaterRef.current) allowLateFramesRef.current = true
+    pageHighWaterRef.current = Math.max(pageHighWaterRef.current, afterSeq)
+  }, [afterSeq, runId])
 
   return events
 }

--- a/packages/web/src/api/run-events.ts
+++ b/packages/web/src/api/run-events.ts
@@ -26,6 +26,13 @@ import type { RunEvent } from '@open-mercato/cezar-api-client'
 export const RUN_EVENT_NAMES = ['run-event', 'ui-event'] as const
 
 /**
+ * EventSource delivers token/delta frames as separate tasks. Rendering once per frame makes a
+ * transcript rebuild the whole visible thread at agent-event rate, so publish at most one batch
+ * every 50 ms. This is below a normal typing frame while bounding React work during fast streams.
+ */
+export const RUN_EVENT_BATCH_MS = 50
+
+/**
  * Parse one SSE frame into a `RunEvent`, or null for anything malformed. Null rather than a
  * throw, as everywhere on the stream boundary: one bad frame costs one frame, not the socket.
  * `seq` must be a number — it is the dedup axis, and a line without one cannot be ordered.
@@ -81,6 +88,8 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     let reopenTimer: ReturnType<typeof setTimeout> | undefined
     let disposed = false
     let compactionRequested = false
+    let pending: RunEvent[] = []
+    let flushTimer: ReturnType<typeof setTimeout> | undefined
     const CLOSED = 2 // EventSource.CLOSED, spelled literally like global-events.tsx
     const REOPEN_DELAY_MS = 1_500
 
@@ -95,15 +104,13 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     let lastFrameAt = Date.now()
     let livenessTimer: ReturnType<typeof setInterval> | undefined
 
-    const onFrame = (event: Event) => {
-      // Any frame proves the socket is alive — bump the watchdog before the dedup drop, so a
-      // replayed prefix (which is dropped below) still counts as liveness.
-      lastFrameAt = Date.now()
-      const parsed = parseRunEvent((event as MessageEvent<string>).data)
-      if (!parsed || !(parsed.seq > maxSeq)) return
-      maxSeq = parsed.seq
+    const flush = (): void => {
+      flushTimer = undefined
+      if (pending.length === 0) return
+      const batch = pending
+      pending = []
       setEvents((current) => {
-        const next = [...current, parsed]
+        const next = [...current, ...batch]
         if (
           !compactionRequested &&
           compactAt !== undefined &&
@@ -116,6 +123,21 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
         }
         return maxEvents === undefined || next.length <= maxEvents ? next : next.slice(-maxEvents)
       })
+    }
+
+    const scheduleFlush = (): void => {
+      if (flushTimer === undefined) flushTimer = setTimeout(flush, RUN_EVENT_BATCH_MS)
+    }
+
+    const onFrame = (event: Event) => {
+      // Any frame proves the socket is alive — bump the watchdog before the dedup drop, so a
+      // replayed prefix (which is dropped below) still counts as liveness.
+      lastFrameAt = Date.now()
+      const parsed = parseRunEvent((event as MessageEvent<string>).data)
+      if (!parsed || !(parsed.seq > maxSeq)) return
+      maxSeq = parsed.seq
+      pending.push(parsed)
+      scheduleFlush()
     }
 
     // The keepalive carries no payload we accumulate — it exists only to prove the socket is
@@ -204,6 +226,9 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
     return () => {
       disposed = true
       clearTimeout(reopenTimer)
+      clearTimeout(flushTimer)
+      flushTimer = undefined
+      pending = []
       clearInterval(livenessTimer)
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('pagehide', onPageHide)

--- a/packages/web/src/api/run-events.ts
+++ b/packages/web/src/api/run-events.ts
@@ -134,8 +134,8 @@ export function parseRunEvent(data: string): RunEvent | null {
 export interface RunEventStreamOptions {
   cursor?: string
   afterSeq?: number
-  /** Optimized history keeps a bounded live tail; full-replay fallback leaves this absent. */
-  maxEvents?: number
+  /** Request another compaction when the live snapshot exceeds this size; never truncates it. */
+  compactWhenOver?: number
   /** Ask the history owner to fold the live prefix into a fresh persisted tail page. */
   compactAt?: number
   /** Return exactly the live sequence numbers now covered by durable history. */
@@ -208,7 +208,7 @@ export function useRunEvents(runId: string | undefined, options: RunEventStreamO
       if (options.onCompact === undefined) return
       if (
         (options.compactAt === undefined || eventsSinceCompaction < options.compactAt)
-        && (options.maxEvents === undefined || snapshot.length <= options.maxEvents)
+        && (options.compactWhenOver === undefined || snapshot.length <= options.compactWhenOver)
       ) return
       if (Date.now() < nextCompactionAt) return
       compactionRequested = true

--- a/packages/web/src/api/run-history.test.tsx
+++ b/packages/web/src/api/run-history.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RunHistoryContext, RunHistoryPage } from '@open-mercato/cezar-api-client'
 import { getRunHistory, getRunHistoryContext } from './client'
-import { mergeRunHistoryEvents, useRunHistory } from './run-history'
+import { coveredLiveEventSeqs, mergeRunHistoryEvents, useRunHistory } from './run-history'
 
 vi.mock('./client', () => ({
   getRunHistory: vi.fn(),
@@ -140,6 +140,85 @@ describe('useRunHistory', () => {
     expect(mockHistory).toHaveBeenLastCalledWith('run-1', undefined, expect.any(Object))
   })
 
+  it('keeps the newest tail when maxPages evicts it during older-page browsing', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    const olderPages: Record<string, RunHistoryPage> = {
+      'older-1': page(90, { olderCursor: 'older-2', newerCursor: 'newer', hasOlder: true }),
+      'older-2': page(80, { olderCursor: 'older-3', newerCursor: 'newer', hasOlder: true }),
+      'older-3': page(70, { olderCursor: 'older-4', newerCursor: 'newer', hasOlder: true }),
+      'older-4': page(60, { olderCursor: 'older-5', newerCursor: 'newer', hasOlder: true }),
+      'older-5': page(50, { newerCursor: 'newer', hasOlder: false }),
+    }
+    mockHistory.mockImplementation(async (_id, cursor) =>
+      cursor === undefined
+        ? page(100, { olderCursor: 'older-1', hasOlder: true })
+        : olderPages[cursor]!,
+    )
+    mockContext.mockResolvedValue(context())
+    const { client, wrapper } = harness()
+    client.setQueryDefaults(['run-history'], { staleTime: Infinity })
+    const first = renderHook(() => useRunHistory('run-1'), { wrapper })
+    const { result } = first
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    for (let index = 1; index <= 5; index += 1) {
+      await act(() => result.current.loadOlder())
+      await waitFor(() => expect(result.current.retainedPages).toBe(Math.min(index + 1, 5)))
+    }
+
+    expect(result.current.retainedPages).toBe(5)
+    expect(result.current.visibleEvents.map(({ seq }) => seq)).toEqual([50, 60, 70, 80, 90, 100])
+    expect(FakeEventSource.instances.at(-1)?.url).toBe('/api/v1/runs/run-1/events?cursor=live-100&afterSeq=100')
+
+    first.unmount()
+    renderHook(() => useRunHistory('run-1'), { wrapper })
+    expect(FakeEventSource.instances.at(-1)?.url).toBe('/api/v1/runs/run-1/events?cursor=live-100&afterSeq=100')
+  })
+
+  it('serializes compaction behind older-page loading so neither can overwrite the other', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    let resolveOlder!: (value: RunHistoryPage) => void
+    const older = new Promise<RunHistoryPage>((resolve) => {
+      resolveOlder = resolve
+    })
+    mockHistory.mockImplementation(async (_id, cursor) => {
+      if (cursor === 'older-100') return older
+      return page(100, { olderCursor: 'older-100', hasOlder: true })
+    })
+    mockContext.mockResolvedValue(context())
+    const { wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    let loadingOlder!: Promise<void>
+    act(() => {
+      loadingOlder = result.current.loadOlder()
+    })
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      for (let seq = 101; seq <= 300; seq += 1) {
+        FakeEventSource.instances[0]!.emit(
+          'run-event',
+          JSON.stringify({ seq, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: `event-${seq}` }),
+        )
+      }
+    })
+    await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(300))
+    // The older fetch owns the history mutation slot; compaction has not even requested its tail
+    // snapshot yet.
+    expect(mockHistory).toHaveBeenCalledTimes(2)
+
+    resolveOlder(page(1))
+    await act(async () => loadingOlder)
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(3))
+    expect(result.current.visibleEvents.map(({ seq }) => seq).at(0)).toBe(1)
+    expect(result.current.visibleEvents.at(-1)?.seq).toBe(300)
+    vi.unstubAllGlobals()
+  })
+
   it('compacts a long live prefix into a fresh persisted tail page', async () => {
     FakeEventSource.instances = []
     vi.stubGlobal('EventSource', FakeEventSource)
@@ -153,9 +232,13 @@ describe('useRunHistory', () => {
       })),
       itemCount: 100,
     }
+    let resolveCompacted!: (value: RunHistoryPage) => void
+    const compacted = new Promise<RunHistoryPage>((resolve) => {
+      resolveCompacted = resolve
+    })
     mockHistory
       .mockResolvedValueOnce(page(100))
-      .mockResolvedValue(compactedTail)
+      .mockImplementationOnce(() => compacted)
     mockContext.mockResolvedValue(context())
     const { wrapper } = harness()
     const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
@@ -176,12 +259,133 @@ describe('useRunHistory', () => {
     })
 
     await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+    // This is live-only: it is emitted after the compaction snapshot request and is not in the
+    // persisted page that will replace the old cursor.
+    FakeEventSource.instances[0]!.emit(
+      'ui-event',
+      JSON.stringify({ seq: 301, ts: '2026-07-30T00:00:00.000Z', type: 'item.delta', itemId: 'm1', field: 'text', delta: 'live-only' }),
+    )
+    resolveCompacted(compactedTail)
     await waitFor(() => expect(result.current.retainedPages).toBe(1))
-    await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(300))
-    expect(result.current.visibleEvents).toHaveLength(100)
-    expect(result.current.visibleEvents[0]?.seq).toBe(201)
+    await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(301))
+    expect(result.current.visibleEvents.some(({ seq, type }) => seq === 301 && type === 'item.delta')).toBe(true)
     expect(result.current.retainedPages).toBe(1)
-    expect(FakeEventSource.instances.length).toBeGreaterThanOrEqual(2)
+    expect(FakeEventSource.instances).toHaveLength(1)
+    vi.unstubAllGlobals()
+  })
+
+  it('only covers live deltas that a durable item snapshot can reconstruct', () => {
+    const delta = {
+      seq: 101,
+      ts: '2026-07-30T00:00:00.000Z',
+      type: 'item.delta',
+      stepId: 'step-1',
+      itemId: 'message-1',
+      field: 'text',
+      delta: 'partial',
+    }
+    expect(coveredLiveEventSeqs([delta], [{
+      seq: 103,
+      ts: '2026-07-30T00:00:00.000Z',
+      type: 'session.ended',
+    }])).toEqual([])
+    expect(coveredLiveEventSeqs([delta], [{
+      seq: 102,
+      ts: '2026-07-30T00:00:00.000Z',
+      type: 'item.completed',
+      stepId: 'step-1',
+      item: { kind: 'message', id: 'message-1', role: 'assistant', text: 'complete' },
+    }])).toEqual([101])
+  })
+
+  it('covers durable live lines that already paged out of the newest history page', () => {
+    const oldLine = { seq: 101, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: 'old' }
+    const liveOnlyUpdate = {
+      seq: 102,
+      ts: '2026-07-30T00:00:00.000Z',
+      type: 'item.updated',
+      stepId: 'step-1',
+      item: { kind: 'message', id: 'message-1', role: 'assistant', text: 'partial' },
+    }
+    const completed = {
+      seq: 103,
+      ts: '2026-07-30T00:00:00.000Z',
+      type: 'item.completed',
+      stepId: 'step-1',
+      item: { kind: 'message', id: 'message-1', role: 'assistant', text: 'complete' },
+    }
+
+    expect(coveredLiveEventSeqs([oldLine, liveOnlyUpdate], [completed], 103)).toEqual([101, 102])
+  })
+
+  it('keeps live events when the optimized history switches to fallback', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    let rejectContext!: (error: Error) => void
+    const pendingContext = new Promise<RunHistoryContext>((_, reject) => {
+      rejectContext = reject
+    })
+    mockHistory.mockResolvedValue(page(100, { olderCursor: 'older-0', hasOlder: true }))
+    mockContext.mockImplementation(() => pendingContext)
+    const { wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    FakeEventSource.instances[0]!.emit(
+      'ui-event',
+      JSON.stringify({ seq: 101, ts: '2026-07-30T00:00:00.000Z', type: 'item.delta', itemId: 'm1', field: 'text', delta: 'live-only' }),
+    )
+    await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(101))
+
+    rejectContext(new Error('context unavailable'))
+    await waitFor(() => expect(result.current.fallback).toBe(true), { timeout: 3_000 })
+
+    // The optimized stream is closed at handoff; its already-rendered tail is merged into the
+    // single full-replay stream so a live-only frame emitted before the error cannot be lost.
+    expect(FakeEventSource.instances).toHaveLength(2)
+    expect(FakeEventSource.instances[0]!.readyState).toBe(2)
+    expect(FakeEventSource.instances[1]!.url).toBe('/api/v1/runs/run-1/events')
+    FakeEventSource.instances[1]!.emit(
+      'run-event',
+      JSON.stringify({ seq: 50, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: 'full-replay' }),
+    )
+    await waitFor(() => expect(result.current.visibleEvents.map(({ seq }) => seq)).toEqual([50, 100, 101]))
+    vi.unstubAllGlobals()
+  })
+
+  it('ignores a stale compaction response when newer history is already cached', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    let resolveStale!: (value: RunHistoryPage) => void
+    const stale = new Promise<RunHistoryPage>((resolve) => {
+      resolveStale = resolve
+    })
+    mockHistory
+      .mockResolvedValueOnce(page(100))
+      .mockImplementationOnce(() => stale)
+    mockContext.mockResolvedValue(context())
+    const { client, wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    act(() => {
+      for (let seq = 101; seq <= 300; seq += 1) {
+        FakeEventSource.instances[0]!.emit(
+          'run-event',
+          JSON.stringify({ seq, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: `event-${seq}` }),
+        )
+      }
+    })
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+
+    client.setQueryData(['run-history', 'default', 'run-1'], {
+      pages: [page(400)],
+      pageParams: [undefined],
+    })
+    resolveStale(page(250))
+    await waitFor(() => expect(result.current.retainedPages).toBe(1))
+    expect(client.getQueryData<{ pages: RunHistoryPage[] }>(['run-history', 'default', 'run-1'])?.pages[0]?.asOfSeq).toBe(400)
+    expect(result.current.visibleEvents.some(({ seq }) => seq === 250)).toBe(true)
     vi.unstubAllGlobals()
   })
 
@@ -218,6 +422,16 @@ describe('useRunHistory', () => {
     expect(result.current.visibleEvents.at(-1)?.seq).toBe(300)
     // A failed compaction is not a load failure: the transcript must NOT drop to full replay.
     expect(result.current.fallback).toBe(false)
+    FakeEventSource.instances[0]!.emit(
+      'run-event',
+      JSON.stringify({ seq: 301, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: 'retry' }),
+    )
+    await new Promise((resolve) => setTimeout(resolve, 1_050))
+    FakeEventSource.instances[0]!.emit(
+      'run-event',
+      JSON.stringify({ seq: 302, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: 'retry-after-backoff' }),
+    )
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(3))
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(unhandled).not.toHaveBeenCalled()
 

--- a/packages/web/src/api/run-history.test.tsx
+++ b/packages/web/src/api/run-history.test.tsx
@@ -140,6 +140,24 @@ describe('useRunHistory', () => {
     expect(result.current.hasOlder).toBe(false)
   })
 
+  it('keeps the optimized stream after an older-page failure so the retry remains available', async () => {
+    mockHistory.mockImplementation(async (_id, cursor) => {
+      if (cursor === 'older-100') throw new Error('older page unavailable')
+      return page(100, { olderCursor: 'older-100', hasOlder: true })
+    })
+    mockContext.mockResolvedValue(context())
+    const { wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(result.current.hasOlder).toBe(true))
+
+    await act(async () => {
+      await result.current.loadOlder().catch(() => undefined)
+    })
+    await waitFor(() => expect(result.current.isFetchingOlder).toBe(false))
+    expect(result.current.fallback).toBe(false)
+    expect(result.current.hasOlder).toBe(true)
+  })
+
   it('jump-to-latest clears retained older pages and refetches the cursorless tail', async () => {
     mockHistory.mockImplementation(async (_id, cursor) =>
       cursor === 'older-100'
@@ -156,6 +174,35 @@ describe('useRunHistory', () => {
     await act(() => result.current.jumpToLatest())
     await waitFor(() => expect(result.current.retainedPages).toBe(1))
     expect(mockHistory).toHaveBeenLastCalledWith('run-1', undefined, expect.any(Object))
+  })
+
+  it('jumps to the latest tail without waiting for a hung older-page request', async () => {
+    let resolveOlder!: (value: RunHistoryPage) => void
+    const older = new Promise<RunHistoryPage>((resolve) => {
+      resolveOlder = resolve
+    })
+    mockHistory.mockImplementation(async (_id, cursor) => {
+      if (cursor === 'older-100') return older
+      return page(100, { olderCursor: 'older-100', hasOlder: true })
+    })
+    mockContext.mockResolvedValue(context())
+    const { wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(result.current.hasOlder).toBe(true))
+
+    let loadingOlder!: Promise<void>
+    act(() => {
+      loadingOlder = result.current.loadOlder().catch(() => undefined)
+    })
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+
+    await act(async () => result.current.jumpToLatest())
+    await waitFor(() => expect(result.current.retainedPages).toBe(1))
+    expect(mockHistory).toHaveBeenCalledTimes(3)
+
+    resolveOlder(page(1))
+    await act(async () => loadingOlder)
+    expect(result.current.visibleEvents.map(({ seq }) => seq)).toEqual([100])
   })
 
   it('keeps the newest tail when maxPages evicts it during older-page browsing', async () => {
@@ -192,6 +239,42 @@ describe('useRunHistory', () => {
     first.unmount()
     renderHook(() => useRunHistory('run-1'), { wrapper })
     expect(FakeEventSource.instances.at(-1)?.url).toBe('/api/v1/runs/run-1/events?cursor=live-100&afterSeq=100')
+  })
+
+  it('does not let an older task request patch the current task cache', async () => {
+    let resolveOlder!: (value: RunHistoryPage) => void
+    const older = new Promise<RunHistoryPage>((resolve) => {
+      resolveOlder = resolve
+    })
+    mockHistory.mockImplementation(async (id, cursor) => {
+      if (id === 'run-a' && cursor === 'older-a') return older
+      if (id === 'run-a') return page(100, { olderCursor: 'older-a', hasOlder: true })
+      return page(200)
+    })
+    mockContext.mockResolvedValue(context())
+    const { client, wrapper } = harness()
+    const { result, rerender } = renderHook(({ runId }: { runId: string }) => useRunHistory(runId), {
+      initialProps: { runId: 'run-a' },
+      wrapper,
+    })
+    await waitFor(() => expect(result.current.hasOlder).toBe(true))
+
+    let loadingOlder!: Promise<void>
+    act(() => {
+      loadingOlder = result.current.loadOlder()
+    })
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+    rerender({ runId: 'run-b' })
+    await waitFor(() => expect(result.current.visibleEvents.map(({ seq }) => seq)).toEqual([200]))
+
+    resolveOlder(page(1))
+    await act(async () => loadingOlder)
+    const runAEvents = client.getQueryData<{ pages: RunHistoryPage[] }>(['run-history', 'default', 'run-a'])?.pages
+      .flatMap(({ events }) => events.map(({ seq }) => seq)) ?? []
+    expect(runAEvents).toContain(100)
+    expect(runAEvents).not.toContain(200)
+    expect(client.getQueryData<{ pages: RunHistoryPage[] }>(['run-history', 'default', 'run-b'])?.pages
+      .flatMap(({ events }) => events.map(({ seq }) => seq))).toEqual([200])
   })
 
   it('refreshes the tail while older-page loading is still pending', async () => {

--- a/packages/web/src/api/run-history.test.tsx
+++ b/packages/web/src/api/run-history.test.tsx
@@ -111,6 +111,24 @@ describe('useRunHistory', () => {
     expect(result.current.retainedPages).toBe(2)
   })
 
+  it('keeps late live frames in current state when context has a newer high-water mark', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    mockHistory.mockResolvedValue(page(100))
+    mockContext.mockResolvedValue({ ...context(), asOfSeq: 300 })
+    const { wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    FakeEventSource.instances[0]!.emit(
+      'ui-event',
+      JSON.stringify({ seq: 250, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: 'late-live' }),
+    )
+    await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(250))
+    expect(result.current.currentEvents.map(({ seq }) => seq)).toEqual([90, 250])
+    vi.unstubAllGlobals()
+  })
+
   it('falls back to the protected full replay when either optimized request cannot load', async () => {
     mockHistory.mockRejectedValue(new Error('old server'))
     mockContext.mockResolvedValue(context())
@@ -176,15 +194,20 @@ describe('useRunHistory', () => {
     expect(FakeEventSource.instances.at(-1)?.url).toBe('/api/v1/runs/run-1/events?cursor=live-100&afterSeq=100')
   })
 
-  it('serializes compaction behind older-page loading so neither can overwrite the other', async () => {
+  it('refreshes the tail while older-page loading is still pending', async () => {
     FakeEventSource.instances = []
     vi.stubGlobal('EventSource', FakeEventSource)
     let resolveOlder!: (value: RunHistoryPage) => void
     const older = new Promise<RunHistoryPage>((resolve) => {
       resolveOlder = resolve
     })
+    let resolveCompacted!: (value: RunHistoryPage) => void
+    const compacted = new Promise<RunHistoryPage>((resolve) => {
+      resolveCompacted = resolve
+    })
     mockHistory.mockImplementation(async (_id, cursor) => {
       if (cursor === 'older-100') return older
+      if (cursor === undefined && mockHistory.mock.calls.length > 1) return compacted
       return page(100, { olderCursor: 'older-100', hasOlder: true })
     })
     mockContext.mockResolvedValue(context())
@@ -207,13 +230,14 @@ describe('useRunHistory', () => {
       }
     })
     await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(300))
-    // The older fetch owns the history mutation slot; compaction has not even requested its tail
-    // snapshot yet.
-    expect(mockHistory).toHaveBeenCalledTimes(2)
+    // Compaction is independent from the older-page queue, so a stuck pagination request cannot
+    // hold the live tail hostage.
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(3))
+    resolveCompacted(page(300))
+    await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(300))
 
     resolveOlder(page(1))
     await act(async () => loadingOlder)
-    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(3))
     expect(result.current.visibleEvents.map(({ seq }) => seq).at(0)).toBe(1)
     expect(result.current.visibleEvents.at(-1)?.seq).toBe(300)
     vi.unstubAllGlobals()
@@ -327,7 +351,7 @@ describe('useRunHistory', () => {
     })
     mockHistory.mockResolvedValue(page(100, { olderCursor: 'older-0', hasOlder: true }))
     mockContext.mockImplementation(() => pendingContext)
-    const { wrapper } = harness()
+    const { client, wrapper } = harness()
     const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
     await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
 
@@ -350,6 +374,46 @@ describe('useRunHistory', () => {
       JSON.stringify({ seq: 50, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: 'full-replay' }),
     )
     await waitFor(() => expect(result.current.visibleEvents.map(({ seq }) => seq)).toEqual([50, 100, 101]))
+    client.setQueryData(['run-history-context', 'default', 'run-1'], context())
+    await waitFor(() => expect(result.current.fallback).toBe(true))
+    vi.unstubAllGlobals()
+  })
+
+  it('compares compaction with the newest cursorless page, not an older page high-water mark', async () => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+    let resolveStale!: (value: RunHistoryPage) => void
+    const stale = new Promise<RunHistoryPage>((resolve) => {
+      resolveStale = resolve
+    })
+    mockHistory
+      .mockResolvedValueOnce(page(100))
+      .mockImplementationOnce(() => stale)
+    mockContext.mockResolvedValue(context())
+    const { client, wrapper } = harness()
+    const { result } = renderHook(() => useRunHistory('run-1'), { wrapper })
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+
+    act(() => {
+      for (let seq = 101; seq <= 300; seq += 1) {
+        FakeEventSource.instances[0]!.emit(
+          'run-event',
+          JSON.stringify({ seq, ts: '2026-07-30T00:00:00.000Z', type: 'note', message: `event-${seq}` }),
+        )
+      }
+    })
+    await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+
+    client.setQueryData(['run-history', 'default', 'run-1'], {
+      pages: [page(100, { newerCursor: 'newer', asOfSeq: 500 }), page(200)],
+      pageParams: ['older', undefined],
+    })
+    resolveStale(page(250))
+    await waitFor(() => expect(
+      client.getQueryData<{ pages: RunHistoryPage[] }>(['run-history', 'default', 'run-1'])?.pages.at(-1)?.asOfSeq,
+    ).toBe(250))
+    expect(client.getQueryData<{ pages: RunHistoryPage[] }>(['run-history', 'default', 'run-1'])?.pages[0]?.asOfSeq).toBe(500)
+    expect(result.current.visibleEvents.some(({ seq }) => seq === 250)).toBe(true)
     vi.unstubAllGlobals()
   })
 

--- a/packages/web/src/api/run-history.test.tsx
+++ b/packages/web/src/api/run-history.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RunHistoryContext, RunHistoryPage } from '@open-mercato/cezar-api-client'
 import { getRunHistory, getRunHistoryContext } from './client'
-import { useRunHistory } from './run-history'
+import { mergeRunHistoryEvents, useRunHistory } from './run-history'
 
 vi.mock('./client', () => ({
   getRunHistory: vi.fn(),
@@ -76,6 +76,20 @@ beforeEach(() => {
 })
 
 describe('useRunHistory', () => {
+  it('appends a strictly newer live tail without re-sorting the retained page', () => {
+    const base = [page(1).events[0]!, page(2).events[0]!]
+    const live = [page(3).events[0]!, page(7).events[0]!]
+
+    expect(mergeRunHistoryEvents(base, live).map(({ seq }) => seq)).toEqual([1, 2, 3, 7])
+  })
+
+  it('keeps reconnect overlap safe by falling back to ordered deduplication', () => {
+    const base = [page(1).events[0]!, page(3).events[0]!]
+    const replay = [page(2).events[0]!, page(3).events[0]!, page(4).events[0]!]
+
+    expect(mergeRunHistoryEvents(base, replay).map(({ seq }) => seq)).toEqual([1, 2, 3, 4])
+  })
+
   it('hydrates the visible tail and current context independently, then prepends one older page', async () => {
     mockHistory.mockImplementation(async (_id, cursor) =>
       cursor === 'older-100'
@@ -162,6 +176,7 @@ describe('useRunHistory', () => {
     })
 
     await waitFor(() => expect(mockHistory).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.retainedPages).toBe(1))
     await waitFor(() => expect(result.current.visibleEvents.at(-1)?.seq).toBe(300))
     expect(result.current.visibleEvents).toHaveLength(100)
     expect(result.current.visibleEvents[0]?.seq).toBe(201)

--- a/packages/web/src/api/run-history.ts
+++ b/packages/web/src/api/run-history.ts
@@ -1,14 +1,15 @@
 import { useInfiniteQuery, useQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import type { RunEvent, RunHistoryPage } from '@open-mercato/cezar-api-client'
 import { queryScope } from '@open-mercato/cezar-api-client'
 import { getRunHistory, getRunHistoryContext } from './client'
-import { useRunEvents } from './run-events'
+import { liveItemKey, useRunEvents, type RunEventCompaction } from './run-events'
 
 const MAX_HISTORY_PAGES = 5
 const COMPACT_LIVE_AT_EVENTS = 200
 const MAX_LIVE_EVENTS = 5_000
+const COMPACTION_TIMEOUT_MS = 15_000
 
 function orderedUnique(...groups: readonly (readonly RunEvent[])[]): RunEvent[] {
   const bySeq = new Map<number, RunEvent>()
@@ -16,6 +17,72 @@ function orderedUnique(...groups: readonly (readonly RunEvent[])[]): RunEvent[] 
     for (const event of group) bySeq.set(event.seq, event)
   }
   return [...bySeq.values()].sort((a, b) => a.seq - b.seq)
+}
+
+function isStrictlyIncreasing(events: readonly RunEvent[]): boolean {
+  let previous = -Infinity
+  for (const event of events) {
+    if (event.seq <= previous) return false
+    previous = event.seq
+  }
+  return true
+}
+
+/** Merge the normal ordered streams without rebuilding a map and sorting their full contents. */
+function mergeOrderedUnique(...groups: readonly (readonly RunEvent[])[]): RunEvent[] {
+  if (!groups.every(isStrictlyIncreasing)) return orderedUnique(...groups)
+  const indexes = groups.map(() => 0)
+  const merged: RunEvent[] = []
+  for (;;) {
+    let nextSeq = Infinity
+    for (let index = 0; index < groups.length; index += 1) {
+      const event = groups[index]![indexes[index]!]
+      if (event !== undefined && event.seq < nextSeq) nextSeq = event.seq
+    }
+    if (nextSeq === Infinity) return merged
+    let selected: RunEvent | undefined
+    for (let index = 0; index < groups.length; index += 1) {
+      const event = groups[index]![indexes[index]!]
+      if (event?.seq === nextSeq) {
+        selected = event
+        indexes[index] = indexes[index]! + 1
+      }
+    }
+    if (selected !== undefined) merged.push(selected)
+  }
+}
+
+/**
+ * `asOfSeq` is a file high-water mark, not a contiguous live watermark: ephemeral deltas create
+ * sequence gaps. Only remove a live sequence when it is present in durable history, or when a
+ * durable full item snapshot after that delta repairs the same item.
+ */
+export function coveredLiveEventSeqs(
+  liveEvents: readonly RunEvent[],
+  persistedEvents: readonly RunEvent[],
+  durableThroughSeq = -Infinity,
+): RunEventCompaction {
+  const durableSeqs = new Set(persistedEvents.map(({ seq }) => seq))
+  const snapshotSeqs = new Map<string, number>()
+  for (const event of persistedEvents) {
+    if (event.type !== 'item.updated' && event.type !== 'item.completed') continue
+    const key = liveItemKey(event)
+    if (key !== undefined) snapshotSeqs.set(key, Math.max(snapshotSeqs.get(key) ?? -Infinity, event.seq))
+  }
+  return liveEvents
+    .filter((event) => {
+      if (durableSeqs.has(event.seq)) return true
+      // Every non-delta/non-streaming snapshot event is persisted by the server. The page only
+      // carries its newest 100 lines, so the file high-water mark also covers durable lines that
+      // have already paged out of the in-memory window.
+      if (event.seq <= durableThroughSeq && event.type !== 'item.delta' && event.type !== 'item.updated') {
+        return true
+      }
+      if (event.type !== 'item.delta' && event.type !== 'item.updated') return false
+      const snapshotSeq = snapshotSeqs.get(liveItemKey(event) ?? '')
+      return snapshotSeq !== undefined && snapshotSeq > event.seq
+    })
+    .map(({ seq }) => seq)
 }
 
 /**
@@ -28,12 +95,17 @@ export function mergeRunHistoryEvents(
 ): RunEvent[] {
   if (live.length === 0) return base.slice()
   const lastSeq = base.at(-1)?.seq ?? -Infinity
-  let previous = lastSeq
+  let previous = -Infinity
   for (const event of live) {
     if (event.seq <= previous) return orderedUnique(base, live)
     previous = event.seq
   }
-  return base.length === 0 ? [...live] : [...base, ...live]
+  if (base.length === 0 || live[0]!.seq > lastSeq) return [...base, ...live]
+
+  // Compaction can replace the persisted page while the live buffer still contains frames from
+  // the old cursor. Both lists are ordered, so merge them without a map/sort and keep every live
+  // frame that the persisted page does not contain.
+  return mergeOrderedUnique(base, live)
 }
 
 export interface RunHistoryState {
@@ -60,6 +132,7 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
   const queryClient = useQueryClient()
   const historyKey = ['run-history', scope, runId] as const
   const contextKey = ['run-history-context', scope, runId] as const
+  const tailKey = ['run-history-tail', scope, runId] as const
 
   const history = useInfiniteQuery({
     queryKey: historyKey,
@@ -79,32 +152,64 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
   })
 
   const fallback = history.isError || context.isError
-  const fallbackEvents = useRunEvents(fallback ? runId : undefined)
   const pages = history.data?.pages ?? []
-  const newestPage = pages.reduce<RunHistoryPage | undefined>(
-    (latest, page) =>
-      page.newerCursor === undefined
-        ? page
-        : latest ?? page,
-    undefined,
-  )
-  const compactingLive = useRef(false)
-  const compactLive = useCallback(() => {
-    if (runId === undefined || compactingLive.current) return
-    compactingLive.current = true
-    void getRunHistory(runId, undefined)
-      .then((latestPage) => {
-        queryClient.setQueryData<InfiniteData<RunHistoryPage, string | undefined>>(
-          ['run-history', scope, runId],
-          (current) => {
-            if (!current) return { pages: [latestPage], pageParams: [undefined] }
+  const newestPageRef = useRef<RunHistoryPage | undefined>(undefined)
+  const ownerKey = `${scope}\0${runId ?? ''}`
+  const ownerRef = useRef(ownerKey)
+  const historyMutationRef = useRef(Promise.resolve())
+  if (ownerRef.current !== ownerKey) {
+    ownerRef.current = ownerKey
+    historyMutationRef.current = Promise.resolve()
+    newestPageRef.current = undefined
+  }
+  const enqueueHistoryMutation = useCallback(<T,>(mutation: () => Promise<T>): Promise<T> => {
+    const previous = historyMutationRef.current
+    let release!: () => void
+    historyMutationRef.current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    return previous.then(mutation).finally(release)
+  }, [])
+  const cachedNewestPage = pages.find((page) => page.newerCursor === undefined)
+  const cachedTail = pages.length > 0
+    ? queryClient.getQueryData<RunHistoryPage>(tailKey)
+    : undefined
+  if (cachedNewestPage) newestPageRef.current = cachedNewestPage
+  else if (cachedTail) newestPageRef.current = cachedTail
+  // With maxPages, TanStack may evict the cursorless newest page while older pages remain. The
+  // tail is kept outside that window so the live cursor never starts after an evicted segment.
+  // The last retained page is only a final recovery for pre-existing cache shapes.
+  const newestPage = cachedNewestPage
+    ?? cachedTail
+    ?? (pages.length > 0 ? newestPageRef.current ?? pages.at(-1) : undefined)
+  const compactingOwnerRef = useRef<string | undefined>(undefined)
+  const compactLive = useCallback(async (liveEvents: readonly RunEvent[]): Promise<RunEventCompaction | false> => {
+    if (runId === undefined || compactingOwnerRef.current === ownerKey) return false
+    compactingOwnerRef.current = ownerKey
+    return enqueueHistoryMutation(async () => {
+      const controller = new AbortController()
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      try {
+        const latestPage = await Promise.race<RunHistoryPage>([
+          getRunHistory(runId, undefined, { signal: controller.signal }),
+          new Promise<RunHistoryPage>((_, reject) => {
+            timeout = setTimeout(() => {
+              controller.abort()
+              reject(new Error('history compaction timed out'))
+            }, COMPACTION_TIMEOUT_MS)
+          }),
+        ])
+        if (ownerRef.current !== ownerKey) return false
+        const current = queryClient.getQueryData<InfiniteData<RunHistoryPage, string | undefined>>(historyKey)
+        // Decide and install against the same snapshot. Computing coverage before an updater can
+        // reject a stale page would remove live frames even though that page never became cache.
+        if (current?.pages.some((page) => page.asOfSeq >= latestPage.asOfSeq)) return []
+        const next: InfiniteData<RunHistoryPage, string | undefined> = current
+          ? (() => {
             const pages = [...current.pages]
             const pageParams = [...current.pageParams]
-            let latestIndex = -1
-            for (let index = 0; index < pages.length; index += 1) {
-              if (latestIndex === -1 || pages[index]!.asOfSeq > pages[latestIndex]!.asOfSeq) latestIndex = index
-            }
-            if (latestIndex >= 0 && pages[latestIndex]!.newerCursor === undefined) {
+            const latestIndex = pages.findIndex((page) => page.newerCursor === undefined)
+            if (latestIndex >= 0) {
               pages[latestIndex] = latestPage
               pageParams[latestIndex] = undefined
             } else {
@@ -116,49 +221,86 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
               pageParams.shift()
             }
             return { pages, pageParams }
-          },
+          })()
+          : { pages: [latestPage], pageParams: [undefined] }
+        queryClient.setQueryData(historyKey, next)
+        queryClient.setQueryData(tailKey, latestPage)
+        newestPageRef.current = latestPage
+        return coveredLiveEventSeqs(
+          liveEvents,
+          next.pages.flatMap((page) => page.events as RunEvent[]),
+          latestPage.asOfSeq,
         )
-      })
-      // Compaction is an optimization, not a load: this call is fire-and-forget (`void`), so a
-      // rejection here has no query to reject and would surface as an unhandled rejection. The
-      // live buffer still holds every event, and the next `onCompact` retries — so swallowing is
-      // the graceful outcome. Reachable via a transport error, and now also via a malformed page
-      // body, which the client validates rather than casts (#827).
-      .catch(() => {})
-      .finally(() => {
-        compactingLive.current = false
-      })
-  }, [queryClient, runId, scope])
-  const liveEvents = useRunEvents(!fallback && newestPage ? runId : undefined, {
-    cursor: newestPage?.liveCursor,
-    afterSeq: newestPage?.asOfSeq,
+      } catch {
+        // Compaction is an optimization, not a load. The live buffer remains the source of truth,
+        // and the stream re-arms its request latch so a later batch can retry.
+        return false
+      } finally {
+        clearTimeout(timeout)
+        controller.abort()
+        if (compactingOwnerRef.current === ownerKey) compactingOwnerRef.current = undefined
+      }
+    })
+  }, [enqueueHistoryMutation, historyKey, ownerKey, queryClient, runId])
+  const liveEvents = useRunEvents(newestPage && !fallback ? runId : undefined, newestPage ? {
+    cursor: newestPage.liveCursor,
+    afterSeq: newestPage.asOfSeq,
     maxEvents: MAX_LIVE_EVENTS,
     compactAt: COMPACT_LIVE_AT_EVENTS,
     onCompact: compactLive,
+  } : {})
+  const fallbackEvents = useRunEvents(fallback ? runId : undefined)
+  const fallbackTailRef = useRef<{ runId: string | undefined; scope: string; events: RunEvent[] }>({
+    runId: undefined,
+    scope,
+    events: [],
   })
+  if (fallbackTailRef.current.runId !== runId || fallbackTailRef.current.scope !== scope) {
+    fallbackTailRef.current = { runId, scope, events: [] }
+  }
+  if (!fallback) fallbackTailRef.current.events = liveEvents
+  const fallbackTail = fallback ? fallbackTailRef.current.events : []
 
   const pagedEvents = useMemo(
-    () => orderedUnique(...pages.map((page) => page.events as RunEvent[])),
-    [pages],
+    () => {
+      const groups = pages.map((page) => page.events as RunEvent[])
+      if (newestPage !== undefined && !pages.includes(newestPage)) groups.push(newestPage.events as RunEvent[])
+      return orderedUnique(...groups)
+    },
+    [newestPage, pages],
   )
+  useEffect(() => {
+    const page = pages.find((candidate) => candidate.newerCursor === undefined)
+    if (!page) return
+    queryClient.setQueryData(tailKey, page)
+  }, [pages, queryClient, runId, scope])
   const visibleEvents = useMemo(
-    () => fallback ? fallbackEvents : mergeRunHistoryEvents(pagedEvents, liveEvents),
-    [fallback, fallbackEvents, pagedEvents, liveEvents],
+    () => fallback
+      ? mergeOrderedUnique(pagedEvents, fallbackTail, fallbackEvents)
+      : mergeRunHistoryEvents(pagedEvents, liveEvents),
+    [fallback, fallbackEvents, fallbackTail, liveEvents, pagedEvents],
   )
   const currentEvents = useMemo(() => {
-    if (fallback) return fallbackEvents
+    if (fallback) return visibleEvents
     const contextEvents = (context.data?.contextEvents ?? []) as RunEvent[]
     const contextHighWater = context.data?.asOfSeq ?? 0
-    return orderedUnique(contextEvents, visibleEvents.filter(({ seq }) => seq > contextHighWater))
-  }, [context.data, fallback, fallbackEvents, visibleEvents])
+    return mergeOrderedUnique(contextEvents, visibleEvents.filter(({ seq }) => seq > contextHighWater))
+  }, [context.data, fallback, visibleEvents])
 
   const loadOlder = useCallback(async () => {
-    await history.fetchPreviousPage()
-  }, [history.fetchPreviousPage])
+    const current = queryClient.getQueryData<InfiniteData<RunHistoryPage, string | undefined>>(historyKey)
+    const tail = current?.pages.find((page) => page.newerCursor === undefined)
+    if (tail) queryClient.setQueryData(tailKey, tail)
+    await enqueueHistoryMutation(() => history.fetchPreviousPage())
+  }, [enqueueHistoryMutation, history.fetchPreviousPage, historyKey, queryClient, tailKey])
 
   const jumpToLatest = useCallback(async () => {
-    await queryClient.resetQueries({ queryKey: historyKey, exact: true })
-  }, [historyKey, queryClient])
+    await enqueueHistoryMutation(async () => {
+      newestPageRef.current = undefined
+      queryClient.removeQueries({ queryKey: tailKey, exact: true })
+      await queryClient.resetQueries({ queryKey: historyKey, exact: true })
+    })
+  }, [enqueueHistoryMutation, historyKey, queryClient, tailKey])
 
   return {
     visibleEvents,

--- a/packages/web/src/api/run-history.ts
+++ b/packages/web/src/api/run-history.ts
@@ -10,12 +10,30 @@ const MAX_HISTORY_PAGES = 5
 const COMPACT_LIVE_AT_EVENTS = 200
 const MAX_LIVE_EVENTS = 5_000
 
-function orderedUnique(...groups: readonly RunEvent[][]): RunEvent[] {
+function orderedUnique(...groups: readonly (readonly RunEvent[])[]): RunEvent[] {
   const bySeq = new Map<number, RunEvent>()
   for (const group of groups) {
     for (const event of group) bySeq.set(event.seq, event)
   }
   return [...bySeq.values()].sort((a, b) => a.seq - b.seq)
+}
+
+/**
+ * The optimized stream is append-only between history compactions. Keep that hot path linear and
+ * preserve the old dedup/sort fallback for reconnects or a page replacement that overlaps it.
+ */
+export function mergeRunHistoryEvents(
+  base: readonly RunEvent[],
+  live: readonly RunEvent[],
+): RunEvent[] {
+  if (live.length === 0) return base.slice()
+  const lastSeq = base.at(-1)?.seq ?? -Infinity
+  let previous = lastSeq
+  for (const event of live) {
+    if (event.seq <= previous) return orderedUnique(base, live)
+    previous = event.seq
+  }
+  return base.length === 0 ? [...live] : [...base, ...live]
 }
 
 export interface RunHistoryState {
@@ -124,7 +142,7 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     [pages],
   )
   const visibleEvents = useMemo(
-    () => fallback ? fallbackEvents : orderedUnique(pagedEvents, liveEvents),
+    () => fallback ? fallbackEvents : mergeRunHistoryEvents(pagedEvents, liveEvents),
     [fallback, fallbackEvents, pagedEvents, liveEvents],
   )
   const currentEvents = useMemo(() => {

--- a/packages/web/src/api/run-history.ts
+++ b/packages/web/src/api/run-history.ts
@@ -28,6 +28,13 @@ function isStrictlyIncreasing(events: readonly RunEvent[]): boolean {
   return true
 }
 
+function newestCursorlessPage(pages: readonly RunHistoryPage[]): RunHistoryPage | undefined {
+  for (let index = pages.length - 1; index >= 0; index -= 1) {
+    if (pages[index]!.newerCursor === undefined) return pages[index]
+  }
+  return undefined
+}
+
 /** Merge the normal ordered streams without rebuilding a map and sorting their full contents. */
 function mergeOrderedUnique(...groups: readonly (readonly RunEvent[])[]): RunEvent[] {
   if (!groups.every(isStrictlyIncreasing)) return orderedUnique(...groups)
@@ -151,17 +158,20 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     retry: 1,
   })
 
-  const fallback = history.isError || context.isError
   const pages = history.data?.pages ?? []
   const newestPageRef = useRef<RunHistoryPage | undefined>(undefined)
   const ownerKey = `${scope}\0${runId ?? ''}`
-  const ownerRef = useRef(ownerKey)
+  const ownerRef = useRef({ key: ownerKey, fallbackLatched: false })
   const historyMutationRef = useRef(Promise.resolve())
-  if (ownerRef.current !== ownerKey) {
-    ownerRef.current = ownerKey
+  const historyGenerationRef = useRef(0)
+  if (ownerRef.current.key !== ownerKey) {
+    ownerRef.current = { key: ownerKey, fallbackLatched: false }
     historyMutationRef.current = Promise.resolve()
+    historyGenerationRef.current += 1
     newestPageRef.current = undefined
   }
+  if (history.isError || context.isError) ownerRef.current.fallbackLatched = true
+  const fallback = ownerRef.current.fallbackLatched
   const enqueueHistoryMutation = useCallback(<T,>(mutation: () => Promise<T>): Promise<T> => {
     const previous = historyMutationRef.current
     let release!: () => void
@@ -170,78 +180,90 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     })
     return previous.then(mutation).finally(release)
   }, [])
-  const cachedNewestPage = pages.find((page) => page.newerCursor === undefined)
+  const cachedNewestPage = newestCursorlessPage(pages)
   const cachedTail = pages.length > 0
     ? queryClient.getQueryData<RunHistoryPage>(tailKey)
     : undefined
-  if (cachedNewestPage) newestPageRef.current = cachedNewestPage
-  else if (cachedTail) newestPageRef.current = cachedTail
+  if (cachedNewestPage && (!newestPageRef.current || cachedNewestPage.asOfSeq >= newestPageRef.current.asOfSeq)) {
+    newestPageRef.current = cachedNewestPage
+  } else if (cachedTail && (!newestPageRef.current || cachedTail.asOfSeq >= newestPageRef.current.asOfSeq)) {
+    newestPageRef.current = cachedTail
+  }
   // With maxPages, TanStack may evict the cursorless newest page while older pages remain. The
   // tail is kept outside that window so the live cursor never starts after an evicted segment.
   // The last retained page is only a final recovery for pre-existing cache shapes.
-  const newestPage = cachedNewestPage
+  const newestPage = newestPageRef.current
+    ?? cachedNewestPage
     ?? cachedTail
-    ?? (pages.length > 0 ? newestPageRef.current ?? pages.at(-1) : undefined)
+    ?? (pages.length > 0 ? pages.at(-1) : undefined)
   const compactingOwnerRef = useRef<string | undefined>(undefined)
   const compactLive = useCallback(async (liveEvents: readonly RunEvent[]): Promise<RunEventCompaction | false> => {
     if (runId === undefined || compactingOwnerRef.current === ownerKey) return false
     compactingOwnerRef.current = ownerKey
-    return enqueueHistoryMutation(async () => {
-      const controller = new AbortController()
-      let timeout: ReturnType<typeof setTimeout> | undefined
-      try {
-        const latestPage = await Promise.race<RunHistoryPage>([
-          getRunHistory(runId, undefined, { signal: controller.signal }),
-          new Promise<RunHistoryPage>((_, reject) => {
-            timeout = setTimeout(() => {
-              controller.abort()
-              reject(new Error('history compaction timed out'))
-            }, COMPACTION_TIMEOUT_MS)
-          }),
-        ])
-        if (ownerRef.current !== ownerKey) return false
-        const current = queryClient.getQueryData<InfiniteData<RunHistoryPage, string | undefined>>(historyKey)
-        // Decide and install against the same snapshot. Computing coverage before an updater can
-        // reject a stale page would remove live frames even though that page never became cache.
-        if (current?.pages.some((page) => page.asOfSeq >= latestPage.asOfSeq)) return []
-        const next: InfiniteData<RunHistoryPage, string | undefined> = current
-          ? (() => {
-            const pages = [...current.pages]
-            const pageParams = [...current.pageParams]
-            const latestIndex = pages.findIndex((page) => page.newerCursor === undefined)
-            if (latestIndex >= 0) {
-              pages[latestIndex] = latestPage
-              pageParams[latestIndex] = undefined
-            } else {
-              pages.push(latestPage)
-              pageParams.push(undefined)
-            }
-            while (pages.length > MAX_HISTORY_PAGES) {
-              pages.shift()
-              pageParams.shift()
-            }
-            return { pages, pageParams }
-          })()
-          : { pages: [latestPage], pageParams: [undefined] }
-        queryClient.setQueryData(historyKey, next)
-        queryClient.setQueryData(tailKey, latestPage)
-        newestPageRef.current = latestPage
-        return coveredLiveEventSeqs(
-          liveEvents,
-          next.pages.flatMap((page) => page.events as RunEvent[]),
-          latestPage.asOfSeq,
-        )
-      } catch {
-        // Compaction is an optimization, not a load. The live buffer remains the source of truth,
-        // and the stream re-arms its request latch so a later batch can retry.
-        return false
-      } finally {
-        clearTimeout(timeout)
-        controller.abort()
-        if (compactingOwnerRef.current === ownerKey) compactingOwnerRef.current = undefined
-      }
-    })
-  }, [enqueueHistoryMutation, historyKey, ownerKey, queryClient, runId])
+    const generation = historyGenerationRef.current
+    const controller = new AbortController()
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    try {
+      const latestPage = await Promise.race<RunHistoryPage>([
+        getRunHistory(runId, undefined, { signal: controller.signal }),
+        new Promise<RunHistoryPage>((_, reject) => {
+          timeout = setTimeout(() => {
+            controller.abort()
+            reject(new Error('history compaction timed out'))
+          }, COMPACTION_TIMEOUT_MS)
+        }),
+      ])
+      if (ownerRef.current.key !== ownerKey || historyGenerationRef.current !== generation) return false
+      const current = queryClient.getQueryData<InfiniteData<RunHistoryPage, string | undefined>>(historyKey)
+      // Only the cursorless page is the current tail. Older pages can carry the same file
+      // high-water mark and must not reject a newer tail snapshot.
+      const currentTail = newestCursorlessPage(current?.pages ?? [])
+      const cachedTail = queryClient.getQueryData<RunHistoryPage>(tailKey)
+      const latestKnownAsOfSeq = Math.max(
+        currentTail?.asOfSeq ?? -Infinity,
+        cachedTail?.asOfSeq ?? -Infinity,
+        newestPageRef.current?.asOfSeq ?? -Infinity,
+      )
+      // Decide and install against the same snapshot. Computing coverage before an updater can
+      // reject a stale page would remove live frames even though that page never became cache.
+      if (latestKnownAsOfSeq >= latestPage.asOfSeq) return false
+      const next: InfiniteData<RunHistoryPage, string | undefined> = current
+        ? (() => {
+          const pages = [...current.pages]
+          const pageParams = [...current.pageParams]
+          const latestIndex = currentTail ? pages.indexOf(currentTail) : -1
+          if (latestIndex >= 0) {
+            pages[latestIndex] = latestPage
+            pageParams[latestIndex] = undefined
+          } else {
+            pages.push(latestPage)
+            pageParams.push(undefined)
+          }
+          while (pages.length > MAX_HISTORY_PAGES) {
+            pages.shift()
+            pageParams.shift()
+          }
+          return { pages, pageParams }
+        })()
+        : { pages: [latestPage], pageParams: [undefined] }
+      queryClient.setQueryData(historyKey, next)
+      queryClient.setQueryData(tailKey, latestPage)
+      newestPageRef.current = latestPage
+      return coveredLiveEventSeqs(
+        liveEvents,
+        next.pages.flatMap((page) => page.events as RunEvent[]),
+        latestPage.asOfSeq,
+      )
+    } catch {
+      // Compaction is an optimization, not a load. The live buffer remains the source of truth,
+      // and the stream re-arms its request latch so a later batch can retry.
+      return false
+    } finally {
+      clearTimeout(timeout)
+      controller.abort()
+      if (compactingOwnerRef.current === ownerKey) compactingOwnerRef.current = undefined
+    }
+  }, [historyKey, ownerKey, queryClient, runId, tailKey])
   const liveEvents = useRunEvents(newestPage && !fallback ? runId : undefined, newestPage ? {
     cursor: newestPage.liveCursor,
     afterSeq: newestPage.asOfSeq,
@@ -270,7 +292,7 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     [newestPage, pages],
   )
   useEffect(() => {
-    const page = pages.find((candidate) => candidate.newerCursor === undefined)
+    const page = newestCursorlessPage(pages)
     if (!page) return
     queryClient.setQueryData(tailKey, page)
   }, [pages, queryClient, runId, scope])
@@ -284,17 +306,36 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     if (fallback) return visibleEvents
     const contextEvents = (context.data?.contextEvents ?? []) as RunEvent[]
     const contextHighWater = context.data?.asOfSeq ?? 0
-    return mergeOrderedUnique(contextEvents, visibleEvents.filter(({ seq }) => seq > contextHighWater))
-  }, [context.data, fallback, visibleEvents])
+    return mergeOrderedUnique(
+      contextEvents,
+      visibleEvents.filter(({ seq }) => seq > contextHighWater),
+      liveEvents.filter(({ seq }) => seq <= contextHighWater),
+    )
+  }, [context.data, fallback, liveEvents, visibleEvents])
 
   const loadOlder = useCallback(async () => {
     const current = queryClient.getQueryData<InfiniteData<RunHistoryPage, string | undefined>>(historyKey)
-    const tail = current?.pages.find((page) => page.newerCursor === undefined)
+    const tail = newestCursorlessPage(current?.pages ?? [])
     if (tail) queryClient.setQueryData(tailKey, tail)
-    await enqueueHistoryMutation(() => history.fetchPreviousPage())
+    try {
+      await enqueueHistoryMutation(() => history.fetchPreviousPage())
+    } finally {
+      const latestTail = newestPageRef.current
+      if (!latestTail) return
+      queryClient.setQueryData<InfiniteData<RunHistoryPage, string | undefined> | undefined>(historyKey, (current) => {
+        if (!current) return current
+        const currentTail = newestCursorlessPage(current.pages)
+        const tailIndex = currentTail ? current.pages.indexOf(currentTail) : -1
+        if (tailIndex < 0 || current.pages[tailIndex]!.asOfSeq >= latestTail.asOfSeq) return current
+        const pages = [...current.pages]
+        pages[tailIndex] = latestTail
+        return { ...current, pages }
+      })
+    }
   }, [enqueueHistoryMutation, history.fetchPreviousPage, historyKey, queryClient, tailKey])
 
   const jumpToLatest = useCallback(async () => {
+    historyGenerationRef.current += 1
     await enqueueHistoryMutation(async () => {
       newestPageRef.current = undefined
       queryClient.removeQueries({ queryKey: tailKey, exact: true })

--- a/packages/web/src/api/run-history.ts
+++ b/packages/web/src/api/run-history.ts
@@ -8,7 +8,7 @@ import { liveItemKey, useRunEvents, type RunEventCompaction } from './run-events
 
 const MAX_HISTORY_PAGES = 5
 const COMPACT_LIVE_AT_EVENTS = 200
-const MAX_LIVE_EVENTS = 5_000
+const LIVE_COMPACTION_SIZE_TRIGGER = 5_000
 const COMPACTION_TIMEOUT_MS = 15_000
 const EMPTY_RUN_EVENTS: RunEvent[] = []
 
@@ -274,7 +274,7 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
   const liveEvents = useRunEvents(newestPage && !fallback ? runId : undefined, newestPage ? {
     cursor: newestPage.liveCursor,
     afterSeq: newestPage.asOfSeq,
-    maxEvents: MAX_LIVE_EVENTS,
+    compactWhenOver: LIVE_COMPACTION_SIZE_TRIGGER,
     compactAt: COMPACT_LIVE_AT_EVENTS,
     onCompact: compactLive,
   } : {})

--- a/packages/web/src/api/run-history.ts
+++ b/packages/web/src/api/run-history.ts
@@ -10,6 +10,7 @@ const MAX_HISTORY_PAGES = 5
 const COMPACT_LIVE_AT_EVENTS = 200
 const MAX_LIVE_EVENTS = 5_000
 const COMPACTION_TIMEOUT_MS = 15_000
+const EMPTY_RUN_EVENTS: RunEvent[] = []
 
 function orderedUnique(...groups: readonly (readonly RunEvent[])[]): RunEvent[] {
   const bySeq = new Map<number, RunEvent>()
@@ -158,6 +159,12 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     retry: 1,
   })
 
+  const initialHistoryError = history.isError
+    && history.data === undefined
+    && !history.isFetchPreviousPageError
+    && !history.isFetchNextPageError
+    && !history.isRefetchError
+  const initialContextError = context.isError && context.data === undefined && !context.isRefetchError
   const pages = history.data?.pages ?? []
   const newestPageRef = useRef<RunHistoryPage | undefined>(undefined)
   const ownerKey = `${scope}\0${runId ?? ''}`
@@ -170,7 +177,7 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     historyGenerationRef.current += 1
     newestPageRef.current = undefined
   }
-  if (history.isError || context.isError) ownerRef.current.fallbackLatched = true
+  if (initialHistoryError || initialContextError) ownerRef.current.fallbackLatched = true
   const fallback = ownerRef.current.fallbackLatched
   const enqueueHistoryMutation = useCallback(<T,>(mutation: () => Promise<T>): Promise<T> => {
     const previous = historyMutationRef.current
@@ -281,7 +288,7 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
     fallbackTailRef.current = { runId, scope, events: [] }
   }
   if (!fallback) fallbackTailRef.current.events = liveEvents
-  const fallbackTail = fallback ? fallbackTailRef.current.events : []
+  const fallbackTail = fallback ? fallbackTailRef.current.events : EMPTY_RUN_EVENTS
 
   const pagedEvents = useMemo(
     () => {
@@ -314,12 +321,15 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
   }, [context.data, fallback, liveEvents, visibleEvents])
 
   const loadOlder = useCallback(async () => {
+    const requestOwnerKey = ownerKey
+    const requestGeneration = historyGenerationRef.current
     const current = queryClient.getQueryData<InfiniteData<RunHistoryPage, string | undefined>>(historyKey)
     const tail = newestCursorlessPage(current?.pages ?? [])
     if (tail) queryClient.setQueryData(tailKey, tail)
     try {
       await enqueueHistoryMutation(() => history.fetchPreviousPage())
     } finally {
+      if (ownerRef.current.key !== requestOwnerKey || historyGenerationRef.current !== requestGeneration) return
       const latestTail = newestPageRef.current
       if (!latestTail) return
       queryClient.setQueryData<InfiniteData<RunHistoryPage, string | undefined> | undefined>(historyKey, (current) => {
@@ -336,12 +346,13 @@ export function useRunHistory(runId: string | undefined): RunHistoryState {
 
   const jumpToLatest = useCallback(async () => {
     historyGenerationRef.current += 1
-    await enqueueHistoryMutation(async () => {
-      newestPageRef.current = undefined
-      queryClient.removeQueries({ queryKey: tailKey, exact: true })
-      await queryClient.resetQueries({ queryKey: historyKey, exact: true })
-    })
-  }, [enqueueHistoryMutation, historyKey, queryClient, tailKey])
+    historyMutationRef.current = Promise.resolve()
+    newestPageRef.current = undefined
+    queryClient.removeQueries({ queryKey: tailKey, exact: true })
+    // resetQueries cancels the in-flight older-page request, clears its data immediately, and
+    // refetches the active cursorless page. Do not await the refetch: the scroller must jump now.
+    void queryClient.resetQueries({ queryKey: historyKey, exact: true })
+  }, [historyKey, queryClient, tailKey])
 
   return {
     visibleEvents,

--- a/packages/web/src/components/app-shell-container.tsx
+++ b/packages/web/src/components/app-shell-container.tsx
@@ -41,11 +41,6 @@ export function skillsUpdateMarkerOf(state: SkillsUpdateState | undefined): bool
   return state?.available === true && (state.status === 'available' || state.status === 'error')
 }
 
-function ToolsMenuContainer() {
-  const health = useHealth()
-  return <ToolsMenu health={health.data} />
-}
-
 /**
  * The app shell, wired to live data.
  *
@@ -145,7 +140,7 @@ export const AppShellContainer = memo(function AppShellContainer({ children }: {
       skillsUpdateAvailable,
     ],
   )
-  const toolsMenu = useMemo(() => <ToolsMenuContainer />, [])
+  const toolsMenu = useMemo(() => <ToolsMenu health={health.data} />, [health.data])
 
   return (
     // The Active/Archived filter is shared by the quick-list below and the Tasks table (Step 3.4),

--- a/packages/web/src/components/app-shell-container.tsx
+++ b/packages/web/src/components/app-shell-container.tsx
@@ -82,7 +82,7 @@ export const AppShellContainer = memo(function AppShellContainer({ children }: {
   const isBootProject = projectId !== null && projectId === bootProjectId
   const activeProject = registry?.projects.find((project) => project.id === projectId)
   const titleRunId = titleContext.taskId
-  const titleRun = useProjectRuns(
+  const titleLabel = useProjectRuns(
     projectId ?? '',
     // Wait for the registry to identify the project before choosing the boot/non-boot cache
     // key. Health can arrive first; fetching then would briefly populate a project-scoped key
@@ -90,7 +90,10 @@ export const AppShellContainer = memo(function AppShellContainer({ children }: {
     activeProject !== undefined && titleRunId !== null,
     registry?.bootProject === projectId,
     useMemo(
-      () => (list) => (titleRunId ? list.find((run) => run.id === titleRunId) : undefined),
+      () => (list) => {
+        const run = titleRunId ? list.find((item) => item.id === titleRunId) : undefined
+        return run ? runTitle(run) : undefined
+      },
       [titleRunId],
     ),
   ).data
@@ -103,7 +106,7 @@ export const AppShellContainer = memo(function AppShellContainer({ children }: {
     ? null
     : (activeProject?.name ??
       (isBootProject ? (repoChipOf(health.data)?.name ?? null) : null))
-  const pageLabel = titleRun ? runTitle(titleRun) : titleContext.pageLabel
+  const pageLabel = titleLabel ?? titleContext.pageLabel
 
   useDocumentTitle({ projectName, pageLabel })
 

--- a/packages/web/src/components/app-shell-container.tsx
+++ b/packages/web/src/components/app-shell-container.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { memo, useMemo, type ReactNode } from 'react'
 import { useLocation } from 'react-router'
 
 import { useHealth, useProjectRuns, useProjects, useRuns, useSkillsUpdate, useTodos } from '@/api/queries'
@@ -41,6 +41,11 @@ export function skillsUpdateMarkerOf(state: SkillsUpdateState | undefined): bool
   return state?.available === true && (state.status === 'available' || state.status === 'error')
 }
 
+function ToolsMenuContainer() {
+  const health = useHealth()
+  return <ToolsMenu health={health.data} />
+}
+
 /**
  * The app shell, wired to live data.
  *
@@ -53,7 +58,7 @@ export function skillsUpdateMarkerOf(state: SkillsUpdateState | undefined): bool
  * so keeping them live is `useHealth`'s job — its poll plus Step 3.2's reconnect/visibility
  * reconcile — not a change here.
  */
-export function AppShellContainer({ children }: { children: ReactNode }) {
+export const AppShellContainer = memo(function AppShellContainer({ children }: { children: ReactNode }) {
   const { pathname } = useLocation()
   const projectId = useActiveProjectId()
   const health = useHealth()
@@ -70,19 +75,24 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
   const skillsUpdateAvailable = skillsUpdateMarkerOf(skillsUpdate.data)
   // Unread done items (#unread-done-items) for the Tasks badge. Reads the same active-scope run
   // list the sidebar quick-list and Tasks table already hold — one cache entry, no extra fetch.
-  const runs = useRuns()
+  const runs = useRuns((list) => unreadDoneCount(list))
   const registry = useProjects().data
   const titleContext = pageTitleContext(pathname)
   const bootProjectId = registry?.bootProject ?? health.data?.bootProject ?? null
   const isBootProject = projectId !== null && projectId === bootProjectId
   const activeProject = registry?.projects.find((project) => project.id === projectId)
-  const titleRuns = useProjectRuns(
+  const titleRunId = titleContext.taskId
+  const titleRun = useProjectRuns(
     projectId ?? '',
     // Wait for the registry to identify the project before choosing the boot/non-boot cache
     // key. Health can arrive first; fetching then would briefly populate a project-scoped key
     // for the boot project before switching to the authoritative `default` key.
-    activeProject !== undefined && titleContext.taskId !== null,
+    activeProject !== undefined && titleRunId !== null,
     registry?.bootProject === projectId,
+    useMemo(
+      () => (list) => (titleRunId ? list.find((run) => run.id === titleRunId) : undefined),
+      [titleRunId],
+    ),
   ).data
 
   // Global settings intentionally has no selected project. Everywhere else the URL id selects
@@ -93,9 +103,6 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
     ? null
     : (activeProject?.name ??
       (isBootProject ? (repoChipOf(health.data)?.name ?? null) : null))
-  const titleRun = titleContext.taskId
-    ? titleRuns?.find((run) => run.id === titleContext.taskId)
-    : undefined
   const pageLabel = titleRun ? runTitle(titleRun) : titleContext.pageLabel
 
   useDocumentTitle({ projectName, pageLabel })
@@ -106,6 +113,36 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
   // flat nav + single quick-list it has always had. That degenerate case is the upgrade path:
   // an existing user boots the new version in their usual repo and sees no difference.
   const projects = registry && registry.projects.length > 1 ? registry : null
+  const repo = useMemo(
+    () => repoChipOf(health.data),
+    [health.data?.repo?.root, health.data?.repo?.branch],
+  )
+  const banner = useMemo(() => <ProviderBannerContainer />, [])
+  const taskQuickList = useMemo(() => <TaskQuickListContainer />, [])
+  const projectGroups = useMemo(
+    () =>
+      projects ? (
+        <ProjectGroups
+          projects={projects.projects}
+          bootProjectId={projects.bootProject}
+          // No forge prop: each group gates its own GitHub tab on its registry entry's
+          // `forge` field (#698) — the boot folder's health-level answer says nothing about
+          // the other projects in the workspace.
+          inboxAvailable={inboxAvailable}
+          automationsAvailable={automationsAvailable}
+          inboxCount={todos.data?.length ?? null}
+          skillsUpdateAvailable={skillsUpdateAvailable}
+        />
+      ) : undefined,
+    [
+      projects,
+      inboxAvailable,
+      automationsAvailable,
+      todos.data?.length,
+      skillsUpdateAvailable,
+    ],
+  )
+  const toolsMenu = useMemo(() => <ToolsMenuContainer />, [])
 
   return (
     // The Active/Archived filter is shared by the quick-list below and the Tasks table (Step 3.4),
@@ -113,7 +150,7 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
     // both of them under it — the spec requires the two sets of tabs to be one filter.
     <ListViewProvider>
       <AppShell
-        repo={repoChipOf(health.data)}
+        repo={repo}
         version={health.data?.version ?? null}
         latestVersion={health.data?.latestVersion ?? null}
         // `?? null` rather than `?? 0`: no badge while the inbox is unknown, and no badge when it
@@ -121,7 +158,7 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
         inboxCount={todos.data?.length ?? null}
         // Same `?? null` honesty: no badge while the list is unknown; a loaded list with none
         // unread is 0, which AppShell also renders as no badge.
-        unreadCount={runs.data ? unreadDoneCount(runs.data) : null}
+        unreadCount={runs.data ?? null}
         skillsUpdateAvailable={skillsUpdateAvailable}
         // Hidden until health confirms the forge driver (R6 Step 1.1) — same honesty rule as
         // the chips: the nav must not claim a GitHub tab it cannot back. The Tools menu's
@@ -132,27 +169,13 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
         inboxAvailable={inboxAvailable}
         // Hidden unless health reports the opt-in automations capability (#801).
         automationsAvailable={automationsAvailable}
-        banner={<ProviderBannerContainer />}
+        banner={banner}
         singleProject={health.data?.capabilities.singleProject === true}
-        taskQuickList={<TaskQuickListContainer />}
+        taskQuickList={taskQuickList}
         // Present only in a multi-project workspace; `AppShell` renders the flat nav and the
         // quick-list above whenever this slot is absent.
-        projectGroups={
-          projects ? (
-            <ProjectGroups
-              projects={projects.projects}
-              bootProjectId={projects.bootProject}
-              // No forge prop: each group gates its own GitHub tab on its registry entry's
-              // `forge` field (#698) — the boot folder's health-level answer says nothing
-              // about the other projects in the workspace.
-              inboxAvailable={inboxAvailable}
-              automationsAvailable={automationsAvailable}
-              inboxCount={todos.data?.length ?? null}
-              skillsUpdateAvailable={skillsUpdateAvailable}
-            />
-          ) : undefined
-        }
-        toolsMenu={<ToolsMenu health={health.data} />}
+        projectGroups={projectGroups}
+        toolsMenu={toolsMenu}
       >
         {children}
       </AppShell>
@@ -161,4 +184,4 @@ export function AppShellContainer({ children }: { children: ReactNode }) {
       <CommandPalette />
     </ListViewProvider>
   )
-}
+})

--- a/packages/web/src/components/app-shell-container.tsx
+++ b/packages/web/src/components/app-shell-container.tsx
@@ -70,7 +70,8 @@ export const AppShellContainer = memo(function AppShellContainer({ children }: {
   const skillsUpdateAvailable = skillsUpdateMarkerOf(skillsUpdate.data)
   // Unread done items (#unread-done-items) for the Tasks badge. Reads the same active-scope run
   // list the sidebar quick-list and Tasks table already hold — one cache entry, no extra fetch.
-  const runs = useRuns((list) => unreadDoneCount(list))
+  const unreadDoneCountSelector = useMemo(() => unreadDoneCount, [])
+  const runs = useRuns(unreadDoneCountSelector)
   const registry = useProjects().data
   const titleContext = pageTitleContext(pathname)
   const bootProjectId = registry?.bootProject ?? health.data?.bootProject ?? null

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -114,6 +114,24 @@ export type AppShellProps = {
  */
 const SidebarNavigateContext = React.createContext<(() => void) | undefined>(undefined)
 
+const AppShellMain = React.memo(function AppShellMain({
+  children,
+  mainRef,
+}: {
+  children: ReactNode
+  mainRef: React.RefObject<HTMLElement | null>
+}) {
+  return (
+    <main
+      ref={mainRef}
+      data-slot="main"
+      className="row-start-3 min-h-0 overflow-y-auto overscroll-contain"
+    >
+      {children}
+    </main>
+  )
+})
+
 export function useSidebarNavigate(): (() => void) | undefined {
   return React.useContext(SidebarNavigateContext)
 }
@@ -144,7 +162,7 @@ export function routeOwnsScrollArrival(pathname: string): boolean {
  *  - Below `md` the sidebar is gone and its content moves, unchanged, into an overlay drawer
  *    (`MobileNavDrawer`). Same components, only the framing changes.
  */
-export function AppShell({
+export const AppShell = React.memo(function AppShell({
   children,
   repo = null,
   inboxCount = null,
@@ -214,9 +232,14 @@ export function AppShell({
     return () => query.removeEventListener('change', onChange)
   }, [])
 
+  const items = React.useMemo(
+    () => visibleNavItems({ forge: forgeAvailable, inbox: inboxAvailable, automations: automationsAvailable }),
+    [forgeAvailable, inboxAvailable, automationsAvailable],
+  )
+
   const nav = {
     activeTo,
-    items: visibleNavItems({ forge: forgeAvailable, inbox: inboxAvailable, automations: automationsAvailable }),
+    items,
     repo,
     // The badge belongs to the Inbox item — with the item gone there is nothing to badge.
     inboxCount: inboxAvailable ? inboxCount : null,
@@ -231,46 +254,39 @@ export function AppShell({
   }
 
   return (
-    // The Sheet root renders no DOM of its own — it is the context that lets the top bar's menu
-    // button be a real SheetTrigger while the open state stays ours to close on navigation.
-    <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
-      <div
-        data-slot="app-shell"
-        className="flex h-dvh overflow-hidden bg-background text-foreground pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
-      >
-        <Sidebar {...nav} width={sidebarWidth} onWidthChange={changeSidebarWidth} />
-        {/* The drawer keeps its fixed 264px: it is a full-height overlay on a phone, where
-            there is no second column to trade width with and no pointer to drag a border. */}
-        <MobileNavDrawer {...nav} onNavigate={() => setMenuOpen(false)} />
-
-        <div className="grid min-w-0 flex-1 grid-rows-[auto_auto_1fr_auto] overflow-hidden">
+    <div
+      data-slot="app-shell"
+      className="flex h-dvh overflow-hidden bg-background text-foreground pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
+    >
+      <Sidebar {...nav} width={sidebarWidth} onWidthChange={changeSidebarWidth} />
+      <div className="grid min-w-0 flex-1 grid-rows-[auto_auto_1fr_auto] overflow-hidden">
+        {/* The Sheet root renders no DOM of its own. Keep only the mobile controls inside its
+            context so a sidebar update cannot propagate through the routed view. */}
+        <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
           <MobileTopBar title={current?.label ?? 'cezar'} />
+          {/* The drawer keeps its fixed 264px: it is a full-height overlay on a phone, where
+              there is no second column to trade width with and no pointer to drag a border. */}
+          <MobileNavDrawer {...nav} onNavigate={() => setMenuOpen(false)} />
+        </Sheet>
 
-          {banner ? (
-            <div data-slot="banner-slot" className="row-start-2">
-              {banner}
-            </div>
-          ) : null}
+        {banner ? (
+          <div data-slot="banner-slot" className="row-start-2">
+            {banner}
+          </div>
+        ) : null}
 
-          <main
-            ref={mainRef}
-            data-slot="main"
-            className="row-start-3 min-h-0 overflow-y-auto overscroll-contain"
-          >
-            {children}
-          </main>
+        <AppShellMain mainRef={mainRef}>{children}</AppShellMain>
 
-          {/* Row 4: the composer dock (thread reply, Step R3). Empty today, but it still carries
-              the bottom safe-area gutter so the scroller never runs under the home indicator. */}
-          <div
-            data-slot="composer"
-            className="row-start-4 pb-[env(safe-area-inset-bottom)]"
-          />
-        </div>
+        {/* Row 4: the composer dock (thread reply, Step R3). Empty today, but it still carries
+            the bottom safe-area gutter so the scroller never runs under the home indicator. */}
+        <div
+          data-slot="composer"
+          className="row-start-4 pb-[env(safe-area-inset-bottom)]"
+        />
       </div>
-    </Sheet>
+    </div>
   )
-}
+})
 
 type NavProps = {
   activeTo: string | null
@@ -299,7 +315,7 @@ type NavProps = {
  * the class is left off entirely below `md`, where `hidden` takes the element out of flow and the
  * drawer (a fixed 264px) is the sidebar instead.
  */
-function Sidebar({ width, onWidthChange, ...props }: NavProps & SidebarResize) {
+const Sidebar = React.memo(function Sidebar({ width, onWidthChange, ...props }: NavProps & SidebarResize) {
   return (
     <aside
       data-slot="sidebar"
@@ -310,7 +326,7 @@ function Sidebar({ width, onWidthChange, ...props }: NavProps & SidebarResize) {
       <SidebarResizeHandle width={width} onWidthChange={onWidthChange} />
     </aside>
   )
-}
+})
 
 type SidebarResize = {
   width: number
@@ -417,7 +433,7 @@ function SidebarResizeHandle({ width, onWidthChange }: SidebarResize) {
  * dismiss-on-tap, and `aria-hidden` on everything outside the portal — which is how it delivers
  * modality (it does not set `aria-modal`; `hideOthers` is the stronger guarantee).
  */
-function MobileNavDrawer({ onNavigate, ...props }: NavProps & { onNavigate: () => void }) {
+const MobileNavDrawer = React.memo(function MobileNavDrawer({ onNavigate, ...props }: NavProps & { onNavigate: () => void }) {
   return (
     <SheetContent
       side="left"
@@ -445,7 +461,7 @@ function MobileNavDrawer({ onNavigate, ...props }: NavProps & { onNavigate: () =
       />
     </SheetContent>
   )
-}
+})
 
 /**
  * Everything inside the sidebar: brand lockup, New task CTA, nav, quick-list, footer. Framed by

--- a/packages/web/src/components/app-shell.tsx
+++ b/packages/web/src/components/app-shell.tsx
@@ -186,6 +186,7 @@ export const AppShell = React.memo(function AppShell({
   const activeTo = activeNavPath(areaPathname)
   const current = activeNavItem(areaPathname)
   const [menuOpen, setMenuOpen] = React.useState(false)
+  const closeMenu = React.useCallback(() => setMenuOpen(false), [])
   const mainRef = React.useRef<HTMLElement>(null)
   const routeOwnsArrival = routeOwnsScrollArrival(pathname)
   // The desktop column's width (#788). Read once, lazily, from `localStorage` — it is a
@@ -266,7 +267,7 @@ export const AppShell = React.memo(function AppShell({
           <MobileTopBar title={current?.label ?? 'cezar'} />
           {/* The drawer keeps its fixed 264px: it is a full-height overlay on a phone, where
               there is no second column to trade width with and no pointer to drag a border. */}
-          <MobileNavDrawer {...nav} onNavigate={() => setMenuOpen(false)} />
+          <MobileNavDrawer {...nav} onNavigate={closeMenu} />
         </Sheet>
 
         {banner ? (

--- a/packages/web/src/components/project-groups.tsx
+++ b/packages/web/src/components/project-groups.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useLocation } from 'react-router'
 
 import { useHealth, usePinRun, useProjectRuns } from '@/api/queries'
-import type { ProjectListEntry } from '@open-mercato/cezar-api-client'
+import type { ProjectListEntry, RunRecord } from '@open-mercato/cezar-api-client'
 import { useSidebarNavigate } from '@/components/app-shell'
 import { useListView } from '@/components/list-view'
 import { activeNavPath, visibleNavItems } from '@/components/nav-items'
@@ -188,7 +188,17 @@ function ProjectGroup({
   // Pinning (#935) from a group that may not be the scoped project: the request is addressed to
   // THIS project, and the cache invalidated is the one `useProjectRuns` above writes — which is
   // `'default'` for the boot project, whose list mounts unscoped.
-  const pin = usePinRun(project.id, boot ? 'default' : project.id)
+  const pinMutation = usePinRun(project.id, boot ? 'default' : project.id)
+  const pinMutationRef = React.useRef(pinMutation)
+  pinMutationRef.current = pinMutation
+  const onTogglePin = React.useCallback(
+    (run: RunRecord, pinned: boolean) =>
+      pinMutationRef.current.mutate(
+        { id: run.id, pinned },
+        { onError: (error: Error) => toast(error.message, { tone: 'danger' }) },
+      ),
+    [],
+  )
 
   const waiting = runs.data ? listCounts(runs.data).waiting : 0
   const buckets = runs.data ? capBuckets(groupRuns(runs.data, view), RECENT_LIMIT) : []
@@ -365,11 +375,7 @@ function ProjectGroup({
                 // the same call `TaskQuickList` and the thread header make.
                 view === 'archived'
                   ? undefined
-                  : (run, pinned) =>
-                      pin.mutate(
-                        { id: run.id, pinned },
-                        { onError: (error: Error) => toast(error.message, { tone: 'danger' }) },
-                      )
+                : onTogglePin
               }
             />
           </ReferenceStatusProvider>

--- a/packages/web/src/components/project-groups.tsx
+++ b/packages/web/src/components/project-groups.tsx
@@ -189,15 +189,13 @@ function ProjectGroup({
   // THIS project, and the cache invalidated is the one `useProjectRuns` above writes — which is
   // `'default'` for the boot project, whose list mounts unscoped.
   const pinMutation = usePinRun(project.id, boot ? 'default' : project.id)
-  const pinMutationRef = React.useRef(pinMutation)
-  pinMutationRef.current = pinMutation
   const onTogglePin = React.useCallback(
     (run: RunRecord, pinned: boolean) =>
-      pinMutationRef.current.mutate(
+      pinMutation.mutate(
         { id: run.id, pinned },
         { onError: (error: Error) => toast(error.message, { tone: 'danger' }) },
       ),
-    [],
+    [pinMutation.mutate],
   )
 
   const waiting = runs.data ? listCounts(runs.data).waiting : 0

--- a/packages/web/src/components/project-groups.tsx
+++ b/packages/web/src/components/project-groups.tsx
@@ -373,7 +373,7 @@ function ProjectGroup({
                 // the same call `TaskQuickList` and the thread header make.
                 view === 'archived'
                   ? undefined
-                : onTogglePin
+                  : onTogglePin
               }
             />
           </ReferenceStatusProvider>

--- a/packages/web/src/components/reference-status.tsx
+++ b/packages/web/src/components/reference-status.tsx
@@ -116,12 +116,16 @@ export function ReferenceStatusProvider({
     .map((ref) => `${ref.projectId} ${ref.kind}#${ref.number}`)
     .sort()
     .join('|')
+  const publish = registry?.publish
+  const retract = registry?.retract
   useEffect(() => {
-    if (!registry) return
-    registry.publish(id, requests)
-    return () => registry.retract(id)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- `signature` IS the content of `requests`
-  }, [registry, id, signature])
+    if (!publish || !retract) return
+    publish(id, requests)
+    return () => retract(id)
+    // `signature` is the content of `requests`; `publish`/`retract` are stable callbacks. The
+    // registry object also carries `lookup`, which changes when a status query answers and must
+    // not make every surface unregister/register just to keep its same request set alive.
+  }, [publish, retract, id, signature])
 
   // Only when there is no registry above us. Called unconditionally with an empty list otherwise:
   // hooks cannot be skipped, and an empty list fetches nothing.

--- a/packages/web/src/components/task-quick-list.tsx
+++ b/packages/web/src/components/task-quick-list.tsx
@@ -494,17 +494,7 @@ const RunRow = React.memo(function RunRow({
       ) : null}
     </div>
   )
-}, (previous, next) =>
-  previous.run === next.run &&
-  previous.queuePosition === next.queuePosition &&
-  previous.currentRunId === next.currentRunId &&
-  previous.now === next.now &&
-  previous.scope === next.scope &&
-  previous.variant === next.variant &&
-  previous.showTokens === next.showTokens &&
-  previous.showCost === next.showCost &&
-  previous.onTogglePin === next.onTogglePin,
-)
+})
 
 /** A variant row's subtitle: what differs between A and B — the backend and what it has spent.
  *  `runner` is absent on records predating the choice; those are Claude by definition. */
@@ -526,8 +516,6 @@ function variantLabel(run: RunRecord, showTokens: boolean, showCost: boolean): s
 export function TaskQuickListContainer() {
   const runs = useRuns()
   const pinMutation = usePinRun()
-  const pinMutationRef = React.useRef(pinMutation)
-  pinMutationRef.current = pinMutation
   const health = useHealth()
   const visibility = usageMetricVisibility(health.data)
   const [view, setView] = useListView()
@@ -537,11 +525,11 @@ export function TaskQuickListContainer() {
   const now = useNow(30_000)
   const onTogglePin = React.useCallback(
     (run: RunRecord, pinned: boolean) =>
-      pinMutationRef.current.mutate(
+      pinMutation.mutate(
         { id: run.id, pinned },
         { onError: (error: Error) => toast(error.message, { tone: 'danger' }) },
       ),
-    [],
+    [pinMutation.mutate],
   )
   // The sidebar's chips are the same chips as the tables', so they get their status the same way:
   // one batched request for the whole list, mounted here where the list is.

--- a/packages/web/src/components/task-quick-list.tsx
+++ b/packages/web/src/components/task-quick-list.tsx
@@ -339,7 +339,7 @@ const ROW_PIN_CLASS =
   ' no-hover:mr-1 no-hover:size-7 no-hover:opacity-100' +
   ' data-[pinned=true]:mr-1 data-[pinned=true]:w-5 data-[pinned=true]:opacity-100'
 
-function RunRow({
+const RunRow = React.memo(function RunRow({
   run,
   queuePosition,
   currentRunId,
@@ -494,7 +494,17 @@ function RunRow({
       ) : null}
     </div>
   )
-}
+}, (previous, next) =>
+  previous.run === next.run &&
+  previous.queuePosition === next.queuePosition &&
+  previous.currentRunId === next.currentRunId &&
+  previous.now === next.now &&
+  previous.scope === next.scope &&
+  previous.variant === next.variant &&
+  previous.showTokens === next.showTokens &&
+  previous.showCost === next.showCost &&
+  previous.onTogglePin === next.onTogglePin,
+)
 
 /** A variant row's subtitle: what differs between A and B — the backend and what it has spent.
  *  `runner` is absent on records predating the choice; those are Claude by definition. */
@@ -515,7 +525,9 @@ function variantLabel(run: RunRecord, showTokens: boolean, showCost: boolean): s
  */
 export function TaskQuickListContainer() {
   const runs = useRuns()
-  const pin = usePinRun()
+  const pinMutation = usePinRun()
+  const pinMutationRef = React.useRef(pinMutation)
+  pinMutationRef.current = pinMutation
   const health = useHealth()
   const visibility = usageMetricVisibility(health.data)
   const [view, setView] = useListView()
@@ -523,6 +535,14 @@ export function TaskQuickListContainer() {
   const match = useProjectMatch('/tasks/:id/*')
   const exact = useProjectMatch('/tasks/:id')
   const now = useNow(30_000)
+  const onTogglePin = React.useCallback(
+    (run: RunRecord, pinned: boolean) =>
+      pinMutationRef.current.mutate(
+        { id: run.id, pinned },
+        { onError: (error: Error) => toast(error.message, { tone: 'danger' }) },
+      ),
+    [],
+  )
   // The sidebar's chips are the same chips as the tables', so they get their status the same way:
   // one batched request for the whole list, mounted here where the list is.
   const projectId = useReferenceProjectId()
@@ -554,12 +574,7 @@ export function TaskQuickListContainer() {
         showCost={visibility.cost}
         // This list is the ACTIVE project's, so the mutation needs no explicit project: the
         // scoped client already addresses the one the URL names.
-        onTogglePin={(run, pinned) =>
-          pin.mutate(
-            { id: run.id, pinned },
-            { onError: (error: Error) => toast(error.message, { tone: 'danger' }) },
-          )
-        }
+        onTogglePin={onTogglePin}
       />
     </ReferenceStatusProvider>
   )

--- a/packages/web/src/routes.tsx
+++ b/packages/web/src/routes.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react'
+import { lazy, memo, Suspense } from 'react'
 import {
   matchPath,
   Navigate,
@@ -302,7 +302,7 @@ export function pageTitleContext(pathname: string): PageTitleContext {
  *  `ProjectScopeRoute` layout above; the flat spellings below are relative to that prefix and
  *  stay stable — they are what teammates paste, and the legacy flat URLs redirect onto them.
  */
-export function AppRoutes() {
+export const AppRoutes = memo(function AppRoutes() {
   const capabilities = useHealth().data?.capabilities
   return (
     <Routes>
@@ -544,4 +544,4 @@ export function AppRoutes() {
       <Route path="*" element={<LegacyPathRedirect />} />
     </Routes>
   )
-}
+})

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -148,11 +148,15 @@ export function RunHeader({
   // The queue position a parked run shows in its pill ("queued #2"). Reads the shared runs-list
   // query — already warm from the sidebar quick-list — because position is a property of the
   // whole queue, not of this record.
-  const runs = useRuns()
+  const queuePosition = useRuns(
+    useMemo(
+      () => (runs: ApiRun[]) =>
+        run.status === 'queued' ? queuePositions(runs).get(run.id) : undefined,
+      [run.id, run.status],
+    ),
+  ).data
   const health = useHealth()
   const metricVisibility = usageMetricVisibility(health.data)
-  const queuePosition =
-    run.status === 'queued' ? queuePositions(runs.data ?? []).get(run.id) : undefined
 
   return (
     <header

--- a/packages/web/src/routes/task-thread/session-transcript.test.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.test.tsx
@@ -136,6 +136,125 @@ describe('SessionTranscript', () => {
     },
   )
 
+  it('updates a memoized entry block when its text changes', () => {
+    const sections = (text: string): TranscriptSection[] => [{
+      id: 'shared',
+      entries: [{ kind: 'note', id: 'note-1', text, tone: 'dim' }],
+    }]
+    const { rerender } = render(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-entry"
+        sections={sections('Initial response')}
+        mode="document"
+        renderMode="flat"
+      />,
+    )
+
+    expect(document.querySelector('[data-slot="note-line"]')?.textContent).toContain('Initial response')
+    rerender(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-entry"
+        sections={sections('Updated response')}
+        mode="document"
+        renderMode="flat"
+      />,
+    )
+
+    const note = document.querySelector('[data-slot="note-line"]')
+    expect(note?.textContent).toContain('Updated response')
+    expect(note?.textContent).not.toContain('Initial response')
+  })
+
+  it('updates a memoized tool block when its live output and status change', () => {
+    const sections = (status: UiToolItem['status'], output: string): TranscriptSection[] => [{
+      id: 'shared',
+      entries: [tool('exec', {
+        name: 'Bash',
+        toolKind: 'execute',
+        title: 'Ran npm test',
+        status,
+        output,
+      })],
+    }]
+    const { rerender } = render(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-tool"
+        sections={sections('running', 'partial output')}
+        mode="document"
+        renderMode="flat"
+      />,
+    )
+
+    expect(document.querySelector('[data-slot="tool-card"]')?.getAttribute('data-status')).toBe('running')
+    expect(document.querySelector('[data-slot="tool-output"]')?.textContent).toContain('partial output')
+    rerender(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-tool"
+        sections={sections('running', 'complete output')}
+        mode="document"
+        renderMode="flat"
+      />,
+    )
+    expect(document.querySelector('[data-slot="tool-output"]')?.textContent).toContain('complete output')
+    expect(document.querySelector('[data-slot="tool-output"]')?.textContent).not.toContain('partial output')
+
+    rerender(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-tool"
+        sections={sections('completed', 'complete output')}
+        mode="document"
+        renderMode="flat"
+      />,
+    )
+    expect(document.querySelector('[data-slot="tool-card"]')?.getAttribute('data-status')).toBe('completed')
+  })
+
+  it('updates an ask block when the injected renderer changes', () => {
+    const sections: TranscriptSection[] = [{
+      id: 'shared',
+      entries: [{
+        kind: 'ask',
+        id: 'ask-1',
+        resolved: false,
+        questions: [{
+          id: 'q1',
+          header: 'Choice',
+          question: 'Continue?',
+          options: [{ label: 'Yes', description: 'Keep going' }],
+        }],
+      }],
+    }]
+    const { rerender } = render(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-ask"
+        sections={sections}
+        mode="document"
+        renderMode="flat"
+        renderAsk={() => <span data-slot="custom-ask">First renderer</span>}
+      />,
+    )
+
+    expect(document.querySelector('[data-slot="custom-ask"]')?.textContent).toBe('First renderer')
+    rerender(
+      <SessionTranscript
+        runId="r1"
+        viewId="memo-ask"
+        sections={sections}
+        mode="document"
+        renderMode="flat"
+        renderAsk={() => <span data-slot="custom-ask">Second renderer</span>}
+      />,
+    )
+
+    expect(document.querySelector('[data-slot="custom-ask"]')?.textContent).toBe('Second renderer')
+  })
+
   it('uses one recursive renderer for task-card children', () => {
     const parent = tool('task', {
       name: 'Task',

--- a/packages/web/src/routes/task-thread/session-transcript.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.tsx
@@ -66,6 +66,8 @@ export interface SessionTranscriptProps {
   /** Main-document integration preserves the shell's existing dock-owned jump pill. */
   scrollControls?: ThreadScrollControls
   renderMode?: 'flat' | 'virtual'
+  /** Reuse rows already derived by the main view; panel callers can omit this. */
+  rowModels?: readonly TranscriptRowModel[]
 }
 
 /** The main run record plus reduced turns, without rendering or backend inspection. */
@@ -149,8 +151,12 @@ export function SessionTranscript({
   messageActions,
   scrollControls,
   renderMode,
+  rowModels: providedRowModels,
 }: SessionTranscriptProps) {
-  const rowModels = useMemo(() => buildTranscriptRows(sections, runId), [sections, runId])
+  const rowModels = useMemo(
+    () => providedRowModels ?? buildTranscriptRows(sections, runId),
+    [providedRowModels, sections, runId],
+  )
   const internalScroll = useThreadScroll(`${runId}:${viewId}`, { surface: mode })
   const controls = scrollControls ?? internalScroll
   const rows = useMemo<ThreadRow[]>(

--- a/packages/web/src/routes/task-thread/session-transcript.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.tsx
@@ -414,21 +414,25 @@ function sameThreadEntry(previous: ThreadEntry | undefined, next: ThreadEntry): 
   }
 }
 
+/** A new UiToolItem field must be added here before it can be ignored by memoization. */
+const TOOL_ITEM_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  name: true,
+  toolKind: true,
+  title: true,
+  status: true,
+  input: true,
+  output: true,
+  error: true,
+  diffs: true,
+  locations: true,
+  exitCode: true,
+  parentItemId: true,
+} satisfies Record<keyof UiToolItem, true>
+
+const TOOL_ITEM_COMPARE_KEYS = Object.keys(TOOL_ITEM_COMPARE_FIELDS) as Array<keyof UiToolItem>
+
 function sameToolItem(previous: UiToolItem, next: UiToolItem): boolean {
-  return (
-    previous.kind === 'tool' &&
-    next.kind === 'tool' &&
-    previous.id === next.id &&
-    previous.name === next.name &&
-    previous.toolKind === next.toolKind &&
-    previous.title === next.title &&
-    previous.status === next.status &&
-    previous.input === next.input &&
-    previous.output === next.output &&
-    previous.error === next.error &&
-    previous.diffs === next.diffs &&
-    previous.locations === next.locations &&
-    previous.exitCode === next.exitCode &&
-    previous.parentItemId === next.parentItemId
-  )
+  return TOOL_ITEM_COMPARE_KEYS.every((key) => previous[key] === next[key])
 }

--- a/packages/web/src/routes/task-thread/session-transcript.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.tsx
@@ -1,6 +1,6 @@
-import { useMemo, type ReactNode } from 'react'
+import { memo, useMemo, type ReactNode } from 'react'
 
-import type { ApiRun } from '@open-mercato/cezar-api-client'
+import type { ApiRun, UiToolItem } from '@open-mercato/cezar-api-client'
 
 import { groupThreadItems, type ThreadBlock } from './thread-groups'
 import {
@@ -224,7 +224,7 @@ function TranscriptUserBubble({
   )
 }
 
-function ThreadBlockRenderer({
+const ThreadBlockRenderer = memo(function ThreadBlockRenderer({
   block,
   scope,
   renderAsk,
@@ -260,7 +260,7 @@ function ThreadBlockRenderer({
     default:
       return assertNever(block)
   }
-}
+}, sameThreadBlockProps)
 
 function GroupedEntries({
   entries,
@@ -317,4 +317,112 @@ function ThreadEntryRenderer({
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled transcript variant: ${JSON.stringify(value)}`)
+}
+
+function sameThreadBlockProps(
+  previous: { block: ThreadBlock; scope: string; renderAsk?: (ask: ThreadAsk) => ReactNode },
+  next: { block: ThreadBlock; scope: string; renderAsk?: (ask: ThreadAsk) => ReactNode },
+): boolean {
+  return (
+    previous.scope === next.scope &&
+    sameThreadBlock(previous.block, next.block) &&
+    (!containsAsk(next.block) || previous.renderAsk === next.renderAsk)
+  )
+}
+
+function containsAsk(block: ThreadBlock): boolean {
+  if (block.kind === 'entry') return block.entry.kind === 'ask'
+  if (block.kind === 'tool-card') return block.children.some((entry) => entry.kind === 'ask')
+  if (block.kind === 'context-group') return false
+  return block.blocks.some(containsAsk)
+}
+
+function sameThreadBlock(previous: ThreadBlock, next: ThreadBlock): boolean {
+  if (previous.kind !== next.kind || previous.id !== next.id) return false
+  switch (next.kind) {
+    case 'entry':
+      return sameThreadEntry(previous.kind === 'entry' ? previous.entry : undefined, next.entry)
+    case 'tool-card':
+      return (
+        previous.kind === 'tool-card' &&
+        sameToolItem(previous.item, next.item) &&
+        sameThreadEntries(previous.children, next.children)
+      )
+    case 'context-group':
+      return (
+        previous.kind === 'context-group' &&
+        previous.files === next.files &&
+        previous.searches === next.searches &&
+        previous.label === next.label &&
+        previous.tools.length === next.tools.length &&
+        previous.tools.every((item, index) => sameToolItem(item, next.tools[index]!))
+      )
+    case 'streak':
+      return (
+        previous.kind === 'streak' &&
+        previous.count === next.count &&
+        previous.blocks.length === next.blocks.length &&
+        previous.blocks.every((block, index) => sameThreadBlock(block, next.blocks[index]!))
+      )
+    default:
+      return false
+  }
+}
+
+function sameThreadEntries(previous: readonly ThreadEntry[], next: readonly ThreadEntry[]): boolean {
+  return previous.length === next.length && previous.every((entry, index) => sameThreadEntry(entry, next[index]!))
+}
+
+function sameThreadEntry(previous: ThreadEntry | undefined, next: ThreadEntry): boolean {
+  if (previous === undefined || previous.kind !== next.kind || previous.id !== next.id) return false
+  switch (next.kind) {
+    case 'message':
+      return previous.kind === 'message' &&
+        previous.text === next.text &&
+        previous.role === next.role &&
+        previous.phase === next.phase &&
+        previous.parentItemId === next.parentItemId
+    case 'reasoning':
+      return previous.kind === 'reasoning' &&
+        previous.text === next.text &&
+        previous.parentItemId === next.parentItemId
+    case 'tool':
+      return previous.kind === 'tool' && sameToolItem(previous, next)
+    case 'note':
+      return previous.kind === 'note' && previous.text === next.text && previous.tone === next.tone
+    case 'image':
+      return previous.kind === 'image' && previous.url === next.url && previous.name === next.name
+    case 'ask':
+      return (
+        previous.kind === 'ask' &&
+        previous.resolved === next.resolved &&
+        previous.answer === next.answer &&
+        previous.questions === next.questions
+      )
+    case 'provider-auth-required':
+      return previous.kind === 'provider-auth-required' &&
+        previous.provider === next.provider &&
+        previous.authFailureId === next.authFailureId
+    default:
+      return false
+  }
+}
+
+function sameToolItem(previous: UiToolItem, next: UiToolItem): boolean {
+  return (
+    previous.kind === 'tool' &&
+    next.kind === 'tool' &&
+    previous.id === next.id &&
+    previous.name === next.name &&
+    previous.toolKind === next.toolKind &&
+    previous.title === next.title &&
+    previous.status === next.status &&
+    previous.input === next.input &&
+    previous.output === next.output &&
+    previous.error === next.error &&
+    previous.diffs === next.diffs &&
+    previous.locations === next.locations &&
+    previous.exitCode === next.exitCode &&
+    previous.parentItemId === next.parentItemId
+  )
 }

--- a/packages/web/src/routes/task-thread/session-transcript.tsx
+++ b/packages/web/src/routes/task-thread/session-transcript.tsx
@@ -1,6 +1,6 @@
 import { memo, useMemo, type ReactNode } from 'react'
 
-import type { ApiRun, UiToolItem } from '@open-mercato/cezar-api-client'
+import type { ApiRun, UiMessageItem, UiReasoningItem, UiToolItem } from '@open-mercato/cezar-api-client'
 
 import { groupThreadItems, type ThreadBlock } from './thread-groups'
 import {
@@ -23,7 +23,14 @@ import {
   type ThreadRow,
   type ThreadScrollControls,
 } from './thread-scroller'
-import type { ThreadAsk, ThreadEntry, ThreadState } from './thread-state'
+import type {
+  ThreadAsk,
+  ThreadEntry,
+  ThreadImage,
+  ThreadNote,
+  ThreadProviderAuthRequired,
+  ThreadState,
+} from './thread-state'
 
 export interface TranscriptUserMessage {
   text: string
@@ -383,38 +390,71 @@ function sameThreadEntry(previous: ThreadEntry | undefined, next: ThreadEntry): 
   if (previous === undefined || previous.kind !== next.kind || previous.id !== next.id) return false
   switch (next.kind) {
     case 'message':
-      return previous.kind === 'message' &&
-        previous.text === next.text &&
-        previous.role === next.role &&
-        previous.phase === next.phase &&
-        previous.parentItemId === next.parentItemId
+      return previous.kind === 'message' && sameFields(previous, next, MESSAGE_COMPARE_FIELDS)
     case 'reasoning':
-      return previous.kind === 'reasoning' &&
-        previous.text === next.text &&
-        previous.parentItemId === next.parentItemId
+      return previous.kind === 'reasoning' && sameFields(previous, next, REASONING_COMPARE_FIELDS)
     case 'tool':
       return previous.kind === 'tool' && sameToolItem(previous, next)
     case 'note':
-      return previous.kind === 'note' && previous.text === next.text && previous.tone === next.tone
+      return previous.kind === 'note' && sameFields(previous, next, NOTE_COMPARE_FIELDS)
     case 'image':
-      return previous.kind === 'image' && previous.url === next.url && previous.name === next.name
+      return previous.kind === 'image' && sameFields(previous, next, IMAGE_COMPARE_FIELDS)
     case 'ask':
-      return (
-        previous.kind === 'ask' &&
-        previous.resolved === next.resolved &&
-        previous.answer === next.answer &&
-        previous.questions === next.questions
-      )
+      return previous.kind === 'ask' && sameFields(previous, next, ASK_COMPARE_FIELDS)
     case 'provider-auth-required':
       return previous.kind === 'provider-auth-required' &&
-        previous.provider === next.provider &&
-        previous.authFailureId === next.authFailureId
+        sameFields(previous, next, PROVIDER_AUTH_COMPARE_FIELDS)
     default:
       return false
   }
 }
 
-/** A new UiToolItem field must be added here before it can be ignored by memoization. */
+const MESSAGE_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  role: true,
+  text: true,
+  phase: true,
+  parentItemId: true,
+} satisfies Record<keyof UiMessageItem, true>
+
+const REASONING_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  text: true,
+  parentItemId: true,
+} satisfies Record<keyof UiReasoningItem, true>
+
+const NOTE_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  text: true,
+  tone: true,
+} satisfies Record<keyof ThreadNote, true>
+
+const IMAGE_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  url: true,
+  name: true,
+} satisfies Record<keyof ThreadImage, true>
+
+const ASK_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  questions: true,
+  resolved: true,
+  answer: true,
+} satisfies Record<keyof ThreadAsk, true>
+
+const PROVIDER_AUTH_COMPARE_FIELDS = {
+  kind: true,
+  id: true,
+  provider: true,
+  authFailureId: true,
+} satisfies Record<keyof ThreadProviderAuthRequired, true>
+
+/** A new transcript item field must be added here before it can be ignored by memoization. */
 const TOOL_ITEM_COMPARE_FIELDS = {
   kind: true,
   id: true,
@@ -431,8 +471,14 @@ const TOOL_ITEM_COMPARE_FIELDS = {
   parentItemId: true,
 } satisfies Record<keyof UiToolItem, true>
 
-const TOOL_ITEM_COMPARE_KEYS = Object.keys(TOOL_ITEM_COMPARE_FIELDS) as Array<keyof UiToolItem>
+function sameFields<T extends object>(
+  previous: T,
+  next: T,
+  fields: Record<keyof T, true>,
+): boolean {
+  return (Object.keys(fields) as Array<keyof T>).every((key) => previous[key] === next[key])
+}
 
 function sameToolItem(previous: UiToolItem, next: UiToolItem): boolean {
-  return TOOL_ITEM_COMPARE_KEYS.every((key) => previous[key] === next[key])
+  return sameFields(previous, next, TOOL_ITEM_COMPARE_FIELDS)
 }

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -324,6 +324,7 @@ export function ThreadView({
           messageActions={messageActions}
           scrollControls={scroll}
           renderMode={mode}
+          rowModels={rows}
         />
 
         {thread.turns.length === 0 ? (

--- a/packages/web/src/routes/task-thread/thread-state.ts
+++ b/packages/web/src/routes/task-thread/thread-state.ts
@@ -1,4 +1,5 @@
 import type { RunEvent, RunStatus } from '@open-mercato/cezar-api-client'
+import { runItemKey } from '@/api/run-events'
 import {
   toolDisplay,
   type PlanEntry,
@@ -197,6 +198,9 @@ function providerId(value: unknown): ThreadProviderAuthRequired['provider'] | un
     : undefined
 }
 
+const isAskQuestion = (value: unknown): value is UiAskQuestion =>
+  isRecord(value) && typeof value.header === 'string' && Array.isArray(value.options)
+
 /** The engine's turn-end markers (`CEZ:DONE`, `CEZ:MONITORING` from #490) plus the in-band
  *  task-reference marker lines (`CEZ:PR=` / `CEZ:ISSUE=` / `CEZ:TITLE=`, spec
  *  2026-07-18-task-ref-markers). v1 `text` lines arrive pre-stripped by the server; v2 message
@@ -338,8 +342,7 @@ export function reduceThread(events: RunEvent[], options: ThreadReduceOptions = 
   const currentTurn = (): DraftTurn => turns.at(-1) ?? newTurn()
 
   const itemKey = (event: RunEvent, itemId: string) => {
-    const stepId = str(event.stepId)
-    return stepId === undefined ? itemId : `${stepId}:${itemId}`
+    return runItemKey(event.stepId, itemId)
   }
 
   const upsertV2 = (turn: DraftTurn, raw: UiItem, key: string) => {
@@ -621,10 +624,12 @@ export function reduceThread(events: RunEvent[], options: ThreadReduceOptions = 
         // turn. Guard the payload (a bad line costs one event, never a throw).
         const requestId = str(event.requestId)
         if (requestId === undefined || !Array.isArray(event.questions)) break
-        const questions = (event.questions as unknown[]).filter(
-          (q): q is UiAskQuestion =>
-            isRecord(q) && typeof q.header === 'string' && Array.isArray(q.options),
-        )
+        const rawQuestions = event.questions as unknown[]
+        // Keep the wire array for the normal valid case. `reduceThread` runs again for every live
+        // batch, and a fresh filtered array would defeat the transcript row comparator.
+        const questions = rawQuestions.every(isAskQuestion)
+          ? rawQuestions as UiAskQuestion[]
+          : rawQuestions.filter(isAskQuestion)
         if (questions.length === 0) break
         const ask: ThreadAsk = { kind: 'ask', id: requestId, questions, resolved: false }
         currentTurn().entries.push({ origin: 'meta', entry: ask })


### PR DESCRIPTION
## Problem

Opening the task detail view, including while a task was streaming, could consume excessive CPU and cause visible frame drops. The page was doing substantial work even when the newly received data affected only a small part of the transcript, or when updates belonged to the shared run list rather than the task being viewed.

## Cause

Two independent update paths multiplied the work:

1. Global run-summary events updated the shared runs cache observed by the shell, sidebar, title/queue consumers, and task route. A change in one run could therefore re-evaluate large parts of the routed view.
2. Per-run SSE transcript frames were published one at a time. Each frame caused a state update, rebuilt the derived thread and row models, and revisited transcript blocks that had not changed.

The live/history handoff also made the hot path more expensive over time: live events accumulated until compaction, while reconnects, pagination, late frames, and temporary history failures all had to be handled without losing transcript data.

## Fix

- Batch per-run SSE frames into one React state update per 50 ms and losslessly coalesce consecutive deltas for the same transcript item.
- Batch global run-summary cache updates and keep project-scoped updates from waking unrelated project/task views.
- Feed shell, title, and badge consumers scalar selections instead of full run lists, and memoize layout boundaries and stable child props so unrelated cache changes do not re-render the task route.
- Reuse derived transcript row models and memoize unchanged transcript blocks and rows with content equality checks.
- Bound and harden the live/history handoff: keep sequence deduplication bounded, compact only events confirmed covered by durable history, preserve late live frames, and handle reconnects, pagination races, fallback, timeouts, and failed compaction without dropping or duplicating transcript content.
- Add regression coverage for memoized transcript updates and make the compaction threshold explicit that it triggers compaction but does not truncate live events.

## Effect

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Total React renders | 5,392 | 1,542 | -71.4% |
| React renders / second | ~194 | ~55 | -71.5% |
| FPS (average / minimum) | 60 / 7 | 60 / 20 | minimum improved |
| Dropped frames (<30 FPS) | 9 | 1 | -88.9% |

The before/after comparison used the same task-detail scenario, workload, and observation window. React Profiler supplied the render counts and render rate; browser performance metrics supplied FPS and dropped-frame counts. These figures describe React rendering and frame delivery, not a direct OS CPU measurement.

Transcript ordering, sequence deduplication, reconnect behavior, history loading, jump-to-latest, and existing user interactions are preserved. The changes are client-side; no API route, event wire format, or persisted-data format was changed.
