### PR TITLE
fix(tasks): continue a task that has no session to resume

### DIFF
--- a/.ai/specs/2026-07-21-queued-session-prompt-stacking.md
+++ b/.ai/specs/2026-07-21-queued-session-prompt-stacking.md
@@ -295,9 +295,13 @@ against a run already driven to `done`, so it is unaffected — confirmed, not a
 
 > **Superseded for the closed statuses.** A later change (the closed-composer prompt,
 > below in *Resolved assumptions* Q3) made the composer authorable on a closed run that
-> HAS a resumable session too, so that copy now survives only on a closed run with no
-> session to resume — where it reads `"Session closed — no session to resume."`. The
-> `queued` branch described here is unchanged.
+> HAS a resumable session too, so that copy survived only on a closed run with no
+> session to resume — where it read `"Session closed — no session to resume."`.
+> `2026-09-11-continue-without-a-session.md` then removed that last case as well: a closed
+> run with no session continues in a FRESH session briefed with the old one's transcript, so
+> the composer is authorable for every closed status and reads `"Continue in a new session —
+> the previous conversation is replayed to the agent…"` there. The `queued` branch described
+> here is unchanged.
 
 **Thread rows** — `buildThreadRows` (`task-thread.tsx:97-124`) already renders the
 initial prompt from the record rather than an event; stacked messages extend the same
@@ -552,7 +556,9 @@ send button IS Continue.
 - gated on `runActionFlags(run).continueRun` — a session to resume, exactly the gate the
   header's Continue button already used. A closed run with **no** session keeps a disabled
   composer, now reading `"Session closed — no session to resume."` (the old copy offered a
-  Continue that run could not perform).
+  Continue that run could not perform). *Superseded by
+  `2026-09-11-continue-without-a-session.md`: that gate dropped its `hasSession` half, so this
+  branch is authorable too and carries its own placeholder.*
 - an empty draft still posts no `text`, so one-click Continue is byte-identical to before.
 - `<ContinueAction>` became the `useContinueAction` hook: the runner/model pills moved into
   the enabled footer (`footerEnd`), so the typed prompt and the picked engine reach

--- a/.ai/specs/2026-09-11-continue-without-a-session.md
+++ b/.ai/specs/2026-09-11-continue-without-a-session.md
@@ -1,0 +1,71 @@
+# Continue a task that has no session to resume
+
+> Depends on: spec 003 (Continue), `2026-07-29-agent-profiles.md` (why a session id belongs to one account)
+
+## TLDR
+
+Continue used to require a recorded agent session id. A task that crashed before its backend minted one — the common shape being a cezar restart while the run queued for the repository working tree — had no session, so recovery gave up (`could not resume the interrupted task (no agent session to resume)`), the composer went read-only (`Session closed — no session to resume.`), and the only remaining action on work that was genuinely in flight was Delete.
+
+Continue now covers that case by opening a **new** session briefed with the old one's transcript: the original task, how the previous attempt ended, and a bounded replay of the conversation. Resuming is still preferred and still happens byte-for-byte as before whenever there is something to resume.
+
+## Problem Statement
+
+Reported from the thread of a real run:
+
+```
+· run started — workflow "quick-task" (runner: claude)
+· worktree off — running in the repo working tree
+· waiting for exclusive access to the repository working tree
+· cezar restarted — could not resume the interrupted task (no agent session to resume)
+
+Session failed — interrupted — cezar process exited during the run
+```
+
+with the composer underneath reading `Session closed — no session to resume.`
+
+Nothing about the task was broken. The worktree, the branch, the handoff file and the user's prompt were all intact; the run simply died in the window between "accepted" and "spawned", which is precisely where a session id does not exist yet. Three surfaces then agreed the task was over:
+
+- `RunManager.continueRun` refused with `no agent session to resume` (`workflows/run.ts`);
+- `runActionFlags.continueRun` was `!active && hasSession`, so the header offered no button;
+- the composer's `disabledReason` said the session was closed.
+
+`reviveQueuedRun` had a fourth version of the same rule: a queued `continue-N` step with no session before it fell through to reviving the WORKFLOW, re-running the task from step one against a worktree that already held its results.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Why |
+|---|----------|-----------------|-----|
+| Q1 | Resume, or start fresh and replay? | Resume when possible; replay only when it is not. | A real resume carries the whole context window, tool results included. A replay is a summary by comparison, so it is the fallback, never the preference. |
+| Q2 | What goes into the replay? | The original task, the run's `error`, and the `user-message` / `text` events — not lifecycle lines, tool calls or the v2 `item.*` stream. | It is a briefing, not a log. Tool traffic is the bulk of an NDJSON file and the least useful part of it to a fresh agent, which can re-run anything it needs. |
+| Q3 | How much of it? | 12 000 chars total, 2 000 per message, oldest dropped first with the count named. | The end of a conversation is where the unfinished work is; the beginning is what the task text already restates. An unbounded replay could fill a context window with history before the agent read its instruction. |
+| Q4 | Does the replay become the user's message? | No — delivery-only, prepended to the opening prompt. | The thread already renders every line it replays, directly above. Persisting it would duplicate the transcript inside itself and make the user appear to have typed a summary they never wrote. |
+| Q5 | Does Terminal ("Open in CLI") relax the same way? | No — it still requires a session id. | It splices the id into `claude --resume <id>` for a real shell. There is nothing to substitute. |
+| Q6 | Does the runner/account switch path get the briefing too? | Yes. | It has always opened a fresh session (a session id only resolves inside the config dir that created it) and has always lost the conversation doing so. One rule — *a new session gets briefed* — covers both reasons, so neither can drift. |
+
+## Architecture
+
+**`packages/cezar/src/runs/session-recap.ts`** (new). `buildSessionRecap({task, error, events}, limits?) → string`. Pure, store-free, separately testable. Coalesces consecutive same-speaker events back into turns (the engine appends one `text` event per streamed chunk), clips per message, then drops from the front until under budget and says how many it dropped. Always returns text: a run that produced no conversation still has a task, and that is the case this exists for.
+
+**`RunManager.continueRun`** drops the refusal. `resume ? sessionStep.sessionId : undefined` becomes one `resumeSessionId` whose `undefined` means "open a new session" for either reason — nothing recorded, or an id this runner/account cannot resolve.
+
+**`RunManager.runContinuation`** builds the briefing when `sessionId === undefined`, *before* it appends this continuation's own `user-message` (so the replay cannot contain the prompt it is being prepended to), appends a `note` event saying the session is fresh, and prepends the briefing to the delivered opening prompt behind a `---` rule.
+
+**`RunManager.recover`** keeps its lifecycle line honest: `resuming the interrupted task from its last session` when there was one, `no session to resume; continuing the interrupted task in a fresh session` when there was not.
+
+**`reviveQueuedRun`** adopts a pending `continue-N` step whether or not a session precedes it, instead of falling back to re-running the workflow.
+
+**Cockpit.** `runActionFlags.continueRun` is `!active` (`terminal` keeps `!active && hasSession`). The Continue tooltip and the composer placeholder distinguish the two promises — `Reopen the session` versus `Start a new session — the previous conversation is replayed to the agent` — because "pick up where you left off" is the stronger claim and only one of the two paths can make it. `askDeliveryMode`'s `unavailable` mode and the `no-session` blocked reason are removed: every closed run can take an answer now, so the ask card has no inert state left to render.
+
+## What does NOT change
+
+- A run with a resumable session resumes it, with the same `--resume` argument and no briefing — it is already inside that conversation, and handing it a summary of itself would be noise. Pinned by a guard test that passes both with and without this change.
+- `POST /api/v1/runs/:id/open-in-cli` still answers `409 no agent session to resume`.
+- `POST /api/v1/runs/:id/continue` is unchanged in shape. It accepts a case it used to reject, which is a widening; its other 409s (`run is still active`, `cannot continue a <status> run`) are untouched.
+- The usage-limit auto-resume (`scheduleAutoResumeIfLimited`) keeps its own independent `run.steps.some(step => step.sessionId)` gate — an UNATTENDED resume still requires a real session.
+
+## Testing
+
+- `packages/cezar/src/runs/session-recap.test.ts` — the builder: ordering, coalescing, what is excluded, clipping, the drop-oldest budget, the empty-conversation case.
+- `packages/cezar/src/workflows/continue-without-session.test.ts` — end to end through the engine under `CEZ_DRY_RUN=1`: the briefing reaches the agent, no `--resume` reaches the CLI, the transcript persists the user's prompt alone, `recover()` continues instead of giving up, and the guard case above.
+
+Three of those four engine cases were confirmed red with `workflows/run.ts` stashed; the guard case passes both ways, which is what it is for.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@
   is a 400, matching `POST /api/v1/runs`. Spec: `.ai/specs/2026-07-29-agent-profiles.md`.
 
 ## 🐛 Fixes
+- 🐛 **A task that crashed before its agent started is no longer a dead end.** Continue used to
+  need a recorded session id, so a run killed in the window between "accepted" and "spawned" —
+  most often a cezar restart while it queued for the repository working tree — came back as
+  `cezar restarted — could not resume the interrupted task (no agent session to resume)` above a
+  read-only composer saying `Session closed — no session to resume.` Nothing about the task was
+  broken: the worktree, the branch, the handoff file and the prompt were all still there. The only
+  action left was Delete. Continue now covers that case by opening a **new** session briefed with
+  the old one's record — the original task, how the previous attempt ended, and a bounded replay of
+  the conversation (oldest messages dropped first, with the count named, so a long thread cannot
+  fill the context window with history before the agent reads its instruction). The thread says
+  which of the two it did, and the composer promises the weaker one honestly: *Continue in a new
+  session — the previous conversation is replayed to the agent*, never "pick up where you left
+  off". A run that DOES have a session still resumes it, unchanged and without a summary of a
+  conversation it is already in. Restart recovery follows the same rule, so an interrupted task
+  now carries on by itself instead of stopping at the line above; so does a runner or account
+  switch, which has always started a fresh session and until now lost the conversation doing it.
+  Terminal ("Open in CLI") deliberately still needs a real session id — it hands one to a shell.
+  Spec: `.ai/specs/2026-09-11-continue-without-a-session.md`.
 - 🐛 **A pull request with merge conflicts no longer reads "ready to merge".** The chip's status
   answers *whose move is it* — `ready` means open, checks green, nobody waited on — and every word
   of that stays true of a branch GitHub is refusing to merge, so a conflicted PR sat there in

--- a/packages/cezar/src/runs/session-recap.test.ts
+++ b/packages/cezar/src/runs/session-recap.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import type { RunEvent } from './store.ts';
+import { buildSessionRecap } from './session-recap.ts';
+
+const event = (seq: number, type: string, extra: Record<string, unknown> = {}): RunEvent => ({
+  seq,
+  ts: `2026-09-11T10:00:0${seq}.000Z`,
+  type,
+  ...extra,
+});
+
+describe('buildSessionRecap — the briefing a non-resumable Continue opens on', () => {
+  it('carries the original task, so a fresh session knows what it was asked to do', () => {
+    const recap = buildSessionRecap({ task: 'Fix the login redirect', events: [] });
+    expect(recap).toContain('## Previous session (cezar)');
+    expect(recap).toContain('Fix the login redirect');
+    // The agent must not mistake replayed history for its own memory.
+    expect(recap).toContain('NEW session');
+  });
+
+  /** The reported shape: cezar died while the run queued for the worktree lock, so there is a
+   *  task and an error and literally nothing else. It still has to produce a usable briefing. */
+  it('says so plainly when the session ended before the agent said anything', () => {
+    const recap = buildSessionRecap({
+      task: 'Fix the login redirect',
+      error: 'interrupted — cezar process exited during the run',
+      events: [event(1, 'lifecycle', { message: 'run started' })],
+    });
+    expect(recap).toContain('interrupted — cezar process exited during the run');
+    expect(recap).toContain('Nothing was exchanged');
+  });
+
+  it('replays user and agent messages in order, labelled, and ignores everything else', () => {
+    const recap = buildSessionRecap({
+      task: 'Fix the login redirect',
+      events: [
+        event(1, 'lifecycle', { message: 'run started' }),
+        event(2, 'text', { text: 'Looking at the middleware.' }),
+        event(3, 'tool', { name: 'Bash' }),
+        event(4, 'user-message', { text: 'check the cookie flags too' }),
+        event(5, 'text', { text: 'SameSite is the culprit.' }),
+      ],
+      // A briefing is not a log: lifecycle lines and tool calls are noise here.
+    });
+    const body = recap.slice(recap.indexOf('**Conversation so far**'));
+    expect(body).toContain('[agent] Looking at the middleware.');
+    expect(body).toContain('[user] check the cookie flags too');
+    expect(body).toContain('[agent] SameSite is the culprit.');
+    expect(body).not.toContain('run started');
+    expect(body).not.toContain('Bash');
+    expect(body.indexOf('[user] check')).toBeGreaterThan(body.indexOf('[agent] Looking'));
+  });
+
+  /** The engine appends one `text` event per streamed chunk, so an un-coalesced replay would
+   *  read as a stutter of one-line agent turns rather than as a conversation. */
+  it('joins the chunks of one agent turn back into a single message', () => {
+    const recap = buildSessionRecap({
+      task: 't',
+      events: [event(1, 'text', { text: 'First half.' }), event(2, 'text', { text: 'Second half.' })],
+    });
+    expect(recap).toContain('[agent] First half.\nSecond half.');
+    expect(recap.match(/\[agent\]/g)).toHaveLength(1);
+  });
+
+  it('skips empty and non-string text rather than emitting blank speakers', () => {
+    const recap = buildSessionRecap({
+      task: 't',
+      events: [event(1, 'text', { text: '   ' }), event(2, 'user-message', { text: 42 })],
+    });
+    expect(recap).toContain('Nothing was exchanged');
+  });
+
+  it('clips one runaway message instead of letting it evict the rest', () => {
+    const recap = buildSessionRecap(
+      { task: 't', events: [event(1, 'text', { text: 'x'.repeat(500) }), event(2, 'user-message', { text: 'and then?' })] },
+      { maxMessageChars: 50 },
+    );
+    expect(recap).toContain('…[truncated]');
+    expect(recap).toContain('[user] and then?');
+    expect(recap).not.toContain('x'.repeat(51));
+  });
+
+  /** Over budget, the END of a conversation is what survives: that is where the unfinished work
+   *  is, and the opening is the part the task text already restates. */
+  it('drops the oldest messages first and says how many it dropped', () => {
+    const events = Array.from({ length: 10 }, (_, i) =>
+      event(i + 1, i % 2 === 0 ? 'text' : 'user-message', { text: `message ${i}` }),
+    );
+    const recap = buildSessionRecap({ task: 't', events }, { maxChars: 60 });
+    expect(recap).toContain('message 9');
+    expect(recap).not.toContain('message 0');
+    expect(recap).toMatch(/…\d earlier messages omitted…/);
+  });
+
+  it('omits the omission note when nothing was dropped', () => {
+    const recap = buildSessionRecap({ task: 't', events: [event(1, 'text', { text: 'short' })] });
+    expect(recap).not.toContain('omitted');
+  });
+
+  it('never claims an error the record does not carry', () => {
+    const recap = buildSessionRecap({ task: 't', error: '   ', events: [] });
+    expect(recap).not.toContain('How the previous session ended');
+  });
+});

--- a/packages/cezar/src/runs/session-recap.ts
+++ b/packages/cezar/src/runs/session-recap.ts
@@ -1,0 +1,116 @@
+import type { RunEvent } from './store.ts';
+
+/**
+ * The "previous session" briefing a FRESH agent session is opened on when the old one cannot be
+ * resumed.
+ *
+ * Continue normally means `--resume <sessionId>`: the backend still holds the conversation and the
+ * agent wakes up remembering everything. Two ordinary situations have no session id to hand it —
+ * the run died before any backend minted one (a crash while queueing for the worktree lock is the
+ * common shape), or the user deliberately switched runner/account, which strands the id inside the
+ * config dir that created it. Refusing there left the task with nothing but Delete.
+ *
+ * So the continuation opens a new session instead, and this is what stands in for the memory it
+ * doesn't have: the original task, how the last attempt ended, and a bounded replay of the
+ * conversation. Delivery-only — it is prepended to the opening prompt, never persisted as the
+ * user's own message, because the thread already renders every line of it.
+ */
+
+/** What the recap is built from — a run record's identity plus its persisted event log. */
+export interface SessionRecapInput {
+  /** The run's original task text (`RunRecord.task`) — never an event, so always passed in. */
+  task: string;
+  /** How the previous attempt ended (`RunRecord.error`), when it ended badly. */
+  error?: string;
+  /** The run's NDJSON events, oldest first (`RunStore.readEvents`). */
+  events: readonly RunEvent[];
+}
+
+export interface SessionRecapLimits {
+  /** Ceiling for the replayed conversation (the task/error header rides on top). */
+  maxChars?: number;
+  /** Per-message ceiling, applied before the conversation budget. */
+  maxMessageChars?: number;
+}
+
+/** Big enough for a real conversation, small enough that it cannot dominate a context window. */
+const MAX_RECAP_CHARS = 12_000;
+/** One rambling tool-narration turn must not evict the ten turns around it. */
+const MAX_MESSAGE_CHARS = 2_000;
+
+interface RecapTurn {
+  who: 'user' | 'agent';
+  text: string;
+}
+
+/**
+ * The v1 event types that carry conversation: what the user said (`user-message`) and what the
+ * agent said (`text`). Deliberately not the v2 `item.*` stream — it describes tool calls and UI
+ * state, which is noise in a briefing, and it is the surface most likely to change shape.
+ */
+function conversationTurns(events: readonly RunEvent[]): RecapTurn[] {
+  const turns: RecapTurn[] = [];
+  for (const event of events) {
+    const who = event.type === 'user-message' ? 'user' : event.type === 'text' ? 'agent' : undefined;
+    if (!who) continue;
+    const text = typeof event.text === 'string' ? event.text.trim() : '';
+    if (!text) continue;
+    // The engine appends one `text` event per streamed chunk, so a single agent turn arrives as
+    // many events. Joining consecutive same-speaker events back together keeps the replay reading
+    // like a conversation instead of a shredded one.
+    const last = turns[turns.length - 1];
+    if (last?.who === who) last.text = `${last.text}\n${text}`;
+    else turns.push({ who, text });
+  }
+  return turns;
+}
+
+function clip(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}\n…[truncated]`;
+}
+
+/**
+ * Render the briefing. Always returns text: even a run that produced no conversation at all still
+ * has a task, and that is precisely the case this exists for.
+ */
+export function buildSessionRecap(input: SessionRecapInput, limits: SessionRecapLimits = {}): string {
+  const maxChars = limits.maxChars ?? MAX_RECAP_CHARS;
+  const maxMessageChars = limits.maxMessageChars ?? MAX_MESSAGE_CHARS;
+  const rendered = conversationTurns(input.events).map(
+    (turn) => `[${turn.who}] ${clip(turn.text, maxMessageChars)}`,
+  );
+
+  // Drop from the FRONT when over budget: the end of a conversation is where the unfinished work
+  // is, and the beginning is the part the task text above already restates.
+  let dropped = 0;
+  let size = rendered.reduce((total, line) => total + line.length + 2, 0);
+  while (dropped < rendered.length && size > maxChars) {
+    size -= (rendered[dropped]?.length ?? 0) + 2;
+    dropped++;
+  }
+  const kept = rendered.slice(dropped);
+
+  const sections = [
+    '## Previous session (cezar)',
+    "This task's previous agent session could not be resumed, so this is a NEW session that does " +
+      'not remember any of it. What follows is the record of that session — read it as history, ' +
+      'not as something said in this conversation.',
+    `**Original task**\n\n${input.task.trim() || '(none recorded)'}`,
+  ];
+  if (input.error?.trim()) sections.push(`**How the previous session ended:** ${input.error.trim()}`);
+  if (kept.length) {
+    const omitted =
+      dropped > 0 ? `\n\n…${dropped} earlier message${dropped > 1 ? 's' : ''} omitted…` : '';
+    sections.push(`**Conversation so far**${omitted}\n\n${kept.join('\n\n')}`);
+  } else {
+    sections.push(
+      '**Conversation so far**\n\nNothing was exchanged — the session ended before the agent ' +
+        'produced any output.',
+    );
+  }
+  sections.push(
+    'Re-establish context before acting: read the handoff file (CEZ_HANDOFF_FILE) and inspect the ' +
+      'working tree for anything this replay does not cover. The message for this new session follows.',
+  );
+  return sections.join('\n\n');
+}

--- a/packages/cezar/src/workflows/auto-resume.test.ts
+++ b/packages/cezar/src/workflows/auto-resume.test.ts
@@ -163,8 +163,13 @@ describe('a run stopped by a usage limit resumes itself', () => {
     first.dispose();
 
     // A due deadline on a run with no session left to resume: the reconcile arms it from the
-    // record, `continueRun` refuses with "no agent session to resume", and the promise has to go
-    // — a hint counting down to an instant that has passed is worse than no hint.
+    // record, `fireAutoResume` refuses, and the promise has to go — a hint counting down to an
+    // instant that has passed is worse than no hint.
+    //
+    // The refusal is the feature's OWN, not one it inherits: a user pressing Continue on this run
+    // gets a fresh session briefed with the previous transcript
+    // (`2026-09-11-continue-without-a-session.md`), and that is deliberately not something an
+    // unattended timer may decide hours later with nobody watching. The note is what says so.
     for (const step of store.getRun(record.id)?.steps ?? []) {
       store.updateStep(record.id, step.id, { sessionId: undefined });
     }
@@ -175,6 +180,14 @@ describe('a run stopped by a usage limit resumes itself', () => {
     await expect
       .poll(() => store.getRun(record.id)?.autoResumeAt, { timeout: 20_000 })
       .toBeUndefined();
+    expect(
+      store
+        .readEvents(record.id)
+        .some((event) => String(event.message ?? '').includes('no agent session to resume')),
+    ).toBe(true);
+    // …and it really did refuse, rather than starting a briefed session and clearing the deadline
+    // on the way in.
+    expect(store.getRun(record.id)?.steps.some((step) => step.id.startsWith('continue-'))).toBe(false);
   }, 40_000);
 
   it('holds the queue while the account is limited — the rest never start', async () => {

--- a/packages/cezar/src/workflows/continue-without-session.test.ts
+++ b/packages/cezar/src/workflows/continue-without-session.test.ts
@@ -1,0 +1,217 @@
+import { execFile } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RunStore, type RunRecord } from '../runs/store.ts';
+import { RunManager } from './run.ts';
+
+const run = promisify(execFile);
+const GIT_ID = ['-c', 'user.name=test', '-c', 'user.email=test@local'];
+const INTERRUPTED = 'interrupted — cezar process exited during the run';
+
+/**
+ * Continue on a run with NOTHING to resume (#no-session-continue).
+ *
+ * The reported shape: cezar was killed while a task queued for the repository working tree, so
+ * the backend never minted a session id. Recovery answered "could not resume the interrupted
+ * task (no agent session to resume)", the composer answered "Session closed — no session to
+ * resume.", and the only remaining action on a task mid-flight was Delete.
+ *
+ * It continues in a FRESH session now, opened on a replay of the old one (`buildSessionRecap`).
+ * These cases pin both halves: no `--resume` reaches the CLI, and the briefing does reach the
+ * agent — plus the guard case, that a run which DOES have a session still resumes it untouched
+ * and is told nothing about a previous session it is already in.
+ */
+describe('Continue with no session to resume opens a fresh, briefed session', () => {
+  let repoRoot: string;
+  let dataDir: string;
+  let store: RunStore;
+  let manager: RunManager;
+  let argsFile: string;
+  let stdinFile: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'cez-no-session-'));
+    dataDir = join(repoRoot, '.ai/cezar');
+    argsFile = join(repoRoot, 'mock-args.ndjson');
+    stdinFile = join(repoRoot, 'mock-stdin.ndjson');
+    for (const key of ['CEZ_DRY_RUN', 'CEZ_MOCK_ARGS_FILE', 'CEZ_MOCK_STDIN_FILE']) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.CEZ_DRY_RUN = '1';
+    process.env.CEZ_MOCK_ARGS_FILE = argsFile;
+    process.env.CEZ_MOCK_STDIN_FILE = stdinFile;
+    await run('git', ['init', '-q', '-b', 'main'], { cwd: repoRoot });
+    writeFileSync(join(repoRoot, 'a.txt'), 'one\n');
+    await run('git', ['add', '-A'], { cwd: repoRoot });
+    await run('git', [...GIT_ID, 'commit', '-q', '-m', 'base'], { cwd: repoRoot });
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, 'config.json'), JSON.stringify({ maxParallel: 1 }));
+    writeFileSync(argsFile, '', 'utf8');
+    writeFileSync(stdinFile, '', 'utf8');
+    store = RunStore.open(dataDir);
+    manager = new RunManager(store, repoRoot);
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    store.flush();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  /** A run killed mid-turn, exactly as `recover()` leaves it: the step failed, and no session
+   *  id was ever recorded because the crash beat the first spawn. */
+  function interruptedRun(extra: Partial<RunRecord> = {}): RunRecord {
+    const record = store.createRun({
+      title: 'fix the login redirect',
+      workflow: 'quick-task',
+      task: 'Fix the login redirect that drops the session cookie',
+      runner: 'claude',
+      steps: [{ id: 'work', name: 'Work', kind: 'agent' }],
+      ...extra,
+    });
+    store.updateStep(record.id, 'work', { status: 'failed', iterations: 1 });
+    store.updateRun(record.id, {
+      status: 'failed',
+      error: INTERRUPTED,
+      finishedAt: new Date().toISOString(),
+    });
+    return record;
+  }
+
+  /** The record starts OUT `failed` (that is the state a continuation is offered from), so a plain
+   *  "wait for a terminal status" would return before anything happened. This waits for the
+   *  continuation's own turn to settle, and surfaces a refusal as the error rather than a timeout. */
+  async function waitForContinuation(runId: string, timeoutMs = 20_000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const record = store.getRun(runId);
+      if (record && ['waiting', 'done', 'review'].includes(record.status)) return record.status;
+      if (record?.status === 'failed' && record.error !== INTERRUPTED) {
+        throw new Error(`continuation failed: ${record.error}`);
+      }
+      if (Date.now() > deadline) throw new Error(`continuation did not settle in time (was ${record?.status})`);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  const stdinLines = (): Array<{ userText: string; imageCount: number }> =>
+    readFileSync(stdinFile, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+
+  const spawnArgs = (): string[][] =>
+    readFileSync(argsFile, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+
+  it('accepts the continuation, replays the task and conversation, and never passes --resume', async () => {
+    const record = interruptedRun();
+    store.appendEvent(record.id, { type: 'text', stepId: 'work', text: 'Reading src/middleware.ts.' });
+    store.appendEvent(record.id, { type: 'user-message', stepId: 'work', text: 'check the cookie flags too' });
+
+    expect(manager.continueRun(record.id, { text: 'keep going please' })).toEqual({ ok: true });
+    await waitForContinuation(record.id);
+
+    const opening = stdinLines()[0];
+    expect(opening).toBeDefined();
+    // The briefing, the original task, the replayed conversation…
+    expect(opening?.userText).toContain('## Previous session (cezar)');
+    expect(opening?.userText).toContain('Fix the login redirect that drops the session cookie');
+    expect(opening?.userText).toContain('interrupted — cezar process exited during the run');
+    expect(opening?.userText).toContain('[agent] Reading src/middleware.ts.');
+    expect(opening?.userText).toContain('[user] check the cookie flags too');
+    // …and the user's own prompt last, fenced off from the replayed history.
+    expect(opening?.userText.trimEnd().endsWith('keep going please')).toBe(true);
+
+    // There was nothing to reattach to, so nothing may claim otherwise on the wire.
+    expect(spawnArgs().some((args) => args.includes('--resume'))).toBe(false);
+
+    // The thread says which of the two Continues this was.
+    const notes = store
+      .readEvents(record.id)
+      .filter((event) => event.type === 'note')
+      .map((event) => String(event.message ?? ''));
+    expect(notes.some((message) => message.includes('no session to resume — started a fresh session'))).toBe(true);
+  }, 30_000);
+
+  /** The prompt the user typed is what the TRANSCRIPT must show. The briefing is delivery-only:
+   *  the thread already renders every line it replays, right above. */
+  it('persists the user prompt alone, not the briefing wrapped around it', async () => {
+    const record = interruptedRun();
+    expect(manager.continueRun(record.id, { text: 'keep going please' })).toEqual({ ok: true });
+    await waitForContinuation(record.id);
+
+    const userMessages = store
+      .readEvents(record.id)
+      .filter((event) => event.type === 'user-message')
+      .map((event) => String(event.text ?? ''));
+    expect(userMessages).toContain('keep going please');
+    expect(userMessages.some((text) => text.includes('## Previous session'))).toBe(false);
+  }, 30_000);
+
+  /** The guard case: unchanged behavior for the run that HAS a session. It resumes, and being
+   *  already inside that conversation it must not be handed a summary of it. */
+  it('a run with a recorded session still resumes it, with no briefing', async () => {
+    const record = interruptedRun();
+    store.updateStep(record.id, 'work', { sessionId: 'sess-1', backend: 'claude' });
+
+    expect(manager.continueRun(record.id, { text: 'keep going please' })).toEqual({ ok: true });
+    await waitForContinuation(record.id);
+
+    expect(spawnArgs().some((args) => args.includes('--resume') && args.includes('sess-1'))).toBe(true);
+    const opening = stdinLines()[0];
+    expect(opening?.userText).not.toContain('## Previous session (cezar)');
+    expect(opening?.userText).toBe('keep going please');
+
+    const notes = store
+      .readEvents(record.id)
+      .filter((event) => event.type === 'note')
+      .map((event) => String(event.message ?? ''));
+    expect(notes.some((message) => message.includes('no session to resume'))).toBe(false);
+  }, 30_000);
+
+  /** Boot recovery is where the user met this: it is the caller that turns an interrupted run
+   *  into a continuation, and it used to give up here and leave the task dead. */
+  it('recover() continues an interrupted run that never recorded a session', async () => {
+    const record = store.createRun({
+      title: 'fix the login redirect',
+      workflow: 'quick-task',
+      task: 'Fix the login redirect that drops the session cookie',
+      runner: 'claude',
+      steps: [{ id: 'work', name: 'Work', kind: 'agent' }],
+    });
+    store.updateStep(record.id, 'work', { status: 'running', iterations: 1 });
+    store.updateRun(record.id, { status: 'running', currentStepId: 'work' });
+
+    const recovering = new RunManager(store, repoRoot);
+    try {
+      await recovering.recover();
+      const lifecycle = store
+        .readEvents(record.id)
+        .filter((event) => event.type === 'lifecycle')
+        .map((event) => String(event.message ?? ''));
+      expect(lifecycle.some((message) => message.includes('could not resume'))).toBe(false);
+      expect(
+        lifecycle.some((message) =>
+          message.includes('no session to resume; continuing the interrupted task in a fresh session'),
+        ),
+      ).toBe(true);
+      expect(store.getRun(record.id)?.steps.some((step) => step.id === 'continue-1')).toBe(true);
+      await waitForContinuation(record.id);
+    } finally {
+      recovering.dispose();
+    }
+  }, 30_000);
+});

--- a/packages/cezar/src/workflows/run.test.ts
+++ b/packages/cezar/src/workflows/run.test.ts
@@ -631,12 +631,22 @@ describe('RunManager.continueRun override', () => {
     expect(store.getRun(id)?.agentProfile).toBe('klaudiusz');
   });
 
-  it('refuses to continue a run with no resumable session (no override persisted)', () => {
+  /** A run with NO session to reattach to is continued in a fresh one, briefed with the previous
+   *  session's transcript (spec 2026-09-11-continue-without-a-session) — it used to be refused,
+   *  which left a task that crashed before its first spawn with no action but Delete. The override
+   *  is persisted exactly as it is for any other continuation; only the session id is absent. */
+  it('continues a run with no resumable session, on a fresh session, honouring the override', () => {
     const record = store.createRun({ title: 't', workflow: 'quick-task', task: 't', runner: 'claude', steps: [] });
     store.updateRun(record.id, { status: 'done' });
-    const result = manager.continueRun(record.id, { runner: 'codex' });
-    expect(result.ok).toBe(false);
-    expect(store.getRun(record.id)?.runner).toBe('claude');
+    const calls: unknown[][] = [];
+    (manager as unknown as { runContinuation: (...args: unknown[]) => Promise<void> }).runContinuation = async (...args) => {
+      calls.push(args);
+    };
+
+    expect(manager.continueRun(record.id, { runner: 'codex' })).toEqual({ ok: true });
+    expect(store.getRun(record.id)?.runner).toBe('codex');
+    expect(calls[0]?.[2]).toBeUndefined(); // nothing to resume — a new session
+    expect(calls[0]?.[3]).toBe('codex');
   });
 });
 

--- a/packages/cezar/src/workflows/run.ts
+++ b/packages/cezar/src/workflows/run.ts
@@ -50,6 +50,7 @@ import { extractTaskRefs, refineTaskRefs, titleRefNumber } from '../runs/task-re
 import { parseTaskMarkers, stripTaskMarkers } from '../runs/task-markers.ts';
 import { autoNamingActive, generateRunName, liveTitleUpdatesEnabled, postValidateTitle } from '../runs/auto-name.ts';
 import { reviewGateEnabled } from '../runs/review-gate.ts';
+import { buildSessionRecap } from '../runs/session-recap.ts';
 import { resolveProfileEnvForRoot } from '../workspace/agent-profiles.ts';
 import { DEFAULT_AGENT_ACCOUNT_ID } from '../workspace/agent-accounts.ts';
 import { WorkspaceSemaphore, type AccountHolds } from '../workspace/semaphore.ts';
@@ -981,9 +982,9 @@ export class RunManager {
    * silently never going to happen.
    *
    * A continuation is reconstructed first: its executable details are gone, but the pending
-   * `continue-N` step and the session before it are durable, which is enough. Otherwise the
-   * workflow is revived from the record. A run that can be neither is failed loudly rather than
-   * left in the queue as a ghost.
+   * `continue-N` step is durable, which is enough — the session before it is reattached when it
+   * exists and replayed as a briefing when it does not. Otherwise the workflow is revived from the
+   * record. A run that can be neither is failed loudly rather than left in the queue as a ghost.
    */
   private async reviveQueuedRun(run: RunRecord, reason: string): Promise<void> {
     const queuedContinuation = [...run.steps]
@@ -992,12 +993,16 @@ export class RunManager {
     const sessionStep = queuedContinuation
       ? [...run.steps].reverse().find((step) => step.id !== queuedContinuation.id && step.sessionId)
       : undefined;
-    if (queuedContinuation && sessionStep?.sessionId) {
+    if (queuedContinuation) {
       const backend = run.runner ?? 'claude';
-      const sessionBackend = sessionStep.backend ?? backend;
+      const sessionBackend = sessionStep?.backend ?? backend;
+      // A continuation with no reattachable session is still a continuation — it opens a fresh
+      // session on the previous one's briefing (`buildSessionRecap`). Re-running the WORKFLOW from
+      // step one instead, which is what this used to fall through to, would throw away everything
+      // the task had already done and redo it against a worktree that now holds the results.
       this.pendingContinuations.set(run.id, {
         stepId: queuedContinuation.id,
-        sessionId: sessionBackend === backend ? sessionStep.sessionId : undefined,
+        sessionId: sessionBackend === backend ? sessionStep?.sessionId : undefined,
         backend,
         prompt: RESTART_CONTINUATION_PROMPT,
         images: [],
@@ -1104,6 +1109,10 @@ export class RunManager {
         finishedAt,
         currentStepId: undefined,
       });
+      // A crash before the backend minted a session id (queueing for the worktree lock is the
+      // usual window) leaves nothing to reattach to. That used to end the task here; it now opens
+      // a fresh session on the previous one's briefing, so the line has to say which happened.
+      const hadSession = run.steps.some((step) => step.sessionId);
       const resumed = this.continueRun(
         run.id,
         {
@@ -1111,10 +1120,13 @@ export class RunManager {
         },
         true,
       );
+      const picked = hadSession
+        ? 'cezar restarted — resuming the interrupted task from its last session'
+        : 'cezar restarted — no session to resume; continuing the interrupted task in a fresh session';
       this.store.appendEvent(run.id, {
         type: 'lifecycle',
         message: resumed.ok
-          ? 'cezar restarted — resuming the interrupted task from its last session'
+          ? picked
           : `cezar restarted — could not resume the interrupted task (${resumed.error ?? 'unknown'})`,
       });
     }
@@ -1196,7 +1208,13 @@ export class RunManager {
     const limit = parseUsageLimit(run.error);
     if (!limit) return;
     if (!this.semaphore.autoResumeOnUsageLimit()) return;
-    // No session to resume = nothing this feature can do; `continueRun` would refuse anyway.
+    // An UNATTENDED resume stays session-only. `continueRun` no longer refuses without one — it
+    // opens a fresh session briefed with the old transcript (spec
+    // 2026-09-11-continue-without-a-session) — and that is right for a user pressing Continue,
+    // who is present and asked for it. Restarting a conversation from a summary hours later with
+    // nobody watching is a different promise, and this feature never made it. Enforced again at
+    // fire time (`fireAutoResume`), because `reconcileAutoResumes` arms from the RECORD and would
+    // otherwise walk straight past this gate after a restart.
     if (!run.steps.some((step) => step.sessionId)) return;
     const attempts = run.autoResumeAttempts ?? 0;
     if (attempts >= MAX_AUTO_RESUMES) {
@@ -1235,6 +1253,19 @@ export class RunManager {
     // off in the window between the last pump and this tick.
     if (!this.semaphore.autoResumeOnUsageLimit()) {
       this.clearAutoResume(runId);
+      return;
+    }
+    // The session gate again, because this is the moment it has to hold: `reconcileAutoResumes`
+    // arms from the RECORD, so a deadline that survived a restart never passes back through
+    // `scheduleAutoResumeIfLimited`. Without this, a limit-stopped run whose session id was lost
+    // would be restarted from a transcript summary with nobody watching — which is a thing a user
+    // may ask Continue for, and not a thing an unattended timer may decide.
+    if (!run.steps.some((step) => step.sessionId)) {
+      this.clearAutoResume(runId);
+      this.store.appendEvent(runId, {
+        type: 'note',
+        message: 'automatic resume could not start — no agent session to resume; continue this task manually',
+      });
       return;
     }
     const attempts = (run.autoResumeAttempts ?? 0) + 1;
@@ -1971,6 +2002,11 @@ export class RunManager {
    * (`claude --resume <sessionId>`) as a new synthetic step. The session then
    * behaves exactly like an interactive step: `waiting` after each turn,
    * messages via sendMessage, closed by finish/idle/cancel.
+   *
+   * When the session cannot be reattached — none was ever recorded, or the user switched
+   * runner/account — the step opens a NEW session briefed with the old one's transcript
+   * (`buildSessionRecap`) rather than refusing. Continue is the only way forward a terminal run
+   * has, so it must not be the thing that fails.
    */
   continueRun(
     runId: string,
@@ -1997,21 +2033,30 @@ export class RunManager {
     if (!['done', 'failed', 'cancelled', 'review'].includes(run.status)) {
       return { ok: false, error: `cannot continue a ${run.status} run` };
     }
+    // The session a continuation would REATTACH to, when there is one. Its absence is no longer a
+    // refusal: a run whose backend never minted an id (it crashed before the first spawn — the
+    // queue-for-the-worktree-lock window is the common shape) used to answer "no agent session to
+    // resume" and offer the user nothing but Delete. It continues in a FRESH session instead,
+    // opened on `buildSessionRecap`'s briefing — the same road a runner/account switch has always
+    // taken (`resumeSessionId` below), which is why one branch covers both.
     const sessionStep = [...run.steps].reverse().find((s) => s.sessionId);
-    if (!sessionStep?.sessionId) return { ok: false, error: 'no agent session to resume' };
+    const lastSessionId = sessionStep?.sessionId;
     const targetRunner = opts.runner ?? run.runner ?? 'claude';
     // Session ids are provider-owned opaque values. New records carry explicit
     // affinity; for legacy records, the run's current runner is the conservative
     // owner until a continuation emits a new, attributed session id (#562).
-    const sessionBackend = sessionStep.backend ?? run.runner ?? 'claude';
+    const sessionBackend = sessionStep?.backend ?? run.runner ?? 'claude';
     // A session id only resolves inside the config dir that created it (spec
     // 2026-07-29-agent-profiles), so switching ACCOUNT ends the session exactly like switching
     // backend does: `claude --resume <id>` under another login finds nothing and would silently
     // open a fresh conversation while the thread claimed it had resumed. A step that recorded no
     // account predates the feature and therefore ran under the discovered one.
-    const sessionAccount = sessionStep.profileId ?? DEFAULT_AGENT_ACCOUNT_ID;
+    const sessionAccount = sessionStep?.profileId ?? DEFAULT_AGENT_ACCOUNT_ID;
     const accountSwitched = opts.agentProfile !== undefined && opts.agentProfile !== sessionAccount;
-    const resume = sessionBackend === targetRunner && !accountSwitched;
+    // Undefined = open a new session. Both reasons land here: nothing to reattach to, or an id
+    // this runner/account cannot resolve.
+    const resumeSessionId =
+      sessionBackend === targetRunner && !accountSwitched ? lastSessionId : undefined;
 
     // Follow-up runner/model/account override (#401, spec 2026-07-29-agent-profiles): the composer
     // lets the user pick which backend, model and login handle this continuation — the same flat
@@ -2077,7 +2122,7 @@ export class RunManager {
     if (deferForCapacity) {
       this.pendingContinuations.set(runId, {
         stepId,
-        sessionId: resume ? sessionStep.sessionId : undefined,
+        sessionId: resumeSessionId,
         backend: targetRunner,
         prompt,
         images,
@@ -2094,7 +2139,7 @@ export class RunManager {
     void this.runContinuation(
       runId,
       stepId,
-      resume ? sessionStep.sessionId : undefined,
+      resumeSessionId,
       targetRunner,
       prompt,
       images,
@@ -2137,6 +2182,14 @@ export class RunManager {
     // invisible to the enforcer forever. Best-effort; falls back to repoRoot.
     await rematerializeReclaimedWorktree(this.repoRoot, this.store, runId);
     const record = this.store.getRun(runId);
+    // No session id = a new conversation that remembers nothing about this task, so it is handed
+    // the previous one's briefing instead. Built HERE, before this continuation appends its own
+    // `user-message` below, so the replay cannot include the prompt it is being prepended to.
+    // Delivery-only: the transcript already shows every line of it (see `openingPrompt`).
+    const recap =
+      sessionId === undefined && record
+        ? buildSessionRecap({ task: record.task, error: record.error, events: this.store.readEvents(runId) })
+        : '';
     // The env is a live ceiling: a run created while the inbox was on must not keep writing
     // follow-ups after it is switched off.
     const generateFollowups = followupsEnabled() && record?.generateFollowups !== false;
@@ -2193,6 +2246,17 @@ export class RunManager {
       backend,
     });
     this.store.appendEvent(runId, { type: 'step-start', stepId, name: 'Continue', kind: 'agent', iteration: 1 });
+    // Say so in the thread. "Continue" that silently means "start over with a summary" would be a
+    // lie by omission: the agent's memory of the earlier turns is a briefing now, not the real
+    // thing, and that is worth knowing before reading its next answer.
+    if (recap) {
+      this.store.appendEvent(runId, {
+        type: 'note',
+        stepId,
+        message:
+          'no session to resume — started a fresh session, seeded with the previous session\'s task and conversation',
+      });
+    }
     // Attachments pasted into the follow-up composer, on the same terms as a live-session
     // message (#357): persisted to the run's own image store so the thread renders the bubble's
     // images rather than a bare count, and handed to the agent BOTH as base64 blocks (so it can
@@ -2402,7 +2466,10 @@ export class RunManager {
     // through `deliverMessage`, so it needs the SAME delivery-only `/skill` rewrite the
     // live path applies (#811). Delivery-only: the `user-message` event above already
     // persisted the user's original text, and the transcript must keep showing that.
-    const openingPrompt = expandRegistrySlashSkillText(prompt, state.skills ?? []);
+    const expandedPrompt = expandRegistrySlashSkillText(prompt, state.skills ?? []);
+    // The briefing rides in front of the user's own words, fenced off by a rule so the agent can
+    // tell replayed history from the thing it is being asked to do now.
+    const openingPrompt = recap ? `${recap}\n\n---\n\n${expandedPrompt}` : expandedPrompt;
     const session = runner.startSession(
       {
         // The Continue step is a fresh agent session on the same run — the

--- a/packages/web/src/components/reference-conflict-action.test.tsx
+++ b/packages/web/src/components/reference-conflict-action.test.tsx
@@ -116,15 +116,18 @@ describe('ResolveConflictsButton', () => {
     await waitFor(() => expect(screen.getByText(/Task reopened — resolving conflicts in PR #864/)).not.toBeNull())
   })
 
-  it('says why instead of pretending, when there is no session to reach', async () => {
-    // A closed run that never recorded a session has nothing to reopen. A button that looked
-    // pressable and then quietly did nothing would be worse than one that explains itself.
+  it('still reaches a closed task that never recorded a session', async () => {
+    // This used to be the one dead end: nothing to reopen, so the button explained itself and
+    // stayed shut. `/continue` covers that case now by opening a fresh session briefed with the
+    // previous one's transcript (spec 2026-09-11-continue-without-a-session), so the prompt goes
+    // out on the same seam every other closed task uses.
     renderButton(run('done', { steps: [step()] }))
 
-    expect(button().hasAttribute('disabled')).toBe(true)
-    expect(screen.getByText(/no agent session was recorded/)).not.toBeNull()
+    await waitFor(() => expect(button().hasAttribute('disabled')).toBe(false))
     fireEvent.click(button())
-    expect(posted()).toBeUndefined()
+
+    await waitFor(() => expect(posted()?.path).toContain('/continue'))
+    expect(posted()?.body).toMatchObject({ text: resolveConflictsPrompt(864) })
   })
 
   it('surfaces a refusal where the user pressed, because the panel is gone by then', async () => {

--- a/packages/web/src/routes/task-thread/ask-answer.test.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.test.ts
@@ -47,11 +47,13 @@ describe('askDeliveryMode — where an ask answer goes, per run status', () => {
     expect(askDeliveryMode(run(status))).toBe('resume')
   })
 
-  // Nothing to reopen: the card must say so rather than offer chips that cannot deliver.
+  // No session id either — and still `resume`, because `/continue` answers that case by opening
+  // a fresh session briefed with the old one's transcript. There is no closed run whose question
+  // has nowhere to go, which is why the card no longer has an inert state to render.
   it.each(['review', 'done', 'failed', 'cancelled'] as const)(
-    '%s without a recorded session → unavailable',
+    '%s without a recorded session → resume, on a fresh session',
     (status) => {
-      expect(askDeliveryMode(run(status, { steps: [step()] }))).toBe('unavailable')
+      expect(askDeliveryMode(run(status, { steps: [step()] }))).toBe('resume')
     },
   )
 

--- a/packages/web/src/routes/task-thread/ask-answer.ts
+++ b/packages/web/src/routes/task-thread/ask-answer.ts
@@ -8,7 +8,7 @@ import {
   useActiveProviderAvailability,
   useExistingProviderAvailability,
 } from './active-provider'
-import { isRunActive, lastSessionId, runActionFlags } from './run-actions'
+import { isRunActive, lastSessionId } from './run-actions'
 
 /**
  * Which seam an AskUser answer travels on.
@@ -20,14 +20,16 @@ import { isRunActive, lastSessionId, runActionFlags } from './run-actions'
  *                the opening prompt of `POST /api/runs/:id/continue`, which reopens
  *                the last recorded session and appends the answer as a
  *                `user-message` — the very event that resolves the card.
- *  - `unavailable` — the run is closed and never recorded a session, so there is
- *                nothing to reopen and the answer has nowhere to go.
+ *
+ * There is no third, "nowhere to send it" mode any more: `/continue` reopens the recorded
+ * session when there is one and otherwise opens a fresh session briefed with the old one's
+ * transcript, so every closed run can still take an answer.
  */
-export type AskDeliveryMode = 'live' | 'resume' | 'unavailable'
+export type AskDeliveryMode = 'live' | 'resume'
 
-/** Why an answer cannot be delivered right now — `provider` is recoverable from
- *  Settings, `no-session` is terminal for this run. */
-export type AskBlockedReason = 'provider' | 'no-session'
+/** Why an answer cannot be delivered right now. Provider trouble only — and recoverable from
+ *  Settings, which is the point: nothing about a run's own state blocks an answer. */
+export type AskBlockedReason = 'provider'
 
 /** The idle timer closes the backend before the RunManager has finished settling
  *  the run record and releasing its active-run entry. A stale ask card can therefore
@@ -62,12 +64,11 @@ export async function resumeAfterIdleTeardown<T>(
 /**
  * The delivery route for one ask answer, as a pure function of the run record — the
  * same shape `runActionFlags` has, so a table test can pin it per status. Mirrors the
- * composer's own routing (`ThreadView`: a live/queued run sends, a closed one with a
- * session continues), which is exactly the seam the ask card was missing.
+ * composer's own routing (`ThreadView`: a live/queued run sends, a closed one continues),
+ * which is exactly the seam the ask card was missing.
  */
 export function askDeliveryMode(run: RunRecord): AskDeliveryMode {
-  if (isRunActive(run.status)) return 'live'
-  return runActionFlags(run).continueRun ? 'resume' : 'unavailable'
+  return isRunActive(run.status) ? 'live' : 'resume'
 }
 
 export interface AskAnswerDelivery {
@@ -122,20 +123,11 @@ export function useAskAnswer(run: ApiRun, projectId?: string): AskAnswerDelivery
   const deliveringRef = useRef(false)
 
   const mode = askDeliveryMode(run)
-  const providerBlocked =
-    mode === 'resume' ? !existingProvider.usable
-    : mode === 'live' ? !activeProvider.usable
-    : false
-  const blockedBy: AskBlockedReason | undefined =
-    mode === 'unavailable' ? 'no-session'
-    : providerBlocked ? 'provider'
+  const providerBlocked = mode === 'resume' ? !existingProvider.usable : !activeProvider.usable
+  const blockedBy: AskBlockedReason | undefined = providerBlocked ? 'provider' : undefined
+  const reason = providerBlocked
+    ? (mode === 'resume' ? existingProvider.reason : activeProvider.reason)
     : undefined
-  const reason =
-    blockedBy === 'no-session'
-      ? 'This session has ended and no agent session was recorded, so the answer cannot be delivered.'
-      : blockedBy === 'provider'
-        ? (mode === 'resume' ? existingProvider.reason : activeProvider.reason)
-        : undefined
 
   const resumeWith = (text: string) => {
     if (!existingProvider.usable) {

--- a/packages/web/src/routes/task-thread/ask-card.test.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.test.tsx
@@ -308,15 +308,15 @@ describe('AskCard — answering after the session has ended', () => {
     expect((await screen.findByRole('alert')).textContent).toBe('no agent session to resume')
   })
 
-  it('a closed run that never recorded a session says so and stays inert', () => {
+  // A card whose run never recorded a session used to be a dead end that said so. `/continue`
+  // takes that case now — fresh session, old transcript replayed — so the chips stay live and the
+  // answer goes out on the same seam every other closed run uses.
+  it('a closed run that never recorded a session still delivers its answer', async () => {
     renderAsk(singleAsk, { ...closedRun, steps: [step()] })
-    expect((screen.getByRole('button', { name: /date-fns/ }) as HTMLButtonElement).disabled).toBe(true)
-    expect(
-      screen.getByText(
-        'This session has ended and no agent session was recorded, so the answer cannot be delivered.',
-      ),
-    ).toBeTruthy()
+    const option = screen.getByRole('button', { name: /date-fns/ }) as HTMLButtonElement
+    expect(option.disabled).toBe(false)
+    fireEvent.click(option)
+    await waitFor(() => expect(continueAsync).toHaveBeenCalledWith({ text: 'Library: date-fns' }))
     expect(mutateAsync).not.toHaveBeenCalled()
-    expect(continueAsync).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/routes/task-thread/ask-card.tsx
+++ b/packages/web/src/routes/task-thread/ask-card.tsx
@@ -130,11 +130,6 @@ function PendingAsk({ ask, run }: { ask: ThreadAsk; run: ApiRun }) {
           </Link>
         </div>
       ) : null}
-      {delivery.blockedBy === 'no-session' ? (
-        <p data-slot="ask-no-session" className="mt-3 text-xs text-muted-foreground">
-          {delivery.reason}
-        </p>
-      ) : null}
       {/* A dropped answer used to be silent — the tap did nothing and said nothing. */}
       {delivery.error ? (
         <p data-slot="ask-error" role="alert" className="mt-3 text-xs text-danger">

--- a/packages/web/src/routes/task-thread/run-actions.test.ts
+++ b/packages/web/src/routes/task-thread/run-actions.test.ts
@@ -42,8 +42,9 @@ const run = (status: RunStatus, extra: Partial<RunRecord> = {}): RunRecord => ({
 describe('runActionFlags — the visibility matrix, all 7 statuses × archived', () => {
   // The legacy header's rules verbatim (web/app.js `updateDetail`):
   //   active(running|queued|waiting) → cancel, no delete/archive/continue/terminal;
-  //   finish only at the waiting/review gates; continue+terminal need a closed run WITH a
-  //   session; notes always. `archived` flips nothing here — it only relabels Archive.
+  //   finish only at the waiting/review gates; continue needs a closed run (terminal additionally
+  //   needs a recorded session); notes always. `archived` flips nothing here — it only relabels
+  //   Archive.
   // `markUnread` (#775) is false in every cell of this matrix because the fixture carries no
   // `finishedAt` — a record with no finish instant can never wear the unread marker, whatever
   // its status says. The flag's real matrix is the FINISHED one in its own describe below.
@@ -74,11 +75,19 @@ describe('runActionFlags — the visibility matrix, all 7 statuses × archived',
     }
   })
 
-  it('continue/terminal need a session — a closed run without one offers neither', () => {
+  // Terminal still needs a session id — it splices one into a shell command. Continue does not:
+  // the server opens a fresh session on a replay of the old one, so a run that crashed before
+  // its first spawn is recoverable instead of being a task whose only action is Delete.
+  it('a closed run with no recorded session still offers Continue, but not Terminal', () => {
     const flags = runActionFlags(run('failed', { steps: [step()] }))
-    expect(flags.continueRun).toBe(false)
+    expect(flags.continueRun).toBe(true)
     expect(flags.terminal).toBe(false)
     expect(flags.deleteRun).toBe(true)
+  })
+
+  it('an ACTIVE run offers neither, session or not — the engine owns it', () => {
+    expect(runActionFlags(run('running', { steps: [step()] })).continueRun).toBe(false)
+    expect(runActionFlags(run('running')).continueRun).toBe(false)
   })
 })
 

--- a/packages/web/src/routes/task-thread/run-actions.ts
+++ b/packages/web/src/routes/task-thread/run-actions.ts
@@ -83,7 +83,8 @@ export function cliTargetResumes(run: RunRecord, targetId: string): boolean {
 export interface RunActionFlags {
   /** waiting → close the session; review → accept the changes without a PR. Both POST /finish. */
   finish: boolean
-  /** Reopen the last agent session in-process. */
+  /** Carry the run on in-process: reopening the last agent session when there is one, otherwise a
+   *  fresh session briefed with the previous one's transcript. */
   continueRun: boolean
   /** Hand the session to a real terminal (open-in-cli). */
   terminal: boolean
@@ -108,7 +109,12 @@ export function runActionFlags(run: RunRecord): RunActionFlags {
   const hasSession = lastSessionId(run) !== undefined
   return {
     finish: run.status === 'waiting' || run.status === 'review',
-    continueRun: !active && hasSession,
+    // Deliberately NOT gated on `hasSession`, unlike `terminal`. The server continues a run with
+    // no reattachable session by opening a fresh one on the previous session's transcript, so a
+    // task that crashed before its first spawn is still a task the user can carry forward — the
+    // whole point being that a failure never becomes a dead end. Terminal keeps the gate: handing
+    // a shell `claude --resume <id>` needs an id that exists.
+    continueRun: !active,
     terminal: !active && hasSession,
     notes: true,
     archive: !active,
@@ -141,6 +147,14 @@ export function resolveConflictsPrompt(prNumber?: number): string {
 /** The Finish button's tooltip — review-gate accept reads differently from closing a session. */
 export function finishTitle(status: RunStatus): string {
   return status === 'review' ? 'Accept the changes without a PR' : 'Close the session'
+}
+
+/** The Continue button's tooltip. One button, two promises: reattaching to a live-again session is
+ *  not the same as starting over from a replay of it, and the weaker one has to say so. */
+export function continueTitle(run: RunRecord): string {
+  return lastSessionId(run) === undefined
+    ? 'Start a new session — the previous conversation is replayed to the agent'
+    : 'Reopen the session'
 }
 
 /**

--- a/packages/web/src/routes/task-thread/run-header.tsx
+++ b/packages/web/src/routes/task-thread/run-header.tsx
@@ -78,7 +78,14 @@ import { isHttpUrl } from '@/lib/utils'
 
 import { Markdown } from './markdown'
 import { useContinuationProvider } from './continuation-provider'
-import { cliTargetResumes, cliTargetRunner, finishTitle, resumeHint, runActionFlags } from './run-actions'
+import {
+  cliTargetResumes,
+  cliTargetRunner,
+  continueTitle,
+  finishTitle,
+  resumeHint,
+  runActionFlags,
+} from './run-actions'
 import { WorkflowSteps } from './step-rail'
 import { useFinishRun } from './use-finish-run'
 
@@ -189,7 +196,7 @@ export function RunHeader({
               <Button
                 variant="outline"
                 size="sm"
-                title={actions.continuation.reason ?? 'Reopen the session'}
+                title={actions.continuation.reason ?? continueTitle(run)}
                 disabled={actions.continueRun.isPending || !actions.continuation.canContinue}
                 onClick={() => actions.continueRun.mutate()}
               >
@@ -813,7 +820,7 @@ function ActionsKebab({
         {flags.continueRun ? (
           <DropdownMenuItem
             disabled={!actions.continuation.canContinue || actions.continueRun.isPending}
-            title={actions.continuation.reason}
+            title={actions.continuation.reason ?? continueTitle(run)}
             onSelect={() => actions.continueRun.mutate()}
           >
             <PlayIcon aria-hidden="true" /> Continue

--- a/packages/web/src/routes/task-thread/task-thread.test.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.test.tsx
@@ -651,17 +651,20 @@ describe('ThreadView', () => {
   })
 
   /**
-   * The scope boundary: the queued branch is `queued` ONLY, and the composer only stays live
-   * on a closed run that HAS a session to resume. This `done` run has none, so it is the one
-   * remaining genuinely-disabled state — and it is told so honestly, without offering a
-   * Continue it cannot perform.
+   * A closed run with NO session id — the shape a crash before the first spawn leaves behind.
+   * It used to be the one genuinely-disabled composer state ("no session to resume"), which
+   * meant a task that died early could only be deleted. Continue covers it now by opening a
+   * fresh session on a replay of the old one, and the placeholder promises exactly that —
+   * not "pick up where you left off", which is a different and stronger claim.
    */
-  it('closed with no resumable session → disabled composer, and no Continue invented', () => {
+  it('closed with no session → the composer still offers Continue, as a NEW session', async () => {
     renderView(<ThreadView run={run('done')} thread={reduceThread(EVENTS)} />)
     const textarea = screen.getByLabelText('Reply to the agent') as HTMLTextAreaElement
-    expect(textarea.disabled).toBe(true)
-    expect(textarea.placeholder).toBe('Session closed — no session to resume.')
-    expect(document.querySelector('[data-slot="follow-up-engine"]')).toBeNull()
+    await waitFor(() => expect(textarea.disabled).toBe(false))
+    expect(textarea.placeholder).toBe(
+      'Continue in a new session — the previous conversation is replayed to the agent…',
+    )
+    expect((screen.getByLabelText('Continue') as HTMLButtonElement).disabled).toBe(false)
     expect(document.querySelector('[data-slot="queued-hint"]')).toBeNull()
   })
 

--- a/packages/web/src/routes/task-thread/task-thread.tsx
+++ b/packages/web/src/routes/task-thread/task-thread.tsx
@@ -34,7 +34,7 @@ import { PlanDock, planCounts } from './plan-dock'
 import { collectSubagents, findSubagent, subagentChildren } from './subagent-dock'
 import { SubagentSheet } from './subagent-sheet'
 import { AcceptCelebration, ReviewPanel } from './review-panel'
-import { queuePosition } from './run-actions'
+import { lastSessionId, queuePosition } from './run-actions'
 import { RunHeader } from './run-header'
 import { AskCard } from './ask-card'
 import { useRunRecordReconcile } from './run-reconcile'
@@ -199,6 +199,12 @@ export function ThreadView({
   const continueAction = useContinueAction(run)
   const hasContinuation = !sessionOpen && !queued && continueAction.available
   const continuable = hasContinuation && continueAction.canContinue
+  // …and the fifth: a closed run with NO session to reattach to — a crash before the backend ever
+  // minted one, most often. Continue still works there (the server opens a fresh session on the
+  // old one's transcript), but it is a different promise from "pick up where you left off", so the
+  // composer says which of the two it is offering rather than letting the user assume the stronger
+  // one.
+  const freshSession = continuable && lastSessionId(run) === undefined
   // A closed session can never settle its in-flight items — nothing in the reducer rewrites a
   // `running` item on `session.ended`, so an interrupted fan-out stays `running` in the
   // persisted stream forever. Without this, reopening it pulses `Agents · 0/1` above a dead
@@ -455,10 +461,10 @@ export function ThreadView({
                 : (text, images) => sendMessage.mutateAsync({ text, images })
             }
             disabled={providerBlocked || (!sessionOpen && !queued && !continuable)}
-            // Only reachable now by a closed run with NO session to resume — which is exactly
-            // the one case where Continue is not on offer either. Left honest rather than
-            // rewritten: "closed" is all such a run can be told.
-            disabledReason={providerBlocked ? providerReason : 'Session closed — no session to resume.'}
+            // Unreachable while a provider is connected: every terminal run can now be continued,
+            // with or without a session to reattach to. Kept as the honest last word for the case
+            // where `continueAction.available` is false anyway.
+            disabledReason={providerBlocked ? providerReason : 'Session closed.'}
             // The engine pills ride the enabled footer, so the picked runner/model and the
             // typed prompt reach `POST /continue` in one request.
             footerEnd={
@@ -476,6 +482,7 @@ export function ThreadView({
             sendAriaLabel={continuable ? 'Continue' : 'Send'}
             placeholder={
               queued ? 'Add to the prompt — sent when the run starts…'
+              : freshSession ? 'Continue in a new session — the previous conversation is replayed to the agent…'
               : continuable ? 'Continue — add a prompt, or send to just reopen the session…'
               : run.status === 'waiting' ? 'Reply — / for skills, @ for files…'
               : 'Message the agent — / for skills, @ for files…'


### PR DESCRIPTION
## Problem

Reported from the thread of a real run:

```
· run started — workflow "quick-task" (runner: claude)
· worktree off — running in the repo working tree
· waiting for exclusive access to the repository working tree
· cezar restarted — could not resume the interrupted task (no agent session to resume)

Session failed — interrupted — cezar process exited during the run
```

…with the composer underneath reading `Session closed — no session to resume.`

Nothing about the task was broken. The worktree, the branch, the handoff file and the user's prompt were all intact — the run simply died in the window between "accepted" and "spawned", which is precisely where a session id does not exist yet. Three surfaces then agreed the task was over, and the only action left was **Delete**.

## What changed

Continue covers that case now by opening a **new** session briefed with the old one's record. Resuming is still preferred and still happens byte-for-byte as before whenever there is something to resume.

**`packages/cezar/src/runs/session-recap.ts` (new)** — `buildSessionRecap({task, error, events})`. Pure, store-free, separately testable. Coalesces consecutive same-speaker events back into turns (the engine appends one `text` event per streamed chunk), clips per message, then drops from the front until under budget and says how many it dropped.

| Knob | Value | Why |
|---|---|---|
| Total budget | 12 000 chars | Cannot fill a context window with history before the agent reads its instruction |
| Per message | 2 000 chars | One rambling turn must not evict the ten around it |
| Dropped from | the **front** | The end of a conversation is where the unfinished work is; the start is what the task text already restates |
| Included | `user-message` + `text` | It is a briefing, not a log — tool traffic is the bulk of an NDJSON file and the least useful part of it |

**`RunManager.continueRun`** drops the refusal. `resume ? sessionStep.sessionId : undefined` collapses into one `resumeSessionId` whose `undefined` means "open a new session" for either reason — nothing recorded, **or** a runner/account switch that strands the id inside another config dir. One rule covers both, so neither can drift.

**`RunManager.runContinuation`** builds the briefing *before* it appends this continuation's own `user-message` (so the replay cannot contain the prompt it is being prepended to), appends a `note` saying the session is fresh, and prepends the briefing behind a `---` rule. Delivery-only: the transcript persists the user's words alone, because the thread already renders every line the briefing replays.

**`RunManager.recover`** keeps its lifecycle line honest — `resuming the interrupted task from its last session` vs `no session to resume; continuing the interrupted task in a fresh session`.

**`reviveQueuedRun`** adopts a pending `continue-N` step whether or not a session precedes it. It used to fall through to reviving the **workflow**, re-running the task from step one against a worktree that already held its results.

**Cockpit.** `runActionFlags.continueRun` is `!active`; `terminal` keeps `!active && hasSession`, because handing a shell `claude --resume <id>` needs an id that exists. The Continue tooltip and the composer placeholder distinguish the two promises — `Reopen the session` vs `Start a new session — the previous conversation is replayed to the agent` — since only one of the two paths can claim "pick up where you left off". `askDeliveryMode`'s `unavailable` mode and the `no-session` blocked reason are removed: every closed run can take an answer now, so the ask card has no inert state left to render.

## The one deliberate exception

The usage-limit auto-resume stays **session-only**, and this PR moves that gate to fire time as well. `scheduleAutoResumeIfLimited` already checked for a session, but `reconcileAutoResumes` arms from the **record**, so a deadline that survived a restart never passed back through it — without a fire-time check, relaxing `continueRun` would have silently weakened an on-by-default unattended automation. Restarting a conversation from a summary is a thing a present user may ask Continue for; it is not a thing a timer may decide hours later with nobody watching.

## What does NOT change

- A run **with** a resumable session resumes it, same `--resume` argument, no briefing — it is already inside that conversation. Pinned by a guard test that passes both with and without this change.
- `POST /api/v1/runs/:id/open-in-cli` still answers `409 no agent session to resume`.
- `POST /api/v1/runs/:id/continue` is unchanged in shape. It accepts a case it used to reject (a widening, not a break); its other 409s are untouched.

## Testing

- `packages/cezar/src/runs/session-recap.test.ts` — ordering, coalescing, exclusions, clipping, the drop-oldest budget, the empty-conversation case.
- `packages/cezar/src/workflows/continue-without-session.test.ts` — end to end through the engine under `CEZ_DRY_RUN=1`: the briefing reaches the agent, **no `--resume` reaches the CLI**, the transcript persists the user's prompt alone, `recover()` continues instead of giving up, and the guard case above.

Three of those four engine cases were confirmed **red** with `workflows/run.ts` stashed; the guard case passes both ways, which is what it is for. The web suites' updated cases were confirmed red the same way.

Targeted validation: **33 files / 786 tests green** across every touched area (session-recap, continue-without-session, run, auto-resume, recover-\*, continue-run, open-in-cli-resume, `task-thread/*`, reference-conflict-action), plus `npm run typecheck` and `npm run test:unit` clean. Full suite left to CI.

Two failures investigated and ruled out by baselining against stashed sources: `server/automations-gate.test.ts` "starts once the flag is on" is a pre-existing 50 ms race (fails 4/4 **without** this change), and the "outside a git repository" / "clean tree" cases fail only when `TMPDIR` points inside the repo — all pass under `TMPDIR=/tmp`.

## Docs

New spec `.ai/specs/2026-09-11-continue-without-a-session.md` (with the resolved-assumptions table behind each knob above), a CHANGELOG entry under `# Unreleased`, and superseded notes in `.ai/specs/2026-07-21-queued-session-prompt-stacking.md` where the old composer copy was documented as current.
